### PR TITLE
Rework gray color definitions

### DIFF
--- a/XBMC Remote/ActorCell.m
+++ b/XBMC Remote/ActorCell.m
@@ -68,7 +68,7 @@ int offsetY = 5;
         [self addSubview:_actorRole];
         
         UIView *myBackView = [[UIView alloc] initWithFrame:self.frame];
-        myBackView.backgroundColor = [Utilities getGrayColor:0.5 alpha:0.5];
+        myBackView.backgroundColor = [Utilities getGrayColor:128 alpha:0.5];
         self.selectedBackgroundView = myBackView;
     }
     return self;

--- a/XBMC Remote/ActorCell.m
+++ b/XBMC Remote/ActorCell.m
@@ -9,6 +9,7 @@
 #import "ActorCell.h"
 #import <QuartzCore/QuartzCore.h>
 #import "AppDelegate.h"
+#import "Utilities.h"
 
 @implementation ActorCell
 
@@ -31,7 +32,7 @@ int offsetY = 5;
         UIView *actorContainer = [[UIView alloc] initWithFrame:CGRectMake(offsetX, offsetY, castWidth, castHeight)];
         [actorContainer setClipsToBounds: NO];
         [actorContainer setBackgroundColor:[UIColor clearColor]];
-        actorContainer.layer.shadowColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0.8].CGColor;
+        actorContainer.layer.shadowColor = [Utilities getGrayColor:0 alpha:0.8].CGColor;
         actorContainer.layer.shadowOpacity = 0.7f;
         actorContainer.layer.shadowOffset = CGSizeZero;
         actorContainer.layer.shadowRadius = 2.0;
@@ -67,7 +68,7 @@ int offsetY = 5;
         [self addSubview:_actorRole];
         
         UIView *myBackView = [[UIView alloc] initWithFrame:self.frame];
-        myBackView.backgroundColor = [UIColor colorWithRed:0.5 green:0.5 blue:0.5 alpha:0.5];
+        myBackView.backgroundColor = [Utilities getGrayColor:0.5 alpha:0.5];
         self.selectedBackgroundView = myBackView;
     }
     return self;

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -32,14 +32,12 @@
 #define IS_AT_LEAST_IPHONE_X_HEIGHT (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 812)
 
 
-#define APP_TINT_COLOR [UIColor colorWithRed:0 green:0 blue:0 alpha:0.3]
-//#define APP_TINT_COLOR [UIColor colorWithRed:61.0f/255.0f green:132.0f/255.0f blue:1.0f alpha:1]
+#define APP_TINT_COLOR [Utilities getGrayColor:0 alpha:0.3]
 
-#define TINT_COLOR [UIColor colorWithRed:1.0f green:1.0f blue:1.0f alpha:.35f]
-//#define TINT_COLOR [UIColor colorWithRed:88.0f/255.0f green:149.0f/255.0f blue:1.0f alpha:1]
+#define TINT_COLOR [Utilities getGrayColor:1 alpha:.35]
 
-#define BAR_TINT_COLOR [UIColor colorWithRed:.1f green:.1f blue:.1f alpha:1]
-#define REMOTE_CONTROL_BAR_TINT_COLOR [UIColor colorWithRed:12.0f/255.0f green:12.0f/255.0f blue:15.0f/255.0f alpha:1]
+#define BAR_TINT_COLOR [Utilities getGrayColor:0.1 alpha:1]
+#define REMOTE_CONTROL_BAR_TINT_COLOR [Utilities getGrayColor:12.0/255.0 alpha:1]
 #define SLIDER_DEFAULT_COLOR [Utilities getSystemTeal]
 
 #define STACKSCROLL_WIDTH 476 // 724

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -34,10 +34,10 @@
 
 #define APP_TINT_COLOR [Utilities getGrayColor:0 alpha:0.3]
 
-#define TINT_COLOR [Utilities getGrayColor:1 alpha:.35]
+#define TINT_COLOR [Utilities getGrayColor:255 alpha:.35]
 
-#define BAR_TINT_COLOR [Utilities getGrayColor:0.1 alpha:1]
-#define REMOTE_CONTROL_BAR_TINT_COLOR [Utilities getGrayColor:12.0/255.0 alpha:1]
+#define BAR_TINT_COLOR [Utilities getGrayColor:26 alpha:1]
+#define REMOTE_CONTROL_BAR_TINT_COLOR [Utilities getGrayColor:12 alpha:1]
 #define SLIDER_DEFAULT_COLOR [Utilities getSystemTeal]
 
 #define STACKSCROLL_WIDTH 476 // 724

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -115,7 +115,7 @@ NSMutableArray *hostRightMenuItems;
         thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
         tvshowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
         NSDictionary *navbarTitleTextAttributes = [NSDictionary dictionaryWithObjectsAndKeys:
-                                                   [Utilities getGrayColor:255 alpha:1], NSForegroundColorAttributeName,
+                                                   [UIColor whiteColor], NSForegroundColorAttributeName,
                                                    [UIFont boldSystemFontOfSize:18], NSFontAttributeName, nil];
         [[UINavigationBar appearance] setTitleTextAttributes:navbarTitleTextAttributes];
     }

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -115,7 +115,7 @@ NSMutableArray *hostRightMenuItems;
         thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
         tvshowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
         NSDictionary *navbarTitleTextAttributes = [NSDictionary dictionaryWithObjectsAndKeys:
-                                                   [Utilities getGrayColor:1 alpha:1], NSForegroundColorAttributeName,
+                                                   [Utilities getGrayColor:255 alpha:1], NSForegroundColorAttributeName,
                                                    [UIFont boldSystemFontOfSize:18], NSFontAttributeName, nil];
         [[UINavigationBar appearance] setTitleTextAttributes:navbarTitleTextAttributes];
     }

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -115,7 +115,7 @@ NSMutableArray *hostRightMenuItems;
         thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
         tvshowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
         NSDictionary *navbarTitleTextAttributes = [NSDictionary dictionaryWithObjectsAndKeys:
-                                                   [UIColor colorWithRed:1 green:1 blue:1 alpha:1], NSForegroundColorAttributeName,
+                                                   [Utilities getGrayColor:1 alpha:1], NSForegroundColorAttributeName,
                                                    [UIFont boldSystemFontOfSize:18], NSFontAttributeName, nil];
         [[UINavigationBar appearance] setTitleTextAttributes:navbarTitleTextAttributes];
     }

--- a/XBMC Remote/BDKCollectionIndexView/BDKCollectionIndexView.m
+++ b/XBMC Remote/BDKCollectionIndexView/BDKCollectionIndexView.m
@@ -191,7 +191,7 @@
 
 - (void)setBackgroundVisibility:(BOOL)flag {
     CGFloat alpha = flag ? 0.5 : 0;
-    self.touchStatusView.backgroundColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:alpha];
+    self.touchStatusView.backgroundColor = [Utilities getGrayColor:0 alpha:alpha];
 }
 
 #pragma mark - Gestures

--- a/XBMC Remote/ClearCacheView.m
+++ b/XBMC Remote/ClearCacheView.m
@@ -8,6 +8,7 @@
 
 #import "ClearCacheView.h"
 #import "PosterLabel.h"
+#import "Utilities.h"
 
 @implementation ClearCacheView
 
@@ -20,8 +21,8 @@
     self = [super initWithFrame:frame];
     if (self) {
         [self setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth];
-        [self setBackgroundColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.7]];
-        CGFloat labelHeight = 300;
+        [self setBackgroundColor:[Utilities getGrayColor:0 alpha:0.7]];
+        float labelHeight = 300;
         PosterLabel *label = [[PosterLabel alloc] initWithFrame:CGRectMake(0, CGRectGetHeight(self.frame)/2 - (labelHeight/2), CGRectGetWidth(self.frame) - borderWidth, labelHeight)];
          [label setAutoresizingMask:
           UIViewAutoresizingFlexibleHeight |

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2442,7 +2442,7 @@ int originYear = 0;
                                   completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
                                       CGFloat thumbBorder = 1.0/[[UIScreen mainScreen] scale];
                                       [thumbImageContainer setBackgroundColor:[UIColor clearColor]];
-                                      thumbImageContainer.layer.shadowColor = [Utilities getGrayColor:0 alpha:1].CGColor;
+                                      thumbImageContainer.layer.shadowColor = [UIColor blackColor].CGColor;
                                       thumbImageContainer.layer.shadowOpacity = 1.0f;
                                       thumbImageContainer.layer.shadowOffset = CGSizeZero;
                                       thumbImageContainer.layer.shadowRadius = 2.0;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -925,12 +925,12 @@
     }
     if ([[parameters objectForKey:@"blackTableSeparator"] boolValue] == YES && [AppDelegate instance].obj.preferTVPosters == NO){
         blackTableSeparator = YES;
-        dataList.separatorColor = [Utilities getGrayColor:0.15 alpha:1];
+        dataList.separatorColor = [Utilities getGrayColor:38 alpha:1];
     }
     else{
         blackTableSeparator = NO;
         self.searchController.searchBar.tintColor = searchBarColor;
-        dataList.separatorColor = [Utilities getGrayColor:0.75 alpha:1];
+        dataList.separatorColor = [Utilities getGrayColor:191 alpha:1];
     }
     if ([[[parameters objectForKey:@"itemSizes"] objectForKey:@"separatorInset"] length]){
         [dataList setSeparatorInset:UIEdgeInsetsMake(0, [[[parameters objectForKey:@"itemSizes"] objectForKey:@"separatorInset"] intValue], 0, 0)];
@@ -1529,7 +1529,7 @@
     sectionNameOverlayView.layer.cornerRadius = cornerRadius;
     CAGradientLayer *gradient = [CAGradientLayer layer];
     gradient.frame = sectionNameOverlayView.bounds;
-    gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getGrayColor:0.1 alpha:0.8] CGColor], (id)[[Utilities getGrayColor:0 alpha:0.8] CGColor], nil];
+    gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getGrayColor:26 alpha:0.8] CGColor], (id)[[Utilities getGrayColor:0 alpha:0.8] CGColor], nil];
     gradient.cornerRadius = cornerRadius;
     [sectionNameOverlayView.layer insertSublayer:gradient atIndex:0];
     
@@ -2395,7 +2395,7 @@ int originYear = 0;
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section{
     if (albumView && [self.richResults count]>0){
         __block UIColor *albumFontColor = [UIColor blackColor];
-        __block UIColor *albumFontShadowColor = [Utilities getGrayColor:1 alpha:0.3];
+        __block UIColor *albumFontShadowColor = [Utilities getGrayColor:255 alpha:0.3];
         __block UIColor *albumDetailsColor = [UIColor darkGrayColor];
 
         UIView *albumDetailView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, albumViewHeight + 2)];
@@ -2465,8 +2465,8 @@ int originYear = 0;
                                           gradient.colors = [NSArray arrayWithObjects:(id)[albumColor CGColor], (id)[[utils lighterColorForColor:albumColor] CGColor], nil];
                                           [albumDetailView.layer insertSublayer:gradient atIndex:1];
                                           albumFontColor = [utils updateColor:albumColor lightColor:[UIColor whiteColor] darkColor:[UIColor blackColor]];
-                                          albumFontShadowColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:0 alpha:0.3] darkColor:[Utilities getGrayColor:1 alpha:0.3]];
-                                          albumDetailsColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:1 alpha:0.7] darkColor:[Utilities getGrayColor:0 alpha:0.6]];
+                                          albumFontShadowColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:0 alpha:0.3] darkColor:[Utilities getGrayColor:255 alpha:0.3]];
+                                          albumDetailsColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:255 alpha:0.7] darkColor:[Utilities getGrayColor:0 alpha:0.6]];
                                           [artist setTextColor:albumFontColor];
                                           [artist setShadowColor:albumFontShadowColor];
                                           [albumLabel setTextColor:albumFontColor];
@@ -2582,7 +2582,7 @@ int originYear = 0;
         return albumDetailView;
     }
     else if (episodesView && [self.richResults count]>0 && !([self doesShowSearchResults])){
-        UIColor *seasonFontShadowColor = [Utilities getGrayColor:1 alpha:0.3];
+        UIColor *seasonFontShadowColor = [Utilities getGrayColor:255 alpha:0.3];
         UIView *albumDetailView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, albumViewHeight + 2)];
         albumDetailView.tag = section;
         int toggleIconSpace = 0;
@@ -2608,7 +2608,7 @@ int originYear = 0;
         [albumDetailView.layer insertSublayer:gradient atIndex:0];
         if (section>0){
             UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, -1, viewWidth, 1)];
-            [lineView setBackgroundColor:[Utilities getGrayColor:0.95 alpha:1]];
+            [lineView setBackgroundColor:[Utilities getGrayColor:242 alpha:1]];
             [albumDetailView addSubview:lineView];
         }
         CGRect toolbarShadowFrame = CGRectMake(0, albumViewHeight + 1, viewWidth, 8);
@@ -2727,7 +2727,7 @@ int originYear = 0;
     NSString *sectionTitle = [self tableView:tableView titleForHeaderInSection:section];
     if (sectionTitle == nil) {
         UIView *sectionView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, 1)];
-        [sectionView setBackgroundColor:[Utilities getGrayColor:0.4 alpha:1]];
+        [sectionView setBackgroundColor:[Utilities getGrayColor:102 alpha:1]];
         CGRect toolbarShadowFrame = CGRectMake(0, 1, viewWidth, 4);
         UIImageView *toolbarShadow = [[UIImageView alloc] initWithFrame:toolbarShadowFrame];
         [toolbarShadow setImage:[UIImage imageNamed:@"tableUp.png"]];
@@ -2745,17 +2745,17 @@ int originYear = 0;
     
     // TEST
     gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getSystemGray1] CGColor], (id)[[Utilities getSystemGray5] CGColor], nil];
-//    gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getGrayColor:0.1 alpha:0.8] CGColor], (id)[[Utilities getGrayColor:0.3 alpha:0.8] CGColor], nil];
+//    gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getGrayColor:26 alpha:0.8] CGColor], (id)[[Utilities getGrayColor:77 alpha:0.8] CGColor], nil];
     //END TEST
 
     [sectionView.layer insertSublayer:gradient atIndex:0];
     
     //TEST
     UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, -1, viewWidth, 1)];
-    [lineView setBackgroundColor:[Utilities getGrayColor:0.5725 alpha:1]];
+    [lineView setBackgroundColor:[Utilities getGrayColor:146 alpha:1]];
     [sectionView addSubview:lineView];
 //    UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, -2, viewWidth, 1)];
-//    [lineView setBackgroundColor:[Utilities getGrayColor:0.1 alpha:1]];
+//    [lineView setBackgroundColor:[Utilities getGrayColor:26 alpha:1]];
 //    [sectionView addSubview:lineView];
     //END TEST
 
@@ -5603,19 +5603,19 @@ NSIndexPath *selected;
     if (button5.hidden && button6.hidden && button7.hidden) {
         buttonsView.hidden = YES;
     }
-    searchBarColor = [Utilities getGrayColor:0.35 alpha:1];
+    searchBarColor = [Utilities getGrayColor:89 alpha:1];
     collectionViewSearchBarColor = [UIColor blackColor];
     
-    searchBarColor = [Utilities getGrayColor:0.572 alpha:1];
-    collectionViewSearchBarColor = [Utilities getGrayColor:22.0/255.0 alpha:1];
+    searchBarColor = [Utilities getGrayColor:146 alpha:1];
+    collectionViewSearchBarColor = [Utilities getGrayColor:22 alpha:1];
 
     if ([[methods objectForKey:@"albumView"] boolValue] == YES){
         albumView = TRUE;
     }
     else if ([[methods objectForKey:@"episodesView"] boolValue] == YES){
         episodesView = TRUE;
-        searchBarColor = [Utilities getGrayColor:0.95 alpha:1];
-        searchBarColor = [Utilities getGrayColor:229.0/255.0 alpha:1];
+        searchBarColor = [Utilities getGrayColor:242 alpha:1];
+        searchBarColor = [Utilities getGrayColor:229 alpha:1];
         [dataList setSeparatorInset:UIEdgeInsetsMake(0, 18, 0, 0)];
     }
     else if ([[methods objectForKey:@"tvshowsView"] boolValue] == YES){
@@ -5634,7 +5634,7 @@ NSIndexPath *selected;
     if ([[parameters objectForKey:@"blackTableSeparator"] boolValue] == YES && [AppDelegate instance].obj.preferTVPosters == NO){
         blackTableSeparator = YES;
         [dataList setSeparatorInset:UIEdgeInsetsZero];
-        dataList.separatorColor = [Utilities getGrayColor:0.15 alpha:1];
+        dataList.separatorColor = [Utilities getGrayColor:38 alpha:1];
     }
     self.searchController.searchBar.tintColor = searchBarColor;
     [self.searchController.searchBar setBackgroundColor:searchBarColor];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -925,12 +925,12 @@
     }
     if ([[parameters objectForKey:@"blackTableSeparator"] boolValue] == YES && [AppDelegate instance].obj.preferTVPosters == NO){
         blackTableSeparator = YES;
-        dataList.separatorColor = [UIColor colorWithRed:.15 green:.15 blue:.15 alpha:1];
+        dataList.separatorColor = [Utilities getGrayColor:0.15 alpha:1];
     }
     else{
         blackTableSeparator = NO;
         self.searchController.searchBar.tintColor = searchBarColor;
-        dataList.separatorColor = [UIColor colorWithRed:.75 green:.75 blue:.75 alpha:1];
+        dataList.separatorColor = [Utilities getGrayColor:0.75 alpha:1];
     }
     if ([[[parameters objectForKey:@"itemSizes"] objectForKey:@"separatorInset"] length]){
         [dataList setSeparatorInset:UIEdgeInsetsMake(0, [[[parameters objectForKey:@"itemSizes"] objectForKey:@"separatorInset"] intValue], 0, 0)];
@@ -1269,7 +1269,7 @@
         collectionView = [[UICollectionView alloc] initWithFrame:dataList.frame collectionViewLayout:flowLayout];
         collectionView.contentInset = dataList.contentInset;
         collectionView.scrollIndicatorInsets = dataList.scrollIndicatorInsets;
-        [collectionView setBackgroundColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.5]];
+        [collectionView setBackgroundColor:[Utilities getGrayColor:0 alpha:0.5]];
         [collectionView setDelegate:self];
         [collectionView setDataSource:self];
         [collectionView registerClass:[PosterCell class] forCellWithReuseIdentifier:@"posterCell"];
@@ -1529,7 +1529,7 @@
     sectionNameOverlayView.layer.cornerRadius = cornerRadius;
     CAGradientLayer *gradient = [CAGradientLayer layer];
     gradient.frame = sectionNameOverlayView.bounds;
-    gradient.colors = [NSArray arrayWithObjects:(id)[[UIColor colorWithRed:.1 green:.1 blue:.1 alpha:.8] CGColor], (id)[[UIColor colorWithRed:.0 green:.0 blue:.0 alpha:.8] CGColor], nil];
+    gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getGrayColor:0.1 alpha:0.8] CGColor], (id)[[Utilities getGrayColor:0 alpha:0.8] CGColor], nil];
     gradient.cornerRadius = cornerRadius;
     [sectionNameOverlayView.layer insertSublayer:gradient atIndex:0];
     
@@ -2395,7 +2395,7 @@ int originYear = 0;
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section{
     if (albumView && [self.richResults count]>0){
         __block UIColor *albumFontColor = [UIColor blackColor];
-        __block UIColor *albumFontShadowColor = [UIColor colorWithRed:1 green:1 blue:1 alpha:0.3];
+        __block UIColor *albumFontShadowColor = [Utilities getGrayColor:1 alpha:0.3];
         __block UIColor *albumDetailsColor = [UIColor darkGrayColor];
 
         UIView *albumDetailView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, albumViewHeight + 2)];
@@ -2442,7 +2442,7 @@ int originYear = 0;
                                   completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
                                       CGFloat thumbBorder = 1.0/[[UIScreen mainScreen] scale];
                                       [thumbImageContainer setBackgroundColor:[UIColor clearColor]];
-                                      thumbImageContainer.layer.shadowColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:1].CGColor;
+                                      thumbImageContainer.layer.shadowColor = [Utilities getGrayColor:0 alpha:1].CGColor;
                                       thumbImageContainer.layer.shadowOpacity = 1.0f;
                                       thumbImageContainer.layer.shadowOffset = CGSizeZero;
                                       thumbImageContainer.layer.shadowRadius = 2.0;
@@ -2465,8 +2465,8 @@ int originYear = 0;
                                           gradient.colors = [NSArray arrayWithObjects:(id)[albumColor CGColor], (id)[[utils lighterColorForColor:albumColor] CGColor], nil];
                                           [albumDetailView.layer insertSublayer:gradient atIndex:1];
                                           albumFontColor = [utils updateColor:albumColor lightColor:[UIColor whiteColor] darkColor:[UIColor blackColor]];
-                                          albumFontShadowColor = [utils updateColor:albumColor lightColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.3] darkColor:[UIColor colorWithRed:1 green:1 blue:1 alpha:0.3]];
-                                          albumDetailsColor = [utils updateColor:albumColor lightColor:[UIColor colorWithRed:1 green:1 blue:1 alpha:0.7] darkColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.6]];
+                                          albumFontShadowColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:0 alpha:0.3] darkColor:[Utilities getGrayColor:1 alpha:0.3]];
+                                          albumDetailsColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:1 alpha:0.7] darkColor:[Utilities getGrayColor:0 alpha:0.6]];
                                           [artist setTextColor:albumFontColor];
                                           [artist setShadowColor:albumFontShadowColor];
                                           [albumLabel setTextColor:albumFontColor];
@@ -2582,7 +2582,7 @@ int originYear = 0;
         return albumDetailView;
     }
     else if (episodesView && [self.richResults count]>0 && !([self doesShowSearchResults])){
-        UIColor *seasonFontShadowColor = [UIColor colorWithRed:1 green:1 blue:1 alpha:0.3];
+        UIColor *seasonFontShadowColor = [Utilities getGrayColor:1 alpha:0.3];
         UIView *albumDetailView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, albumViewHeight + 2)];
         albumDetailView.tag = section;
         int toggleIconSpace = 0;
@@ -2608,7 +2608,7 @@ int originYear = 0;
         [albumDetailView.layer insertSublayer:gradient atIndex:0];
         if (section>0){
             UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, -1, viewWidth, 1)];
-            [lineView setBackgroundColor:[UIColor colorWithRed:.95 green:.95 blue:.95 alpha:1]];
+            [lineView setBackgroundColor:[Utilities getGrayColor:0.95 alpha:1]];
             [albumDetailView addSubview:lineView];
         }
         CGRect toolbarShadowFrame = CGRectMake(0, albumViewHeight + 1, viewWidth, 8);
@@ -2727,7 +2727,7 @@ int originYear = 0;
     NSString *sectionTitle = [self tableView:tableView titleForHeaderInSection:section];
     if (sectionTitle == nil) {
         UIView *sectionView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, 1)];
-        [sectionView setBackgroundColor:[UIColor colorWithRed:.4 green:.4 blue:.4 alpha:1]];
+        [sectionView setBackgroundColor:[Utilities getGrayColor:0.4 alpha:1]];
         CGRect toolbarShadowFrame = CGRectMake(0, 1, viewWidth, 4);
         UIImageView *toolbarShadow = [[UIImageView alloc] initWithFrame:toolbarShadowFrame];
         [toolbarShadow setImage:[UIImage imageNamed:@"tableUp.png"]];
@@ -2745,17 +2745,17 @@ int originYear = 0;
     
     // TEST
     gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getSystemGray1] CGColor], (id)[[Utilities getSystemGray5] CGColor], nil];
-//    gradient.colors = [NSArray arrayWithObjects:(id)[[UIColor colorWithRed:.1 green:.1 blue:.1 alpha:.8] CGColor], (id)[[UIColor colorWithRed:.3 green:.3 blue:.3 alpha:.8f] CGColor], nil];
+//    gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getGrayColor:0.1 alpha:0.8] CGColor], (id)[[Utilities getGrayColor:0.3 alpha:0.8] CGColor], nil];
     //END TEST
 
     [sectionView.layer insertSublayer:gradient atIndex:0];
     
     //TEST
     UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, -1, viewWidth, 1)];
-    [lineView setBackgroundColor:[UIColor colorWithRed:.5725 green:.5725 blue:.5725 alpha:1]];
+    [lineView setBackgroundColor:[Utilities getGrayColor:0.5725 alpha:1]];
     [sectionView addSubview:lineView];
 //    UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, -2, viewWidth, 1)];
-//    [lineView setBackgroundColor:[UIColor colorWithRed:.1 green:.1 blue:.1 alpha:1]];
+//    [lineView setBackgroundColor:[Utilities getGrayColor:0.1 alpha:1]];
 //    [sectionView addSubview:lineView];
     //END TEST
 
@@ -2785,7 +2785,7 @@ int originYear = 0;
     UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(12, labelOriginY, viewWidth - 20, sectionHeight)];
     label.backgroundColor = [UIColor clearColor];
     label.textColor = [UIColor whiteColor];
-    [label setShadowColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:.4]];
+    [label setShadowColor:[Utilities getGrayColor:0 alpha:0.4]];
     [label setShadowOffset:CGSizeMake(0, shadowOffset)];
     label.font = [UIFont boldSystemFontOfSize: labelFontSize];
     label.text = sectionTitle;
@@ -3462,7 +3462,6 @@ NSIndexPath *selected;
     if (self.detailItem) {
         NSDictionary *parameters=[self indexKeyedDictionaryFromArray:[[self.detailItem mainParameters] objectAtIndex:choosedTab]];
         self.navigationItem.title = [parameters objectForKey:@"label"];
-        UIColor *shadowColor = [[UIColor alloc] initWithRed:0.0 green:0.0 blue:0.0 alpha:0.5] ;
         topNavigationLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, -1, 240, 44)];
         topNavigationLabel.backgroundColor = [UIColor clearColor];
         topNavigationLabel.font = [UIFont boldSystemFontOfSize:11];
@@ -3471,7 +3470,7 @@ NSIndexPath *selected;
         topNavigationLabel.adjustsFontSizeToFitWidth = YES;
         topNavigationLabel.textAlignment = NSTextAlignmentLeft;
         topNavigationLabel.textColor = [UIColor whiteColor];
-        topNavigationLabel.shadowColor = shadowColor;
+        topNavigationLabel.shadowColor = [Utilities getGrayColor:0 alpha:0.5];
         topNavigationLabel.shadowOffset    = CGSizeMake (0, -1);
         topNavigationLabel.highlightedTextColor = [UIColor blackColor];
         topNavigationLabel.opaque=YES;
@@ -3615,7 +3614,7 @@ NSIndexPath *selected;
                                               animations:^{
                                                   collectionView.alpha = 1;
                                                   [fullscreenButton setImage:[UIImage imageNamed:@"button_exit_fullscreen.png"] forState:UIControlStateNormal];
-                                                  fullscreenButton.backgroundColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:0.5];
+                                                  fullscreenButton.backgroundColor = [Utilities getGrayColor:0 alpha:0.5];
                                               }
                                               completion:^(BOOL finished) {
                                                   [activityIndicatorView stopAnimating];
@@ -5543,7 +5542,7 @@ NSIndexPath *selected;
     [self.searchController.searchBar setSearchBarStyle:UISearchBarStyleMinimal];
     [dataList setSectionIndexBackgroundColor:[UIColor clearColor]];
     [dataList setSectionIndexColor:[UIColor systemBlueColor]];
-    [dataList setSectionIndexTrackingBackgroundColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.3]];
+    [dataList setSectionIndexTrackingBackgroundColor:[Utilities getGrayColor:0 alpha:0.3]];
     [dataList setSeparatorInset:UIEdgeInsetsMake(0, 53, 0, 0)];
     
     UIEdgeInsets tableViewInsets = dataList.contentInset;
@@ -5604,19 +5603,19 @@ NSIndexPath *selected;
     if (button5.hidden && button6.hidden && button7.hidden) {
         buttonsView.hidden = YES;
     }
-    searchBarColor = [UIColor colorWithRed:.35 green:.35 blue:.35 alpha:1];
+    searchBarColor = [Utilities getGrayColor:0.35 alpha:1];
     collectionViewSearchBarColor = [UIColor blackColor];
     
-    searchBarColor = [UIColor colorWithRed:.572f green:.572f blue:.572f alpha:1];
-    collectionViewSearchBarColor = [UIColor colorWithRed:22.0f/255.0f green:22.0f/255.0f blue:22.0f/255.0f alpha:1];
+    searchBarColor = [Utilities getGrayColor:0.572 alpha:1];
+    collectionViewSearchBarColor = [Utilities getGrayColor:22.0/255.0 alpha:1];
 
     if ([[methods objectForKey:@"albumView"] boolValue] == YES){
         albumView = TRUE;
     }
     else if ([[methods objectForKey:@"episodesView"] boolValue] == YES){
         episodesView = TRUE;
-        searchBarColor = [UIColor colorWithRed:.95 green:.95 blue:.95 alpha:1];
-        searchBarColor = [UIColor colorWithRed:229.0f/255.0f green:229.0f/255.0f blue:229.0f/255.0f alpha:1];
+        searchBarColor = [Utilities getGrayColor:0.95 alpha:1];
+        searchBarColor = [Utilities getGrayColor:229.0/255.0 alpha:1];
         [dataList setSeparatorInset:UIEdgeInsetsMake(0, 18, 0, 0)];
     }
     else if ([[methods objectForKey:@"tvshowsView"] boolValue] == YES){
@@ -5635,7 +5634,7 @@ NSIndexPath *selected;
     if ([[parameters objectForKey:@"blackTableSeparator"] boolValue] == YES && [AppDelegate instance].obj.preferTVPosters == NO){
         blackTableSeparator = YES;
         [dataList setSeparatorInset:UIEdgeInsetsZero];
-        dataList.separatorColor = [UIColor colorWithRed:.15 green:.15 blue:.15 alpha:1];
+        dataList.separatorColor = [Utilities getGrayColor:0.15 alpha:1];
     }
     self.searchController.searchBar.tintColor = searchBarColor;
     [self.searchController.searchBar setBackgroundColor:searchBarColor];

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -9,6 +9,7 @@
 #import "InitialSlidingViewController.h"
 #import "HostManagementViewController.h"
 #import "AppDelegate.h"
+#import "Utilities.h"
 
 @interface InitialSlidingViewController ()
 

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -113,7 +113,7 @@
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.row == 0){
-        cell.backgroundColor = [UIColor colorWithRed:.208f green:.208f blue:.208f alpha:1];
+        cell.backgroundColor = [Utilities getGrayColor:0.208 alpha:1];
     }
 }
 
@@ -126,7 +126,7 @@
     if (cell == nil){
         cell = resultMenuCell;
         UIView *backgroundView = [[UIView alloc] initWithFrame:CGRectMake(cell.frame.origin.x, cell.frame.origin.y, cell.frame.size.width, cell.frame.size.height)];
-        [backgroundView setBackgroundColor:[UIColor colorWithRed:.086 green:.086 blue:.086 alpha:1]];
+        [backgroundView setBackgroundColor:[Utilities getGrayColor:0.086 alpha:1]];
         cell.selectedBackgroundView = backgroundView;
         [(UILabel*) [cell viewWithTag:3] setText:NSLocalizedString(@"No connection", nil)];
         UILabel *title = (UILabel*) [cell viewWithTag:3];
@@ -237,7 +237,7 @@
     [newBar setBarStyle:UIBarStyleBlack];
     [newBar setTintColor:TINT_COLOR];
     if (setBarTintColor) {
-        [newBar setBackgroundColor:[UIColor colorWithRed:.8f green:.8f blue:.8f alpha:0.35f]];
+        [newBar setBackgroundColor:[Utilities getGrayColor:0.8 alpha:0.35]];
     }
     if (hideBottonLine) {
         [navController hideNavBarBottomLine:YES];
@@ -383,7 +383,7 @@
                                                  name: @"XBMCServerConnectionFailed"
                                                object: nil];
     
-    [self.view setBackgroundColor:[UIColor colorWithRed:.141f green:.141f blue:.141f alpha:1]];
+    [self.view setBackgroundColor:[Utilities getGrayColor:0.141 alpha:1]];
     [menuList selectRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] animated:YES scrollPosition:UITableViewScrollPositionNone];
 }
 

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -113,7 +113,7 @@
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.row == 0){
-        cell.backgroundColor = [Utilities getGrayColor:0.208 alpha:1];
+        cell.backgroundColor = [Utilities getGrayColor:53 alpha:1];
     }
 }
 
@@ -126,7 +126,7 @@
     if (cell == nil){
         cell = resultMenuCell;
         UIView *backgroundView = [[UIView alloc] initWithFrame:CGRectMake(cell.frame.origin.x, cell.frame.origin.y, cell.frame.size.width, cell.frame.size.height)];
-        [backgroundView setBackgroundColor:[Utilities getGrayColor:0.086 alpha:1]];
+        [backgroundView setBackgroundColor:[Utilities getGrayColor:22 alpha:1]];
         cell.selectedBackgroundView = backgroundView;
         [(UILabel*) [cell viewWithTag:3] setText:NSLocalizedString(@"No connection", nil)];
         UILabel *title = (UILabel*) [cell viewWithTag:3];
@@ -237,7 +237,7 @@
     [newBar setBarStyle:UIBarStyleBlack];
     [newBar setTintColor:TINT_COLOR];
     if (setBarTintColor) {
-        [newBar setBackgroundColor:[Utilities getGrayColor:0.8 alpha:0.35]];
+        [newBar setBackgroundColor:[Utilities getGrayColor:204 alpha:0.35]];
     }
     if (hideBottonLine) {
         [navController hideNavBarBottomLine:YES];
@@ -383,7 +383,7 @@
                                                  name: @"XBMCServerConnectionFailed"
                                                object: nil];
     
-    [self.view setBackgroundColor:[Utilities getGrayColor:0.141 alpha:1]];
+    [self.view setBackgroundColor:[Utilities getGrayColor:36 alpha:1]];
     [menuList selectRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] animated:YES scrollPosition:UITableViewScrollPositionNone];
 }
 

--- a/XBMC Remote/MessagesView.m
+++ b/XBMC Remote/MessagesView.m
@@ -8,6 +8,7 @@
 
 #import "MessagesView.h"
 #import "AppDelegate.h"
+#import "Utilities.h"
 
 @implementation MessagesView
 
@@ -18,10 +19,10 @@
     if (self) {
         CALayer *bottomBorder = [CALayer layer];
         CGFloat borderSize = 0.5;
-        bottomBorder.frame = CGRectMake(0, frame.size.height - borderSize, frame.size.width, borderSize);
-        bottomBorder.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.35f].CGColor;
+        bottomBorder.frame = CGRectMake(0.0, frame.size.height - borderSize, frame.size.width, borderSize);
+        bottomBorder.backgroundColor = [Utilities getGrayColor:0 alpha:0.35].CGColor;
         [self.layer addSublayer:bottomBorder];
-        [self setBackgroundColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.9f]];
+        [self setBackgroundColor:[Utilities getGrayColor:0 alpha:0.9]];
         slideHeight = frame.size.height;
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){
             slideHeight += 22.0;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -65,7 +65,7 @@ CGFloat cellBarWidth=45;
 //        viewTitle.font = [UIFont boldSystemFontOfSize:18];
 //        viewTitle.shadowColor = [Utilities getGrayColor:0 alpha:0.5];
 //        viewTitle.textAlignment = UITextAlignmentCenter;
-//        viewTitle.textColor = [Utilities getGrayColor:0.9 alpha:1];
+//        viewTitle.textColor = [Utilities getGrayColor:230 alpha:1];
 //        viewTitle.text = NSLocalizedString(@"Now Playing", nil);
 //        [viewTitle sizeToFit];
 //        self.navigationItem.titleView = viewTitle;
@@ -640,7 +640,7 @@ int currentItemID;
                                               duration:1.0
                                                options:UIViewAnimationOptionTransitionCrossDissolve
                                             animations:^{
-                                                [songName setTextColor:[Utilities getGrayColor:0.9 alpha:1]];
+                                                [songName setTextColor:[Utilities getGrayColor:230 alpha:1]];
                                             }
                                             completion:NULL];
                             [UIView transitionWithView:artistName
@@ -733,8 +733,8 @@ int currentItemID;
                                              completion:NULL];
                              if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){
                                  NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
-                                                         [Utilities getGrayColor:0.141 alpha:1], @"startColor",
-                                                         [Utilities getGrayColor:0.086 alpha:1], @"endColor",
+                                                         [Utilities getGrayColor:36 alpha:1], @"startColor",
+                                                         [Utilities getGrayColor:22 alpha:1], @"endColor",
                                                          nil, @"image",
                                                          nil];
                                  [[NSNotificationCenter defaultCenter] postNotificationName:@"UIViewChangeBackgroundGradientColor" object:nil userInfo:params];
@@ -2375,7 +2375,7 @@ int currentItemID;
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
-//	cell.backgroundColor = [Utilities getGrayColor:0.85 alpha:1];
+//	cell.backgroundColor = [Utilities getGrayColor:217 alpha:1];
     cell.backgroundColor = [Utilities getSystemGray6];
 
 }
@@ -3040,7 +3040,7 @@ int currentItemID;
     [noItemsLabel setText:NSLocalizedString(@"No items found.", nil)];
     CGFloat toolbarAlpha = 0.8;
     pg_thumb_name = @"pgbar_thumb.png";
-    cellBackgroundColor = [Utilities getGrayColor:0.85 alpha:1];
+    cellBackgroundColor = [Utilities getGrayColor:217 alpha:1];
     [self addSegmentControl];
     pg_thumb_name = @"pgbar_thumb_iOS7.png";
     cellBackgroundColor = [UIColor whiteColor];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -63,9 +63,9 @@ CGFloat cellBarWidth=45;
 //        viewTitle.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 //        viewTitle.backgroundColor = [UIColor clearColor];
 //        viewTitle.font = [UIFont boldSystemFontOfSize:18];
-//        viewTitle.shadowColor = [UIColor colorWithWhite:0.0 alpha:.5];
+//        viewTitle.shadowColor = [Utilities getGrayColor:0 alpha:0.5];
 //        viewTitle.textAlignment = UITextAlignmentCenter;
-//        viewTitle.textColor = [UIColor colorWithRed:.9 green:.9 blue:.9 alpha:1];
+//        viewTitle.textColor = [Utilities getGrayColor:0.9 alpha:1];
 //        viewTitle.text = NSLocalizedString(@"Now Playing", nil);
 //        [viewTitle sizeToFit];
 //        self.navigationItem.titleView = viewTitle;
@@ -640,7 +640,7 @@ int currentItemID;
                                               duration:1.0
                                                options:UIViewAnimationOptionTransitionCrossDissolve
                                             animations:^{
-                                                [songName setTextColor:[UIColor colorWithRed:0.9f green:0.9f blue:0.9f alpha:1.0f]];
+                                                [songName setTextColor:[Utilities getGrayColor:0.9 alpha:1]];
                                             }
                                             completion:NULL];
                             [UIView transitionWithView:artistName
@@ -733,8 +733,8 @@ int currentItemID;
                                              completion:NULL];
                              if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){
                                  NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
-                                                         [UIColor colorWithRed:0.141f green:0.141f blue:0.141f alpha:1.0f], @"startColor",
-                                                         [UIColor colorWithRed:0.086f green:0.086f blue:0.086f alpha:1.0f], @"endColor",
+                                                         [Utilities getGrayColor:0.141 alpha:1], @"startColor",
+                                                         [Utilities getGrayColor:0.086 alpha:1], @"endColor",
                                                          nil, @"image",
                                                          nil];
                                  [[NSNotificationCenter defaultCenter] postNotificationName:@"UIViewChangeBackgroundGradientColor" object:nil userInfo:params];
@@ -2375,7 +2375,7 @@ int currentItemID;
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
-//	cell.backgroundColor = [UIColor colorWithRed:0.85f green:0.85f blue:0.85f alpha:1];
+//	cell.backgroundColor = [Utilities getGrayColor:0.85 alpha:1];
     cell.backgroundColor = [Utilities getSystemGray6];
 
 }
@@ -3040,7 +3040,7 @@ int currentItemID;
     [noItemsLabel setText:NSLocalizedString(@"No items found.", nil)];
     CGFloat toolbarAlpha = 0.8;
     pg_thumb_name = @"pgbar_thumb.png";
-    cellBackgroundColor = [UIColor colorWithRed:0.85f green:0.85f blue:0.85f alpha:1];
+    cellBackgroundColor = [Utilities getGrayColor:0.85 alpha:1];
     [self addSegmentControl];
     pg_thumb_name = @"pgbar_thumb_iOS7.png";
     cellBackgroundColor = [UIColor whiteColor];

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -38,7 +38,7 @@
         [_posterLabel setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_posterLabel setBackgroundColor:[UIColor clearColor]];
         [_posterLabel setTextAlignment:NSTextAlignmentCenter];
-        [_posterLabel setTextColor:[Utilities getGrayColor:255 alpha:1]];
+        [_posterLabel setTextColor:[UIColor whiteColor]];
         [_posterLabel setShadowColor:[Utilities getGrayColor:0 alpha:0.6]];
         [_posterLabel setShadowOffset:CGSizeMake(0,1)];
         [_posterLabel setNumberOfLines:2];

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -38,8 +38,8 @@
         [_posterLabel setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_posterLabel setBackgroundColor:[UIColor clearColor]];
         [_posterLabel setTextAlignment:NSTextAlignmentCenter];
-        [_posterLabel setTextColor:[UIColor colorWithRed:1 green:1 blue:1 alpha:1]];
-        [_posterLabel setShadowColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.6]];
+        [_posterLabel setTextColor:[Utilities getGrayColor:1 alpha:1]];
+        [_posterLabel setShadowColor:[Utilities getGrayColor:0 alpha:0.6]];
         [_posterLabel setShadowOffset:CGSizeMake(0,1)];
         [_posterLabel setNumberOfLines:2];
         [_posterLabel setMinimumScaleFactor:0.8];

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -38,7 +38,7 @@
         [_posterLabel setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_posterLabel setBackgroundColor:[UIColor clearColor]];
         [_posterLabel setTextAlignment:NSTextAlignmentCenter];
-        [_posterLabel setTextColor:[Utilities getGrayColor:1 alpha:1]];
+        [_posterLabel setTextColor:[Utilities getGrayColor:255 alpha:1]];
         [_posterLabel setShadowColor:[Utilities getGrayColor:0 alpha:0.6]];
         [_posterLabel setShadowOffset:CGSizeMake(0,1)];
         [_posterLabel setNumberOfLines:2];

--- a/XBMC Remote/PosterHeaderView.m
+++ b/XBMC Remote/PosterHeaderView.m
@@ -25,7 +25,7 @@
         
 //        if (self.frame.size.height > 0){
 //            UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.frame.size.width, 1)];
-//            [lineView setBackgroundColor:[Utilities getGrayColor:130.0/255.0 alpha:1]];
+//            [lineView setBackgroundColor:[Utilities getGrayColor:130 alpha:1]];
 //            [self addSubview:lineView];
 //        }
         
@@ -37,12 +37,12 @@
             [self insertSubview: buttonsToolbar atIndex:0];
             
             // TYPE 2
-//            [self setBackgroundColor:[Utilities getGrayColor:30.0/255.0 alpha:0.95]];
+//            [self setBackgroundColor:[Utilities getGrayColor:30 alpha:0.95]];
             
             // TYPE 3
 //            CAGradientLayer *gradient = [CAGradientLayer layer];
 //            gradient.frame = self.bounds;
-//            gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getGrayColor:75.0/255.0 alpha:0.95] CGColor], (id)[[Utilities getGrayColor:35.0/255.0 alpha:0.95] CGColor], nil];
+//            gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getGrayColor:75 alpha:0.95] CGColor], (id)[[Utilities getGrayColor:35 alpha:0.95] CGColor], nil];
 //            [self.layer insertSublayer:gradient atIndex:0];
         }
 
@@ -50,10 +50,10 @@
             _headerLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(10, 0, self.frame.size.width - 10, self.frame.size.height - 1)];
             [_headerLabel setBackgroundColor:[UIColor clearColor]];
             [_headerLabel setFont:[UIFont boldSystemFontOfSize:(self.frame.size.height > 20 ? 17 : self.frame.size.height - 5)]];
-            [_headerLabel setShadowColor:[Utilities getGrayColor:10.0/255.0 alpha:1]];
+            [_headerLabel setShadowColor:[Utilities getGrayColor:10 alpha:1]];
             [_headerLabel setShadowOffset:CGSizeZero];
             
-            [_headerLabel setTextColor:[Utilities getGrayColor:120.0/255.0 alpha:1]];
+            [_headerLabel setTextColor:[Utilities getGrayColor:120 alpha:1]];
             [_headerLabel setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
             
             [self addSubview:_headerLabel];

--- a/XBMC Remote/PosterHeaderView.m
+++ b/XBMC Remote/PosterHeaderView.m
@@ -11,6 +11,7 @@
 #import <QuartzCore/QuartzCore.h>
 #import "PosterLabel.h"
 #import "AppDelegate.h"
+#import "Utilities.h"
 
 @implementation PosterHeaderView
 
@@ -24,7 +25,7 @@
         
 //        if (self.frame.size.height > 0){
 //            UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.frame.size.width, 1)];
-//            [lineView setBackgroundColor:[UIColor colorWithRed:130.0f/255.0f green:130.0f/255.0f blue:130.0f/255.0f alpha:1]];
+//            [lineView setBackgroundColor:[Utilities getGrayColor:130.0/255.0 alpha:1]];
 //            [self addSubview:lineView];
 //        }
         
@@ -36,12 +37,12 @@
             [self insertSubview: buttonsToolbar atIndex:0];
             
             // TYPE 2
-//            [self setBackgroundColor:[UIColor colorWithRed:30.0f/255.0f green:30.0f/255.0f blue:30.0f/255.0f alpha:.95]];
+//            [self setBackgroundColor:[Utilities getGrayColor:30.0/255.0 alpha:0.95]];
             
             // TYPE 3
 //            CAGradientLayer *gradient = [CAGradientLayer layer];
 //            gradient.frame = self.bounds;
-//            gradient.colors = [NSArray arrayWithObjects:(id)[[UIColor colorWithRed:75.0f/255.0f green:75.0f/255.0f blue:75.0f/255.0f alpha:.95] CGColor], (id)[[UIColor colorWithRed:35.0f/255.0f green:35.0f/255.0f blue:35.0f/255.0f alpha:.95] CGColor], nil];
+//            gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getGrayColor:75.0/255.0 alpha:0.95] CGColor], (id)[[Utilities getGrayColor:35.0/255.0 alpha:0.95] CGColor], nil];
 //            [self.layer insertSublayer:gradient atIndex:0];
         }
 
@@ -49,10 +50,10 @@
             _headerLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(10, 0, self.frame.size.width - 10, self.frame.size.height - 1)];
             [_headerLabel setBackgroundColor:[UIColor clearColor]];
             [_headerLabel setFont:[UIFont boldSystemFontOfSize:(self.frame.size.height > 20 ? 17 : self.frame.size.height - 5)]];
-            [_headerLabel setShadowColor:[UIColor colorWithRed:10.0f/255.0f green:10.0f/255.0f blue:10.0f/255.0f alpha:1]];
+            [_headerLabel setShadowColor:[Utilities getGrayColor:10.0/255.0 alpha:1]];
             [_headerLabel setShadowOffset:CGSizeZero];
             
-            [_headerLabel setTextColor:[UIColor colorWithRed:120.0f/255.0f green:120.0f/255.0f blue:120.0f/255.0f alpha:1]];
+            [_headerLabel setTextColor:[Utilities getGrayColor:120.0/255.0 alpha:1]];
             [_headerLabel setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
             
             [self addSubview:_headerLabel];

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -54,7 +54,7 @@
          _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, posterYOffset, fanartWidth - labelPadding -borderWidth * 4, labelHeight - borderWidth)];
         [_posterLabel setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_posterLabel setBackgroundColor:[UIColor clearColor]];
-        [_posterLabel setTextColor:[Utilities getGrayColor:255 alpha:1]];
+        [_posterLabel setTextColor:[UIColor whiteColor]];
         [_posterLabel setShadowColor:[Utilities getGrayColor:0 alpha:0.6]];
         [_posterLabel setShadowOffset:CGSizeMake(0,1)];
         [_posterLabel setNumberOfLines:1];
@@ -65,7 +65,7 @@
         _posterGenre = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, frameHeight - genreHeight - yearHeight + borderWidth, fanartWidth - labelPadding - borderWidth * 4, genreHeight - borderWidth)];
         [_posterGenre setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_posterGenre setBackgroundColor:[UIColor clearColor]];
-        [_posterGenre setTextColor:[Utilities getGrayColor:255 alpha:1]];
+        [_posterGenre setTextColor:[UIColor whiteColor]];
         [_posterGenre setShadowColor:[Utilities getGrayColor:0 alpha:0.6]];
         [_posterGenre setShadowOffset:CGSizeMake(0,1)];
         [_posterGenre setNumberOfLines:1];
@@ -76,7 +76,7 @@
         _posterYear = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, frameHeight - yearHeight, fanartWidth - labelPadding - borderWidth * 4, yearHeight - borderWidth)];
         [_posterYear setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_posterYear setBackgroundColor:[UIColor clearColor]];
-        [_posterYear setTextColor:[Utilities getGrayColor:255 alpha:1]];
+        [_posterYear setTextColor:[UIColor whiteColor]];
         [_posterYear setShadowColor:[Utilities getGrayColor:0 alpha:0.6]];
         [_posterYear setShadowOffset:CGSizeMake(0,1)];
         [_posterYear setNumberOfLines:1];

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -54,8 +54,8 @@
          _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, posterYOffset, fanartWidth - labelPadding -borderWidth * 4, labelHeight - borderWidth)];
         [_posterLabel setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_posterLabel setBackgroundColor:[UIColor clearColor]];
-        [_posterLabel setTextColor:[UIColor colorWithRed:1 green:1 blue:1 alpha:1]];
-        [_posterLabel setShadowColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.6]];
+        [_posterLabel setTextColor:[Utilities getGrayColor:1 alpha:1]];
+        [_posterLabel setShadowColor:[Utilities getGrayColor:0 alpha:0.6]];
         [_posterLabel setShadowOffset:CGSizeMake(0,1)];
         [_posterLabel setNumberOfLines:1];
         [_posterLabel setMinimumScaleFactor:0.5];
@@ -65,8 +65,8 @@
         _posterGenre = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, frameHeight - genreHeight - yearHeight + borderWidth, fanartWidth - labelPadding - borderWidth * 4, genreHeight - borderWidth)];
         [_posterGenre setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_posterGenre setBackgroundColor:[UIColor clearColor]];
-        [_posterGenre setTextColor:[UIColor colorWithRed:1 green:1 blue:1 alpha:1]];
-        [_posterGenre setShadowColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.6]];
+        [_posterGenre setTextColor:[Utilities getGrayColor:1 alpha:1]];
+        [_posterGenre setShadowColor:[Utilities getGrayColor:0 alpha:0.6]];
         [_posterGenre setShadowOffset:CGSizeMake(0,1)];
         [_posterGenre setNumberOfLines:1];
         [_posterGenre setMinimumScaleFactor:0.5];
@@ -76,8 +76,8 @@
         _posterYear = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, frameHeight - yearHeight, fanartWidth - labelPadding - borderWidth * 4, yearHeight - borderWidth)];
         [_posterYear setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_posterYear setBackgroundColor:[UIColor clearColor]];
-        [_posterYear setTextColor:[UIColor colorWithRed:1 green:1 blue:1 alpha:1]];
-        [_posterYear setShadowColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.6]];
+        [_posterYear setTextColor:[Utilities getGrayColor:1 alpha:1]];
+        [_posterYear setShadowColor:[Utilities getGrayColor:0 alpha:0.6]];
         [_posterYear setShadowOffset:CGSizeMake(0,1)];
         [_posterYear setNumberOfLines:1];
         [_posterYear setMinimumScaleFactor:0.5];

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -54,7 +54,7 @@
          _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, posterYOffset, fanartWidth - labelPadding -borderWidth * 4, labelHeight - borderWidth)];
         [_posterLabel setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_posterLabel setBackgroundColor:[UIColor clearColor]];
-        [_posterLabel setTextColor:[Utilities getGrayColor:1 alpha:1]];
+        [_posterLabel setTextColor:[Utilities getGrayColor:255 alpha:1]];
         [_posterLabel setShadowColor:[Utilities getGrayColor:0 alpha:0.6]];
         [_posterLabel setShadowOffset:CGSizeMake(0,1)];
         [_posterLabel setNumberOfLines:1];
@@ -65,7 +65,7 @@
         _posterGenre = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, frameHeight - genreHeight - yearHeight + borderWidth, fanartWidth - labelPadding - borderWidth * 4, genreHeight - borderWidth)];
         [_posterGenre setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_posterGenre setBackgroundColor:[UIColor clearColor]];
-        [_posterGenre setTextColor:[Utilities getGrayColor:1 alpha:1]];
+        [_posterGenre setTextColor:[Utilities getGrayColor:255 alpha:1]];
         [_posterGenre setShadowColor:[Utilities getGrayColor:0 alpha:0.6]];
         [_posterGenre setShadowOffset:CGSizeMake(0,1)];
         [_posterGenre setNumberOfLines:1];
@@ -76,7 +76,7 @@
         _posterYear = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, frameHeight - yearHeight, fanartWidth - labelPadding - borderWidth * 4, yearHeight - borderWidth)];
         [_posterYear setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
         [_posterYear setBackgroundColor:[UIColor clearColor]];
-        [_posterYear setTextColor:[Utilities getGrayColor:1 alpha:1]];
+        [_posterYear setTextColor:[Utilities getGrayColor:255 alpha:1]];
         [_posterYear setShadowColor:[Utilities getGrayColor:0 alpha:0.6]];
         [_posterYear setShadowOffset:CGSizeMake(0,1)];
         [_posterYear setNumberOfLines:1];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -81,7 +81,7 @@
                                                alpha:1];
     }
     else { // xcode xib bug with ipad?
-        cell.backgroundColor = [UIColor colorWithRed:0.141176f green:0.141176f blue:0.141176f alpha:1.0f];
+        cell.backgroundColor = [Utilities getGrayColor:0.141176 alpha:1];
     }
 }
 
@@ -92,7 +92,7 @@
     if ( cell == nil ) {
         cell = rightMenuCell;
         UIView *backView = [[UIView alloc] initWithFrame:cell.frame];
-        [backView setBackgroundColor:[UIColor colorWithRed:.086 green:.086 blue:.086 alpha:1]];
+        [backView setBackgroundColor:[Utilities getGrayColor:0.086 alpha:1]];
         cell.selectedBackgroundView = backView;
         UIImage *logo = [UIImage imageNamed:@"xbmc_logo.png"];
         UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:44 width:self.view.bounds.size.width]];
@@ -158,14 +158,14 @@
         int cellHeight = 50;
         cell = rightMenuCell;
         [cell setAccessoryView:nil];
-        cell.backgroundColor = [UIColor colorWithRed:0.141176f green:0.141176f blue:0.141176f alpha:1.0f];
+        cell.backgroundColor = [Utilities getGrayColor:0.141176 alpha:1];
         [cell setTintColor:[UIColor lightGrayColor]];
         [cell setEditingAccessoryType:UITableViewCellAccessoryDetailDisclosureButton];
         icon = (UIImageView*) [cell viewWithTag:1];
         title = (UILabel*) [cell viewWithTag:3];
         line = (UIImageView*) [cell viewWithTag:4];
         UIView *backView = [[UIView alloc] initWithFrame:cell.frame];
-        [backView setBackgroundColor:[UIColor colorWithRed:.086 green:.086 blue:.086 alpha:1]];
+        [backView setBackgroundColor:[Utilities getGrayColor:0.086 alpha:1]];
         cell.selectedBackgroundView = backView;
         UIImage *logo = [UIImage imageNamed:@"xbmc_logo.png"];
         UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:44 width:self.view.bounds.size.width]];
@@ -234,7 +234,7 @@
         [title setHighlightedTextColor:fontColor];
     }
     else{
-        UIColor *fontColor = [UIColor colorWithRed:.49f green:.49f blue:.49f alpha:1];
+        UIColor *fontColor = [Utilities getGrayColor:0.49 alpha:1];
         [title setTextColor:fontColor];
         [title setHighlightedTextColor:fontColor];
     }
@@ -626,7 +626,7 @@
     [infoLabel setBackgroundColor:[UIColor clearColor]];
     [infoLabel setFont:[UIFont fontWithName:@"Roboto-Regular" size:20]];
     [infoLabel setTextAlignment:NSTextAlignmentCenter];
-    [infoLabel setTextColor:[UIColor colorWithRed:.49f green:.49f blue:.49f alpha:1]];
+    [infoLabel setTextColor:[Utilities getGrayColor:0.49 alpha:1]];
     infoLabel.alpha = 0;
     [self.view addSubview:infoLabel];
     
@@ -659,7 +659,7 @@
     }
     menuTableView = [[UITableView alloc] initWithFrame:CGRectMake(self.peekLeftAmount, deltaY, frame.size.width - self.peekLeftAmount, self.view.frame.size.height - deltaY - footerHeight - 1) style:UITableViewStylePlain];
     [menuTableView setSeparatorStyle:UITableViewCellSeparatorStyleSingleLine];
-    [menuTableView setSeparatorColor:[UIColor colorWithRed:0.114f green:0.114f blue:0.114f alpha:1]];
+    [menuTableView setSeparatorColor:[Utilities getGrayColor:0.114 alpha:1]];
     [menuTableView setDelegate:self];
     [menuTableView setDataSource:self];
     [menuTableView setBackgroundColor:[UIColor clearColor]];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -81,7 +81,7 @@
                                                alpha:1];
     }
     else { // xcode xib bug with ipad?
-        cell.backgroundColor = [Utilities getGrayColor:0.141176 alpha:1];
+        cell.backgroundColor = [Utilities getGrayColor:36 alpha:1];
     }
 }
 
@@ -92,7 +92,7 @@
     if ( cell == nil ) {
         cell = rightMenuCell;
         UIView *backView = [[UIView alloc] initWithFrame:cell.frame];
-        [backView setBackgroundColor:[Utilities getGrayColor:0.086 alpha:1]];
+        [backView setBackgroundColor:[Utilities getGrayColor:22 alpha:1]];
         cell.selectedBackgroundView = backView;
         UIImage *logo = [UIImage imageNamed:@"xbmc_logo.png"];
         UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:44 width:self.view.bounds.size.width]];
@@ -158,14 +158,14 @@
         int cellHeight = 50;
         cell = rightMenuCell;
         [cell setAccessoryView:nil];
-        cell.backgroundColor = [Utilities getGrayColor:0.141176 alpha:1];
+        cell.backgroundColor = [Utilities getGrayColor:36 alpha:1];
         [cell setTintColor:[UIColor lightGrayColor]];
         [cell setEditingAccessoryType:UITableViewCellAccessoryDetailDisclosureButton];
         icon = (UIImageView*) [cell viewWithTag:1];
         title = (UILabel*) [cell viewWithTag:3];
         line = (UIImageView*) [cell viewWithTag:4];
         UIView *backView = [[UIView alloc] initWithFrame:cell.frame];
-        [backView setBackgroundColor:[Utilities getGrayColor:0.086 alpha:1]];
+        [backView setBackgroundColor:[Utilities getGrayColor:22 alpha:1]];
         cell.selectedBackgroundView = backView;
         UIImage *logo = [UIImage imageNamed:@"xbmc_logo.png"];
         UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:44 width:self.view.bounds.size.width]];
@@ -234,7 +234,7 @@
         [title setHighlightedTextColor:fontColor];
     }
     else{
-        UIColor *fontColor = [Utilities getGrayColor:0.49 alpha:1];
+        UIColor *fontColor = [Utilities getGrayColor:125 alpha:1];
         [title setTextColor:fontColor];
         [title setHighlightedTextColor:fontColor];
     }
@@ -626,7 +626,7 @@
     [infoLabel setBackgroundColor:[UIColor clearColor]];
     [infoLabel setFont:[UIFont fontWithName:@"Roboto-Regular" size:20]];
     [infoLabel setTextAlignment:NSTextAlignmentCenter];
-    [infoLabel setTextColor:[Utilities getGrayColor:0.49 alpha:1]];
+    [infoLabel setTextColor:[Utilities getGrayColor:125 alpha:1]];
     infoLabel.alpha = 0;
     [self.view addSubview:infoLabel];
     
@@ -659,7 +659,7 @@
     }
     menuTableView = [[UITableView alloc] initWithFrame:CGRectMake(self.peekLeftAmount, deltaY, frame.size.width - self.peekLeftAmount, self.view.frame.size.height - deltaY - footerHeight - 1) style:UITableViewStylePlain];
     [menuTableView setSeparatorStyle:UITableViewCellSeparatorStyleSingleLine];
-    [menuTableView setSeparatorColor:[Utilities getGrayColor:0.114 alpha:1]];
+    [menuTableView setSeparatorColor:[Utilities getGrayColor:29 alpha:1]];
     [menuTableView setDelegate:self];
     [menuTableView setDataSource:self];
     [menuTableView setBackgroundColor:[UIColor clearColor]];

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -149,7 +149,7 @@
         
         scrubbingView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, 44)];
         [scrubbingView setCenter:CGPointMake((int)(frame.size.width / 2), (int)(frame.size.height / 2) + 50)];
-        [scrubbingView setBackgroundColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.9f]];
+        [scrubbingView setBackgroundColor:[Utilities getGrayColor:0 alpha:0.9]];
         scrubbingView.alpha = 0.0;
         CGRect toolbarShadowFrame = CGRectMake(0, 44, self.view.frame.size.width, 4);
         UIImageView *toolbarShadow = [[UIImageView alloc] initWithFrame:toolbarShadowFrame];
@@ -674,7 +674,7 @@
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
     NSInteger viewWidth = self.view.frame.size.width;
     UIView *sectionView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, 1)];
-    [sectionView setBackgroundColor:[UIColor colorWithRed:.4 green:.4 blue:.4 alpha:1]];
+    [sectionView setBackgroundColor:[Utilities getGrayColor:0.4 alpha:1]];
     CGRect toolbarShadowFrame = CGRectMake(0, 1, viewWidth, 4);
     UIImageView *toolbarShadow = [[UIImageView alloc] initWithFrame:toolbarShadowFrame];
     [toolbarShadow setImage:[UIImage imageNamed:@"tableUp.png"]];
@@ -705,7 +705,7 @@
         [helpView setBackgroundColor:[Utilities getSystemRed:1.0]];
     }
     else{
-        [helpView setBackgroundColor:[UIColor colorWithRed:45.0f/255.0f green:45.0f/255.0f blue:45.0f/255.0f alpha:0.95f]];
+        [helpView setBackgroundColor:[Utilities getGrayColor:45.0/255.0 alpha:0.95]];
     }
     CGRect descriptionRect = [descriptionLabel.text  boundingRectWithSize:CGSizeMake(descriptionLabel.bounds.size.width, NSIntegerMax)
                                                                   options:NSStringDrawingUsesLineFragmentOrigin

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -674,7 +674,7 @@
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section {
     NSInteger viewWidth = self.view.frame.size.width;
     UIView *sectionView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, 1)];
-    [sectionView setBackgroundColor:[Utilities getGrayColor:0.4 alpha:1]];
+    [sectionView setBackgroundColor:[Utilities getGrayColor:102 alpha:1]];
     CGRect toolbarShadowFrame = CGRectMake(0, 1, viewWidth, 4);
     UIImageView *toolbarShadow = [[UIImageView alloc] initWithFrame:toolbarShadowFrame];
     [toolbarShadow setImage:[UIImage imageNamed:@"tableUp.png"]];
@@ -705,7 +705,7 @@
         [helpView setBackgroundColor:[Utilities getSystemRed:1.0]];
     }
     else{
-        [helpView setBackgroundColor:[Utilities getGrayColor:45.0/255.0 alpha:0.95]];
+        [helpView setBackgroundColor:[Utilities getGrayColor:45 alpha:0.95]];
     }
     CGRect descriptionRect = [descriptionLabel.text  boundingRectWithSize:CGSizeMake(descriptionLabel.bounds.size.width, NSIntegerMax)
                                                                   options:NSStringDrawingUsesLineFragmentOrigin

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -59,7 +59,7 @@ int count=0;
         viewTitle.minimumScaleFactor = 6.0/11.0;
         viewTitle.autoresizingMask = UIViewAutoresizingFlexibleWidth;
         viewTitle.backgroundColor = [UIColor clearColor];
-        viewTitle.shadowColor = [UIColor colorWithWhite:0.0 alpha:0];
+        viewTitle.shadowColor = [Utilities getGrayColor:0 alpha:0];
         viewTitle.textAlignment = NSTextAlignmentCenter;
         viewTitle.textColor = [UIColor whiteColor];
         viewTitle.text = [item objectForKey:@"label"];
@@ -151,7 +151,7 @@ int count=0;
             viewTitle.minimumScaleFactor = 6.0/22.0;
             viewTitle.adjustsFontSizeToFitWidth = YES;
             viewTitle.shadowOffset = CGSizeMake(1, 1);
-            viewTitle.shadowColor = [UIColor colorWithWhite:0.0 alpha:0.7];
+            viewTitle.shadowColor = [Utilities getGrayColor:0 alpha:0.7];
             viewTitle.autoresizingMask = UIViewAutoresizingNone;
             viewTitle.contentMode = UIViewContentModeScaleAspectFill;
             [viewTitle setFrame:CGRectMake(0, 0, titleWidth, 44)];
@@ -1525,7 +1525,7 @@ int h=0;
                 if (((NSNull *)[[trailerView subviews] objectAtIndex:0] != [NSNull null])){
                     ((UIScrollView *)[[trailerView subviews] objectAtIndex:0]).scrollsToTop = NO;
                 }
-                [trailerView setBackgroundColor:[UIColor colorWithRed:0.5f green:0.5f blue:0.5f alpha:0.5f]];
+                [trailerView setBackgroundColor:[Utilities getGrayColor:0.5 alpha:0.5]];
                 [trailerView setClipsToBounds: NO];
                 trailerView.layer.shadowColor = [UIColor blackColor].CGColor;
                 trailerView.layer.shadowOpacity = 0.7f;
@@ -1612,7 +1612,7 @@ int h=0;
     if (!([[item objectForKey:@"family"] isEqualToString:@"broadcastid"] || [[item objectForKey:@"family"] isEqualToString:@"recordingid"])){
         clearlogoButton = [UIButton buttonWithType:UIButtonTypeCustom];
         [clearlogoButton setFrame:CGRectMake(10, startY, clearLogoWidth, clearLogoHeight)];
-        [clearlogoButton.titleLabel setShadowColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.8]];
+        [clearlogoButton.titleLabel setShadowColor:[Utilities getGrayColor:0 alpha:0.8]];
         [clearlogoButton.titleLabel setShadowOffset:CGSizeMake(0, 1)];
         [clearlogoButton addTarget:self action:@selector(showBackground:) forControlEvents:UIControlEventTouchUpInside];
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone){
@@ -1731,7 +1731,7 @@ int h=0;
             int cbWidth = clearLogoWidth / 2;
             int cbHeight = clearLogoHeight / 2;
             closeButton = [[UIButton alloc] initWithFrame:CGRectMake(self.view.bounds.size.width/2 - cbWidth/2, self.view.bounds.size.height - cbHeight - 20, cbWidth, cbHeight)];
-            [closeButton.titleLabel setShadowColor:[UIColor colorWithRed:0 green:0 blue:0 alpha:0.8]];
+            [closeButton.titleLabel setShadowColor:[Utilities getGrayColor:0 alpha:0.8]];
             [closeButton.titleLabel setShadowOffset:CGSizeMake(0, 1)];
             [closeButton setAutoresizingMask:
              UIViewAutoresizingFlexibleTopMargin    |

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1525,7 +1525,7 @@ int h=0;
                 if (((NSNull *)[[trailerView subviews] objectAtIndex:0] != [NSNull null])){
                     ((UIScrollView *)[[trailerView subviews] objectAtIndex:0]).scrollsToTop = NO;
                 }
-                [trailerView setBackgroundColor:[Utilities getGrayColor:0.5 alpha:0.5]];
+                [trailerView setBackgroundColor:[Utilities getGrayColor:128 alpha:0.5]];
                 [trailerView setClipsToBounds: NO];
                 trailerView.layer.shadowColor = [UIColor blackColor].CGColor;
                 trailerView.layer.shadowOpacity = 0.7f;

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -35,7 +35,7 @@
 + (UIColor*)get2ndLabelColor;
 + (UIColor*)get3rdLabelColor;
 + (UIColor*)get4thLabelColor;
-+ (UIColor*)getGrayColor:(CGFloat)tone alpha:(CGFloat)alpha;
++ (UIColor*)getGrayColor:(int)tone alpha:(CGFloat)alpha;
 + (CGRect)createXBMCInfoframe:(UIImage *)logo height:(CGFloat)height width:(CGFloat)width;
 
 @end

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -35,6 +35,7 @@
 + (UIColor*)get2ndLabelColor;
 + (UIColor*)get3rdLabelColor;
 + (UIColor*)get4thLabelColor;
++ (UIColor*)getGrayColor:(CGFloat)tone alpha:(CGFloat)alpha;
 + (CGRect)createXBMCInfoframe:(UIImage *)logo height:(CGFloat)height width:(CGFloat)width;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -8,6 +8,7 @@
 
 #import "Utilities.h"
 #import "AppDelegate.h"
+#import "Utilities.h"
 
 #define RGBA(r, g, b, a) [UIColor colorWithRed:(r)/255.0 green:(g)/255.0 blue:(b)/255.0 alpha:(a)]
 #define HEADROOM_FOR_XBMC_LOGO 10
@@ -280,6 +281,10 @@
     } else {
         return RGBA(60, 60, 67, 0.18);
     }
+}
+
++ (UIColor*)getGrayColor:(CGFloat)tone alpha:(CGFloat)alpha{
+    return [UIColor colorWithRed:tone green:tone blue:tone alpha:alpha];
 }
 
 + (CGRect)createXBMCInfoframe:(UIImage *)logo height:(CGFloat)height width:(CGFloat)width {

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -283,8 +283,8 @@
     }
 }
 
-+ (UIColor*)getGrayColor:(CGFloat)tone alpha:(CGFloat)alpha{
-    return [UIColor colorWithRed:tone green:tone blue:tone alpha:alpha];
++ (UIColor*)getGrayColor:(int)tone alpha:(CGFloat)alpha{
+    return RGBA(tone, tone, tone, alpha);
 }
 
 + (CGRect)createXBMCInfoframe:(UIImage *)logo height:(CGFloat)height width:(CGFloat)width {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -19,6 +19,7 @@
 #import "ClearCacheView.h"
 #import "gradientUIView.h"
 #import "CustomNavigationController.h"
+#import "Utilities.h"
 
 #define CONNECTION_TIMEOUT 240.0
 #define SERVER_TIMEOUT 2.0
@@ -200,7 +201,7 @@
     self.serverPickerPopover = [[UIPopoverController alloc]
                                 initWithContentViewController:[AppDelegate instance].navigationController];
     self.serverPickerPopover.delegate = self;
-    [self.serverPickerPopover setBackgroundColor:[UIColor colorWithRed:41.0f/255.0f green:41.0f/255.0f blue:41.0f/255.0f alpha:1.0f]];
+    [self.serverPickerPopover setBackgroundColor:[Utilities getGrayColor:41.0/255.0 alpha:1]];
     [self.serverPickerPopover setPopoverContentSize:CGSizeMake(320, 436)];
 }
 
@@ -231,7 +232,7 @@
                                     initWithContentViewController:_appInfoView];
         self.appInfoPopover.delegate = self;
         [self.appInfoPopover setPopoverContentSize:CGSizeMake(320, 460)];
-        self.appInfoPopover.backgroundColor = [UIColor colorWithRed:187.0f/255.0f green:187.0f/255.0f blue:187.0f/255.0f alpha:1.0f];
+        self.appInfoPopover.backgroundColor = [Utilities getGrayColor:187.0/255.0 alpha:1];
     }
     [self.appInfoPopover presentPopoverFromRect:xbmcLogo.frame inView:self.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
 }
@@ -422,7 +423,7 @@
     
     UIView* horizontalLineView1 = [[UIView alloc] initWithFrame:CGRectMake(0, tableHeight + separator - 2, tableWidth, 1)];
 //    [horizontalLineView1 setAutoresizingMask:UIViewAutoresizingFlexibleHeight];
-    [horizontalLineView1 setBackgroundColor:[UIColor colorWithRed:0.3f green:0.3f blue:0.3f alpha:.2]];
+    [horizontalLineView1 setBackgroundColor:[Utilities getGrayColor:0.3 alpha:0.2]];
     [leftMenuView addSubview:horizontalLineView1];
 
     self.nowPlayingController = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
@@ -451,7 +452,7 @@
 	[rootView addSubview:leftMenuView];
 	[rootView addSubview:rightSlideView];
     
-//    self.view.backgroundColor = [UIColor colorWithWhite:.14 alpha:1];
+//    self.view.backgroundColor = [Utilities getGrayColor:0.14 alpha:1];
 //    self.view.backgroundColor = [[UIColor scrollViewTexturedBackgroundColor] colorWithAlphaComponent:0.5];
 //	[self.view setBackgroundColor:[UIColor colorWithPatternImage: [UIImage imageNamed:@"backgroundImage_repeat.png"]]];
     [self.view addSubview:rootView];
@@ -616,8 +617,8 @@
     
     [self initHostManagemetPopOver];
     
-    [(gradientUIView *)self.view setColoursWithCGColors:[UIColor colorWithRed:0.141f green:0.141f blue:0.141f alpha:1.0f].CGColor
-                                               endColor:[UIColor colorWithRed:0.086f green:0.086f blue:0.086f alpha:1.0f].CGColor];
+    [(gradientUIView *)self.view setColoursWithCGColors:[Utilities getGrayColor:0.141 alpha:1].CGColor
+                                               endColor:[Utilities getGrayColor:0.086 alpha:1].CGColor];
 }
 
 -(void)handleChangeBackgroundImage:(NSNotification *)sender {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -201,7 +201,7 @@
     self.serverPickerPopover = [[UIPopoverController alloc]
                                 initWithContentViewController:[AppDelegate instance].navigationController];
     self.serverPickerPopover.delegate = self;
-    [self.serverPickerPopover setBackgroundColor:[Utilities getGrayColor:41.0/255.0 alpha:1]];
+    [self.serverPickerPopover setBackgroundColor:[Utilities getGrayColor:41 alpha:1]];
     [self.serverPickerPopover setPopoverContentSize:CGSizeMake(320, 436)];
 }
 
@@ -232,7 +232,7 @@
                                     initWithContentViewController:_appInfoView];
         self.appInfoPopover.delegate = self;
         [self.appInfoPopover setPopoverContentSize:CGSizeMake(320, 460)];
-        self.appInfoPopover.backgroundColor = [Utilities getGrayColor:187.0/255.0 alpha:1];
+        self.appInfoPopover.backgroundColor = [Utilities getGrayColor:187 alpha:1];
     }
     [self.appInfoPopover presentPopoverFromRect:xbmcLogo.frame inView:self.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
 }
@@ -423,7 +423,7 @@
     
     UIView* horizontalLineView1 = [[UIView alloc] initWithFrame:CGRectMake(0, tableHeight + separator - 2, tableWidth, 1)];
 //    [horizontalLineView1 setAutoresizingMask:UIViewAutoresizingFlexibleHeight];
-    [horizontalLineView1 setBackgroundColor:[Utilities getGrayColor:0.3 alpha:0.2]];
+    [horizontalLineView1 setBackgroundColor:[Utilities getGrayColor:77 alpha:0.2]];
     [leftMenuView addSubview:horizontalLineView1];
 
     self.nowPlayingController = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
@@ -452,7 +452,7 @@
 	[rootView addSubview:leftMenuView];
 	[rootView addSubview:rightSlideView];
     
-//    self.view.backgroundColor = [Utilities getGrayColor:0.14 alpha:1];
+//    self.view.backgroundColor = [Utilities getGrayColor:36 alpha:1];
 //    self.view.backgroundColor = [[UIColor scrollViewTexturedBackgroundColor] colorWithAlphaComponent:0.5];
 //	[self.view setBackgroundColor:[UIColor colorWithPatternImage: [UIImage imageNamed:@"backgroundImage_repeat.png"]]];
     [self.view addSubview:rootView];
@@ -617,8 +617,8 @@
     
     [self initHostManagemetPopOver];
     
-    [(gradientUIView *)self.view setColoursWithCGColors:[Utilities getGrayColor:0.141 alpha:1].CGColor
-                                               endColor:[Utilities getGrayColor:0.086 alpha:1].CGColor];
+    [(gradientUIView *)self.view setColoursWithCGColors:[Utilities getGrayColor:36 alpha:1].CGColor
+                                               endColor:[Utilities getGrayColor:22 alpha:1].CGColor];
 }
 
 -(void)handleChangeBackgroundImage:(NSNotification *)sender {

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -71,8 +71,8 @@
             frame_tmp.origin.x = 22;
             volumeLabel.frame = frame_tmp;
             [volumeLabel setFont:[UIFont boldSystemFontOfSize:15]];
-            UIColor *darkShadow =[UIColor colorWithRed:.2 green:.2 blue:.2 alpha:.6];
-            [volumeLabel setTextColor:[UIColor colorWithRed:.1 green:.1 blue:.1 alpha:.8]];
+            UIColor *darkShadow =[Utilities getGrayColor:0.2 alpha:0.6];
+            [volumeLabel setTextColor:[Utilities getGrayColor:0.1 alpha:0.8]];
             [volumeLabel setShadowColor:darkShadow];
             [volumeLabel setShadowOffset:CGSizeMake(0.5, 0.7)];
             volumeLabel.layer.shadowColor = darkShadow.CGColor;

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -71,8 +71,8 @@
             frame_tmp.origin.x = 22;
             volumeLabel.frame = frame_tmp;
             [volumeLabel setFont:[UIFont boldSystemFontOfSize:15]];
-            UIColor *darkShadow =[Utilities getGrayColor:0.2 alpha:0.6];
-            [volumeLabel setTextColor:[Utilities getGrayColor:0.1 alpha:0.8]];
+            UIColor *darkShadow =[Utilities getGrayColor:51 alpha:0.6];
+            [volumeLabel setTextColor:[Utilities getGrayColor:26 alpha:0.8]];
             [volumeLabel setShadowColor:darkShadow];
             [volumeLabel setShadowOffset:CGSizeMake(0.5, 0.7)];
             volumeLabel.layer.shadowColor = darkShadow.CGColor;

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -61,7 +61,7 @@
 		[_tableView setDataSource:self];
         [_tableView setBackgroundColor:[UIColor clearColor]];
         [_tableView setSeparatorStyle:UITableViewCellSeparatorStyleSingleLine];
-        [_tableView setSeparatorColor:[UIColor colorWithWhite:0.0f alpha:0.1]];
+        [_tableView setSeparatorColor:[Utilities getGrayColor:0 alpha:0.1]];
         mainMenuItems=menu;
         UIView* footerView =  [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 1)];
 		_tableView.tableFooterView = footerView;        
@@ -87,7 +87,7 @@
         
 //        UIView* verticalLineView = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width, -5, 1, self.view.frame.size.height+5)];
 //		[verticalLineView setAutoresizingMask:UIViewAutoresizingFlexibleHeight];
-//		[verticalLineView setBackgroundColor:[UIColor colorWithRed:0.1f green:0.1f blue:0.1f alpha:1]];
+//		[verticalLineView setBackgroundColor:[Utilities getGrayColor:0.1 alpha:1]];
 //		[self.view addSubview:verticalLineView];
 
 //        UIView* verticalLineView1 = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width + 1, -5, 5, self.view.frame.size.height-39)];
@@ -98,14 +98,14 @@
         
 		UIView* verticalLineView1 = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width, 0, 1, self.view.frame.size.height-39)];
 		[verticalLineView1 setAutoresizingMask:UIViewAutoresizingFlexibleHeight];
-		[verticalLineView1 setBackgroundColor:[UIColor colorWithRed:0.0f green:0.0f blue:0.0f alpha:.3]];
+		[verticalLineView1 setBackgroundColor:[Utilities getGrayColor:0 alpha:0.3]];
 		[self.view addSubview:verticalLineView1];
         [self.view bringSubviewToFront:verticalLineView1];
 
         
         UIView* verticalLineView2 = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width+1, 0, 1, self.view.frame.size.height-39)];
 		[verticalLineView2 setAutoresizingMask:UIViewAutoresizingFlexibleHeight];
-		[verticalLineView2 setBackgroundColor:[UIColor colorWithRed:0.3f green:0.3f blue:0.3f alpha:0.2f]];
+		[verticalLineView2 setBackgroundColor:[Utilities getGrayColor:0.3 alpha:0.2]];
 		[self.view addSubview:verticalLineView2];
         
         [self.view bringSubviewToFront:verticalLineView2];
@@ -218,10 +218,10 @@
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.row == 0){
-        cell.backgroundColor = [UIColor colorWithRed:.508f green:.508f blue:.508f alpha:0.1f];
+        cell.backgroundColor = [Utilities getGrayColor:0.508 alpha:0.1];
     }
     else{
-//        cell.backgroundColor = [UIColor colorWithRed:.141f green:.141f blue:.141f alpha:1];
+//        cell.backgroundColor = [Utilities getGrayColor:0.141 alpha:1];
         cell.backgroundColor = [UIColor clearColor];
     }
 }
@@ -234,10 +234,10 @@
     if (cell==nil){
         cell = resultMenuCell;
         UIView *backgroundView = [[UIView alloc] initWithFrame:CGRectMake(cell.frame.origin.x, cell.frame.origin.y, cell.frame.size.width, cell.frame.size.height)];
-        [backgroundView setBackgroundColor:[UIColor colorWithRed:0.0f green:0.0f blue:0.0f alpha:0.4f]];
+        [backgroundView setBackgroundColor:[Utilities getGrayColor:0 alpha:0.4]];
         cell.selectedBackgroundView = backgroundView;
         if (indexPath.row == 0){
-            [backgroundView setBackgroundColor:[UIColor colorWithRed:.508f green:.508f blue:.508f alpha:0.1f]];
+            [backgroundView setBackgroundColor:[Utilities getGrayColor:0.508 alpha:0.1]];
             cell.selectedBackgroundView = backgroundView;
             UIImage *logo = [UIImage imageNamed:@"xbmc_logo.png"];
             UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:PAD_MENU_INFO_HEIGHT width:PAD_MENU_TABLE_WIDTH]];

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -87,7 +87,7 @@
         
 //        UIView* verticalLineView = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width, -5, 1, self.view.frame.size.height+5)];
 //		[verticalLineView setAutoresizingMask:UIViewAutoresizingFlexibleHeight];
-//		[verticalLineView setBackgroundColor:[Utilities getGrayColor:0.1 alpha:1]];
+//		[verticalLineView setBackgroundColor:[Utilities getGrayColor:26 alpha:1]];
 //		[self.view addSubview:verticalLineView];
 
 //        UIView* verticalLineView1 = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width + 1, -5, 5, self.view.frame.size.height-39)];
@@ -105,7 +105,7 @@
         
         UIView* verticalLineView2 = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width+1, 0, 1, self.view.frame.size.height-39)];
 		[verticalLineView2 setAutoresizingMask:UIViewAutoresizingFlexibleHeight];
-		[verticalLineView2 setBackgroundColor:[Utilities getGrayColor:0.3 alpha:0.2]];
+		[verticalLineView2 setBackgroundColor:[Utilities getGrayColor:77 alpha:0.2]];
 		[self.view addSubview:verticalLineView2];
         
         [self.view bringSubviewToFront:verticalLineView2];
@@ -218,10 +218,10 @@
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
     if (indexPath.row == 0){
-        cell.backgroundColor = [Utilities getGrayColor:0.508 alpha:0.1];
+        cell.backgroundColor = [Utilities getGrayColor:130 alpha:0.1];
     }
     else{
-//        cell.backgroundColor = [Utilities getGrayColor:0.141 alpha:1];
+//        cell.backgroundColor = [Utilities getGrayColor:36 alpha:1];
         cell.backgroundColor = [UIColor clearColor];
     }
 }
@@ -237,7 +237,7 @@
         [backgroundView setBackgroundColor:[Utilities getGrayColor:0 alpha:0.4]];
         cell.selectedBackgroundView = backgroundView;
         if (indexPath.row == 0){
-            [backgroundView setBackgroundColor:[Utilities getGrayColor:0.508 alpha:0.1]];
+            [backgroundView setBackgroundColor:[Utilities getGrayColor:130 alpha:0.1]];
             cell.selectedBackgroundView = backgroundView;
             UIImage *logo = [UIImage imageNamed:@"xbmc_logo.png"];
             UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:PAD_MENU_INFO_HEIGHT width:PAD_MENU_TABLE_WIDTH]];


### PR DESCRIPTION
This PR reworks the color definitions for all gray UI parts. Instead of calls like  `[UIColor colorWithRed:0.141176f green:0.141176f blue:0.141176f alpha:1.0f]` this is now reduced to a method call `[Utilities getGrayColor:36 alpha:1.0]`.