### PR TITLE
Fix sometimes wrong position of message in HostManagementVC

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -377,7 +377,7 @@ static inline BOOL IsEmpty(id obj) {
 
 - (void)viewDidLoad{
     [super viewDidLoad];
-    CGFloat deltaY = CGRectGetMaxY(self.navigationController.navigationBar.frame);
+    CGFloat deltaY = 44 + [[UIApplication sharedApplication] statusBarFrame].size.height;
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
         deltaY = 0;
     }


### PR DESCRIPTION
Fix https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/136

- Checking for the height of navigationController in HostManagementVC sometimes gives 0 even though the bar is shown. To work around this we go back to former solution of hard coding this offset.
- Hard coding is not really preferred, but in this case I want to avoid the hassles to implement this properly (was already dropped for another message positioning case in another PR which was merged).