### PR TITLE
Fix posters not shown with Kodi 19+

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4389,6 +4389,9 @@ NSIndexPath *selected;
                  
                  NSString *thumbnailPath = [videoLibraryMovieDetail objectForKey:@"thumbnail"];
                  NSDictionary *art = [videoLibraryMovieDetail objectForKey:@"art"];
+                 if ([art count] && [[art objectForKey:@"poster"] length]!=0) {
+                     thumbnailPath = [art objectForKey:@"poster"];
+                 }
 
                  NSString *clearlogo = @"";
                  NSString *clearart = @"";
@@ -4655,6 +4658,9 @@ NSIndexPath *selected;
                          NSDictionary *art = [[videoLibraryMovies objectAtIndex:i] objectForKey:@"art"];
                          if ([art count] && [[art objectForKey:@"banner"] length]!=0 && tvshowsView){
                              thumbnailPath = [art objectForKey:@"banner"];
+                         }
+                         if ([art count] && [[art objectForKey:@"poster"] length]!=0) {
+                             thumbnailPath = [art objectForKey:@"poster"];
                          }
                          NSString *fanartPath = [[videoLibraryMovies objectAtIndex:i] objectForKey:@"fanart"];
                          NSString *fanartURL=@"";


### PR DESCRIPTION
Fixes issue https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/96 and https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/88

Details:
- Since Kodi19 there is no fallback to use poster or banner in case there is no thumbnail.
- Use poster if available