### PR TITLE
Fix scaling for iPhones

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -28,9 +28,6 @@
 #define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 #define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
 #define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
-#define IS_IPHONE_6 (fabs((double)[[UIScreen mainScreen]bounds].size.height - (double)667) < DBL_EPSILON)
-#define IS_IPHONE_6_PLUS (fabs((double)[[UIScreen mainScreen]bounds].size.height - (double)736) < DBL_EPSILON)
-#define IS_IPHONE_X     (fabs((double)[[UIScreen mainScreen]bounds].size.height - (double)812) < DBL_EPSILON)
 
 #define GET_TRANSFORM_X (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/320.0f)
 #define GET_TRANSFORM_Y (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/480.0f)

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -33,6 +33,8 @@
 #define IS_IPHONE_X     (fabs((double)[[UIScreen mainScreen]bounds].size.height - (double)812) < DBL_EPSILON)
 
 #define GET_TRANSFORM_X (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/320.0f)
+#define GET_TRANSFORM_Y (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/480.0f)
+
 #define IS_AT_LEAST_IPHONE_X_HEIGHT (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 812)
 
 

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -29,8 +29,8 @@
 #define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
 #define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
 
-#define GET_TRANSFORM_X (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/320.0f)
-#define GET_TRANSFORM_Y (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/480.0f)
+#define GET_TRANSFORM_X (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/320.0)
+#define GET_TRANSFORM_Y (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/480.0)
 
 #define IS_AT_LEAST_IPHONE_X_HEIGHT (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 812)
 

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -31,6 +31,8 @@
 #define IS_IPHONE_6 (fabs((double)[[UIScreen mainScreen]bounds].size.height - (double)667) < DBL_EPSILON)
 #define IS_IPHONE_6_PLUS (fabs((double)[[UIScreen mainScreen]bounds].size.height - (double)736) < DBL_EPSILON)
 #define IS_IPHONE_X     (fabs((double)[[UIScreen mainScreen]bounds].size.height - (double)812) < DBL_EPSILON)
+
+#define GET_TRANSFORM_X (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/320.0f)
 #define IS_AT_LEAST_IPHONE_X_HEIGHT (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 812)
 
 

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -110,13 +110,7 @@ NSMutableArray *hostRightMenuItems;
     obj=[GlobalData getInstance];
     
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-        float transform = 1.0f;
-        if (IS_IPHONE_6 || IS_IPHONE_X) {
-            transform = 1.18f;
-        }
-        else if (IS_IPHONE_6_PLUS){
-            transform = 1.294f;
-        }
+        float transform = GET_TRANSFORM_X;
         thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
         tvshowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
         NSDictionary *navbarTitleTextAttributes = [NSDictionary dictionaryWithObjectsAndKeys:

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5523,20 +5523,10 @@ NSIndexPath *selected;
         else{
             cellMinimumLineSpacing = 0;
             cellGridWidth = [[itemSizes objectForKey:@"width"] floatValue];
-            if (IS_IPHONE_6 || IS_IPHONE_X) {
-                cellGridWidth = (int)(cellGridWidth * 1.18f);
-            }
-            else if (IS_IPHONE_6_PLUS){
-                cellGridWidth = (int)(cellGridWidth * 1.31f);
-            }
+            cellGridWidth = (int)(cellGridWidth * GET_TRANSFORM_X);
         }
         cellGridHeight =  [[itemSizes objectForKey:@"height"] floatValue];
-        if (IS_IPHONE_6 || IS_IPHONE_X) {
-            cellGridHeight = (int)(cellGridHeight * 1.18f);
-        }
-        else if (IS_IPHONE_6_PLUS){
-            cellGridHeight = (int)(cellGridHeight * 1.31f);
-        }
+        cellGridHeight = (int)(cellGridHeight * GET_TRANSFORM_X);
     }
     if ([itemSizes objectForKey:@"fullscreenWidth"] && [itemSizes objectForKey:@"fullscreenHeight"]){
         fullscreenCellGridWidth = [[itemSizes objectForKey:@"fullscreenWidth"] floatValue];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5756,10 +5756,8 @@ NSIndexPath *selected;
     searchBarColor = [UIColor colorWithRed:.35 green:.35 blue:.35 alpha:1];
     collectionViewSearchBarColor = [UIColor blackColor];
     
-    CGFloat deltaY = 0;
     searchBarColor = [UIColor colorWithRed:.572f green:.572f blue:.572f alpha:1];
     collectionViewSearchBarColor = [UIColor colorWithRed:22.0f/255.0f green:22.0f/255.0f blue:22.0f/255.0f alpha:1];
-    deltaY = 64.0f;
 
     if ([[methods objectForKey:@"albumView"] boolValue] == YES){
         albumView = TRUE;
@@ -5810,20 +5808,16 @@ NSIndexPath *selected;
     NSDictionary *itemSizes = [parameters objectForKey:@"itemSizes"];
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone){
         [self setIphoneInterface:[itemSizes objectForKey:@"iphone"]];
-        if (IS_IPHONE_X) {
-            deltaY = 0;
-        }
     }
     else {
         [self setIpadInterface:[itemSizes objectForKey:@"ipad"]];
-        deltaY = 0;
     }
     
     if ([[[parameters objectForKey:@"itemSizes"] objectForKey:@"separatorInset"] length]){
         [dataList setSeparatorInset:UIEdgeInsetsMake(0, [[[parameters objectForKey:@"itemSizes"] objectForKey:@"separatorInset"] intValue], 0, 0)];
     }
     
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, deltaY + 42.0f) deltaY:deltaY deltaX:0];
+    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, 42.0f) deltaY:0 deltaX:0];
     [self.view addSubview:messagesView];
     
     frame = dataList.frame;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -371,13 +371,9 @@ static inline BOOL IsEmpty(id obj) {
 
 - (void)viewDidLoad{
     [super viewDidLoad];
-    int deltaY = 62;
-    int deltaX = 0;
+    int deltaY = 44 + [[UIApplication sharedApplication] statusBarFrame].size.height;
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
         deltaY = 0;
-    }
-    else if (IS_IPHONE_X) {
-        deltaY += 26;
     }
     CGFloat bottomPadding = 0;
     if (@available(iOS 11.0, *)) {
@@ -404,7 +400,7 @@ static inline BOOL IsEmpty(id obj) {
     frame.origin.y -= bottomPadding;
     [editTableButton setFrame:frame];
     
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 36 + deltaY) deltaY:deltaY deltaX:deltaX];
+    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 36 + deltaY) deltaY:deltaY deltaX:0];
     [messagesView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin];
     [self.view addSubview:messagesView];
     [addHostButton setTitle:NSLocalizedString(@"Add Host", nil) forState:UIControlStateNormal];

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -420,13 +420,7 @@
 }
 
 - (void) handleXBMCServerHasChanged: (NSNotification*) sender{
-    float transform = 1.0f;
-    if (IS_IPHONE_6 || IS_IPHONE_X) {
-        transform = 1.18f;
-    }
-    else if (IS_IPHONE_6_PLUS){
-        transform = 1.294f;
-    }
+    float transform = GET_TRANSFORM_X;
     int thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
     int tvshowHeight =  (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
     if ([AppDelegate instance].obj.preferTVPosters==YES){

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -382,12 +382,20 @@ float storePercentage;
 int storedItemID;
 int currentItemID;
 
+-(CGRect)transformFrame:(CGRect)frame{
+    CGFloat center_x = CGRectGetMidX(frame);
+    CGFloat center_y = CGRectGetMidY(frame);
+    CGFloat transform_x = GET_TRANSFORM_X;
+    CGFloat transform_y = GET_TRANSFORM_Y;
+    frame.size.width *= transform_x;
+    frame.size.height *= transform_x;
+    frame.origin.x = center_x*transform_x - frame.size.width/2;
+    frame.origin.y = center_y*transform_y - frame.size.height/2;
+    return frame;
+}
+
 -(void)setCoverSize:(NSString *)type{
     NSString *jewelImg = @"";
-    float screenSize = [[UIScreen mainScreen ] bounds].size.height;
-    float screenWidth = [[UIScreen mainScreen ] bounds].size.width;
-    float originalSize = 480.0f;
-
     if ([type isEqualToString:@"song"]){
         jewelImg = @"jewel_cd.9.png";
         CGRect frame = thumbnailView.frame;
@@ -396,15 +404,7 @@ int currentItemID;
             frame.origin.y = 43;
             frame.size.width = 238;
             frame.size.height = 238;
-            if(screenSize >= 568) {
-                frame.origin.y = frame.origin.y  + 36;
-            }
-            if (screenWidth > 320) {
-                frame.origin.x = frame.origin.x * (screenWidth/320);
-                frame.origin.y = frame.origin.y * (screenWidth/320) + ( 36 * (screenWidth/320)) - 36;
-                frame.size.width = frame.size.width * (screenWidth/320) + ( 6 * (screenWidth/320));
-                frame.size.height = frame.size.height * (screenWidth/320) + ( 6 * (screenWidth/320));
-            }
+            frame = [self transformFrame:frame];
         }
         else {
             jewelImg=@"jewel_cd.9@2x.png";
@@ -431,23 +431,7 @@ int currentItemID;
             frame.origin.y = 39;
             frame.size.width = 172;
             frame.size.height = 248;
-            if(screenSize >= 568) {
-                frame.origin.x = frame.origin.x - 12;
-                frame.origin.y = frame.origin.y + 10;
-                frame.size.width = frame.size.width * (screenSize/originalSize);
-                frame.size.height = frame.size.height * (screenSize/originalSize) + 10;
-            }
-            if (screenWidth > 320) {
-                float transform = 1.0f/GET_TRANSFORM_X;
-                if (IS_IPHONE_6_PLUS){
-                    frame.origin.x = frame.origin.x + 8;
-                    frame.origin.y = frame.origin.y + 3;
-                }
-                frame.origin.x = frame.origin.x * (screenWidth/320) * transform;
-                frame.origin.y = frame.origin.y * (screenWidth/320);
-                frame.size.width = frame.size.width * (screenWidth/320) * transform;
-                frame.size.height = frame.size.height * (screenWidth/320) * transform;
-            }
+            frame = [self transformFrame:frame];
         }
         else{
             jewelImg=@"jewel_dvd.9@2x.png";
@@ -474,17 +458,7 @@ int currentItemID;
             frame.origin.y = 78;
             frame.size.width = 280;
             frame.size.height = 158;
-            if(screenSize >= 568) {
-                frame.origin.y = frame.origin.y  + 36;
-                frame.origin.x = frame.origin.x  + 2;
-            }
-            if (screenWidth > 320) {
-                frame.origin.x = frame.origin.x * (screenWidth/320);
-                frame.origin.y = frame.origin.y * (screenWidth/320) + ( 36 * (screenWidth/320)) - 34;
-                frame.size.width = frame.size.width * (screenWidth/320);
-                frame.size.height = frame.size.height * (screenWidth/320) + ( 6 * (screenWidth/320));
-            }
-
+            frame = [self transformFrame:frame];
         }
         else{
             jewelImg=@"jewel_tv.9@2x.png";
@@ -511,15 +485,7 @@ int currentItemID;
             frame.origin.y = 43;
             frame.size.width = 238;
             frame.size.height = 238;
-            if(screenSize >= 568) {
-                frame.origin.y = frame.origin.y  + 36;
-            }
-            if (screenWidth > 320) {
-                frame.origin.x = frame.origin.x * (screenWidth/320);
-                frame.origin.y = frame.origin.y * (screenWidth/320) + ( 36 * (screenWidth/320)) - 36;
-                frame.size.width = frame.size.width * (screenWidth/320) + ( 6 * (screenWidth/320));
-                frame.size.height = frame.size.height * (screenWidth/320) + ( 6 * (screenWidth/320));
-            }
+            frame = [self transformFrame:frame];
         }
         else {
             jewelImg=@"jewel_cd.9@2x.png";

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -438,12 +438,8 @@ int currentItemID;
                 frame.size.height = frame.size.height * (screenSize/originalSize) + 10;
             }
             if (screenWidth > 320) {
-                float transform = 1.0f;
-                if (IS_IPHONE_6 || IS_IPHONE_X) {
-                    transform = 0.9f;
-                }
-                else if (IS_IPHONE_6_PLUS){
-                    transform = 0.82f;
+                float transform = 1.0f/GET_TRANSFORM_X;
+                if (IS_IPHONE_6_PLUS){
                     frame.origin.x = frame.origin.x + 8;
                     frame.origin.y = frame.origin.y + 3;
                 }

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -20,7 +20,7 @@
 #import "DetailViewController.h"
 
 #define ROTATION_TRIGGER 0.015f 
-#define SCALE_TO_REDUCE_BORDERS 1.05f
+#define SCALE_TO_REDUCE_BORDERS 1.05
 
 @interface RemoteController ()
 
@@ -144,7 +144,7 @@
     }
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
         quickHelpImageView.image = [UIImage imageNamed:@"remote quick help.png"];
-        float transform = GET_TRANSFORM_X;
+        CGFloat transform = GET_TRANSFORM_X;
         CGRect frame = remoteControlView.frame;
         frame.size.height = frame.size.height *transform;
         frame.size.width = frame.size.width*transform;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -53,20 +53,19 @@
 
 - (void)setEmbeddedView{
     CGRect frame = TransitionalView.frame;
-    float transform = 1.0f;
+    float transform = GET_TRANSFORM_X;
     int startX = -6;
     int startY = 6;
     int transViewY = 46;
     if (IS_IPHONE_6 || IS_IPHONE_X) {
-        transform = 1.16f;
         startX = 3;
         transViewY = 58;
     }
     else if (IS_IPHONE_6_PLUS){
-        transform = 1.29f;
         startX = 6;
         transViewY = 66;
     }
+        
     int newWidth = (int) (296.0f * transform);
     [self hideButton: [NSArray arrayWithObjects:
                        [(UIButton *) self.view viewWithTag:2],
@@ -143,13 +142,7 @@
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
         quickHelpImageView.image = [UIImage imageNamed:@"remote quick help.png"];
         if([[UIScreen mainScreen ] bounds].size.height >= 568){
-            float transform = 1.0f;
-            if (IS_IPHONE_6 || IS_IPHONE_X) {
-                transform = 1.16f;
-            }
-            else if (IS_IPHONE_6_PLUS){
-                transform = 1.29f;
-            }
+            float transform = GET_TRANSFORM_X;
             CGRect frame = remoteControlView.frame;
             frame.size.height = frame.size.height *transform;
             frame.size.width = frame.size.width*transform;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -58,13 +58,15 @@
     int startX = -6;
     int startY = 6;
     int transViewY = 46;
-    if (IS_IPHONE_6 || IS_IPHONE_X) {
-        startX = 3;
-        transViewY = 58;
-    }
-    else if (IS_IPHONE_6_PLUS){
+    if (transform>=1.29f) {
+        // All devices with width >= 414
         startX = 6;
         transViewY = 66;
+    }
+    else if (transform>1.0f) {
+        // All devices with 320 > width > 414
+        startX = 3;
+        transViewY = 58;
     }
         
     int newWidth = (int) (296.0f * transform);

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -20,6 +20,7 @@
 #import "DetailViewController.h"
 
 #define ROTATION_TRIGGER 0.015f 
+#define SCALE_TO_REDUCE_BORDERS 1.05f
 
 @interface RemoteController ()
 
@@ -141,14 +142,12 @@
     }
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
         quickHelpImageView.image = [UIImage imageNamed:@"remote quick help.png"];
-        if([[UIScreen mainScreen ] bounds].size.height >= 568){
-            float transform = GET_TRANSFORM_X;
-            CGRect frame = remoteControlView.frame;
-            frame.size.height = frame.size.height *transform;
-            frame.size.width = frame.size.width*transform;
-            [remoteControlView setFrame:CGRectMake(frame.origin.x, frame.origin.y + 12, frame.size.width * 1.075, frame.size.height * 1.075)];
-        }
-        CGRect frame = subsInfoLabel.frame;
+        float transform = GET_TRANSFORM_X;
+        CGRect frame = remoteControlView.frame;
+        frame.size.height = frame.size.height *transform;
+        frame.size.width = frame.size.width*transform;
+        [remoteControlView setFrame:CGRectMake(frame.origin.x, frame.origin.y, frame.size.width* SCALE_TO_REDUCE_BORDERS, frame.size.height* SCALE_TO_REDUCE_BORDERS)];
+        frame = subsInfoLabel.frame;
         frame.size.width = [[UIScreen mainScreen ] bounds].size.width;
         frame.origin.x = ((remoteControlView.frame.size.width - [[UIScreen mainScreen ] bounds].size.width) / 2);
         subsInfoLabel.frame = frame;
@@ -1120,7 +1119,7 @@ NSInteger buttonAction;
         [UIView setAnimationDuration:0.2];
         quickHelpView.alpha = 1.0;
         [UIView commitAnimations];
-        [self.navigationController setNavigationBarHidden:YES animated:YES];
+        [self.navigationController setNavigationBarHidden:NO animated:YES];
 
     }
     else {

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -595,7 +595,7 @@
 
 - (void)viewDidLoad{
     [super viewDidLoad];
-    int deltaY = 22.0f;
+    CGFloat deltaY = [[UIApplication sharedApplication] statusBarFrame].size.height;
     self.peekLeftAmount = 40.0f;
     CGRect frame = [[UIScreen mainScreen ] bounds];
     CGFloat deltaX = 40.0f;
@@ -604,9 +604,6 @@
         deltaX = 0.0f;
         deltaY = 0.0f;
         self.peekLeftAmount = 0.0f;
-    }
-    else if (IS_IPHONE_X) {
-        deltaY += 26.0f;
     }
     torchIsOn = NO;
     Class captureDeviceClass = NSClassFromString(@"AVCaptureDevice");

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -143,9 +143,6 @@
             frame.size.width = STACKSCROLL_WIDTH;
             deltaY = 0;
         }
-        else if (IS_IPHONE_X) {
-            deltaY += 26.0f;
-        }
         
         scrubbingView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, 44)];
         [scrubbingView setCenter:CGPointMake((int)(frame.size.width / 2), (int)(frame.size.height / 2) + 50)];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -767,8 +767,8 @@ int h=0;
     clearLogoWidth = self.view.frame.size.width - 20.0f;
     clearLogoHeight = 116;
     float transform = GET_TRANSFORM_X;
-    thumbWidth = PHONE_TV_SHOWS_BANNER_WIDTH * transform;
-    tvshowHeight = PHONE_TV_SHOWS_BANNER_HEIGHT * transform;
+    thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
+    tvshowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
     int shiftParentalRating = -20;
     NSString *contributorString = @"cast";
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -821,13 +821,7 @@ int h=0;
         [self setAndMoveLabels:arrayLabels size:size];
     }
     else {
-        float transform = 1.0f;
-        if (IS_IPHONE_6 || IS_IPHONE_X) {
-            transform = 1.18f;
-        }
-        else if (IS_IPHONE_6_PLUS){
-            transform = 1.294f;
-        }
+        float transform = GET_TRANSFORM_X;
         thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
         tvshowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
         if (!enableJewel) {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -766,8 +766,9 @@ int h=0;
     }
     clearLogoWidth = self.view.frame.size.width - 20.0f;
     clearLogoHeight = 116;
-    thumbWidth = PHONE_TV_SHOWS_BANNER_WIDTH;
-    tvshowHeight = PHONE_TV_SHOWS_BANNER_HEIGHT;
+    float transform = GET_TRANSFORM_X;
+    thumbWidth = PHONE_TV_SHOWS_BANNER_WIDTH * transform;
+    tvshowHeight = PHONE_TV_SHOWS_BANNER_HEIGHT * transform;
     int shiftParentalRating = -20;
     NSString *contributorString = @"cast";
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -90,23 +90,13 @@
             frame_tmp.size.width = [self currentScreenBoundsDependOnOrientation].size.width;
             self.frame = frame_tmp;
             plusButton.frame = minusButton.frame;
-            float transform = 1.0f;
-            if (IS_IPHONE_6 || IS_IPHONE_X) {
-                transform = 1.30f;
-                frame_tmp = plusButton.frame;
-                frame_tmp.origin.y = frame_tmp.origin.y + 54.0f;
-                plusButton.frame = frame_tmp;
-            }
-            else if (IS_IPHONE_6_PLUS){
-                transform = 1.53f;
-                frame_tmp = plusButton.frame;
-                frame_tmp.origin.y = frame_tmp.origin.y + 94.0f;
-                plusButton.frame = frame_tmp;
-            }
+            frame_tmp = plusButton.frame;
+            frame_tmp.origin.y = [self currentScreenBoundsDependOnOrientation].size.width - 44 - plusButton.frame.size.height;
+            plusButton.frame = frame_tmp;
             frame_tmp = minusButton.frame;
             [minusButton setFrame:CGRectMake(frame_tmp.origin.x, 26, frame_tmp.size.width, frame_tmp.size.height)];
             frame_tmp = volumeSlider.frame;
-            [volumeSlider setFrame:CGRectMake(frame_tmp.origin.x, 33 + minusButton.frame.size.width, frame_tmp.size.width, frame_tmp.size.height * transform)];
+            [volumeSlider setFrame:CGRectMake(frame_tmp.origin.x, 33 + minusButton.frame.size.width, frame_tmp.size.width, plusButton.frame.origin.y - minusButton.frame.origin.y - minusButton.frame.size.height - 12)];
         }
         [[NSNotificationCenter defaultCenter] addObserver: self
                                                  selector: @selector(handleApplicationOnVolumeChanged:)


### PR DESCRIPTION
This fixes issue https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/111.

Details already given in https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/99#issuecomment-757415645:

> Still not checked for all screens and view modes. It is hard to see what exactly was calculated to get those hard coded numbers. In general the code on master tries to use different scaling factors for several items (e.g. thumbviews, the remote or the volume slider). There are three families of scaling factors which reflect the three different x-axis resolutions at the time when the last changes were done, the fourth one (e.g. iPhone 12) was not taken into account. As the factors are not 100% identical for each family (like 1.29, 1.294 and 1.31) I think there was some manual tweaking done in some places, possibly to handle the effect of separators.
Also, I doubt that all of the code is still active. In some places I could mess around with the scaling and the thumbviews and remote still looked fine.

This PR implement a centralized macro/define which calculates the transform/scaling factor from the current screen width. This factor is now applied instead of hard coded values. The macros should support future screen sizes as well.

Test were done on simulator with
- iPhone 12 Pro Max (width = 428)
- iPhone 11 Pro Max (width = 414)
- iPhone Xs (width = 375)
- iPod Touch (width = 320) and 
- iPad 8G (only to double check if regressions are seen for non-iPhone devices).

As I am mainly using Music it would be good to have some tests specifically with Movies and TV Shows.