### PR TITLE
Hotfix for Dark Mode

### DIFF
--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -56,6 +56,7 @@
         [backgroundTextField setBorderStyle:UITextBorderStyleRoundedRect];
         [backgroundTextField setBackgroundColor:[UIColor whiteColor]];
         [backgroundTextField setFont:[UIFont systemFontOfSize:textSize]];
+        [backgroundTextField setTextColor:[UIColor blackColor]];
         [backgroundTextField setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleLeftMargin];
         backgroundTextField.autocorrectionType = UITextAutocorrectionTypeNo;
         backgroundTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;


### PR DESCRIPTION
Fixes issue https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/113.

Define blackColor for keyboard text field (which has a white background defined). This way the text field stays readable when entering Dark Mode.