### PR TITLE
Fix message position for iPhones in settings menu

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5693,7 +5693,7 @@ NSIndexPath *selected;
         [dataList setSeparatorInset:UIEdgeInsetsMake(0, [[[parameters objectForKey:@"itemSizes"] objectForKey:@"separatorInset"] intValue], 0, 0)];
     }
     
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, 42.0f) deltaY:0 deltaX:0];
+    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, DEFAULT_MSG_HEIGHT) deltaY:0 deltaX:0];
     [self.view addSubview:messagesView];
     
     frame = dataList.frame;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -12,6 +12,9 @@
 #import "mainMenu.h"
 #import "AppInfoViewController.h"
 
+// +2 to cover two single-line separators
+#define HOSTMANAGERVC_MSG_HEIGHT (supportedVersionView.frame.size.height + 2)
+
 @interface HostManagementViewController ()
 
 @end
@@ -374,7 +377,7 @@ static inline BOOL IsEmpty(id obj) {
 
 - (void)viewDidLoad{
     [super viewDidLoad];
-    int deltaY = 44 + [[UIApplication sharedApplication] statusBarFrame].size.height;
+    CGFloat deltaY = CGRectGetMaxY(self.navigationController.navigationBar.frame);
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
         deltaY = 0;
     }
@@ -403,7 +406,7 @@ static inline BOOL IsEmpty(id obj) {
     frame.origin.y -= bottomPadding;
     [editTableButton setFrame:frame];
     
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 36 + deltaY) deltaY:deltaY deltaX:0];
+    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, HOSTMANAGERVC_MSG_HEIGHT + deltaY) deltaY:deltaY deltaX:0];
     [messagesView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin];
     [self.view addSubview:messagesView];
     [addHostButton setTitle:NSLocalizedString(@"Add Host", nil) forState:UIControlStateNormal];

--- a/XBMC Remote/MessagesView.h
+++ b/XBMC Remote/MessagesView.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+#define DEFAULT_MSG_HEIGHT 44
+
 @interface MessagesView : UIView {
     NSTimer *fadeoutTimer;
     CGFloat slideHeight;

--- a/XBMC Remote/MessagesView.h
+++ b/XBMC Remote/MessagesView.h
@@ -15,7 +15,7 @@
     CGFloat slideHeight;
 }
 
-- (id)initWithFrame:(CGRect)frame deltaY:(float)deltaY deltaX:(float)deltaX;
+- (id)initWithFrame:(CGRect)frame deltaY:(CGFloat)deltaY deltaX:(CGFloat)deltaX;
 - (void)showMessage:(NSString *)message timeout:(float)timeout color:(UIColor *)color;
 
 @property (nonatomic, retain) UILabel *viewMessage;

--- a/XBMC Remote/MessagesView.m
+++ b/XBMC Remote/MessagesView.m
@@ -13,19 +13,18 @@
 
 @synthesize viewMessage;
 
-- (id)initWithFrame:(CGRect)frame deltaY:(float)deltaY deltaX:(float)deltaX {
+- (id)initWithFrame:(CGRect)frame deltaY:(CGFloat)deltaY deltaX:(CGFloat)deltaX {
     self = [super initWithFrame:frame];
     if (self) {
         CALayer *bottomBorder = [CALayer layer];
-        CGFloat borderSize = 1.0f;
-        borderSize = 0.5f;
-        bottomBorder.frame = CGRectMake(0.0f, frame.size.height - borderSize, frame.size.width, borderSize);
+        CGFloat borderSize = 0.5;
+        bottomBorder.frame = CGRectMake(0.0, frame.size.height - borderSize, frame.size.width, borderSize);
         bottomBorder.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.35f].CGColor;
         [self.layer addSublayer:bottomBorder];
         [self setBackgroundColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.9f]];
         slideHeight = frame.size.height;
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){
-            slideHeight += 22.0f;
+            slideHeight += 22.0;
         }
         [self setFrame:CGRectMake(frame.origin.x, -slideHeight, frame.size.width, frame.size.height)];
         viewMessage = [[UILabel alloc] initWithFrame:CGRectMake(deltaX, deltaY, frame.size.width - deltaX, frame.size.height - deltaY)];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -681,7 +681,7 @@
         putXBMClogo = YES;
         [self setRightMenuOption:@"utility" reloadTableData:NO];
     }
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, 44.0f + deltaY) deltaY:deltaY deltaX:deltaX];
+    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, DEFAULT_MSG_HEIGHT + deltaY) deltaY:deltaY deltaX:deltaX];
     [self.view addSubview:messagesView];
     
     [[NSNotificationCenter defaultCenter] addObserver: self

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -137,11 +137,13 @@
         [longPressGesture setDelegate:self];
         [_tableView addGestureRecognizer:longPressGesture];
         
-        CGFloat deltaY = 64.0f;
+        CGFloat deltaY = 0;
         CGRect frame = [[UIScreen mainScreen ] bounds];
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){
             frame.size.width = STACKSCROLL_WIDTH;
-            deltaY = 0;
+        }
+        else {
+            deltaY = 44 + CGRectGetHeight(UIApplication.sharedApplication.statusBarFrame);
         }
         
         scrubbingView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, 44)];

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -185,7 +185,7 @@
         
         [self.view insertSubview:scrubbingView aboveSubview:_tableView];
 
-        messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, deltaY + 42.0f) deltaY:deltaY deltaX:0];
+        messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, deltaY + DEFAULT_MSG_HEIGHT) deltaY:deltaY deltaX:0];
         [self.view addSubview:messagesView];
 	}
     return self;


### PR DESCRIPTION
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/125.

Since 7a67e37 (set modal presentation style to fullscreen ...) messages are displayed at the wrong vertical position in the `SettingsValuesViewController`, e.g. when adding buttons manually. This PR uses `safeAreaInsets` to gather the correct offset for iPhones, and keeps using the former hardcoded value otherwise.