### PR TITLE
Rework color grading

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2453,9 +2453,9 @@ int originYear = 0;
                                       thumbImageContainer.layer.shadowPath = path.CGPath;
                                       if (enableBarColor == YES){
                                           albumColor = [utils averageColor:image inverse:NO];
-                                          UIColor *slightLightAlbumColor = [utils slightLighterColorForColor:albumColor];
-                                          self.navigationController.navigationBar.tintColor = slightLightAlbumColor;
-                                          self.searchController.searchBar.tintColor = slightLightAlbumColor;
+                                          UIColor *lightAlbumColor = [utils lighterColorForColor:albumColor];
+                                          self.navigationController.navigationBar.tintColor = lightAlbumColor;
+                                          self.searchController.searchBar.tintColor = lightAlbumColor;
                                           if ([[[self.searchController.searchBar subviews] objectAtIndex:0] isKindOfClass:[UIImageView class]]){
                                               [[[self.searchController.searchBar subviews] objectAtIndex:0] removeFromSuperview];
                                           }
@@ -2480,9 +2480,9 @@ int originYear = 0;
                                               if ([searchTextField respondsToSelector:@selector(setAttributedPlaceholder:)]) {
                                                   UIImageView *iconView = (id)searchTextField.leftView;
                                                   iconView.image = [iconView.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-                                                  iconView.tintColor = slightLightAlbumColor;
-                                                  searchTextField.textColor = slightLightAlbumColor;
-                                                  searchTextField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.searchController.searchBar.placeholder attributes: @{NSForegroundColorAttributeName: slightLightAlbumColor}];
+                                                  iconView.tintColor = lightAlbumColor;
+                                                  searchTextField.textColor = lightAlbumColor;
+                                                  searchTextField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.searchController.searchBar.placeholder attributes: @{NSForegroundColorAttributeName: lightAlbumColor}];
                                               }
                                           }
                                       }
@@ -5232,7 +5232,7 @@ NSIndexPath *selected;
     [activeLayoutView setScrollsToTop:YES];
     if (albumColor!=nil){
         [self.navigationController.navigationBar setTintColor:albumColor];
-        [self.navigationController.navigationBar setTintColor:[utils slightLighterColorForColor:albumColor]];
+        [self.navigationController.navigationBar setTintColor:[utils lighterColorForColor:albumColor]];
     }
     if (isViewDidLoad){
         [activeLayoutView addSubview:self.searchController.searchBar];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -669,8 +669,8 @@ int currentItemID;
                             Utilities *utils = [[Utilities alloc] init];
                             UIColor *lighterColor = [utils lighterColorForColor:color];
                             UIColor *slightLighterColor = [utils slightLighterColorForColor:color];
-                            UIColor *progressColor =[utils updateColor:color lightColor:slightLighterColor darkColor:color trigger:0.2];
-                            UIColor *pgThumbColor = [utils updateColor:color lightColor:lighterColor darkColor:slightLighterColor trigger:0.2];
+                            UIColor *progressColor = slightLighterColor;
+                            UIColor *pgThumbColor = lighterColor;
                             [ProgressSlider setMinimumTrackTintColor:progressColor];
                             if (ProgressSlider.userInteractionEnabled){
                                 UIImage *thumbImage = [utils colorizeImage:[UIImage imageNamed:pg_thumb_name] withColor:pgThumbColor];
@@ -744,9 +744,7 @@ int currentItemID;
                          else{
                              Utilities *utils = [[Utilities alloc] init];
                              UIColor *lighterColor = [utils lighterColorForColor:color];
-                             UIColor *slightLighterColor = [utils slightLighterColorForColor:color];
-                             UIColor *navBarColor = [utils updateColor:color lightColor:slightLighterColor darkColor:color trigger:0.4];
-                             self.navigationController.navigationBar.tintColor = navBarColor;
+                             self.navigationController.navigationBar.tintColor = lighterColor;
                              [UIView transitionWithView:backgroundImageView
                                                duration:1.0
                                                 options:UIViewAnimationOptionTransitionCrossDissolve

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1328,7 +1328,7 @@ int h=0;
             CGFloat red, green, blue, alpha;
             [averageColor getRed:&red green:&green blue:&blue alpha:&alpha];
             if (alpha > 0){
-                foundTintColor = [utils slightLighterColorForColor:[utils averageColor:image inverse:NO]];
+                foundTintColor = [utils lighterColorForColor:[utils averageColor:image inverse:NO]];
             }
             self.navigationController.navigationBar.tintColor = foundTintColor;
             toolbar.tintColor = foundTintColor;
@@ -1351,7 +1351,7 @@ int h=0;
                      if (error == nil){
                          if (image !=nil){
                              Utilities *utils = [[Utilities alloc] init];
-                             newColor = [utils slightLighterColorForColor:[utils averageColor:image inverse:NO]];
+                             newColor = [utils lighterColorForColor:[utils averageColor:image inverse:NO]];
                              [sf setIOS7barTintColor:newColor];
                          }
                      }
@@ -1367,7 +1367,7 @@ int h=0;
                                      if (image !=nil){
                                          if (error == nil){
                                              Utilities *utils = [[Utilities alloc] init];
-                                             newColor = [utils slightLighterColorForColor:[utils averageColor:image inverse:NO]];
+                                             newColor = [utils lighterColorForColor:[utils averageColor:image inverse:NO]];
                                              [sf setIOS7barTintColor:newColor];
                                          }
                                          [NSThread detachNewThreadSelector:@selector(elaborateImage:) toTarget:sf withObject:image];

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -58,34 +58,37 @@
 	return [UIColor colorWithRed:f * red  green:f * green blue:f * blue alpha:1];
 }
 
-- (UIColor *)slightLighterColorForColor:(UIColor *)c{
-    CGFloat r, g, b, a;
-    if ([c getRed:&r green:&g blue:&b alpha:&a])
-        return [UIColor colorWithRed:MIN(r + 0.2, 1.0)
-                               green:MIN(g + 0.2, 1.0)
-                                blue:MIN(b + 0.2, 1.0)
-                               alpha:a];
-    return nil;
+- (UIColor *)slightLighterColorForColor:(UIColor *)color_in{
+    CGFloat hue, sat, bright, alpha;
+    UIColor *color_out = nil;
+    if ([color_in getHue:&hue saturation:&sat brightness:&bright alpha:&alpha]) {
+        sat = MAX(sat / 3, 0);  // de-saturate, but do not remove saturation fully
+        bright = MIN((MAX(bright * 1.2, 0.5)), 0.6); // limit brightness to range [0.5 ... 0.6]
+        color_out = [UIColor colorWithHue:hue saturation:sat brightness:bright alpha:alpha];
+    }
+    return color_out;
 }
 
-- (UIColor *)lighterColorForColor:(UIColor *)c{
-    CGFloat r, g, b, a;
-    if ([c getRed:&r green:&g blue:&b alpha:&a])
-        return [UIColor colorWithRed:MIN(r + 0.4, 1.0)
-                               green:MIN(g + 0.4, 1.0)
-                                blue:MIN(b + 0.4, 1.0)
-                               alpha:a];
-    return nil;
+- (UIColor *)lighterColorForColor:(UIColor *)color_in{
+    CGFloat hue, sat, bright, alpha;
+    UIColor *color_out = nil;
+    if ([color_in getHue:&hue saturation:&sat brightness:&bright alpha:&alpha]) {
+        sat = MAX(sat / 3, 0); // de-saturate, but do not remove saturation fully
+        bright = MIN((MAX(bright * 1.5, 0.7)), 0.9); // limit brightness to range [0.7 ... 0.9]
+        color_out = [UIColor colorWithHue:hue saturation:sat brightness:bright alpha:alpha];
+    }
+    return color_out;
 }
 
-- (UIColor *)darkerColorForColor:(UIColor *)c{
-    CGFloat r, g, b, a;
-    if ([c getRed:&r green:&g blue:&b alpha:&a])
-        return [UIColor colorWithRed:MAX(r - 0.1, 0.0)
-                               green:MAX(g - 0.1, 0.0)
-                                blue:MAX(b - 0.1, 0.0)
-                               alpha:a];
-    return nil;
+- (UIColor *)darkerColorForColor:(UIColor *)color_in{
+    CGFloat hue, sat, bright, alpha;
+    UIColor *color_out = nil;
+    if ([color_in getHue:&hue saturation:&sat brightness:&bright alpha:&alpha]) {
+        sat = MAX(sat / 3, 0); // de-saturate, but do not remove saturation fully
+        bright = MIN((MAX(bright * 0.75, 0.2)), 0.4); // limit brightness to range [0.2 ... 0.4]
+        color_out = [UIColor colorWithHue:hue saturation:sat brightness:bright alpha:alpha];
+    }
+    return color_out;
 }
 
 - (UIColor *)updateColor:(UIColor *) newColor lightColor:(UIColor *)lighter darkColor:(UIColor *)darker{

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -58,37 +58,29 @@
 	return [UIColor colorWithRed:f * red  green:f * green blue:f * blue alpha:1];
 }
 
-- (UIColor *)slightLighterColorForColor:(UIColor *)color_in{
++ (UIColor *)tailorColor:(UIColor *)color_in satscale:(CGFloat)satscale brightscale:(CGFloat)brightscale brightmin:(CGFloat)brightmin brightmax:(CGFloat)brightmax{
     CGFloat hue, sat, bright, alpha;
     UIColor *color_out = nil;
     if ([color_in getHue:&hue saturation:&sat brightness:&bright alpha:&alpha]) {
-        sat = MAX(sat / 3, 0);  // de-saturate, but do not remove saturation fully
-        bright = MIN((MAX(bright * 1.2, 0.5)), 0.6); // limit brightness to range [0.5 ... 0.6]
+        // de-saturate, but do not remove saturation fully
+        sat = MIN(MAX(sat * satscale, 0), 1);
+        // scale and limit brightness to range [brightmin ... brightmax]
+        bright = MIN((MAX(bright * brightscale, brightmin)), brightmax);
         color_out = [UIColor colorWithHue:hue saturation:sat brightness:bright alpha:alpha];
     }
     return color_out;
+}
+
+- (UIColor *)slightLighterColorForColor:(UIColor *)color_in{
+    return [Utilities tailorColor:color_in satscale:0.33 brightscale:1.2 brightmin:0.5 brightmax:0.6];
 }
 
 - (UIColor *)lighterColorForColor:(UIColor *)color_in{
-    CGFloat hue, sat, bright, alpha;
-    UIColor *color_out = nil;
-    if ([color_in getHue:&hue saturation:&sat brightness:&bright alpha:&alpha]) {
-        sat = MAX(sat / 3, 0); // de-saturate, but do not remove saturation fully
-        bright = MIN((MAX(bright * 1.5, 0.7)), 0.9); // limit brightness to range [0.7 ... 0.9]
-        color_out = [UIColor colorWithHue:hue saturation:sat brightness:bright alpha:alpha];
-    }
-    return color_out;
+    return [Utilities tailorColor:color_in satscale:0.33 brightscale:1.5 brightmin:0.7 brightmax:0.9];
 }
 
 - (UIColor *)darkerColorForColor:(UIColor *)color_in{
-    CGFloat hue, sat, bright, alpha;
-    UIColor *color_out = nil;
-    if ([color_in getHue:&hue saturation:&sat brightness:&bright alpha:&alpha]) {
-        sat = MAX(sat / 3, 0); // de-saturate, but do not remove saturation fully
-        bright = MIN((MAX(bright * 0.75, 0.2)), 0.4); // limit brightness to range [0.2 ... 0.4]
-        color_out = [UIColor colorWithHue:hue saturation:sat brightness:bright alpha:alpha];
-    }
-    return color_out;
+    return [Utilities tailorColor:color_in satscale:0.33 brightscale:0.7 brightmin:0.2 brightmax:0.4];
 }
 
 - (UIColor *)updateColor:(UIColor *) newColor lightColor:(UIColor *)lighter darkColor:(UIColor *)darker{


### PR DESCRIPTION
Fix https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/143.

This PR changes the way how colors for text and UI elements are derived from the average cover color (e.g. from music albums). It now uses hue/saturation/brightness instead of adding offsets to the RGB components. This way hue stays intact, and only desaturation is applied to wash out the colors and the brightness is kept in a certain range to have a more stable representation over different covers.