### PR TITLE
Fix bottom padding for iPads without Home button

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5805,11 +5805,13 @@ NSIndexPath *selected;
         UIWindow *window = UIApplication.sharedApplication.keyWindow;
         bottomPadding = window.safeAreaInsets.bottom;
     }
-    if (bottomPadding > 0) {
-        frame = buttonsView.frame;
-        frame.size.height += bottomPadding;
-        frame.origin.y -= bottomPadding;
-        buttonsView.frame = frame;
+    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone){
+        if (bottomPadding > 0) {
+            frame = buttonsView.frame;
+            frame.size.height += bottomPadding;
+            frame.origin.y -= bottomPadding;
+            buttonsView.frame = frame;
+        }
     }
     
     [detailView setClipsToBounds:YES];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2744,12 +2744,12 @@ int currentItemID;
     [songName setFont:[UIFont systemFontOfSize:20]];
 
     frame=songName.frame;
-    frame.origin.y=frame.origin.y+6;
+    frame.origin.y=frame.origin.y - 12;
     songName.frame=frame;
     
     [artistName setFont:[UIFont systemFontOfSize:18]];
     frame=artistName.frame;
-    frame.origin.y=frame.origin.y+12;
+    frame.origin.y=frame.origin.y - 8;
     artistName.frame=frame;
     
     [currentTime setFont:[UIFont systemFontOfSize:16]];
@@ -2760,7 +2760,7 @@ int currentItemID;
     playlistTableView.frame=frame;
     
     frame = ProgressSlider.frame;
-    frame.origin.y = frame.origin.y - 5;
+    frame.origin.y = frame.origin.y - 14;
     ProgressSlider.frame = frame;
     
     /* TODO: Find an elegant solution for the following code.

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -532,6 +532,31 @@
         [self.view addSubview:clearView];
         [NSThread detachNewThreadSelector:@selector(startClearAppDiskCache:) toTarget:self withObject:clearView];
     }
+
+    int bottomPadding = 0;
+    if (@available(iOS 11.0, *)) {
+        UIWindow *window = UIApplication.sharedApplication.keyWindow;
+        bottomPadding = window.safeAreaInsets.bottom;
+    }
+    
+    if (bottomPadding > 0) {
+        frame = volumeSliderView.frame;
+        frame.origin.y -= bottomPadding;
+        volumeSliderView.frame = frame;
+        
+        frame = powerButton.frame;
+        frame.origin.y -= bottomPadding;
+        powerButton.frame = frame;
+        
+        frame = xbmcInfo.frame;
+        frame.origin.y -= bottomPadding;
+        xbmcInfo.frame = frame;
+        
+        frame = xbmcLogo.frame;
+        frame.origin.y -= bottomPadding;
+        xbmcLogo.frame = frame;
+    }
+
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleXBMCServerHasChanged:)
                                                  name: @"XBMCServerHasChanged"

--- a/XBMC Remote/iPad/StackScrollViewController.h
+++ b/XBMC Remote/iPad/StackScrollViewController.h
@@ -67,6 +67,8 @@
     BOOL stackScrollIsFullscreen;
     
     NSMutableArray *stackViewsFrames;
+    
+    CGFloat bottomPadding;
 }
 
 - (void)offView;

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -56,6 +56,12 @@ const NSInteger SLIDE_VIEWS_START_X_POS = 0;
 	
 	if(self= [super init]) {
 		
+        bottomPadding = 0;
+        if (@available(iOS 11.0, *)) {
+            UIWindow *window = UIApplication.sharedApplication.keyWindow;
+            bottomPadding = window.safeAreaInsets.bottom;
+        }
+        
 		viewControllersStack = [[NSMutableArray alloc] init];
         stackViewsFrames = [[NSMutableArray alloc] init];
 		borderViews = [[UIView alloc] initWithFrame:CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION - 2, -2, 2, self.view.frame.size.height + 2)];
@@ -77,7 +83,7 @@ const NSInteger SLIDE_VIEWS_START_X_POS = 0;
 		
 		[self.view addSubview:borderViews];
 		
-		slideViews = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height)];
+		slideViews = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height - bottomPadding)];
 		[slideViews setBackgroundColor:[UIColor clearColor]];
 		[self.view setBackgroundColor:[UIColor clearColor]];
 		[self.view setFrame:slideViews.frame];
@@ -978,7 +984,7 @@ const NSInteger SLIDE_VIEWS_START_X_POS = 0;
 	
 	if ([slideViews.subviews count] != 0) {
 //        NSLog(@"QUATTRO");
-        UIView* verticalLineView = [[UIView alloc] initWithFrame:CGRectMake(-40, 0, 40 , self.view.frame.size.height)];
+        UIView* verticalLineView = [[UIView alloc] initWithFrame:CGRectMake(-40, 0, 40 , self.view.frame.size.height - bottomPadding)];
 		[verticalLineView setBackgroundColor:[UIColor clearColor]];
 		[verticalLineView setAutoresizingMask:UIViewAutoresizingFlexibleHeight];
 		[verticalLineView setClipsToBounds:NO];
@@ -995,12 +1001,12 @@ const NSInteger SLIDE_VIEWS_START_X_POS = 0;
 		slideStartPosition = SLIDE_VIEWS_START_X_POS;
 		viewXPosition = slideStartPosition;
 	}
-	[[controller view] setFrame:CGRectMake(viewXPosition, 0, [controller view].frame.size.width, self.view.frame.size.height)];
+	[[controller view] setFrame:CGRectMake(viewXPosition, 0, [controller view].frame.size.width, self.view.frame.size.height - bottomPadding)];
 	[controller.view setTag:([viewControllersStack count]-1) + VIEW_TAG];
 	[controller viewWillAppear:FALSE];
 	[controller viewDidAppear:FALSE];
     
-    CGRect shadowRect = CGRectMake(-16.0f, 0.0f, 16.0f, self.view.frame.size.height);
+    CGRect shadowRect = CGRectMake(-16.0f, 0.0f, 16.0f, self.view.frame.size.height - bottomPadding);
     UIImageView *shadow = [[UIImageView alloc] initWithFrame:shadowRect];
     [shadow setAutoresizingMask:UIViewAutoresizingFlexibleHeight];
     [shadow setImage:[UIImage imageNamed:@"tableLeft.png"]];
@@ -1008,7 +1014,7 @@ const NSInteger SLIDE_VIEWS_START_X_POS = 0;
     shadow.tag = 2001;
     [controller.view addSubview:shadow];
     
-    shadowRect = CGRectMake(STACKSCROLL_WIDTH, 0.0f, 16.0f, self.view.frame.size.height);
+    shadowRect = CGRectMake(STACKSCROLL_WIDTH, 0.0f, 16.0f, self.view.frame.size.height - bottomPadding);
     UIImageView *shadowRight = [[UIImageView alloc] initWithFrame:shadowRect];
     [shadowRight setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleLeftMargin];
     [shadowRight setImage:[UIImage imageNamed:@"tableRight.png"]];
@@ -1027,12 +1033,12 @@ const NSInteger SLIDE_VIEWS_START_X_POS = 0;
 		if ([[slideViews subviews] count]==1) {
 //            NSLog(@"SETTE"); //FIRST
 			viewAtLeft = [[slideViews subviews] objectAtIndex:[[slideViews subviews] count]-1];
-            [[controller view] setFrame:CGRectMake(animX, 0, [controller view].frame.size.width, self.view.frame.size.height)];
+            [[controller view] setFrame:CGRectMake(animX, 0, [controller view].frame.size.width, self.view.frame.size.height - bottomPadding)];
 
             [UIView beginAnimations:nil context:NULL];
 			[UIView setAnimationTransition:UIViewAnimationTransitionNone forView:viewAtLeft cache:YES];	
 			[UIView setAnimationBeginsFromCurrentState:NO];	
-            [[controller view] setFrame:CGRectMake(viewXPosition, 0, [controller view].frame.size.width, self.view.frame.size.height)];
+            [[controller view] setFrame:CGRectMake(viewXPosition, 0, [controller view].frame.size.width, self.view.frame.size.height - bottomPadding)];
 
             [UIView commitAnimations];
 			viewAtLeft2 = nil;
@@ -1113,38 +1119,38 @@ const NSInteger SLIDE_VIEWS_START_X_POS = 0;
 	for (UIViewController* subController in viewControllersStack) {
 		if (viewAtRight != nil && [viewAtRight isEqual:subController.view]) {
 			if (viewAtRight.frame.origin.x <= (viewAtLeft.frame.origin.x + viewAtLeft.frame.size.width)) {
-				[subController.view setFrame:CGRectMake(self.view.frame.size.width - subController.view.frame.size.width, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height)];
+				[subController.view setFrame:CGRectMake(self.view.frame.size.width - subController.view.frame.size.width, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height - bottomPadding)];
 			}else{
-				[subController.view setFrame:CGRectMake(viewAtLeft.frame.origin.x + viewAtLeft.frame.size.width, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height)];
+				[subController.view setFrame:CGRectMake(viewAtLeft.frame.origin.x + viewAtLeft.frame.size.width, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height - bottomPadding)];
 			}
 			isViewOutOfScreen = TRUE;
 		}
 		else if (viewAtLeft != nil && [viewAtLeft isEqual:subController.view]) {
 			if (viewAtLeft2 == nil) {
 				if(viewAtRight == nil){					
-					[subController.view setFrame:CGRectMake(posX, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height)];
+					[subController.view setFrame:CGRectMake(posX, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height - bottomPadding)];
 				}
 				else{
-					[subController.view setFrame:CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height)];
-					[viewAtRight setFrame:CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + subController.view.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height)];
+					[subController.view setFrame:CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height - bottomPadding)];
+					[viewAtRight setFrame:CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + subController.view.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height - bottomPadding)];
 				}
 			}
 			else if (viewAtLeft.frame.origin.x == SLIDE_VIEWS_MINUS_X_POSITION || viewAtLeft.frame.origin.x == SLIDE_VIEWS_START_X_POS) {
-				[subController.view setFrame:CGRectMake(subController.view.frame.origin.x, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height)];
+				[subController.view setFrame:CGRectMake(subController.view.frame.origin.x, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height - bottomPadding)];
 			}
 			else {
 				if (viewAtLeft.frame.origin.x + viewAtLeft.frame.size.width == self.view.frame.size.width) {
-					[subController.view setFrame:CGRectMake(self.view.frame.size.width - subController.view.frame.size.width, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height)];
+					[subController.view setFrame:CGRectMake(self.view.frame.size.width - subController.view.frame.size.width, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height - bottomPadding)];
 				}else{
-					[subController.view setFrame:CGRectMake(viewAtLeft2.frame.origin.x + viewAtLeft2.frame.size.width, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height)];
+					[subController.view setFrame:CGRectMake(viewAtLeft2.frame.origin.x + viewAtLeft2.frame.size.width, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height - bottomPadding)];
 				}
 			}
 		}
 		else if(!isViewOutOfScreen){
-			[subController.view setFrame:CGRectMake(subController.view.frame.origin.x, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height)];
+			[subController.view setFrame:CGRectMake(subController.view.frame.origin.x, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height - bottomPadding)];
 		}
 		else {
-			[subController.view setFrame:CGRectMake(self.view.frame.size.width, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height)];
+			[subController.view setFrame:CGRectMake(self.view.frame.size.width, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height - bottomPadding)];
 		}
 		
 	}


### PR DESCRIPTION
The newer iPads without Home button need some special treatment for the DetailViewController´s button toolbar and the StackViewController views. With this change both types of iPads (with and without Home button) will show the bar and views properly, including rotation.