### PR TITLE
Rework of NowPlaying screen

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -30,6 +30,7 @@
 #define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
 
 #define IS_AT_LEAST_IPHONE_X_HEIGHT (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 812)
+#define IS_AT_LEAST_IPAD_1K_WIDTH (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 1024)
 
 
 #define APP_TINT_COLOR [Utilities getGrayColor:0 alpha:0.3]

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -53,7 +53,6 @@
 @synthesize sectionArrayOpen;
 //@synthesize detailDescriptionLabel = _detailDescriptionLabel;
 #define SECTIONS_START_AT 100
-#define SHOW_ONLY_VISIBLE_THUMBNAIL_START_AT 50
 #define MAX_NORMAL_BUTTONS 4
 #define WARNING_TIMEOUT 30.0
 #define COLLECTION_HEADER_HEIGHT 16

--- a/XBMC Remote/HostManagementViewController.h
+++ b/XBMC Remote/HostManagementViewController.h
@@ -27,7 +27,6 @@
     BOOL doRevealMenu;
     AppInfoViewController *appInfoView;
     __weak IBOutlet UIButton *addHostButton;
-    UIView *iOS7navBarEffect;
     __weak IBOutlet UIView *supportedVersionView;
     __weak IBOutlet UILabel *supportedVersionLabel;
     MessagesView *messagesView;

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -72,7 +72,6 @@
     int iPadthumbHeight;
     IBOutlet UIView *playlistActionView;
     IBOutlet UIImageView *pgbar;
-    BOOL portraitMode;
     NSString *currentType;
     BOOL nothingIsPlaying;
     IBOutlet UIImageView *xbmcOverlayImage;
@@ -118,7 +117,7 @@
     CGFloat bottomPadding;
 }
 
-- (void)setToolbarWidth:(int)width height:(int)height YPOS:(int)YPOS portrait:(BOOL)isPortrait;
+- (void)setNowPlayingDimension:(int)width height:(int)height YPOS:(int)YPOS;
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil;
 - (IBAction)startVibrate:(id)sender;
 - (void)toggleSongDetails;

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -118,7 +118,7 @@
     CGFloat bottomPadding;
 }
 
-- (void)setToolbarWidth:(int)width height:(int)height YPOS:(int)YPOS playBarWidth:(int)playBarWidth portrait:(BOOL)isPortrait;
+- (void)setToolbarWidth:(int)width height:(int)height YPOS:(int)YPOS portrait:(BOOL)isPortrait;
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil;
 - (IBAction)startVibrate:(id)sender;
 - (void)toggleSongDetails;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2551,7 +2551,7 @@ int currentItemID;
 
 #pragma mark - Interface customizations
 
--(void)setToolbarWidth:(int)width height:(int)height YPOS:(int)YPOS portrait:(BOOL)isPortrait{
+-(void)setNowPlayingDimension:(int)width height:(int)height YPOS:(int)YPOS {
     CGRect frame;
     
     // Maximum allowed height shall be 90% of visible height in landscape mode
@@ -2584,7 +2584,6 @@ int currentItemID;
     frame.size.height = maxheight;
     frame.size.width = width - (PAD_MENU_TABLE_WIDTH + 2);
     nowPlayingView.frame = frame;
-    portraitMode = isPortrait;
     
     frame = iOS7bgEffect.frame;
     frame.size.width = width;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -47,6 +47,8 @@ CGFloat cellBarWidth=45;
 #define SHOW_ONLY_VISIBLE_THUMBNAIL_START_AT 50
 #define PROGRESSBAR_PADDING_LEFT 20
 #define PROGRESSBAR_PADDING_BOTTOM 80
+#define SEGMENTCONTROL_WIDTH 122
+#define SEGMENTCONTROL_HEIGHT 29
 
 - (void)setDetailItem:(id)newDetailItem{
     if (_detailItem != newDetailItem) {
@@ -2725,12 +2727,11 @@ int currentItemID;
                                                                           [[NSLocalizedString(@"Video ", nil) capitalizedString] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]], nil
                                                                           ]
                                 ];
-    CGFloat seg_width = 122;
-    CGFloat left_margin = 99;
+    CGFloat left_margin = (PAD_MENU_TABLE_WIDTH - SEGMENTCONTROL_WIDTH)/2;
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-        left_margin = (int)(([self currentScreenBoundsDependOnOrientation].size.width/2) - (seg_width/2));
+        left_margin = floor(([self currentScreenBoundsDependOnOrientation].size.width - SEGMENTCONTROL_WIDTH)/2);
     }
-    playlistSegmentedControl.frame = CGRectMake(left_margin, 7, seg_width, 29);
+    playlistSegmentedControl.frame = CGRectMake(left_margin, (playlistActionView.frame.size.height - SEGMENTCONTROL_HEIGHT)/2, SEGMENTCONTROL_WIDTH, SEGMENTCONTROL_HEIGHT);
     playlistSegmentedControl.tintColor = [UIColor whiteColor];
     [playlistSegmentedControl addTarget:self action:@selector(segmentValueChanged:) forControlEvents: UIControlEventValueChanged];
     [playlistActionView addSubview:playlistSegmentedControl];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -43,9 +43,10 @@
 //@synthesize presentedFromNavigation;
 
 CGFloat startx=14;
-CGFloat barwidth=280;
 CGFloat cellBarWidth=45;
 #define SHOW_ONLY_VISIBLE_THUMBNAIL_START_AT 50
+#define PROGRESSBAR_PADDING_LEFT 20
+#define PROGRESSBAR_PADDING_BOTTOM 80
 
 - (void)setDetailItem:(id)newDetailItem{
     if (_detailItem != newDetailItem) {
@@ -382,127 +383,39 @@ float storePercentage;
 int storedItemID;
 int currentItemID;
 
--(CGRect)transformFrame:(CGRect)frame{
-    CGFloat center_x = CGRectGetMidX(frame);
-    CGFloat center_y = CGRectGetMidY(frame);
-    CGFloat transform_x = [Utilities getTransformX];
-    CGFloat transform_y = [Utilities getTransformY];
-    frame.size.width *= transform_x;
-    frame.size.height *= transform_x;
-    frame.origin.x = center_x*transform_x - frame.size.width/2;
-    frame.origin.y = center_y*transform_y - frame.size.height/2;
-    return frame;
-}
-
 -(void)setCoverSize:(NSString *)type{
     NSString *jewelImg = @"";
     if ([type isEqualToString:@"song"]){
-        jewelImg = @"jewel_cd.9.png";
-        CGRect frame = thumbnailView.frame;
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-            frame.origin.x = 52;
-            frame.origin.y = 43;
-            frame.size.width = 238;
-            frame.size.height = 238;
-            frame = [self transformFrame:frame];
+            jewelImg = @"jewel_cd.9.png";
         }
         else {
             jewelImg=@"jewel_cd.9@2x.png";
-            if (portraitMode){
-                frame.origin.x = 82;
-                frame.origin.y = 60;
-                frame.size.width = 334;
-                frame.size.height = 334;
-            }
-            else {
-                frame.origin.x = 158;
-                frame.origin.y = 80;
-                frame.size.width = 435;
-                frame.size.height = 435;
-            }
         }
-        thumbnailView.frame = frame;
     }
     else if ([type isEqualToString:@"movie"]){
-        jewelImg=@"jewel_dvd.9.png";
-        CGRect frame = thumbnailView.frame;
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-            frame.origin.x = 86;
-            frame.origin.y = 39;
-            frame.size.width = 172;
-            frame.size.height = 248;
-            frame = [self transformFrame:frame];
+            jewelImg=@"jewel_dvd.9.png";
         }
         else{
             jewelImg=@"jewel_dvd.9@2x.png";
-            if (portraitMode){
-                frame.origin.x = 128;
-                frame.origin.y = 56;
-                frame.size.width = 240;
-                frame.size.height = 346;
-            }
-            else {
-                frame.origin.x = 222;
-                frame.origin.y = 74;
-                frame.size.width = 306;
-                frame.size.height = 450;
-            }
         }
-        thumbnailView.frame = frame;
     }
     else if ([type isEqualToString:@"episode"]){
-        jewelImg = @"jewel_tv.9.png";
-        CGRect frame = thumbnailView.frame;
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-            frame.origin.x = 22;
-            frame.origin.y = 78;
-            frame.size.width = 280;
-            frame.size.height = 158;
-            frame = [self transformFrame:frame];
+            jewelImg = @"jewel_tv.9.png";
         }
         else{
             jewelImg=@"jewel_tv.9@2x.png";
-            if (portraitMode){
-                frame.origin.x = 28;
-                frame.origin.y = 102;
-                frame.size.width = 412;
-                frame.size.height = 236;
-            }
-            else {
-                frame.origin.x = 38 ;
-                frame.origin.y = 102;
-                frame.size.width = 646;
-                frame.size.height = 364;
-            }
         }
-        thumbnailView.frame = frame;
     }
     else{
-        jewelImg = @"jewel_cd.9.png";
-        CGRect frame = thumbnailView.frame;
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-            frame.origin.x = 52;
-            frame.origin.y = 43;
-            frame.size.width = 238;
-            frame.size.height = 238;
-            frame = [self transformFrame:frame];
+            jewelImg = @"jewel_cd.9.png";
         }
         else {
             jewelImg=@"jewel_cd.9@2x.png";
-            if (portraitMode){
-                frame.origin.x = 82;
-                frame.origin.y = 60;
-                frame.size.width = 334;
-                frame.size.height = 334;
-            }
-            else {
-                frame.origin.x = 158;
-                frame.origin.y = 80;
-                frame.size.width = 435;
-                frame.size.height = 435;
-            }
         }
-        thumbnailView.frame = frame;
     }
     if ([self enableJewelCases]){
         jewelView.image = [UIImage imageNamed:jewelImg];
@@ -2638,24 +2551,45 @@ int currentItemID;
 
 #pragma mark - Interface customizations
 
--(void)setToolbarWidth:(int)width height:(int)height YPOS:(int)YPOS playBarWidth:(int)playBarWidth portrait:(BOOL)isPortrait{
+-(void)setToolbarWidth:(int)width height:(int)height YPOS:(int)YPOS portrait:(BOOL)isPortrait{
     CGRect frame;
-    barwidth = playBarWidth;
-    frame=playlistToolbar.frame;
-    frame.size.width=width+20;
-    frame.origin.x=0;
-    playlistToolbar.frame=frame;
-    frame=nowPlayingView.frame;
-    frame.origin.x=302;
-    frame.origin.y=YPOS;
-    frame.size.height=height - 84;
-    frame.size.width=width - 302;
-    nowPlayingView.frame=frame;
+    
+    // Maximum allowed height shall be 90% of visible height in landscape mode
+    CGFloat bottomPadding = 0;
+    if (@available(iOS 11.0, *)) {
+        UIWindow *window = UIApplication.sharedApplication.keyWindow;
+        bottomPadding = window.safeAreaInsets.bottom;
+    }
+    CGFloat maxheight = floor((CGRectGetHeight(UIScreen.mainScreen.bounds) - bottomPadding - playlistToolbar.frame.size.height) * 0.9);
+    
+    frame = ProgressSlider.frame;
+    frame.origin.y = maxheight - PROGRESSBAR_PADDING_BOTTOM;
+    frame.origin.x = PAD_MENU_TABLE_WIDTH + PROGRESSBAR_PADDING_LEFT;
+    ProgressSlider.frame=frame;
+    
+    frame = scrabbingView.frame;
+    frame.origin.y = ProgressSlider.frame.origin.y - scrabbingView.frame.size.height - 2;
+    frame.origin.x = ProgressSlider.frame.origin.x;
+    frame.size.width = ProgressSlider.frame.size.width;
+    scrabbingView.frame=frame;
+    
+    frame = playlistToolbar.frame;
+    frame.size.width = width;
+    frame.origin.x = 0;
+    playlistToolbar.frame = frame;
+    
+    frame = nowPlayingView.frame;
+    frame.origin.x = PAD_MENU_TABLE_WIDTH + 2;
+    frame.origin.y = YPOS;
+    frame.size.height = maxheight;
+    frame.size.width = width - (PAD_MENU_TABLE_WIDTH + 2);
+    nowPlayingView.frame = frame;
     portraitMode = isPortrait;
     
     frame = iOS7bgEffect.frame;
     frame.size.width = width;
     iOS7bgEffect.frame = frame;
+    
     [self setCoverSize:currentType];
 }
 
@@ -2698,34 +2632,46 @@ int currentItemID;
 }
 
 -(void)setIpadInterface:(CGFloat)toolbarAlpha{
-    playlistLeftShadow.hidden = NO;
-    slideFrom=-300;
+    slideFrom = -PAD_MENU_TABLE_WIDTH;
     CGRect frame;
-    [albumName setFont:[UIFont systemFontOfSize:24]];
-    frame=albumName.frame;
-    frame.origin.y=10;
-    albumName.frame=frame;
-    [songName setFont:[UIFont systemFontOfSize:20]];
-
-    frame=songName.frame;
-    frame.origin.y=frame.origin.y - 12;
-    songName.frame=frame;
-    
-    [artistName setFont:[UIFont systemFontOfSize:18]];
-    frame=artistName.frame;
-    frame.origin.y=frame.origin.y - 8;
-    artistName.frame=frame;
-    
-    [currentTime setFont:[UIFont systemFontOfSize:16]];
-    [duration setFont:[UIFont systemFontOfSize:16]];
-
-    frame=playlistTableView.frame;
-    frame.origin.x=slideFrom;
-    playlistTableView.frame=frame;
-    
-    frame = ProgressSlider.frame;
-    frame.origin.y = frame.origin.y - 14;
-    ProgressSlider.frame = frame;
+    if (IS_AT_LEAST_IPAD_1K_WIDTH) {
+        [albumName setFont:[UIFont systemFontOfSize:28]];
+        [songName setFont:[UIFont systemFontOfSize:24]];
+        [artistName setFont:[UIFont systemFontOfSize:22]];
+        [currentTime setFont:[UIFont systemFontOfSize:20]];
+        [duration setFont:[UIFont systemFontOfSize:20]];
+        
+        frame = songName.frame;
+        frame.origin.y += 15;
+        songName.frame=frame;
+        
+        frame = artistName.frame;
+        frame.origin.y += 25;
+        artistName.frame = frame;
+        
+        frame = playlistTableView.frame;
+        frame.origin.x = slideFrom;
+        playlistTableView.frame = frame;
+    }
+    else {
+        [albumName setFont:[UIFont systemFontOfSize:24]];
+        [songName setFont:[UIFont systemFontOfSize:20]];
+        [artistName setFont:[UIFont systemFontOfSize:18]];
+        [currentTime setFont:[UIFont systemFontOfSize:16]];
+        [duration setFont:[UIFont systemFontOfSize:16]];
+        
+        frame = songName.frame;
+        frame.origin.y += 10;
+        songName.frame=frame;
+        
+        frame = artistName.frame;
+        frame.origin.y += 15;
+        artistName.frame = frame;
+        
+        frame = playlistTableView.frame;
+        frame.origin.x = slideFrom;
+        playlistTableView.frame = frame;
+    }
     
     /* TODO: Find an elegant solution for the following code.
        Toolbar items defined in xib are:
@@ -2747,18 +2693,16 @@ int currentItemID;
     [playlistToolbar setItems:items animated:NO];
     playlistToolbar.alpha = toolbarAlpha;
     
-    nowPlayingView.hidden=NO;
-    playlistView.hidden=NO;
+    nowPlayingView.hidden = NO;
+    playlistView.hidden = NO;
     xbmcOverlayImage_iphone.hidden = YES;
+    playlistLeftShadow.hidden = NO;
     
     frame = playlistActionView.frame;
     frame.origin.y = playlistToolbar.frame.origin.y - playlistToolbar.frame.size.height;
     playlistActionView.frame = frame;
     playlistActionView.alpha = 1.0;
     
-    frame = scrabbingView.frame;
-    frame.origin.y =frame.origin.y - 24;
-    [scrabbingView setFrame:frame];
     [itemDescription setFont:[UIFont systemFontOfSize:15]];
 }
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2599,7 +2599,7 @@ int currentItemID;
     }
 }
 
--(void)setIpadInterface:(CGFloat)toolbarAlpha{
+-(void)setIpadInterface {
     slideFrom = -PAD_MENU_TABLE_WIDTH;
     CGRect frame;
     
@@ -2657,7 +2657,7 @@ int currentItemID;
     [items removeObjectAtIndex:2];
     [items removeObjectAtIndex:0];
     [playlistToolbar setItems:items animated:NO];
-    playlistToolbar.alpha = toolbarAlpha;
+    playlistToolbar.alpha = 1.0;
     
     nowPlayingView.hidden = NO;
     playlistView.hidden = NO;
@@ -2950,9 +2950,6 @@ int currentItemID;
     editTableButton.titleLabel.numberOfLines = 1;
     editTableButton.titleLabel.adjustsFontSizeToFitWidth = YES;
     [noItemsLabel setText:NSLocalizedString(@"No items found.", nil)];
-    CGFloat toolbarAlpha = 0.8;
-    pg_thumb_name = @"pgbar_thumb.png";
-    cellBackgroundColor = [Utilities getGrayColor:217 alpha:1];
     [self addSegmentControl];
     pg_thumb_name = @"pgbar_thumb_iOS7.png";
     cellBackgroundColor = [UIColor whiteColor];
@@ -2961,7 +2958,6 @@ int currentItemID;
         UIWindow *window = UIApplication.sharedApplication.keyWindow;
         bottomPadding = window.safeAreaInsets.bottom;
     }
-    toolbarAlpha = 1.0;
     [self setIOS7toolbar];
 
     if (bottomPadding > 0) {
@@ -3003,7 +2999,7 @@ int currentItemID;
         [self setIphoneInterface];
     }
     else{
-        [self setIpadInterface:toolbarAlpha];
+        [self setIpadInterface];
     }
     playlistData = [[NSMutableArray alloc] init ];
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -383,39 +383,30 @@ float storePercentage;
 int storedItemID;
 int currentItemID;
 
+-(NSString*)getJewelImage:(NSString*)name {
+    NSString *jewelImageName = nil;
+    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        jewelImageName = [NSString stringWithFormat:@"%@@2x.png", name];
+    }
+    else {
+        jewelImageName = [NSString stringWithFormat:@"%@.png", name];
+    }
+    return jewelImageName;
+}
+
 -(void)setCoverSize:(NSString *)type{
     NSString *jewelImg = @"";
     if ([type isEqualToString:@"song"]){
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-            jewelImg = @"jewel_cd.9.png";
-        }
-        else {
-            jewelImg=@"jewel_cd.9@2x.png";
-        }
+        jewelImg = [self getJewelImage:@"jewel_cd.9"];
     }
     else if ([type isEqualToString:@"movie"]){
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-            jewelImg=@"jewel_dvd.9.png";
-        }
-        else{
-            jewelImg=@"jewel_dvd.9@2x.png";
-        }
+        jewelImg = [self getJewelImage:@"jewel_dvd.9"];
     }
     else if ([type isEqualToString:@"episode"]){
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-            jewelImg = @"jewel_tv.9.png";
-        }
-        else{
-            jewelImg=@"jewel_tv.9@2x.png";
-        }
+        jewelImg = [self getJewelImage:@"jewel_tv.9"];
     }
     else{
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-            jewelImg = @"jewel_cd.9.png";
-        }
-        else {
-            jewelImg=@"jewel_cd.9@2x.png";
-        }
+        jewelImg = [self getJewelImage:@"jewel_cd.9"];
     }
     if ([self enableJewelCases]){
         jewelView.image = [UIImage imageNamed:jewelImg];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2874,9 +2874,8 @@ int currentItemID;
     }
     // lower half of top area is colored in album color
     if (iOS7navBarEffect == nil && [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone){
-        CGFloat topBarHeight = CGRectGetMaxY(self.navigationController.navigationBar.frame);
-        CGFloat effectHeight = topBarHeight/2;
-        iOS7navBarEffect = [[UIView alloc] initWithFrame:CGRectMake(0, topBarHeight - effectHeight, self.view.frame.size.width, effectHeight)];
+        CGFloat effectHeight = CGRectGetMaxY(self.navigationController.navigationBar.frame)/2;
+        iOS7navBarEffect = [[UIView alloc] initWithFrame:CGRectMake(0, -effectHeight, self.view.frame.size.width, effectHeight)];
         iOS7navBarEffect.autoresizingMask = UIViewAutoresizingFlexibleTopMargin;
         [self.view insertSubview:iOS7navBarEffect atIndex:0];
     }
@@ -2965,27 +2964,24 @@ int currentItemID;
         bottomPadding = window.safeAreaInsets.bottom;
     }
     toolbarAlpha = 1.0;
-    int barHeight = 44;
-    int statusBarHeight = [[UIApplication sharedApplication] statusBarFrame].size.height;
     [self setIOS7toolbar];
-    
-    CGRect frame;
-    frame = nowPlayingView.frame;
-    frame.origin.y = barHeight + statusBarHeight;
-    frame.size.height = frame.size.height - barHeight - statusBarHeight - bottomPadding;
-    nowPlayingView.frame = frame;
-    
+
     if (bottomPadding > 0) {
-        frame = playlistToolbar.frame;
+        CGRect frame = playlistToolbar.frame;
         frame.origin.y -= bottomPadding;
         playlistToolbar.frame = frame;
+        
+        frame = nowPlayingView.frame;
+        frame.size.height -= bottomPadding;
+        nowPlayingView.frame = frame;
         
         frame= playlistTableView.frame;
         frame.size.height -= bottomPadding;
         playlistView.frame = frame;
         playlistTableView.frame = frame;
     }
-    [playlistTableView setContentInset:UIEdgeInsetsMake(0, 0, barHeight, 0)];
+    [playlistTableView setContentInset:UIEdgeInsetsMake(0, 0, 44, 0)];
+    self.edgesForExtendedLayout = UIRectEdgeNone;
     
     [ProgressSlider setMinimumTrackTintColor:SLIDER_DEFAULT_COLOR];
     [ProgressSlider setMaximumTrackTintColor:APP_TINT_COLOR];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -416,16 +416,15 @@ int currentItemID;
         thumbnailView.hidden = NO;
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
             CGRect frame = jewelView.frame;
-            frame.origin.x = 10;
+            frame.origin.x = (nowPlayingView.frame.size.width - jewelView.frame.size.width)/2;
             jewelView.frame = frame;
             frame = thumbnailView.frame;
             frame.origin.x += PAD_MENU_TABLE_WIDTH;
-            frame.origin.y += 22;
+            frame.origin.y += [[UIApplication sharedApplication] statusBarFrame].size.height + 2;
             songDetailsView.frame = frame;
         }
         else {
             songDetailsView.frame = thumbnailView.frame;
-
         }
     }
     else {
@@ -433,10 +432,10 @@ int currentItemID;
         thumbnailView.hidden = YES;
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
             CGRect frame = jewelView.frame;
-            frame.origin.x = 14;
+            frame.origin.x = (nowPlayingView.frame.size.width - jewelView.frame.size.width)/2;
             jewelView.frame = frame;
             frame.origin.x += PAD_MENU_TABLE_WIDTH;
-            frame.origin.y += 22;
+            frame.origin.y += [[UIApplication sharedApplication] statusBarFrame].size.height + 2;
             songDetailsView.frame = frame;
         }
         else {
@@ -2888,15 +2887,19 @@ int currentItemID;
         rightMenuViewController.rightMenuItems = [AppDelegate instance].nowPlayingMenuItems;
         self.slidingViewController.underRightViewController = rightMenuViewController;
     }
-    int effectHeight = 22;
-    int barEffectHeight = 32;
+    // upper half of bottom area is colored in album color
     if (iOS7bgEffect == nil){
-        iOS7bgEffect = [[UIView alloc] initWithFrame:CGRectMake(0, self.view.frame.size.height - 44, self.view.frame.size.width, effectHeight)];
+        CGFloat bottomBarHeight = playlistToolbar.frame.size.height + bottomPadding;
+        CGFloat effectHeight = bottomBarHeight/2;
+        iOS7bgEffect = [[UIView alloc] initWithFrame:CGRectMake(0, self.view.frame.size.height - bottomBarHeight, self.view.frame.size.width, effectHeight)];
         iOS7bgEffect.autoresizingMask = playlistToolbar.autoresizingMask;
         [self.view insertSubview:iOS7bgEffect atIndex:0];
     }
+    // lower half of top area is colored in album color
     if (iOS7navBarEffect == nil && [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone){
-        iOS7navBarEffect = [[UIView alloc] initWithFrame:CGRectMake(0, 64 - barEffectHeight, self.view.frame.size.width, barEffectHeight)];
+        CGFloat topBarHeight = CGRectGetMaxY(self.navigationController.navigationBar.frame);
+        CGFloat effectHeight = topBarHeight/2;
+        iOS7navBarEffect = [[UIView alloc] initWithFrame:CGRectMake(0, topBarHeight - effectHeight, self.view.frame.size.width, effectHeight)];
         iOS7navBarEffect.autoresizingMask = UIViewAutoresizingFlexibleTopMargin;
         [self.view insertSubview:iOS7navBarEffect atIndex:0];
     }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -42,9 +42,7 @@
 @synthesize itemDescription;
 //@synthesize presentedFromNavigation;
 
-CGFloat startx=14;
-CGFloat cellBarWidth=45;
-#define SHOW_ONLY_VISIBLE_THUMBNAIL_START_AT 50
+#define MAX_CELLBAR_WIDTH 45
 #define PROGRESSBAR_PADDING_LEFT 20
 #define PROGRESSBAR_PADDING_BOTTOM 80
 #define SEGMENTCONTROL_WIDTH 122
@@ -193,28 +191,9 @@ CGFloat cellBarWidth=45;
     return (NSDictionary *)mutableDictionary;
 }
 
--(void)animCursor:(CGFloat)x{
-    NSTimeInterval time=1.0;
-    if (x==startx){
-        time=0.1;
-    }
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:time];
-    [UIView setAnimationCurve:UIViewAnimationCurveLinear ];
-    CGRect frame;
-    frame = [timeCursor frame];
-    frame.origin.x = x;
-    timeCursor.frame = frame;
-    [UIView commitAnimations];
-}
-
 -(void)resizeCellBar:(CGFloat)width image:(UIImageView *)cellBarImage{
-    NSTimeInterval time=1.0;
-    if (width==0){
-        time=0.1;
-    }
-    if (width>cellBarWidth)
-        width=cellBarWidth;
+    NSTimeInterval time = (width==0) ? 0.1 : 1.0;
+    width = MIN(width, MAX_CELLBAR_WIDTH);
     [UIView beginAnimations:nil context:nil];
     [UIView setAnimationDuration:time];
     [UIView setAnimationCurve:UIViewAnimationCurveLinear];
@@ -1002,9 +981,7 @@ int currentItemID;
                                      UILabel *playlistActualTime=(UILabel*) [cell viewWithTag:6];
                                      playlistActualTime.text=actualTime;
                                      UIImageView *playlistActualBar=(UIImageView*) [cell viewWithTag:7];
-                                     CGFloat newx=cellBarWidth * [(NSNumber*) [methodResult objectForKey:@"percentage"] floatValue] / 100;
-                                     if (newx<1)
-                                         newx=1;
+                                     CGFloat newx = MAX(MAX_CELLBAR_WIDTH * [(NSNumber *)methodResult[@"percentage"] doubleValue] / 100, 1.0);
                                      [self resizeCellBar:newx image:playlistActualBar];
                                      UIView *timePlaying=(UIView*) [cell viewWithTag:5];
                                      if (timePlaying.hidden==YES)
@@ -2991,7 +2968,6 @@ int currentItemID;
     int barHeight = 44;
     int statusBarHeight = [[UIApplication sharedApplication] statusBarFrame].size.height;
     [self setIOS7toolbar];
-    [playlistTableView setSeparatorInset:UIEdgeInsetsMake(0, 53, 0, 0)];
     
     CGRect frame;
     frame = nowPlayingView.frame;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2602,44 +2602,42 @@ int currentItemID;
 -(void)setIpadInterface:(CGFloat)toolbarAlpha{
     slideFrom = -PAD_MENU_TABLE_WIDTH;
     CGRect frame;
+    
+    // fontsizes and offsets for smaller iPads
+    CGFloat albumFontSize  = 24;
+    CGFloat songFontSize   = 20;
+    CGFloat artistFontSize = 18;
+    CGFloat timeFontSize   = 16;
+    CGFloat songOffset     = 10;
+    CGFloat artistOffset   = 15;
+    
+    // fontsizes and offsets for larger iPads
     if (IS_AT_LEAST_IPAD_1K_WIDTH) {
-        [albumName setFont:[UIFont systemFontOfSize:28]];
-        [songName setFont:[UIFont systemFontOfSize:24]];
-        [artistName setFont:[UIFont systemFontOfSize:22]];
-        [currentTime setFont:[UIFont systemFontOfSize:20]];
-        [duration setFont:[UIFont systemFontOfSize:20]];
-        
-        frame = songName.frame;
-        frame.origin.y += 15;
-        songName.frame=frame;
-        
-        frame = artistName.frame;
-        frame.origin.y += 25;
-        artistName.frame = frame;
-        
-        frame = playlistTableView.frame;
-        frame.origin.x = slideFrom;
-        playlistTableView.frame = frame;
+        albumFontSize  = 28;
+        songFontSize   = 24;
+        artistFontSize = 22;
+        timeFontSize   = 20;
+        songOffset     = 15;
+        artistOffset   = 25;
     }
-    else {
-        [albumName setFont:[UIFont systemFontOfSize:24]];
-        [songName setFont:[UIFont systemFontOfSize:20]];
-        [artistName setFont:[UIFont systemFontOfSize:18]];
-        [currentTime setFont:[UIFont systemFontOfSize:16]];
-        [duration setFont:[UIFont systemFontOfSize:16]];
-        
-        frame = songName.frame;
-        frame.origin.y += 10;
-        songName.frame=frame;
-        
-        frame = artistName.frame;
-        frame.origin.y += 15;
-        artistName.frame = frame;
-        
-        frame = playlistTableView.frame;
-        frame.origin.x = slideFrom;
-        playlistTableView.frame = frame;
-    }
+    
+    [albumName setFont:[UIFont systemFontOfSize:albumFontSize]];
+    [songName setFont:[UIFont systemFontOfSize:songFontSize]];
+    [artistName setFont:[UIFont systemFontOfSize:artistFontSize]];
+    [currentTime setFont:[UIFont systemFontOfSize:timeFontSize]];
+    [duration setFont:[UIFont systemFontOfSize:timeFontSize]];
+    
+    frame = songName.frame;
+    frame.origin.y += songOffset;
+    songName.frame=frame;
+    
+    frame = artistName.frame;
+    frame.origin.y += artistOffset;
+    artistName.frame = frame;
+    
+    frame = playlistTableView.frame;
+    frame.origin.x = slideFrom;
+    playlistTableView.frame = frame;
     
     /* TODO: Find an elegant solution for the following code.
        Toolbar items defined in xib are:

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -20,7 +20,6 @@
 + (NSDictionary*)buildPlayerSeekPercentageParams:(int)playerID percentage:(float)percentage;
 + (NSArray*)buildPlayerSeekStepParams:(NSString*)stepmode;
 + (CGFloat)getTransformX;
-+ (CGFloat)getTransformY;
 + (UIColor*)getSystemRed:(CGFloat)alpha;
 + (UIColor*)getSystemGreen:(CGFloat)alpha;
 + (UIColor*)getSystemBlue;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -180,17 +180,6 @@
     }
 }
 
-+ (CGFloat)getTransformY {
-    // We scale for iPhone with their different device widths.
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-        return (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds)/480.0);
-    }
-    // For iPad a fixed frame width is used.
-    else {
-        return 1.0;
-    }
-}
-
 + (UIColor*)getSystemRed:(CGFloat)alpha{
     return [[UIColor systemRedColor] colorWithAlphaComponent:alpha];
 }

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -435,7 +435,7 @@
     self.nowPlayingController.view.autoresizingMask=UIViewAutoresizingFlexibleHeight;
     self.nowPlayingController.view.frame=frame;
     
-    [self.nowPlayingController setToolbarWidth:[self screenSizeOrientationIndependent].width height:[self screenSizeOrientationIndependent].height - 414 YPOS:YPOS playBarWidth:1426 portrait:TRUE];
+    [self.nowPlayingController setToolbarWidth:[self screenSizeOrientationIndependent].width height:[self screenSizeOrientationIndependent].height YPOS:YPOS portrait:TRUE];
     
     [leftMenuView addSubview:self.nowPlayingController.view];
 
@@ -515,14 +515,6 @@
     
     [self.view insertSubview:self.nowPlayingController.scrabbingView aboveSubview:rootView];
     [self.view insertSubview:self.nowPlayingController.songDetailsView aboveSubview:rootView];
-    frame = self.nowPlayingController.ProgressSlider.frame;
-    frame.origin.x = self.nowPlayingController.ProgressSlider.frame.origin.x + PAD_MENU_TABLE_WIDTH;
-    self.nowPlayingController.ProgressSlider.frame=frame;
-    
-    frame = self.nowPlayingController.scrabbingView.frame;
-    frame.size.width += 2;
-    frame.origin.x = self.nowPlayingController.scrabbingView.frame.origin.x + PAD_MENU_TABLE_WIDTH;
-    self.nowPlayingController.scrabbingView.frame=frame;
     
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [userDefaults synchronize];
@@ -737,26 +729,8 @@
 }
 
 - (void)viewWillLayoutSubviews{
-    UIInterfaceOrientation toInterfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
-    if (toInterfaceOrientation == UIInterfaceOrientationPortrait || toInterfaceOrientation == UIInterfaceOrientationPortraitUpsideDown) {
-        CGRect frame = self.nowPlayingController.ProgressSlider.frame;
-        frame.origin.y = [self currentScreenBoundsDependOnOrientation].size.height - 580;
-        self.nowPlayingController.ProgressSlider.frame=frame;
-        frame = self.nowPlayingController.scrabbingView.frame;
-        frame.origin.y = self.nowPlayingController.ProgressSlider.frame.origin.y - self.nowPlayingController.scrabbingView.frame.size.height - 2;
-        self.nowPlayingController.scrabbingView.frame=frame;
-
-        [self.nowPlayingController setToolbarWidth:[self currentScreenBoundsDependOnOrientation].size.width height:[self currentScreenBoundsDependOnOrientation].size.height - 414 YPOS:YPOS playBarWidth:426 portrait:TRUE];
-	}
-	else if (toInterfaceOrientation == UIInterfaceOrientationLandscapeLeft || toInterfaceOrientation == UIInterfaceOrientationLandscapeRight){
-        CGRect frame = self.nowPlayingController.ProgressSlider.frame;
-        frame.origin.y = [self currentScreenBoundsDependOnOrientation].size.height - 168;
-        self.nowPlayingController.ProgressSlider.frame=frame;
-        frame = self.nowPlayingController.scrabbingView.frame;
-        frame.origin.y = self.nowPlayingController.ProgressSlider.frame.origin.y - self.nowPlayingController.scrabbingView.frame.size.height - 2;
-        self.nowPlayingController.scrabbingView.frame=frame;
-        [self.nowPlayingController setToolbarWidth:[self currentScreenBoundsDependOnOrientation].size.width height:[self currentScreenBoundsDependOnOrientation].size.height YPOS:YPOS playBarWidth:680 portrait:FALSE];
-	}
+    UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
+    [self.nowPlayingController setToolbarWidth:[self currentScreenBoundsDependOnOrientation].size.width height:[self currentScreenBoundsDependOnOrientation].size.height YPOS:YPOS portrait:(orientation == UIInterfaceOrientationPortrait || orientation == UIInterfaceOrientationPortraitUpsideDown)];
 }
 
 -(void) willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration{

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -435,7 +435,7 @@
     self.nowPlayingController.view.autoresizingMask=UIViewAutoresizingFlexibleHeight;
     self.nowPlayingController.view.frame=frame;
     
-    [self.nowPlayingController setToolbarWidth:[self screenSizeOrientationIndependent].width height:[self screenSizeOrientationIndependent].height YPOS:YPOS portrait:TRUE];
+    [self.nowPlayingController setNowPlayingDimension:[self screenSizeOrientationIndependent].width height:[self screenSizeOrientationIndependent].height YPOS:YPOS];
     
     [leftMenuView addSubview:self.nowPlayingController.view];
 
@@ -729,8 +729,7 @@
 }
 
 - (void)viewWillLayoutSubviews{
-    UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
-    [self.nowPlayingController setToolbarWidth:[self currentScreenBoundsDependOnOrientation].size.width height:[self currentScreenBoundsDependOnOrientation].size.height YPOS:YPOS portrait:(orientation == UIInterfaceOrientationPortrait || orientation == UIInterfaceOrientationPortraitUpsideDown)];
+    [self.nowPlayingController setNowPlayingDimension:[self currentScreenBoundsDependOnOrientation].size.width height:[self currentScreenBoundsDependOnOrientation].size.height YPOS:YPOS];
 }
 
 -(void) willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration{


### PR DESCRIPTION
In `NowPlaying` screen a variety of hardcoded magic numbers was used during layout of the views. Most of them are now either removed (as not needed at all), replaced with calculations based on other view´s dimensions or -- where needed -- replaced by defines. While on it I also found some unused code and removed it, as well as refactored some code where appropriate.
As an optimization/feature the new code uses bigger fonts for newer iPads with higher resolution. Also, the NowPlaying´s view height is now derived from the maximum possible height in Landscape mode. This avoids some space/visibility issues in Portrait mode on newer iPads which were before worked around via hardcoded offsets.

Summary:
- Removing magic numbers
- Refactored code
- Removed unneeded variables, code and defines
- Bigger fonts for newer iPads with high resolution
- Changed logic for NowPlaying view´s available height on iPad
- Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/159