### PR TITLE
More code cleanup

### DIFF
--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -4347,6 +4347,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XBMC Remote/Kodi Remote-Prefix.pch";
 				INFOPLIST_FILE = "XBMC Remote/Kodi Remote-Info.plist";
@@ -4366,6 +4367,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XBMC Remote/Kodi Remote-Prefix.pch";
 				INFOPLIST_FILE = "XBMC Remote/Kodi Remote-Info.plist";

--- a/XBMC Remote/AppInfoViewController.m
+++ b/XBMC Remote/AppInfoViewController.m
@@ -107,12 +107,7 @@
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }
 

--- a/XBMC Remote/AppInfoViewController.m
+++ b/XBMC Remote/AppInfoViewController.m
@@ -97,12 +97,6 @@
     [appGreeting setText:NSLocalizedString(@"enjoy!", nil)];
 }
 
-- (void)dealloc {
-    creditsMask = nil;
-    creditsSign = nil;
-    audioPlayer = nil;
-}
-
 -(BOOL)shouldAutorotate{
     return YES;
 }

--- a/XBMC Remote/AppInfoViewController.m
+++ b/XBMC Remote/AppInfoViewController.m
@@ -97,11 +97,10 @@
     [appGreeting setText:NSLocalizedString(@"enjoy!", nil)];
 }
 
-- (void)viewDidUnload{
+- (void)dealloc {
     creditsMask = nil;
     creditsSign = nil;
     audioPlayer = nil;
-    [super viewDidUnload];
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{

--- a/XBMC Remote/AppInfoViewController.m
+++ b/XBMC Remote/AppInfoViewController.m
@@ -103,10 +103,6 @@
     audioPlayer = nil;
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
-}
-
 -(BOOL)shouldAutorotate{
     return YES;
 }

--- a/XBMC Remote/CustomNavigationController.m
+++ b/XBMC Remote/CustomNavigationController.m
@@ -58,8 +58,4 @@
     return NO;
 }
 
-- (void)dealloc{
-    navBarHairlineImageView = nil;
-}
-
 @end

--- a/XBMC Remote/CustomNavigationController.m
+++ b/XBMC Remote/CustomNavigationController.m
@@ -50,12 +50,7 @@
     [super didReceiveMemoryWarning];
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5986,34 +5986,10 @@ NSIndexPath *selected;
 //}
 
 -(void)dealloc{
-    jsonRPC = nil;
     [self.richResults removeAllObjects];
     [self.filteredListContent removeAllObjects];
-    self.richResults = nil;
-    self.filteredListContent = nil;
-    self.detailItem = nil;
     [self.sections removeAllObjects];
-    self.sections = nil;
-    self.sectionArray = nil;
-    self.sectionArrayOpen = nil;
-    self.extraSectionRichResults = nil;
-    self.indexView = nil;
-    dataList = nil;
-    collectionView = nil;
-    jsonCell = nil;
-    activityIndicatorView = nil;
-    nowPlaying = nil;
-    self.playFileViewController = nil;
-    self.nowPlaying = nil;
-    self.webViewController = nil;
-    self.showInfoViewController = nil;
-    self.detailViewController = nil;
-    epgDownloadQueue = nil;
-    epgDict = nil;
-    debugText = nil;
-    playFileViewController = nil;
     [channelListUpdateTimer invalidate];
-    channelListUpdateTimer = nil;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -691,7 +691,6 @@
 -(void)changeViewMode:(int)newWatchMode forceRefresh:(BOOL)refresh{
     [activityIndicatorView startAnimating];
     if (!refresh){
-        if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0")){
             [UIView transitionWithView: activeLayoutView
                               duration: 0.2
                                options: UIViewAnimationOptionBeginFromCurrentState
@@ -706,11 +705,6 @@
                             completion:^(BOOL finished){
                                 [self changeViewMode:newWatchMode];
                             }];
-        }
-        else{
-            [self AnimTable:(UITableView *)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
-            [self changeViewMode:newWatchMode];
-        }
     }
     else{
         [self changeViewMode:newWatchMode];
@@ -5377,7 +5371,7 @@ NSIndexPath *selected;
 
 -(BOOL)collectionViewCanBeEnabled{
     NSDictionary *parameters=[self indexKeyedDictionaryFromArray:[[self.detailItem mainParameters] objectAtIndex:choosedTab]];
-    return (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"6.0") && ([[parameters objectForKey:@"enableCollectionView"] boolValue] == YES));
+    return (([[parameters objectForKey:@"enableCollectionView"] boolValue] == YES));
 }
 
 -(BOOL)collectionViewIsEnabled{
@@ -5415,7 +5409,7 @@ NSIndexPath *selected;
         }
     }
     NSString *viewKey = [NSString stringWithFormat:@"%@_grid_preference", [self getCacheKey:[methods objectForKey:@"method"] parameters:tempDict]];
-    return (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"6.0") && ([[parameters objectForKey:@"enableCollectionView"] boolValue] == YES) && ([[userDefaults objectForKey:viewKey] boolValue] == YES));
+    return (([[parameters objectForKey:@"enableCollectionView"] boolValue] == YES) && ([[userDefaults objectForKey:viewKey] boolValue] == YES));
 }
 
 -(NSString *)getCurrentSortMethod:(NSDictionary *)methods withParameters:(NSDictionary *)parameters {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5992,26 +5992,6 @@ NSIndexPath *selected;
     }
 }
 
-- (void)viewDidUnload{
-    debugText = nil;
-    [super viewDidUnload];
-    jsonRPC = nil;
-    self.richResults = nil;
-    self.filteredListContent = nil;
-    self.sections = nil;
-    dataList = nil;
-    collectionView = nil;
-    jsonCell = nil;
-    activityIndicatorView = nil;
-    nowPlaying = nil;
-    playFileViewController = nil;
-    epgDownloadQueue = nil;
-    epgDict = nil;
-    [[NSNotificationCenter defaultCenter] removeObserver: self];
-    [channelListUpdateTimer invalidate];
-    channelListUpdateTimer = nil;
-}
-
 //- (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation) interfaceOrientation duration:(NSTimeInterval)duration {
 //	if (interfaceOrientation == UIInterfaceOrientationPortrait || interfaceOrientation == UIInterfaceOrientationPortraitUpsideDown) {
 //        dataList.alpha = 1;
@@ -6046,6 +6026,10 @@ NSIndexPath *selected;
     self.detailViewController = nil;
     epgDownloadQueue = nil;
     epgDict = nil;
+    debugText = nil;
+    playFileViewController = nil;
+    [channelListUpdateTimer invalidate];
+    channelListUpdateTimer = nil;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 //- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3490,23 +3490,7 @@ NSIndexPath *selected;
 }
 
 -(CGRect)currentScreenBoundsDependOnOrientation {
-    NSString *reqSysVer = @"8.0";
-    NSString *currSysVer = [[UIDevice currentDevice] systemVersion];
-    if ([currSysVer compare:reqSysVer options:NSNumericSearch] != NSOrderedAscending) {
-        return [UIScreen mainScreen].bounds;
-    }
-    CGRect screenBounds = [UIScreen mainScreen].bounds;
-    CGFloat width = CGRectGetWidth(screenBounds);
-    CGFloat height = CGRectGetHeight(screenBounds);
-    UIInterfaceOrientation interfaceOrientation = [UIApplication sharedApplication].statusBarOrientation;
-    
-    if(UIInterfaceOrientationIsPortrait(interfaceOrientation)) {
-        screenBounds.size = CGSizeMake(width, height);
-    }
-    else if(UIInterfaceOrientationIsLandscape(interfaceOrientation)) {
-        screenBounds.size = CGSizeMake(height, width);
-    }
-    return screenBounds ;
+    return UIScreen.mainScreen.bounds;
 }
 
 - (void)toggleFullscreen:(id)sender {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6037,12 +6037,7 @@ NSIndexPath *selected;
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }
 ////EXPERIMENTAL CODE

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6032,15 +6032,6 @@ NSIndexPath *selected;
     channelListUpdateTimer = nil;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
-//- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-////    return (interfaceOrientation != UIInterfaceOrientationPortraitUpsideDown);
-//    return interfaceOrientation;
-//
-//}
-
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
-}
 
 -(BOOL)shouldAutorotate{
     return YES;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -648,8 +648,6 @@ static inline BOOL IsEmpty(id obj) {
 }
 
 - (void)dealloc {
-    jsonRPC = nil;
-    connectingActivityIndicator = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -643,12 +643,7 @@ static inline BOOL IsEmpty(id obj) {
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }
 

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -639,10 +639,6 @@ static inline BOOL IsEmpty(id obj) {
     }
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
-}
-
 -(BOOL)shouldAutorotate{
     return YES;
 }

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -639,12 +639,6 @@ static inline BOOL IsEmpty(id obj) {
     }
 }
 
-- (void)viewDidUnload{
-    connectingActivityIndicator = nil;
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [super viewDidUnload];
-}
-
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
     return (interfaceOrientation == UIInterfaceOrientationPortrait);
 }
@@ -664,6 +658,7 @@ static inline BOOL IsEmpty(id obj) {
 
 - (void)dealloc {
     jsonRPC = nil;
+    connectingActivityIndicator = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -412,7 +412,7 @@
 
 #pragma mark - NSURLConnection Delegate Methods
 
-- (void)connection:(NSURLConnection *)connection didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
+- (void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
     [self fillMacAddressInfo];
 }
 

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -525,10 +525,6 @@
     [self.view addGestureRecognizer:rightSwipe];
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
-}
-
 -(BOOL)shouldAutorotate{
     return YES;
 }

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -529,12 +529,7 @@
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }
 

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -533,20 +533,4 @@
     return UIInterfaceOrientationMaskPortrait;
 }
 
--(void)dealloc{
-    services = nil;
-    netServiceBrowser = nil;
-    descriptionUI = nil;
-    ipUI = nil;
-    usernameUI = nil;
-    passwordUI = nil;
-    portUI = nil;
-    mac_0_UI = nil;
-    mac_1_UI = nil;
-    mac_2_UI = nil;
-    mac_3_UI = nil;
-    mac_4_UI = nil;
-    mac_5_UI = nil;
-}
-
 @end

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -525,10 +525,6 @@
     [self.view addGestureRecognizer:rightSwipe];
 }
 
-- (void)viewDidUnload{
-    [super viewDidUnload];
-}
-
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
     return (interfaceOrientation == UIInterfaceOrientationPortrait);
 }

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -70,10 +70,6 @@
     [super didReceiveMemoryWarning];
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
-}
-
 -(BOOL)shouldAutorotate{
     return YES;
 }

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -74,12 +74,7 @@
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }
 

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -435,12 +435,6 @@
 }
 
 -(void)dealloc{
-    self.detailViewController = nil;
-    self.nowPlaying = nil;
-    self.remoteController = nil;
-    self.hostController = nil;
-    navController = nil;
-    self.tcpJSONRPCconnection = nil;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -444,17 +444,6 @@
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 
-- (void)viewDidUnload{
-    [super viewDidUnload];
-    self.detailViewController = nil;
-    self.nowPlaying = nil;
-    self.remoteController = nil;
-    self.hostController = nil;
-    navController = nil;
-    self.tcpJSONRPCconnection = nil;
-    [[NSNotificationCenter defaultCenter] removeObserver: self];
-}
-
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
     return (interfaceOrientation == UIInterfaceOrientationPortrait);
 }

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -448,12 +448,7 @@
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }
 

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -444,10 +444,6 @@
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
-}
-
 -(BOOL)shouldAutorotate{
     return YES;
 }

--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -92,10 +92,6 @@
     [super viewDidLoad];
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
-}
-
 -(BOOL)shouldAutorotate{
     return YES;
 }

--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -96,12 +96,7 @@
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }
 

--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -92,10 +92,6 @@
     [super viewDidLoad];
 }
 
-- (void)viewDidUnload{
-    [super viewDidUnload];
-}
-
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
     return (interfaceOrientation == UIInterfaceOrientationPortrait);
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -3193,12 +3193,7 @@ int currentItemID;
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -3173,18 +3173,6 @@ int currentItemID;
     [playlistTableView performSelectorOnMainThread:@selector(reloadData) withObject:nil waitUntilDone:YES];
 }
 
-- (void)viewDidUnload{
-    playlistLeftShadow = nil;
-    scrabbingView = nil;
-    scrabbingMessage = nil;
-    scrabbingRate = nil;
-    [super viewDidUnload];
-    [[NSNotificationCenter defaultCenter] removeObserver: self];
-    volumeSliderView = nil;
-    [timer invalidate];
-    timer = nil;
-}
-
 -(void)dealloc{
     volumeSliderView = nil;
     self.detailItem = nil;
@@ -3195,6 +3183,10 @@ int currentItemID;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
     [timer invalidate];
     timer = nil;
+    playlistLeftShadow = nil;
+    scrabbingView = nil;
+    scrabbingMessage = nil;
+    scrabbingRate = nil;
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -3158,19 +3158,8 @@ int currentItemID;
 }
 
 -(void)dealloc{
-    volumeSliderView = nil;
-    self.detailItem = nil;
-    playlistData = nil;
-    jsonRPC = nil;
-    self.remoteController=nil;
-    sheetActions = nil;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
     [timer invalidate];
-    timer = nil;
-    playlistLeftShadow = nil;
-    scrabbingView = nil;
-    scrabbingMessage = nil;
-    scrabbingRate = nil;
 }
 
 -(BOOL)shouldAutorotate{

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -3189,10 +3189,6 @@ int currentItemID;
     scrabbingRate = nil;
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
-}
-
 -(BOOL)shouldAutorotate{
     return YES;
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2777,23 +2777,7 @@ int currentItemID;
 #pragma mark - UISegmentControl
 
 -(CGRect)currentScreenBoundsDependOnOrientation {
-    NSString *reqSysVer = @"8.0";
-    NSString *currSysVer = [[UIDevice currentDevice] systemVersion];
-    if ([currSysVer compare:reqSysVer options:NSNumericSearch] != NSOrderedAscending) {
-        return [UIScreen mainScreen].bounds;
-    }
-    CGRect screenBounds = [UIScreen mainScreen].bounds;
-    CGFloat width = CGRectGetWidth(screenBounds);
-    CGFloat height = CGRectGetHeight(screenBounds);
-    UIInterfaceOrientation interfaceOrientation = [UIApplication sharedApplication].statusBarOrientation;
-    
-    if(UIInterfaceOrientationIsPortrait(interfaceOrientation)) {
-        screenBounds.size = CGSizeMake(width, height);
-    }
-    else if(UIInterfaceOrientationIsLandscape(interfaceOrientation)) {
-        screenBounds.size = CGSizeMake(height, width);
-    }
-    return screenBounds ;
+    return UIScreen.mainScreen.bounds;
 }
 
 -(void)addSegmentControl{

--- a/XBMC Remote/PlayFileViewController.m
+++ b/XBMC Remote/PlayFileViewController.m
@@ -62,13 +62,6 @@
     // Do any additional setup after loading the view from its nib.
 }
 
-- (void)viewDidUnload
-{
-    [super viewDidUnload];
-    // Release any retained subviews of the main view.
-    // e.g. self.myOutlet = nil;
-}
-
 -(void)dealloc{
     jsonRPC=nil;
 }

--- a/XBMC Remote/PlayFileViewController.m
+++ b/XBMC Remote/PlayFileViewController.m
@@ -66,8 +66,8 @@
     jsonRPC=nil;
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
 }
 
 @end

--- a/XBMC Remote/PlayFileViewController.m
+++ b/XBMC Remote/PlayFileViewController.m
@@ -62,10 +62,6 @@
     // Do any additional setup after loading the view from its nib.
 }
 
--(void)dealloc{
-    jsonRPC=nil;
-}
-
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1348,17 +1348,11 @@ NSInteger buttonAction;
     }
 }
 
-- (void)viewDidUnload{
-    TransitionalView = nil;
-    gestureZoneImageView = nil;
-    [super viewDidUnload];
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-    jsonRPC = nil;
-}
-
 -(void)dealloc{
     jsonRPC = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    TransitionalView = nil;
+    gestureZoneImageView = nil;
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1349,10 +1349,7 @@ NSInteger buttonAction;
 }
 
 -(void)dealloc{
-    jsonRPC = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    TransitionalView = nil;
-    gestureZoneImageView = nil;
 }
 
 -(BOOL)shouldAutorotate{

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1359,12 +1359,7 @@ NSInteger buttonAction;
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait;
 }
 

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1355,10 +1355,6 @@ NSInteger buttonAction;
     gestureZoneImageView = nil;
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-    return (interfaceOrientation == UIInterfaceOrientationPortrait);
-}
-
 -(BOOL)shouldAutorotate{
     return YES;
 }

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -917,7 +917,6 @@
 }
 
 - (void)dealloc{
-    jsonRPC = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -917,6 +917,7 @@
 }
 
 - (void)dealloc{
+    jsonRPC = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -2264,10 +2264,6 @@ int h=0;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-    return (interfaceOrientation != UIInterfaceOrientationPortraitUpsideDown);
-}
-
 -(BOOL)shouldAutorotate{
     return YES;
 }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -2268,12 +2268,7 @@ int h=0;
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskAllButUpsideDown;
 }
 

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -2240,11 +2240,6 @@ int h=0;
     jsonRPC = [[DSJSONRPC alloc] initWithServiceEndpoint:[AppDelegate instance].getServerJSONEndPoint andHTTPHeaders:[AppDelegate instance].getServerHTTPHeaders];
 }
 
-- (void)viewDidUnload{
-    [super viewDidUnload];
-    [[NSNotificationCenter defaultCenter] removeObserver: self];
-}
-
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
 }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1647,24 +1647,7 @@ int h=0;
 }
 
 -(CGRect)currentScreenBoundsDependOnOrientation {
-    NSString *reqSysVer = @"8.0";
-    NSString *currSysVer = [[UIDevice currentDevice] systemVersion];
-    if ([currSysVer compare:reqSysVer options:NSNumericSearch] != NSOrderedAscending) {
-        return [UIScreen mainScreen].bounds;
-    }
-    CGRect screenBounds = [UIScreen mainScreen].bounds;
-    CGFloat width = CGRectGetWidth(screenBounds);
-    CGFloat height = CGRectGetHeight(screenBounds);
-    UIInterfaceOrientation interfaceOrientation = [UIApplication sharedApplication].statusBarOrientation;
-    
-    if(UIInterfaceOrientationIsPortrait(interfaceOrientation)) {
-        screenBounds.size = CGSizeMake(width, height);
-    }
-    else if(UIInterfaceOrientationIsLandscape(interfaceOrientation)) {
-        screenBounds.size = CGSizeMake(height, width);
-    }
-    
-    return screenBounds ;
+    return UIScreen.mainScreen.bounds;
 }
 
 - (void)showBackground:(id)sender {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -2228,22 +2228,10 @@ int h=0;
 }
 
 -(void)dealloc{
-    trailerView.delegate = nil;
     [trailerView stopLoading];
     [trailerView removeFromSuperview];
-    trailerView = nil;
-    actorsTable = nil;
     [kenView removeFromSuperview];
     [self.kenView removeFromSuperview];
-    kenView = nil;
-    clearLogoImageView = nil;
-    nowPlaying=nil;
-    jsonRPC=nil;
-    fanartView=nil;
-    coverView=nil;
-    scrollView=nil;
-    self.nowPlaying = nil;
-    self.kenView = nil;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1678,14 +1678,6 @@ int h=0;
                                 options:UIViewAnimationOptionCurveEaseInOut
                              animations:^ {
                                  [toolbar setAlpha:1.0];
-                                 if ([self isModal]){
-                                     if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0")) {
-//                                         self.view.superview.bounds = originalSelfFrame;
-                                     }
-                                     else {
-                                         self.view.superview.bounds = originalSelfFrame;
-                                     }
-                                 }
                              }
                              completion:^(BOOL finished) {}
              ];
@@ -1711,12 +1703,6 @@ int h=0;
                                      originalSelfFrame = self.view.frame;
                                      CGRect fullscreenRect = [self currentScreenBoundsDependOnOrientation];
                                      fullscreenRect.origin.y += 10;
-                                     if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.0")) {
-//                                         self.view.superview.bounds = fullscreenRect;
-                                     }
-                                     else {
-                                         self.view.superview.bounds = fullscreenRect;
-                                     }
                                  }
                              }
                              completion:^(BOOL finished) {}

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -716,7 +716,6 @@
 }
 
 - (void)dealloc {
-    self.tcpJSONRPCconnection = nil;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -804,13 +804,12 @@
     }
 }	
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-	return YES;
-}
-
 -(BOOL)shouldAutorotate{
     return !stackScrollIsFullscreen;
 }
 
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+     return UIInterfaceOrientationMaskAll;
+ }
 
 @end

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -738,29 +738,11 @@
 }
 
 -(CGSize)screenSizeOrientationIndependent {
-    CGSize screenSize = [UIScreen mainScreen].bounds.size;
-    return CGSizeMake(MIN(screenSize.width, screenSize.height), MAX(screenSize.width, screenSize.height));
+    return UIScreen.mainScreen.fixedCoordinateSpace.bounds.size;
 }
 
 -(CGRect)currentScreenBoundsDependOnOrientation {
-    NSString *reqSysVer = @"8.0";
-    NSString *currSysVer = [[UIDevice currentDevice] systemVersion];
-    if ([currSysVer compare:reqSysVer options:NSNumericSearch] != NSOrderedAscending) {
-        return [UIScreen mainScreen].bounds;
-    }
-    CGRect screenBounds = [UIScreen mainScreen].bounds;
-    CGFloat width = CGRectGetWidth(screenBounds);
-    CGFloat height = CGRectGetHeight(screenBounds);
-    UIInterfaceOrientation interfaceOrientation = [UIApplication sharedApplication].statusBarOrientation;
-    
-    if(UIInterfaceOrientationIsPortrait(interfaceOrientation)) {
-        screenBounds.size = CGSizeMake(width, height);
-    }
-    else if(UIInterfaceOrientationIsLandscape(interfaceOrientation)) {
-        screenBounds.size = CGSizeMake(height, width);
-    }
-    
-    return screenBounds ;
+    return UIScreen.mainScreen.bounds;
 }
 
 - (void)viewWillLayoutSubviews{

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -715,12 +715,9 @@
     }
 }
 
-- (void)viewDidUnload{
-    [super viewDidUnload];
+- (void)dealloc {
     self.tcpJSONRPCconnection = nil;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
-    // Release any retained subviews of the main view.
-    // e.g. self.myOutlet = nil;
 }
 
 -(void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -117,23 +117,7 @@
 }
 
 -(CGRect)currentScreenBoundsDependOnOrientation {
-    NSString *reqSysVer = @"8.0";
-    NSString *currSysVer = [[UIDevice currentDevice] systemVersion];
-    if ([currSysVer compare:reqSysVer options:NSNumericSearch] != NSOrderedAscending) {
-        return [UIScreen mainScreen].bounds;
-    }
-    CGRect screenBounds = [UIScreen mainScreen].bounds;
-    CGFloat width = CGRectGetWidth(screenBounds);
-    CGFloat height = CGRectGetHeight(screenBounds);
-    UIInterfaceOrientation interfaceOrientation = [UIApplication sharedApplication].statusBarOrientation;
-    
-    if(UIInterfaceOrientationIsPortrait(interfaceOrientation)) {
-        screenBounds.size = CGSizeMake(width, height);
-    }
-    else if(UIInterfaceOrientationIsLandscape(interfaceOrientation)) {
-        screenBounds.size = CGSizeMake(height, width);
-    }
-    return screenBounds ;
+    return UIScreen.mainScreen.bounds;
 }
 
 -(void)handleApplicationOnVolumeChanged:(NSNotification *)sender{

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -217,7 +217,6 @@ NSInteger action;
 }
 
 -(void)dealloc{
-    jsonRPC = nil;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
     [self stopTimer];
 }

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -233,6 +233,7 @@ NSInteger action;
 }
 
 -(void)dealloc{
+    jsonRPC = nil;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
     [self stopTimer];
 }

--- a/XBMC Remote/WebViewController.m
+++ b/XBMC Remote/WebViewController.m
@@ -306,12 +306,7 @@
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 90000
-- (NSUInteger)supportedInterfaceOrientations
-#else
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-#endif
-{
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskAllButUpsideDown;
 }
 

--- a/XBMC Remote/WebViewController.m
+++ b/XBMC Remote/WebViewController.m
@@ -302,11 +302,6 @@
     [Twitterweb loadRequest:self.urlRequest];
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
-//    return (interfaceOrientation == UIInterfaceOrientationPortrait);
-    return YES;
-}
-
 -(BOOL)shouldAutorotate{
     return YES;
 }

--- a/XBMC Remote/WebViewController.m
+++ b/XBMC Remote/WebViewController.m
@@ -302,12 +302,6 @@
     [Twitterweb loadRequest:self.urlRequest];
 }
 
-- (void)viewDidUnload{
-    [super viewDidUnload];
-    // Release any retained subviews of the main view.
-    // e.g. self.myOutlet = nil;
-}
-
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation{
 //    return (interfaceOrientation == UIInterfaceOrientationPortrait);
     return YES;

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -230,7 +230,6 @@
 #pragma mark - lifecycle
 
 -(void)dealloc{
-    jsonRPC = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.h
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.h
@@ -99,7 +99,7 @@ typedef enum {
 typedef void (^DSJSONRPCCompletionHandler)(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *internalError);
 
 
-@interface DSJSONRPC : NSObject{
+@interface DSJSONRPC : NSObject <NSURLConnectionDataDelegate> {
     NSTimer* timer;
 }
 

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -229,7 +229,7 @@
 
 #pragma mark - NSURLConnection Delegate Methods
 
-- (void)connection:(NSURLConnection *)connection didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
+- (void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
     [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerAuthenticationFailed" object:nil userInfo:nil];
 }
 

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -339,11 +339,6 @@
     [super didReceiveMemoryWarning];
 }
 
-- (void)dealloc {
-//    [_tableView release];
-//    [super dealloc];
-}
-
 
 @end
 

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -193,11 +193,6 @@
 	[super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    // Override to allow orientations other than the default portrait orientation.
-    return YES;
-}
-
 
 #pragma mark -
 #pragma mark Table view data source

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -1092,13 +1092,6 @@ const NSInteger SLIDE_VIEWS_START_X_POS = 0;
     [super didReceiveMemoryWarning];
 }
 
-- (void)viewDidUnload {
-	[super viewDidUnload];
-	for (UIViewController* subController in viewControllersStack) {
-		[subController viewDidUnload];
-	}
-}
-
 
 #pragma mark -
 #pragma mark Rotation support

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -1097,12 +1097,6 @@ const NSInteger SLIDE_VIEWS_START_X_POS = 0;
 #pragma mark Rotation support
 
 
-// Ensure that the view controller supports rotation and that the split view can therefore show in both portrait and landscape.
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    return YES;
-}
-
-
 -(void) willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration{
 	BOOL isViewOutOfScreen = FALSE; 
     int posX=SLIDE_VIEWS_START_X_POS;

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -237,9 +237,7 @@ NSOutputStream	*outStream;
 
 
 - (void)dealloc{
-    inStream = nil;
     [[NSNotificationCenter defaultCenter] removeObserver: self];
-//    outStream = nil;
 }
 
 @end


### PR DESCRIPTION
Based on an ask from @kambala-decapitator I looked into the changes from his local branch [xcode11](https://github.com/kambala-decapitator/Official-Kodi-Remote-iOS/tree/xcode11) and brought those changes into a series of commits which were not yet merged to master as part of the latest updates.

Changes:
- Enable warning for overwriting deprecated functions
- Replace `didReceiveAuthenticationChallenge` with `willSendRequestForAuthenticationChallenge`
- Remove deprecated `viewDidUnload` and ensure all cleanups are moved to `dealloc`
- Remove deprecated `shouldAutorotateToInterfaceOrientation`
- Rework declarations of `supportedInterfaceOrientations`
- Remove pre-iOS 8 screen size retrieval