### PR TITLE
Increase the timeout for API requests

### DIFF
--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -153,7 +153,7 @@
     [serviceRequest setValue:[NSString stringWithFormat:@"%i", (int)postData.length] forHTTPHeaderField:@"Content-Length"];
     [serviceRequest setHTTPMethod:@"POST"];
     [serviceRequest setHTTPBody:postData];
-    [serviceRequest setTimeoutInterval:240];
+    [serviceRequest setTimeoutInterval:3600];
     
     // Create dictionary to store information about the request so we can recall it later
     NSMutableDictionary *connectionInfo = [NSMutableDictionary dictionaryWithCapacity:3];


### PR DESCRIPTION
I've been running into timeout issues when trying to refresh the song view with a library of > 20k songs on a RasPi 2 and Intel-Atom-based computers. Nothing is wrong with the connection, just takes some time to transfer the data. This just ups the timeout.