### PR TITLE
Use dark background for station icons (VU+ PVR plugin)

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2066,6 +2066,7 @@ int originYear = 0;
             hasTimer.hidden = YES;
             [hasTimer setBackgroundColor:[UIColor clearColor]];
             [cell.contentView addSubview:hasTimer];
+            [cell.urlImageView setBackgroundColor:[Utilities getGrayColor:28 alpha:0.8]];
         }
         else if (channelListView) {
             CGFloat pieSize = 28;
@@ -2082,6 +2083,7 @@ int originYear = 0;
             isRecordingImageView.hidden = YES;
             [isRecordingImageView setBackgroundColor:[UIColor clearColor]];
             [cell.contentView addSubview:isRecordingImageView];
+            [cell.urlImageView setBackgroundColor:[Utilities getGrayColor:28 alpha:0.8]];
         }
         [(UILabel*) [cell viewWithTag:1] setHighlightedTextColor:[Utilities get1stLabelColor]];
         [(UILabel*) [cell viewWithTag:2] setHighlightedTextColor:[Utilities get2ndLabelColor]];


### PR DESCRIPTION
Minor fix for better readability of TV station logos.

I experience that many TV station logos are hardly readable in Light Mode of iPhones (white icons on white background). In Dark Mode or in grid view -- here a dark background is used -- the station logos are well readable. This change applies a dark background for logos when TV station lists are shown.

But: Is this a common problem, or could someone experience a similar problem with too dark station logos?

https://abload.de/img/simulatorscreenshot-i17ku9.png (Light Mode, hard to recognize statin logos)
https://abload.de/img/simulatorscreenshot-i5wkbq.png (Light Mode, with this fix)
https://abload.de/img/simulatorscreenshot-ipuj12.png (Dark Mode)


