### PR TITLE
Fix thumb size for TV Shows when posters are preferred

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1667,6 +1667,32 @@
 
 #pragma mark - Cell Formatting 
 
+-(void)setTVshowThumbSize {
+    mainMenu *Menuitem = self.detailItem;
+    // Adapt thumbsize if viewing TV Shows and "preferTVPoster" feature is enabled
+    if (!tvshowsView) {
+        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+            Menuitem.thumbWidth = PAD_TV_SHOWS_POSTER_WIDTH;
+            Menuitem.rowHeight = PAD_TV_SHOWS_POSTER_HEIGHT;
+        }
+        else {
+            Menuitem.thumbWidth = PHONE_TV_SHOWS_POSTER_WIDTH;
+            Menuitem.rowHeight = PHONE_TV_SHOWS_POSTER_HEIGHT;
+        }
+    }
+    else {
+        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+            Menuitem.thumbWidth = PAD_TV_SHOWS_BANNER_WIDTH;
+            Menuitem.rowHeight = PAD_TV_SHOWS_BANNER_HEIGHT;
+        }
+        else {
+            CGFloat transform = [Utilities getTransformX];
+            Menuitem.thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
+            Menuitem.rowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
+        }
+    }
+}
+
 int originYear = 0;
 -(void)choseParams{ // DA OTTIMIZZARE TROPPI IF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     flagX = 43;
@@ -5588,6 +5614,7 @@ NSIndexPath *selected;
     }
     else if ([[methods objectForKey:@"tvshowsView"] boolValue] == YES){
         tvshowsView = [AppDelegate instance].serverVersion > 11 && [AppDelegate instance].obj.preferTVPosters == NO;
+        [self setTVshowThumbSize];
     }
     else if ([[methods objectForKey:@"channelGuideView"] boolValue] == YES){
         channelGuideView = YES;

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -421,16 +421,6 @@
 }
 
 - (void) handleXBMCServerHasChanged: (NSNotification*) sender{
-    CGFloat transform = [Utilities getTransformX];
-    int thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
-    int tvshowHeight =  (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
-    if ([AppDelegate instance].obj.preferTVPosters==YES){
-        thumbWidth = PHONE_TV_SHOWS_POSTER_WIDTH;
-        tvshowHeight = PHONE_TV_SHOWS_POSTER_HEIGHT;
-    }
-    mainMenu *menuItem=[self.mainMenu objectAtIndex:3];
-    menuItem.thumbWidth=thumbWidth;
-    menuItem.rowHeight=tvshowHeight;
     [self changeServerStatus:NO infoText:NSLocalizedString(@"No connection", nil) icon:@"connection_off"];
 }
 

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -679,15 +679,6 @@
 }
 
 - (void) handleXBMCServerHasChanged: (NSNotification*) sender{
-    int thumbWidth = PAD_TV_SHOWS_BANNER_WIDTH;
-    int tvshowHeight = PAD_TV_SHOWS_BANNER_HEIGHT;
-    if ([AppDelegate instance].obj.preferTVPosters==YES){
-        thumbWidth = PAD_TV_SHOWS_POSTER_WIDTH;
-        tvshowHeight = PAD_TV_SHOWS_POSTER_HEIGHT;
-    }
-    mainMenu *menuItem=[self.mainMenu objectAtIndex:3];
-    menuItem.thumbWidth=thumbWidth;
-    menuItem.rowHeight=tvshowHeight;
     [[AppDelegate instance].windowController.stackScrollViewController offView];
     NSIndexPath *selection=[menuViewController.tableView indexPathForSelectedRow];
     if (selection){


### PR DESCRIPTION
Fixes an issue discussed in this [forum thread](https://forum.kodi.tv/showthread.php?tid=312272). Alternative solution to https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/92.

Details:
- Move thumbSize adaption from `handleXBMCServerHasChanged` to `DetailViewController`´s `viewDidLoad`
- Will ensure the thumbSize for TV Shows is correctly set when entering the TV Show menu, independent of when the connection status changes
- Tested with Kodi19 server