### PR TITLE
[german] fix typo 'Unterstitel -> Untertitel'

### DIFF
--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -331,7 +331,7 @@
 
 "Unknown" = "Unbekannt";
 "Audio stream" = "Audiospur";
-"Disable subtitles" = "Unterstitel ausblenden";
+"Disable subtitles" = "Untertitel ausblenden";
 "Subtitles" = "Untertitel";
 
 "Execute a specific action" = "Eine bestimmte Aktion ausführen";


### PR DESCRIPTION
follow up to https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/119 german translations
just caught my eye recently