### PR TITLE
AppStore distribution fix

### DIFF
--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -4296,8 +4296,6 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				ONLY_ACTIVE_ARCH = YES;
-				PROVISIONING_PROFILE = "";
-				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -4340,8 +4338,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
-				PROVISIONING_PROFILE = "";
-				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -4351,20 +4347,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XBMC Remote/Kodi Remote-Prefix.pch";
 				INFOPLIST_FILE = "XBMC Remote/Kodi Remote-Info.plist";
 				MARKETING_VERSION = 1.6;
-				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-w",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "it.joethefox.XBMC-Remote";
 				PRODUCT_NAME = "Kodi Remote";
-				PROVISIONING_PROFILE = "";
-				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "x86_64 armv7s arm64";
 				"VALID_ARCHS[sdk=*]" = "x86_64 armv7s arm64";
@@ -4376,17 +4368,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XBMC Remote/Kodi Remote-Prefix.pch";
 				INFOPLIST_FILE = "XBMC Remote/Kodi Remote-Info.plist";
 				MARKETING_VERSION = 1.6;
-				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "it.joethefox.XBMC-Remote";
 				PRODUCT_NAME = "Kodi Remote";
-				PROVISIONING_PROFILE = "";
-				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				PROVISIONING_PROFILE_SPECIFIER = "Kodi Remote AppStore";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALID_ARCHS = "x86_64 armv7s arm64";

--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -4358,8 +4358,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "it.joethefox.XBMC-Remote";
 				PRODUCT_NAME = "Kodi Remote";
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "x86_64 armv7s arm64";
-				"VALID_ARCHS[sdk=*]" = "x86_64 armv7s arm64";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -4377,7 +4375,6 @@
 				PRODUCT_NAME = "Kodi Remote";
 				PROVISIONING_PROFILE_SPECIFIER = "Kodi Remote AppStore";
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "x86_64 armv7s arm64";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Features
 
 ### For testers
 
-TODO
+Join beta testing: https://testflight.apple.com/join/VQkpfqDN
 
 ### For maintainers (team Kodi)
 
@@ -27,3 +27,4 @@ Use [fastlane](https://fastlane.tools/) to build and submit to Testflight.
 1. `cd` to project's directory in terminal
 2. Install or update Ruby dependencies: `bundle install` or `bundle update`
 3. Run fastlane: `bundle exec fastlane tf`
+    - to avoid username prompt, use `FASTLANE_USER` environment variable

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,5 +24,8 @@ lane :tf do
     include_bitcode: true,
     export_method: 'app-store',
   )
-  testflight
+  testflight(
+    distribute_external: true,
+    groups: ['external testers'],
+  )
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,6 +2,7 @@ default_platform(:ios)
 
 before_all do
   ensure_bundle_exec
+  ensure_git_status_clean
   skip_docs
   xcversion(version: "~> 12.3")
 end


### PR DESCRIPTION
- Testflight script improvements
- bring back support for 32-bit devices (that run pre-iOS 11): noticed that previous builds had been built only for arm64
![Screenshot 2021-01-11 at 20 06 28](https://user-images.githubusercontent.com/1557784/104215691-2fba8c80-544a-11eb-9b70-a62f5e57109d.png)
