### PR TITLE
Fixes crash in iPad with iOS7 showing 'Movies' collection

### DIFF
--- a/XBMC Remote.xcodeproj/project.xcworkspace/xcshareddata/XBMC Remote.xccheckout
+++ b/XBMC Remote.xcodeproj/project.xcworkspace/xcshareddata/XBMC Remote.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>9B59A030-E560-4ED3-A82E-F68C219032CB</string>
+	<key>IDESourceControlProjectName</key>
+	<string>XBMC Remote</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>7155501A-EE01-4870-AF00-285DFFD33031</key>
+		<string>https://github.com/vbergae/Unofficial-Official-XBMC-Remote.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>XBMC Remote.xcodeproj/project.xcworkspace</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>7155501A-EE01-4870-AF00-285DFFD33031</key>
+		<string>../..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>https://github.com/vbergae/Unofficial-Official-XBMC-Remote.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>110</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>7155501A-EE01-4870-AF00-285DFFD33031</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>7155501A-EE01-4870-AF00-285DFFD33031</string>
+			<key>IDESourceControlWCCName</key>
+			<string>Unofficial-Official-XBMC-Remote</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/XBMC Remote/FloatingHeaderFlowLayout.m
+++ b/XBMC Remote/FloatingHeaderFlowLayout.m
@@ -34,8 +34,8 @@
         
         UICollectionViewLayoutAttributes *layoutAttributes = [self layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionHeader atIndexPath:indexPath];
         
-        [answer addObject:layoutAttributes];
-        
+        if (layoutAttributes)
+            [answer addObject:layoutAttributes];
     }];
     
     for (UICollectionViewLayoutAttributes *layoutAttributes in answer) {


### PR DESCRIPTION
I don't know why, but using iOS7 for iPad
'layoutAttributesForSupplementaryViewOfKind:atIndexPath:' returns 'nil'
every time.

Checking 'layoutAttributes' before to adding it inside 'answare' array
fixes the crash.
