### PR TITLE
Implement Dark Mode support

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -40,7 +40,7 @@
 
 #define BAR_TINT_COLOR [UIColor colorWithRed:.1f green:.1f blue:.1f alpha:1]
 #define REMOTE_CONTROL_BAR_TINT_COLOR [UIColor colorWithRed:12.0f/255.0f green:12.0f/255.0f blue:15.0f/255.0f alpha:1]
-#define SLIDER_DEFAULT_COLOR [UIColor colorWithRed:87.0f/255.0f green:158.0f/255.0f blue:186.0f/255.0f alpha:1]
+#define SLIDER_DEFAULT_COLOR [Utilities getSystemTeal]
 
 #define STACKSCROLL_WIDTH 476 // 724
 

--- a/XBMC Remote/BDKCollectionIndexView/BDKCollectionIndexView.m
+++ b/XBMC Remote/BDKCollectionIndexView/BDKCollectionIndexView.m
@@ -1,5 +1,5 @@
 #import "BDKCollectionIndexView.h"
-
+#import "Utilities.h"
 #import <QuartzCore/QuartzCore.h>
 
 #define DEFAULT_ALPHA 0.3f
@@ -119,7 +119,7 @@
 - (UIView *)touchStatusView {
     if (_touchStatusView) return _touchStatusView;
     _touchStatusView = [[UIView alloc] initWithFrame:CGRectInset(self.bounds, 2, 2)];
-    _touchStatusView.backgroundColor = [[UIColor redColor] colorWithAlphaComponent:0];
+    _touchStatusView.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0];
     _touchStatusView.layer.cornerRadius = 0;
     _touchStatusView.layer.masksToBounds = YES;
     return _touchStatusView;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -783,7 +783,7 @@
         [collectionView setScrollsToTop:NO];
         activeLayoutView = dataList;
         self.indexView.hidden = YES;
-        self.searchController.searchBar.backgroundColor = [UIColor whiteColor];
+        self.searchController.searchBar.backgroundColor = [Utilities getSystemGray6];
         self.searchController.searchBar.barStyle = UIBarStyleBlack;
         self.searchController.searchBar.tintColor = tableViewSearchBarColor;
         searchBarColor = tableViewSearchBarColor;
@@ -1994,7 +1994,7 @@ int originYear = 0;
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {    
-	cell.backgroundColor = [UIColor whiteColor];
+	cell.backgroundColor = [Utilities getSystemGray6];
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath{
@@ -2058,13 +2058,20 @@ int originYear = 0;
             [isRecordingImageView setBackgroundColor:[UIColor clearColor]];
             [cell.contentView addSubview:isRecordingImageView];
         }
-        [(UILabel*) [cell viewWithTag:1] setHighlightedTextColor:[UIColor blackColor]];
-        [(UILabel*) [cell viewWithTag:2] setHighlightedTextColor:[UIColor blackColor]];
-        [(UILabel*) [cell viewWithTag:3] setHighlightedTextColor:[UIColor blackColor]];
-        [(UILabel*) [cell viewWithTag:4] setHighlightedTextColor:[UIColor blackColor]];
-        [(UILabel*) [cell viewWithTag:5] setHighlightedTextColor:[UIColor darkGrayColor]];
-        [(UILabel*) [cell viewWithTag:101] setHighlightedTextColor:[UIColor blackColor]];
-        [(UILabel*) [cell viewWithTag:102] setHighlightedTextColor:[UIColor blackColor]];
+        [(UILabel*) [cell viewWithTag:1] setHighlightedTextColor:[Utilities get1stLabelColor]];
+        [(UILabel*) [cell viewWithTag:2] setHighlightedTextColor:[Utilities get2ndLabelColor]];
+        [(UILabel*) [cell viewWithTag:3] setHighlightedTextColor:[Utilities get2ndLabelColor]];
+        [(UILabel*) [cell viewWithTag:4] setHighlightedTextColor:[Utilities get2ndLabelColor]];
+        [(UILabel*) [cell viewWithTag:5] setHighlightedTextColor:[Utilities get2ndLabelColor]];
+        [(UILabel*) [cell viewWithTag:101] setHighlightedTextColor:[Utilities get1stLabelColor]];
+        [(UILabel*) [cell viewWithTag:102] setHighlightedTextColor:[Utilities get2ndLabelColor]];
+        [(UILabel*) [cell viewWithTag:1] setTextColor:[Utilities get1stLabelColor]];
+        [(UILabel*) [cell viewWithTag:2] setTextColor:[Utilities get2ndLabelColor]];
+        [(UILabel*) [cell viewWithTag:3] setTextColor:[Utilities get2ndLabelColor]];
+        [(UILabel*) [cell viewWithTag:4] setTextColor:[Utilities get2ndLabelColor]];
+        [(UILabel*) [cell viewWithTag:5] setTextColor:[Utilities get2ndLabelColor]];
+        [(UILabel*) [cell viewWithTag:101] setTextColor:[Utilities get1stLabelColor]];
+        [(UILabel*) [cell viewWithTag:102] setTextColor:[Utilities get2ndLabelColor]];
     }
     mainMenu *Menuitem = self.detailItem;
 //    NSDictionary *mainFields=[[Menuitem mainFields] objectAtIndex:choosedTab];
@@ -2306,12 +2313,12 @@ int originYear = 0;
         else{
             progressView.hidden = YES;
             progressView.pieLabel.hidden = YES;
-            [title setTextColor:[UIColor blackColor]];
-            [genre setTextColor:[UIColor blackColor]];
-            [programStartTime setTextColor:[UIColor blackColor]];
-            [title setHighlightedTextColor:[UIColor blackColor]];
-            [genre setHighlightedTextColor:[UIColor blackColor]];
-            [programStartTime setHighlightedTextColor:[UIColor blackColor]];
+            [title setTextColor:[Utilities get1stLabelColor]];
+            [genre setTextColor:[Utilities get2ndLabelColor]];
+            [programStartTime setTextColor:[Utilities get2ndLabelColor]];
+            [title setHighlightedTextColor:[Utilities get1stLabelColor]];
+            [genre setHighlightedTextColor:[Utilities get2ndLabelColor]];
+            [programStartTime setHighlightedTextColor:[Utilities get2ndLabelColor]];
         }
         UIImageView *hasTimer = (UIImageView*) [cell viewWithTag:104];
         if ([[item objectForKey:@"hastimer"] boolValue]){
@@ -2375,7 +2382,7 @@ int originYear = 0;
         UILabel *releasedLabel = [[UILabel alloc] initWithFrame:CGRectMake(albumViewHeight, bottomMargin - trackCountFontSize -labelPadding/2, viewWidth - albumViewHeight - albumViewPadding, trackCountFontSize + labelPadding)];
         CAGradientLayer *gradient = [CAGradientLayer layer];
         gradient.frame = albumDetailView.bounds;
-        gradient.colors = [NSArray arrayWithObjects:(id)[[UIColor colorWithRed:.6 green:.6 blue:.6 alpha:.95] CGColor], (id)[[UIColor colorWithRed:.9 green:.9 blue:.9 alpha:.95] CGColor], nil];
+        gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getSystemGray1] CGColor], (id)[[Utilities getSystemGray5] CGColor], nil];
         [albumDetailView.layer insertSublayer:gradient atIndex:0];
         CGRect toolbarShadowFrame = CGRectMake(0.0f, albumViewHeight + 1, viewWidth, 8);
         UIImageView *toolbarShadow = [[UIImageView alloc] initWithFrame:toolbarShadowFrame];
@@ -2574,7 +2581,7 @@ int originYear = 0;
         }
         CAGradientLayer *gradient = [CAGradientLayer layer];
         gradient.frame = albumDetailView.bounds;
-        gradient.colors = [NSArray arrayWithObjects:(id)[[UIColor colorWithRed:.9 green:.9 blue:.9 alpha:1] CGColor], (id)[[UIColor colorWithRed:.6 green:.6 blue:.6 alpha:.95] CGColor], nil];
+        gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getSystemGray5] CGColor], (id)[[Utilities getSystemGray1] CGColor], nil];
         [albumDetailView.layer insertSublayer:gradient atIndex:0];
         if (section>0){
             UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, -1, viewWidth, 1)];
@@ -2714,7 +2721,7 @@ int originYear = 0;
     gradient.frame = sectionView.bounds;
     
     // TEST
-    gradient.colors = [NSArray arrayWithObjects:(id)[[UIColor colorWithRed:.6 green:.6 blue:.6 alpha:.95] CGColor], (id)[[UIColor colorWithRed:.9 green:.9 blue:.9 alpha:.95] CGColor], nil];
+    gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getSystemGray1] CGColor], (id)[[Utilities getSystemGray5] CGColor], nil];
 //    gradient.colors = [NSArray arrayWithObjects:(id)[[UIColor colorWithRed:.1 green:.1 blue:.1 alpha:.8] CGColor], (id)[[UIColor colorWithRed:.3 green:.3 blue:.3 alpha:.8f] CGColor], nil];
     //END TEST
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2289,13 +2289,13 @@ int originYear = 0;
         float percent_elapsed = (elapsed_seconds/total_seconds) * 100.0f;
 
         if (percent_elapsed >= 0 && percent_elapsed < 100) {
-            [title setTextColor:[UIColor blueColor]];
-            [genre setTextColor:[UIColor blueColor]];
-            [programStartTime setTextColor:[UIColor blueColor]];
+            [title setTextColor:[Utilities getSystemBlue]];
+            [genre setTextColor:[Utilities getSystemBlue]];
+            [programStartTime setTextColor:[Utilities getSystemBlue]];
 
-            [title setHighlightedTextColor:[UIColor blueColor]];
-            [genre setHighlightedTextColor:[UIColor blueColor]];
-            [programStartTime setHighlightedTextColor:[UIColor blueColor]];
+            [title setHighlightedTextColor:[Utilities getSystemBlue]];
+            [genre setHighlightedTextColor:[Utilities getSystemBlue]];
+            [programStartTime setHighlightedTextColor:[Utilities getSystemBlue]];
 
             [progressView updateProgressPercentage:percent_elapsed];
             progressView.pieLabel.hidden = NO;
@@ -3359,7 +3359,7 @@ NSIndexPath *selected;
     customButton *arrayButtons = [[customButton alloc] init];
     [arrayButtons.buttons addObject:button];
     [arrayButtons saveData];
-    [messagesView showMessage:NSLocalizedString(@"Button added", nil) timeout:2.0f color:[UIColor colorWithRed:39.0f/255.0f green:158.0f/255.0f blue:34.0f/255.0f alpha:0.95f]];
+    [messagesView showMessage:NSLocalizedString(@"Button added", nil) timeout:2.0f color:[Utilities getSystemGreen:0.95]];
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){
         [[NSNotificationCenter defaultCenter] postNotificationName: @"UIInterfaceCustomButtonAdded" object: nil];
     }
@@ -4077,10 +4077,10 @@ NSIndexPath *selected;
 -(void)SimpleAction:(NSString *)action params:(NSDictionary *)parameters success:(NSString *)successMessage failure:(NSString *)failureMessage{
     [jsonRPC callMethod:action withParameters:parameters onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
         if ( error == nil && methodError == nil ){
-            [messagesView showMessage:successMessage timeout:2.0f color:[UIColor colorWithRed:39.0f/255.0f green:158.0f/255.0f blue:34.0f/255.0f alpha:0.95f]];
+            [messagesView showMessage:successMessage timeout:2.0f color:[Utilities getSystemGreen:0.95]];
         }
         else {
-            [messagesView showMessage:failureMessage timeout:2.0f color:[UIColor colorWithRed:189.0f/255.0f green:36.0f/255.0f blue:36.0f/255.0f alpha:0.95f]];
+            [messagesView showMessage:failureMessage timeout:2.0f color:[Utilities getSystemRed:0.95]];
         }
     }];
 }

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -614,7 +614,7 @@ static inline BOOL IsEmpty(id obj) {
 
 -(void)connectionError:(NSNotification *)note {
     NSDictionary *theData = [note userInfo];
-    [messagesView showMessage:[theData objectForKey:@"error_message"] timeout:2.0f color:[UIColor colorWithRed:189.0f/255.0f green:36.0f/255.0f blue:36.0f/255.0f alpha:0.95f]];
+    [messagesView showMessage:[theData objectForKey:@"error_message"] timeout:2.0f color:[Utilities getSystemRed:0.95]];
 }
 
 -(void)authFailed:(NSNotification *)note {

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -11,6 +11,7 @@
 #import "AppDelegate.h"
 #import "mainMenu.h"
 #import "AppInfoViewController.h"
+#import "Utilities.h"
 
 // +2 to cover two single-line separators
 #define HOSTMANAGERVC_MSG_HEIGHT (supportedVersionView.frame.size.height + 2)
@@ -90,8 +91,10 @@
     [[NSBundle mainBundle] loadNibNamed:@"serverListCellView" owner:self options:NULL];
     if (cell==nil){
         cell = serverListCell;
-        [(UILabel*) [cell viewWithTag:2] setHighlightedTextColor:[UIColor blackColor]];
-        [(UILabel*) [cell viewWithTag:3] setHighlightedTextColor:[UIColor blackColor]];
+        [(UILabel*) [cell viewWithTag:2] setHighlightedTextColor:[Utilities get1stLabelColor]];
+        [(UILabel*) [cell viewWithTag:3] setHighlightedTextColor:[Utilities get1stLabelColor]];
+        [(UILabel*) [cell viewWithTag:2] setTextColor:[Utilities getSystemGray1]];
+        [(UILabel*) [cell viewWithTag:3] setTextColor:[Utilities getSystemGray1]];
         [cell setTintColor:[UIColor lightGrayColor]];
         cell.editingAccessoryType = UITableViewCellAccessoryDetailDisclosureButton;
     }

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -25,6 +25,7 @@
 #import <net/if_dl.h>
 #import <net/if.h>
 #import <netinet/in.h>
+#import "Utilities.h"
 
 #define serviceType @"_xbmc-jsonrpc-h._tcp"
 #define domainName @"local"
@@ -153,7 +154,7 @@
 #pragma mark - UITextFieldDelegate Methods
 
 - (void)textFieldDidBeginEditing:(UITextField *)textField{
-    [textField setTextColor:[UIColor blackColor]];
+    [textField setTextColor:[Utilities get1stLabelColor]];
 }
 -(void)resignKeyboard{
     [descriptionUI resignFirstResponder];
@@ -459,14 +460,14 @@
     mac_5_UI.text = @"";
     preferTVPostersUI.on = FALSE;
     [descriptionUI setTextColor:[UIColor blackColor]];
-    [ipUI setTextColor:[UIColor blackColor]];
-    [portUI setTextColor:[UIColor blackColor]];
-    [mac_0_UI setTextColor:[UIColor blackColor]];
-    [mac_1_UI setTextColor:[UIColor blackColor]];
-    [mac_2_UI setTextColor:[UIColor blackColor]];
-    [mac_3_UI setTextColor:[UIColor blackColor]];
-    [mac_4_UI setTextColor:[UIColor blackColor]];
-    [mac_5_UI setTextColor:[UIColor blackColor]];
+    [ipUI setTextColor:[Utilities get1stLabelColor]];
+    [portUI setTextColor:[Utilities get1stLabelColor]];
+    [mac_0_UI setTextColor:[Utilities get1stLabelColor]];
+    [mac_1_UI setTextColor:[Utilities get1stLabelColor]];
+    [mac_2_UI setTextColor:[Utilities get1stLabelColor]];
+    [mac_3_UI setTextColor:[Utilities get1stLabelColor]];
+    [mac_4_UI setTextColor:[Utilities get1stLabelColor]];
+    [mac_5_UI setTextColor:[Utilities get1stLabelColor]];
     [self AnimLabel:noInstances AnimDuration:0.0 Alpha:0.0 XPos:self.view.frame.size.width];
 }
 
@@ -505,19 +506,19 @@
     [usernameUI setPlaceholder:NSLocalizedString(@"Username", nil)];
     [passwordUI setPlaceholder:NSLocalizedString(@"Password", nil)];
     self.edgesForExtendedLayout = 0;
-    [descriptionUI setBackgroundColor:[UIColor whiteColor]];
-    [ipUI setBackgroundColor:[UIColor whiteColor]];
-    [portUI setBackgroundColor:[UIColor whiteColor]];
-    [tcpPortUI setBackgroundColor:[UIColor whiteColor]];
-    [usernameUI setBackgroundColor:[UIColor whiteColor]];
-    [passwordUI setBackgroundColor:[UIColor whiteColor]];
-    [mac_0_UI setBackgroundColor:[UIColor whiteColor]];
-    [mac_1_UI setBackgroundColor:[UIColor whiteColor]];
-    [mac_2_UI setBackgroundColor:[UIColor whiteColor]];
-    [mac_3_UI setBackgroundColor:[UIColor whiteColor]];
-    [mac_4_UI setBackgroundColor:[UIColor whiteColor]];
-    [mac_5_UI setBackgroundColor:[UIColor whiteColor]];
-    [discoveredInstancesTableView setBackgroundColor:[UIColor whiteColor]];
+    [descriptionUI setBackgroundColor:[Utilities getSystemGray6]];
+    [ipUI setBackgroundColor:[Utilities getSystemGray6]];
+    [portUI setBackgroundColor:[Utilities getSystemGray6]];
+    [tcpPortUI setBackgroundColor:[Utilities getSystemGray6]];
+    [usernameUI setBackgroundColor:[Utilities getSystemGray6]];
+    [passwordUI setBackgroundColor:[Utilities getSystemGray6]];
+    [mac_0_UI setBackgroundColor:[Utilities getSystemGray6]];
+    [mac_1_UI setBackgroundColor:[Utilities getSystemGray6]];
+    [mac_2_UI setBackgroundColor:[Utilities getSystemGray6]];
+    [mac_3_UI setBackgroundColor:[Utilities getSystemGray6]];
+    [mac_4_UI setBackgroundColor:[Utilities getSystemGray6]];
+    [mac_5_UI setBackgroundColor:[Utilities getSystemGray6]];
+    [discoveredInstancesTableView setBackgroundColor:[Utilities getSystemGray6]];
     UISwipeGestureRecognizer *rightSwipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFromRight:)];
     rightSwipe.numberOfTouchesRequired = 1;
     rightSwipe.cancelsTouchesInView=NO;

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -307,17 +307,17 @@
     NSArray *macPart = [macAddress componentsSeparatedByString:@":"];
     if ([macPart count] == 6 && ![macAddress isEqualToString:@"02:00:00:00:00:00"]){
         [mac_0_UI setText:[macPart objectAtIndex:0]];
-        [mac_0_UI setTextColor:[UIColor blueColor]];
+        [mac_0_UI setTextColor:[Utilities getSystemBlue]];
         [mac_1_UI setText:[macPart objectAtIndex:1]];
-        [mac_1_UI setTextColor:[UIColor blueColor]];
+        [mac_1_UI setTextColor:[Utilities getSystemBlue]];
         [mac_2_UI setText:[macPart objectAtIndex:2]];
-        [mac_2_UI setTextColor:[UIColor blueColor]];
+        [mac_2_UI setTextColor:[Utilities getSystemBlue]];
         [mac_3_UI setText:[macPart objectAtIndex:3]];
-        [mac_3_UI setTextColor:[UIColor blueColor]];
+        [mac_3_UI setTextColor:[Utilities getSystemBlue]];
         [mac_4_UI setText:[macPart objectAtIndex:4]];
-        [mac_4_UI setTextColor:[UIColor blueColor]];
+        [mac_4_UI setTextColor:[Utilities getSystemBlue]];
         [mac_5_UI setText:[macPart objectAtIndex:5]];
-        [mac_5_UI setTextColor:[UIColor blueColor]];
+        [mac_5_UI setTextColor:[Utilities getSystemBlue]];
     }
 }
 
@@ -343,9 +343,9 @@
                 descriptionUI.text = [service name];
                 ipUI.text = [NSString stringWithFormat:@"%s", addressStr];
                 portUI.text = [NSString stringWithFormat:@"%d", port];
-                [descriptionUI setTextColor:[UIColor blueColor]];
-                [ipUI setTextColor:[UIColor blueColor]];
-                [portUI setTextColor:[UIColor blueColor]];
+                [descriptionUI setTextColor:[Utilities getSystemBlue]];
+                [ipUI setTextColor:[Utilities getSystemBlue]];
+                [portUI setTextColor:[Utilities getSystemBlue]];
                 NSString *serverJSON=[NSString stringWithFormat:@"http://%@:%@/jsonrpc", ipUI.text, portUI.text];
                 NSURL *url = [[NSURL alloc] initWithString:serverJSON];
                 NSURLRequest *request = [NSURLRequest requestWithURL:url];

--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -72,7 +72,7 @@
     if (![[item objectForKey:@"icon"] isEqualToString:@""]){
         CGRect iconImageViewRect = CGRectMake(8.0f, 6.0f, 34.0f, 30.0f);
         UIImageView *iconImage = [[UIImageView alloc] initWithFrame:iconImageViewRect];
-        [iconImage setImage:[UIImage imageNamed:[NSString stringWithFormat:@"%@_black", [item objectForKey:@"icon"]]]];
+        [iconImage setImage:[UIImage imageNamed:@"nocover_filemode.png"]];
         [cell.contentView addSubview:iconImage];
     }
     return cell;

--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -8,6 +8,7 @@
 
 #import "MoreItemsViewController.h"
 #import "AppDelegate.h"
+#import "Utilities.h"
 
 @implementation MoreItemsViewController
 
@@ -50,7 +51,7 @@
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {    
-	cell.backgroundColor = [UIColor whiteColor];
+	cell.backgroundColor = [Utilities getSystemGray6];
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -63,7 +64,7 @@
 
     UILabel *cellLabel = [[UILabel alloc] initWithFrame:CGRectMake(cellLabelOffset, 0, self.view.bounds.size.width - cellLabelOffset - 24, 43)];
     [cellLabel setFont:[UIFont systemFontOfSize:18]];
-    [cellLabel setTextColor:[UIColor blackColor]];
+    [cellLabel setTextColor:[Utilities get1stLabelColor]];
     [cellLabel setHighlightedTextColor:[UIColor whiteColor]];
     NSDictionary *item = [mainMenuItems objectAtIndex:indexPath.row];
     [cellLabel setText:[item objectForKey:@"label"]];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2377,7 +2377,7 @@ int currentItemID;
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
 //	cell.backgroundColor = [UIColor colorWithRed:0.85f green:0.85f blue:0.85f alpha:1];
-    cell.backgroundColor = cellBackgroundColor;
+    cell.backgroundColor = [Utilities getSystemGray6];
 
 }
 
@@ -2386,9 +2386,13 @@ int currentItemID;
     if (cell == nil){
         NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"playlistCellView" owner:self options:nil];
         cell = [nib objectAtIndex:0];
-        [(UILabel*) [cell viewWithTag:1] setHighlightedTextColor:[UIColor blackColor]];
-        [(UILabel*) [cell viewWithTag:2] setHighlightedTextColor:[UIColor blackColor]];
-        [(UILabel*) [cell viewWithTag:3] setHighlightedTextColor:[UIColor blackColor]];
+        [(UILabel*) [cell viewWithTag:1] setHighlightedTextColor:[Utilities get1stLabelColor]];
+        [(UILabel*) [cell viewWithTag:2] setHighlightedTextColor:[Utilities get2ndLabelColor]];
+        [(UILabel*) [cell viewWithTag:3] setHighlightedTextColor:[Utilities get2ndLabelColor]];
+        
+        [(UILabel*) [cell viewWithTag:1] setTextColor:[Utilities get1stLabelColor]];
+        [(UILabel*) [cell viewWithTag:2] setTextColor:[Utilities get2ndLabelColor]];
+        [(UILabel*) [cell viewWithTag:3] setTextColor:[Utilities get2ndLabelColor]];
     }
     NSDictionary *item = [playlistData objectAtIndex:indexPath.row];
     UIImageView *thumb = (UIImageView*) [cell viewWithTag:4];

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -7,6 +7,7 @@
 //
 
 #import "PosterCell.h"
+#import "Utilities.h"
 
 @implementation PosterCell
 
@@ -68,7 +69,7 @@
         [self.contentView addSubview:_busyView];
 
         UIView *bgView = [[UIView alloc] initWithFrame:frame];
-        [bgView setBackgroundColor:[UIColor colorWithRed:0.0f green:132.0f/255.0f blue:1.0f alpha:1]];
+        [bgView setBackgroundColor:[Utilities getSystemGreen:1.0]];
         self.selectedBackgroundView = bgView;
     }
     return self;

--- a/XBMC Remote/ProgressPieView.m
+++ b/XBMC Remote/ProgressPieView.m
@@ -7,6 +7,7 @@
 //
 
 #import "ProgressPieView.h"
+#import "Utilities.h"
 
 @implementation ProgressPieView
 
@@ -23,7 +24,7 @@
 - (id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        [self pieCustomization:[UIColor blueColor]];
+        [self pieCustomization:[Utilities getSystemBlue]];
     }
     return self;
 }

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -7,6 +7,7 @@
 //
 
 #import "RecentlyAddedCell.h"
+#import "Utilities.h"
 
 @implementation RecentlyAddedCell
 
@@ -91,7 +92,7 @@
         [self.contentView addSubview:_busyView];
         
         UIView *bgView = [[UIView alloc] initWithFrame:frame];
-        [bgView setBackgroundColor:[UIColor colorWithRed:0.0f green:132.0f/255.0f blue:1.0f alpha:1]];
+        [bgView setBackgroundColor:[Utilities getSystemGreen:1.0]];
         self.selectedBackgroundView = bgView;
     }
     return self;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -500,7 +500,7 @@
                                      [self showActionSheet:NSLocalizedString(@"Subtitles", nil) sheetActions:actionSheetTitles destructiveButtonTitle:disableSubs actionTag:0 rectOriginX:subsButton.center.x rectOriginY:subsButton.center.y];
                                 }
                                  else {
-                                     [self showSubInfo:NSLocalizedString(@"Subtitles not available",nil) timeout:2.0 color:[UIColor redColor]];
+                                     [self showSubInfo:NSLocalizedString(@"Subtitles not available",nil) timeout:2.0 color:[Utilities getSystemRed:1.0]];
                                  }
                              }
                          }
@@ -508,7 +508,7 @@
                  }];
             }
             else{
-                [self showSubInfo:NSLocalizedString(@"Subtitles not available",nil) timeout:2.0 color:[UIColor redColor]];
+                [self showSubInfo:NSLocalizedString(@"Subtitles not available",nil) timeout:2.0 color:[Utilities getSystemRed:1.0]];
             }
         }
     }];
@@ -571,7 +571,7 @@
                                      [self showActionSheet:NSLocalizedString(@"Audio stream", nil) sheetActions:actionSheetTitles destructiveButtonTitle:nil actionTag:1 rectOriginX:audioStreamsButton.center.x rectOriginY:audioStreamsButton.center.y];
                                  }
                                  else {
-                                     [self showSubInfo:NSLocalizedString(@"Audiostreams not available",nil) timeout:2.0 color:[UIColor redColor]];
+                                     [self showSubInfo:NSLocalizedString(@"Audiostreams not available",nil) timeout:2.0 color:[Utilities getSystemRed:1.0]];
                                  }
                              }
                         }
@@ -579,7 +579,7 @@
                  }];
             }
             else{
-                [self showSubInfo:NSLocalizedString(@"Audiostream not available",nil) timeout:2.0 color:[UIColor redColor]];
+                [self showSubInfo:NSLocalizedString(@"Audiostream not available",nil) timeout:2.0 color:[Utilities getSystemRed:1.0]];
             }
         }
     }];
@@ -702,7 +702,7 @@
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex{
     NSString *option = [actionSheet buttonTitleAtIndex:buttonIndex];
     if (buttonIndex == actionSheet.destructiveButtonIndex && actionSheet.tag == 0) {
-        [self showSubInfo:NSLocalizedString(@"Subtitles disabled", nil) timeout:2.0 color:[UIColor redColor]];
+        [self showSubInfo:NSLocalizedString(@"Subtitles disabled", nil) timeout:2.0 color:[Utilities getSystemRed:1.0]];
         [self playbackAction:@"Player.SetSubtitle" params:[NSArray arrayWithObjects:@"off", @"subtitle", nil]];
     }
     else if (buttonIndex != actionSheet.cancelButtonIndex) {

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -453,7 +453,7 @@
                 NSString *serverMAC = [AppDelegate instance].obj.serverHWAddr;
                 if (serverMAC != nil && ![serverMAC isEqualToString:@":::::"]){
                     [self wakeUp:[AppDelegate instance].obj.serverHWAddr];
-                    [messagesView showMessage:NSLocalizedString(@"Command executed", nil) timeout:2.0f color:[UIColor colorWithRed:39.0f/255.0f green:158.0f/255.0f blue:34.0f/255.0f alpha:0.95f]];
+                    [messagesView showMessage:NSLocalizedString(@"Command executed", nil) timeout:2.0f color:[Utilities getSystemGreen:0.95]];
                 }
                 else{
                     UIAlertView * alertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Warning", nil) message:NSLocalizedString(@"No server MAC address defined", nil) delegate:nil cancelButtonTitle:nil otherButtonTitles:@"OK", nil];
@@ -513,10 +513,10 @@
     jsonRPC = [[DSJSONRPC alloc] initWithServiceEndpoint:[AppDelegate instance].getServerJSONEndPoint andHTTPHeaders:[AppDelegate instance].getServerHTTPHeaders];
     [jsonRPC callMethod:action withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
         if (methodError==nil && error == nil){
-            [messagesView showMessage:NSLocalizedString(@"Command executed", nil) timeout:2.0f color:[UIColor colorWithRed:39.0f/255.0f green:158.0f/255.0f blue:34.0f/255.0f alpha:0.95f]];
+            [messagesView showMessage:NSLocalizedString(@"Command executed", nil) timeout:2.0f color:[Utilities getSystemGreen:0.95]];
         }
         else{
-            [messagesView showMessage:NSLocalizedString(@"Cannot do that", nil) timeout:2.0f color:[UIColor colorWithRed:189.0f/255.0f green:36.0f/255.0f blue:36.0f/255.0f alpha:0.95f]];
+            [messagesView showMessage:NSLocalizedString(@"Cannot do that", nil) timeout:2.0f color:[Utilities getSystemRed:0.95]];
         }
         if ([sender respondsToSelector:@selector(setUserInteractionEnabled:)]){
             [sender setUserInteractionEnabled:YES];
@@ -727,7 +727,7 @@
 }
 
 -(void)showNotificationMessage:(NSNotification *)note {
-    [messagesView showMessage:note.name timeout:2.0f color:[UIColor colorWithRed:39.0f/255.0f green:158.0f/255.0f blue:34.0f/255.0f alpha:0.95f]];
+    [messagesView showMessage:note.name timeout:2.0f color:[Utilities getSystemGreen:0.95]];
 }
 
 -(void)reloadCustomButtonTable:(NSNotification *)note {

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -13,6 +13,7 @@
 #import "customButton.h"
 #import "ViewControllerIPad.h"
 #import "StackScrollViewController.h"
+#import "Utilities.h"
 
 @interface SettingsValuesViewController ()
 
@@ -370,7 +371,7 @@
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
-	cell.backgroundColor = [UIColor whiteColor];
+	cell.backgroundColor = [Utilities getSystemGray6];
 }
 
 - (void)adjustFontSize:(UILabel *)label {
@@ -404,7 +405,7 @@
         [cellLabel setFont:[UIFont systemFontOfSize:18]];
         [cellLabel setAdjustsFontSizeToFitWidth:YES];
         [cellLabel setMinimumScaleFactor:12.0f/18.0f];
-        [cellLabel setTextColor:[UIColor blackColor]];
+        [cellLabel setTextColor:[Utilities get1stLabelColor]];
         [cellLabel setHighlightedTextColor:[UIColor whiteColor]];
         [cell.contentView addSubview:cellLabel];
         
@@ -420,7 +421,7 @@
         [descriptionLabel setAdjustsFontSizeToFitWidth:YES];
         [descriptionLabel setNumberOfLines:0];
         [descriptionLabel setMinimumScaleFactor:11.0f/12.0f];
-        [descriptionLabel setTextColor:[UIColor grayColor]];
+        [descriptionLabel setTextColor:[Utilities get2ndLabelColor]];
         [descriptionLabel setHighlightedTextColor:[UIColor lightGrayColor]];
         [cell.contentView addSubview:descriptionLabel];
         
@@ -444,7 +445,7 @@
         [uiSliderLabel setFont:[UIFont systemFontOfSize:14]];
         [uiSliderLabel setAdjustsFontSizeToFitWidth:YES];
         [uiSliderLabel setMinimumScaleFactor:12.0f/14.0f];
-        [uiSliderLabel setTextColor:[UIColor grayColor]];
+        [uiSliderLabel setTextColor:[Utilities get2ndLabelColor]];
         [uiSliderLabel setHighlightedTextColor:[UIColor lightGrayColor]];
         [cell.contentView addSubview:uiSliderLabel];
         
@@ -462,9 +463,9 @@
         textInputField.delegate = self;
         textInputField.tag = 301;
         [cell.contentView addSubview:textInputField];
-        [cellLabel setHighlightedTextColor:[UIColor blackColor]];
-        [descriptionLabel setHighlightedTextColor:[UIColor grayColor]];
-        [uiSliderLabel setHighlightedTextColor:[UIColor grayColor]];
+        [cellLabel setHighlightedTextColor:[Utilities get1stLabelColor]];
+        [descriptionLabel setHighlightedTextColor:[Utilities get2ndLabelColor]];
+        [uiSliderLabel setHighlightedTextColor:[Utilities get2ndLabelColor]];
 	}
     cell.accessoryType =  UITableViewCellAccessoryNone;
 

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -292,7 +292,7 @@
     customButton *arrayButtons = [[customButton alloc] init];
     [arrayButtons.buttons addObject:button];
     [arrayButtons saveData];
-    [messagesView showMessage:NSLocalizedString(@"Button added", nil) timeout:2.0f color:[UIColor colorWithRed:39.0f/255.0f green:158.0f/255.0f blue:34.0f/255.0f alpha:0.95f]];
+    [messagesView showMessage:NSLocalizedString(@"Button added", nil) timeout:2.0f color:[Utilities getSystemGreen:0.95]];
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){
         [[NSNotificationCenter defaultCenter] postNotificationName: @"UIInterfaceCustomButtonAdded" object: nil];
     }
@@ -310,10 +310,10 @@
     [jsonRPC callMethod:action withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
         [activityIndicator stopAnimating];
         if (methodError==nil && error == nil){
-            [messagesView showMessage:NSLocalizedString(@"Command executed", nil) timeout:2.0f color:[UIColor colorWithRed:39.0f/255.0f green:158.0f/255.0f blue:34.0f/255.0f alpha:0.95f]];
+            [messagesView showMessage:NSLocalizedString(@"Command executed", nil) timeout:2.0f color:[Utilities getSystemGreen:0.95]];
         }
         else{
-            [messagesView showMessage:NSLocalizedString(@"Cannot do that", nil) timeout:2.0f color:[UIColor colorWithRed:189.0f/255.0f green:36.0f/255.0f blue:36.0f/255.0f alpha:0.95f]];
+            [messagesView showMessage:NSLocalizedString(@"Cannot do that", nil) timeout:2.0f color:[Utilities getSystemRed:0.95]];
         }
         if ([sender respondsToSelector:@selector(setUserInteractionEnabled:)]){
             [sender setUserInteractionEnabled:YES];
@@ -702,7 +702,7 @@
     [descriptionLabel setHighlightedTextColor:[UIColor grayColor]];
     [descriptionLabel setText:[footerMessage stringByReplacingOccurrencesOfString:@"[CR]" withString:@"\n"]];
     if (xbmcSetting == cUnsupported){
-        [helpView setBackgroundColor:[UIColor colorWithRed:.741f green:.141f blue:.141f alpha:1.0f]];
+        [helpView setBackgroundColor:[Utilities getSystemRed:1.0]];
     }
     else{
         [helpView setBackgroundColor:[UIColor colorWithRed:45.0f/255.0f green:45.0f/255.0f blue:45.0f/255.0f alpha:0.95f]];

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -21,6 +21,10 @@
 + (NSArray*)buildPlayerSeekStepParams:(NSString*)stepmode;
 + (CGFloat)getTransformX;
 + (CGFloat)getTransformY;
++ (UIColor*)getSystemRed:(CGFloat)alpha;
++ (UIColor*)getSystemGreen:(CGFloat)alpha;
++ (UIColor*)getSystemBlue;
++ (UIColor*)getSystemTeal;
 + (UIColor*)getSystemGray1;
 + (UIColor*)getSystemGray2;
 + (UIColor*)getSystemGray3;

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -21,5 +21,15 @@
 + (NSArray*)buildPlayerSeekStepParams:(NSString*)stepmode;
 + (CGFloat)getTransformX;
 + (CGFloat)getTransformY;
++ (UIColor*)getSystemGray1;
++ (UIColor*)getSystemGray2;
++ (UIColor*)getSystemGray3;
++ (UIColor*)getSystemGray4;
++ (UIColor*)getSystemGray5;
++ (UIColor*)getSystemGray6;
++ (UIColor*)get1stLabelColor;
++ (UIColor*)get2ndLabelColor;
++ (UIColor*)get3rdLabelColor;
++ (UIColor*)get4thLabelColor;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -9,6 +9,8 @@
 #import "Utilities.h"
 #import "AppDelegate.h"
 
+#define RGBA(r, g, b, a) [UIColor colorWithRed:(r)/255.0 green:(g)/255.0 blue:(b)/255.0 alpha:(a)]
+
 @implementation Utilities
 
 - (UIColor *)averageColor:(UIImage *)image inverse:(BOOL)inverse{
@@ -194,5 +196,82 @@
         return 1.0;
     }
 }
+
++ (UIColor*)getSystemGray1{
+    return [UIColor systemGrayColor];
+}
+
++ (UIColor*)getSystemGray2{
+    if (@available(iOS 13.0, *)) {
+        return [UIColor systemGray2Color];
+    } else {
+        return RGBA(174, 174, 178, 1.0);
+    }
+}
+
++ (UIColor*)getSystemGray3{
+    if (@available(iOS 13.0, *)) {
+        return [UIColor systemGray3Color];
+    } else {
+        return RGBA(199, 199, 204, 1.0);
+    }
+}
+
++ (UIColor*)getSystemGray4{
+    if (@available(iOS 13.0, *)) {
+        return [UIColor systemGray4Color];
+    } else {
+        return RGBA(209, 209, 214, 1.0);
+    }
+}
+
++ (UIColor*)getSystemGray5{
+    if (@available(iOS 13.0, *)) {
+        return [UIColor systemGray5Color];
+    } else {
+        return RGBA(229, 229, 234, 1.0);
+    }
+}
+
++ (UIColor*)getSystemGray6{
+    if (@available(iOS 13.0, *)) {
+        return [UIColor systemGray6Color];
+    } else {
+        return RGBA(242, 242, 247, 1.0);
+    }
+}
+
++ (UIColor*)get1stLabelColor{
+    if (@available(iOS 13.0, *)) {
+        return [UIColor labelColor];
+    } else {
+        return RGBA(0, 0, 0, 1.0);
+    }
+}
+
++ (UIColor*)get2ndLabelColor{
+    if (@available(iOS 13.0, *)) {
+        return [UIColor secondaryLabelColor];
+    } else {
+        return RGBA(60, 60, 67, 0.6);
+    }
+}
+
++ (UIColor*)get3rdLabelColor{
+    if (@available(iOS 13.0, *)) {
+        return [UIColor tertiaryLabelColor];
+    } else {
+        return RGBA(60, 60, 67, 0.3);
+    }
+}
+
++ (UIColor*)get4thLabelColor{
+    if (@available(iOS 13.0, *)) {
+        return [UIColor quaternaryLabelColor];
+    } else {
+        return RGBA(60, 60, 67, 0.18);
+    }
+}
+
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -197,6 +197,22 @@
     }
 }
 
++ (UIColor*)getSystemRed:(CGFloat)alpha{
+    return [[UIColor systemRedColor] colorWithAlphaComponent:alpha];
+}
+
++ (UIColor*)getSystemGreen:(CGFloat)alpha{
+    return [[UIColor systemGreenColor] colorWithAlphaComponent:alpha];
+}
+
++ (UIColor*)getSystemBlue{
+    return [UIColor systemBlueColor];
+}
+
++ (UIColor*)getSystemTeal{
+    return [UIColor systemTealColor];
+}
+
 + (UIColor*)getSystemGray1{
     return [UIColor systemGrayColor];
 }

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -10,6 +10,7 @@
 #import "GlobalData.h"
 #import "DSJSONRPC.h"
 #import "AppDelegate.h"
+#import "Utilities.h"
 
 @implementation VolumeSliderView
 

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -8,6 +8,7 @@
 
 #import "XBMCVirtualKeyboard.h"
 #import "AppDelegate.h"
+#import "Utilities.h"
 
 @implementation XBMCVirtualKeyboard
 
@@ -21,7 +22,7 @@
         textSize = 14;
         background_padding = 6;
         alignBottom = 10;
-        UIColor *accessoryBackgroundColor = [UIColor colorWithRed:202.0f/255.0f green:205.0f/255.0f blue:212.0f/255.0f alpha:1];
+        UIColor *accessoryBackgroundColor = [Utilities getSystemGray4];
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){
             accessoryHeight = 74;
             verboseHeight = 34;
@@ -54,9 +55,9 @@
         backgroundTextField = [[UITextField alloc] initWithFrame:CGRectMake(padding - background_padding, (int)(accessoryHeight/2) - (int)(verboseHeight/2) + alignBottom, screenWidth - (padding - background_padding) * 2, verboseHeight)];
         [backgroundTextField setUserInteractionEnabled:YES];
         [backgroundTextField setBorderStyle:UITextBorderStyleRoundedRect];
-        [backgroundTextField setBackgroundColor:[UIColor whiteColor]];
+        [backgroundTextField setBackgroundColor:[Utilities getSystemGray6]];
         [backgroundTextField setFont:[UIFont systemFontOfSize:textSize]];
-        [backgroundTextField setTextColor:[UIColor blackColor]];
+        [backgroundTextField setTextColor:[Utilities get1stLabelColor]];
         [backgroundTextField setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleLeftMargin];
         backgroundTextField.autocorrectionType = UITextAutocorrectionTypeNo;
         backgroundTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;


### PR DESCRIPTION
This PR basically implements Dark Mode support and will fix some observations from test reports. Nevertheless this PR needs some testing (TestFlight?) to find menus and textfields not taken into account yet.

- Add new methods to allow setting system colors which support Dark Mode
- Use standard colors in case of iOS w/o Dark Mode support
- Use new system colors for main list/cell background d text colors

In addition this PR changes the used colors towards system red/green/blue/teal instead of homebrewn color definitions:

- Use system colors for red/green/blue/teal
- Use systemRed instead of Red

Some screenshots:
https://abload.de/img/simulatorscreenshot-iptk5v.png
https://abload.de/img/simulatorscreenshot-ijejte.png
https://abload.de/img/simulatorscreenshot-il7k9e.png
https://abload.de/img/simulatorscreenshot-idrkdg.png
https://abload.de/img/simulatorscreenshot-ix6jjq.png