### PR TITLE
Fix thumb/banner scaling for iPad

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -29,9 +29,6 @@
 #define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
 #define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
 
-#define GET_TRANSFORM_X (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/320.0)
-#define GET_TRANSFORM_Y (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/480.0)
-
 #define IS_AT_LEAST_IPHONE_X_HEIGHT (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 812)
 
 

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -14,6 +14,7 @@
 #import <arpa/inet.h>
 #import "InitialSlidingViewController.h"
 #import "UIImageView+WebCache.h"
+#import "Utilities.h"
 
 @implementation AppDelegate
 
@@ -110,7 +111,7 @@ NSMutableArray *hostRightMenuItems;
     obj=[GlobalData getInstance];
     
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-        float transform = GET_TRANSFORM_X;
+        CGFloat transform = [Utilities getTransformX];
         thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
         tvshowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
         NSDictionary *navbarTitleTextAttributes = [NSDictionary dictionaryWithObjectsAndKeys:

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5318,6 +5318,7 @@ NSIndexPath *selected;
 
 -(void)checkParamSize:(NSDictionary *)itemSizes viewWidth:(int)fullWidth{
     if ([itemSizes objectForKey:@"width"] && [itemSizes objectForKey:@"height"]){
+        CGFloat transform = [Utilities getTransformX];
         if ([[itemSizes objectForKey:@"width"] isKindOfClass:[NSString class]]){
             if ([[itemSizes objectForKey:@"width"] isEqualToString:@"fullWidth"]){
                 cellGridWidth = fullWidth;
@@ -5327,10 +5328,10 @@ NSIndexPath *selected;
         else{
             cellMinimumLineSpacing = 0;
             cellGridWidth = [[itemSizes objectForKey:@"width"] floatValue];
-            cellGridWidth = (int)(cellGridWidth * GET_TRANSFORM_X);
+            cellGridWidth = (int)(cellGridWidth * transform);
         }
         cellGridHeight =  [[itemSizes objectForKey:@"height"] floatValue];
-        cellGridHeight = (int)(cellGridHeight * GET_TRANSFORM_X);
+        cellGridHeight = (int)(cellGridHeight * transform);
     }
     if ([itemSizes objectForKey:@"fullscreenWidth"] && [itemSizes objectForKey:@"fullscreenHeight"]){
         fullscreenCellGridWidth = [[itemSizes objectForKey:@"fullscreenWidth"] floatValue];

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -420,7 +420,7 @@
 }
 
 - (void) handleXBMCServerHasChanged: (NSNotification*) sender{
-    float transform = GET_TRANSFORM_X;
+    CGFloat transform = [Utilities getTransformX];
     int thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
     int tvshowHeight =  (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
     if ([AppDelegate instance].obj.preferTVPosters==YES){

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -385,8 +385,8 @@ int currentItemID;
 -(CGRect)transformFrame:(CGRect)frame{
     CGFloat center_x = CGRectGetMidX(frame);
     CGFloat center_y = CGRectGetMidY(frame);
-    CGFloat transform_x = GET_TRANSFORM_X;
-    CGFloat transform_y = GET_TRANSFORM_Y;
+    CGFloat transform_x = [Utilities getTransformX];
+    CGFloat transform_y = [Utilities getTransformY];
     frame.size.width *= transform_x;
     frame.size.height *= transform_x;
     frame.origin.x = center_x*transform_x - frame.size.width/2;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -54,7 +54,7 @@
 
 - (void)setEmbeddedView{
     CGRect frame = TransitionalView.frame;
-    float transform = GET_TRANSFORM_X;
+    CGFloat transform = [Utilities getTransformX];
     int startX = -6;
     int startY = 6;
     int transViewY = 46;
@@ -69,7 +69,7 @@
         transViewY = 58;
     }
         
-    int newWidth = (int) (296.0f * transform);
+    int newWidth = (int) (296 * transform);
     [self hideButton: [NSArray arrayWithObjects:
                        [(UIButton *) self.view viewWithTag:2],
                        [(UIButton *) self.view viewWithTag:3],
@@ -144,7 +144,7 @@
     }
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
         quickHelpImageView.image = [UIImage imageNamed:@"remote quick help.png"];
-        CGFloat transform = GET_TRANSFORM_X;
+        CGFloat transform = [Utilities getTransformX];
         CGRect frame = remoteControlView.frame;
         frame.size.height = frame.size.height *transform;
         frame.size.width = frame.size.width*transform;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -766,7 +766,7 @@ int h=0;
     }
     clearLogoWidth = self.view.frame.size.width - 20.0f;
     clearLogoHeight = 116;
-    float transform = GET_TRANSFORM_X;
+    CGFloat transform = [Utilities getTransformX];
     thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
     tvshowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
     int shiftParentalRating = -20;
@@ -822,7 +822,7 @@ int h=0;
         [self setAndMoveLabels:arrayLabels size:size];
     }
     else {
-        float transform = GET_TRANSFORM_X;
+        CGFloat transform = [Utilities getTransformX];
         thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
         tvshowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
         if (!enableJewel) {

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -19,5 +19,7 @@
 - (UIImage*)colorizeImage:(UIImage *)image withColor:(UIColor*)color;
 + (NSDictionary*)buildPlayerSeekPercentageParams:(int)playerID percentage:(float)percentage;
 + (NSArray*)buildPlayerSeekStepParams:(NSString*)stepmode;
++ (CGFloat)getTransformX;
++ (CGFloat)getTransformY;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -173,4 +173,26 @@
     return params;
 }
 
++ (CGFloat)getTransformX {
+    // We scale for iPhone with their different device widths.
+    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        return (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/320.0);
+    }
+    // For iPad a fixed frame width is used.
+    else {
+        return 1.0;
+    }
+}
+
++ (CGFloat)getTransformY {
+    // We scale for iPhone with their different device widths.
+    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        return (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/480.0);
+    }
+    // For iPad a fixed frame width is used.
+    else {
+        return 1.0;
+    }
+}
+
 @end


### PR DESCRIPTION
Fixes issue https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/122.

- Latest scaling changes for iPhone assume that full available screen width is used. This is only true for iPhones.
- For iPads the reduced and fixed width STACKSCROLL_WIDTH is used. In this case do not scale the thumb/banner.
- Implemented methods instead of #defines.


Interesting other aspect: The newer iPads are much wider than the older ones. Therefore it is possible to use broader frames for the views in the StackScrollViewController via

#define PAD_MENU_TABLE_WIDTH 300
#define STACKSCOLL_WIDTH (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds)-PAD_MENU_TABLE_WIDTH)

This way the stackview is taking exactly the space on the rights side of the menu when in Portrait orientation. But this needs some further review and tests.