### PR TITLE
Prefer TV Show banner when configured

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4608,11 +4608,11 @@ NSIndexPath *selected;
                          
                          NSString *thumbnailPath = [[videoLibraryMovies objectAtIndex:i] objectForKey:@"thumbnail"];
                          NSDictionary *art = [[videoLibraryMovies objectAtIndex:i] objectForKey:@"art"];
-                         if ([art count] && [[art objectForKey:@"banner"] length]!=0 && tvshowsView){
-                             thumbnailPath = [art objectForKey:@"banner"];
-                         }
                          if ([art count] && [[art objectForKey:@"poster"] length]!=0) {
                              thumbnailPath = [art objectForKey:@"poster"];
+                         }
+                         if ([art count] && [[art objectForKey:@"banner"] length]!=0 && tvshowsView){
+                             thumbnailPath = [art objectForKey:@"banner"];
                          }
                          NSString *fanartPath = [[videoLibraryMovies objectAtIndex:i] objectForKey:@"fanart"];
                          NSString *fanartURL=@"";


### PR DESCRIPTION
Fix https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/132.

Details:
Correct the order of image assignments to have the preferred assignment of banners done last, if configured by user.

Important:
Because of the way how the "Prefer banners for TV Show" feature is implemented, user needs to synchronize with Kodi again after the fix is rolled out.