### PR TITLE
Feature: Enable Video Playlists support

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1647,7 +1647,7 @@ NSMutableArray *hostRightMenuItems;
                       
                       [NSArray arrayWithObjects:@"Files.GetDirectory", @"method", nil],
                       
-//                      [NSArray arrayWithObjects:@"Files.GetDirectory", @"method",nil],
+                      [NSArray arrayWithObjects:@"Files.GetDirectory", @"method", nil],
                       
                       nil];
     
@@ -1815,25 +1815,25 @@ NSMutableArray *hostRightMenuItems;
                             nil], @"itemSizes",
                            nil],
                           
-//                          [NSMutableArray arrayWithObjects:
-//                           [NSMutableDictionary dictionaryWithObjectsAndKeys:
-//                            [NSMutableDictionary dictionaryWithObjectsAndKeys:
-//                             @"ascending",@"order",
-//                             [NSNumber numberWithBool:FALSE],@"ignorearticle",
-//                             @"label", @"method",
-//                             nil],@"sort",
-//                            @"video", @"media",
-//                            @"special://profile/playlists/video", @"directory",
-//                            [NSArray arrayWithObjects:@"thumbnail", @"file", nil], @"properties",
-//                            [NSArray arrayWithObjects:@"thumbnail", @"file", nil], @"file_properties",
-//                            nil], @"parameters",
-//                           NSLocalizedString(@"Video Playlists", nil), @"label",
-//                           NSLocalizedString(@"Video Playlists", nil), @"morelabel",
-//                           @"nocover_filemode.png", @"defaultThumb",
-//                           filemodeRowHeight, @"rowHeight",
-//                           filemodeThumbWidth, @"thumbWidth",
-//                           @"YES", @"isMusicPlaylist",
-//                           nil],
+                          [NSMutableArray arrayWithObjects:
+                           [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                            [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                             @"ascending", @"order",
+                             [NSNumber numberWithBool:FALSE],@"ignorearticle",
+                             @"label", @"method",
+                             nil], @"sort",
+                            @"video", @"media",
+                            @"special://videoplaylists", @"directory",
+                            [NSArray arrayWithObjects:@"thumbnail", @"file", nil], @"properties",
+                            [NSArray arrayWithObjects:@"thumbnail", @"file", nil], @"file_properties",
+                            nil], @"parameters",
+                           NSLocalizedString(@"Video Playlists", nil), @"label",
+                           NSLocalizedString(@"Video Playlists", nil), @"morelabel",
+                           @"nocover_filemode.png", @"defaultThumb",
+                           filemodeRowHeight, @"rowHeight",
+                           filemodeThumbWidth, @"thumbWidth",
+                           @"YES", @"isMusicPlaylist",
+                           nil],
                           
                           nil];
     

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1832,7 +1832,7 @@ NSMutableArray *hostRightMenuItems;
                            @"nocover_filemode.png", @"defaultThumb",
                            filemodeRowHeight, @"rowHeight",
                            filemodeThumbWidth, @"thumbWidth",
-                           @"YES", @"isMusicPlaylist",
+                           @"YES", @"isVideoPlaylist",
                            nil],
                           
                           nil];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1237,7 +1237,7 @@
             NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
             [userDefaults synchronize];
             if ([[userDefaults objectForKey:@"song_preference"] boolValue] == NO || [[parameters objectForKey:@"forceActionSheet"] boolValue] == YES) {
-                sheetActions = [self checkMusicPlaylists:sheetActions item:item params:[self indexKeyedMutableDictionaryFromArray:[[MenuItem mainParameters] objectAtIndex:choosedTab]]];
+                sheetActions = [self getPlaylistActions:sheetActions item:item params:[self indexKeyedMutableDictionaryFromArray:[[MenuItem mainParameters] objectAtIndex:choosedTab]]];
                 selected=indexPath;
                 [self showActionSheet:indexPath sheetActions:sheetActions item:item rectOriginX:rectOriginX rectOriginY:rectOriginY];
             }
@@ -1248,8 +1248,9 @@
     }
 }
 
--(NSMutableArray *)checkMusicPlaylists:(NSMutableArray *)sheetActions item:(NSDictionary *)item params:(NSMutableDictionary *)parameters{
-    if ([[parameters objectForKey:@"isMusicPlaylist"] boolValue] == YES){ // NOTE: sheetActions objects must be moved outside from there
+-(NSMutableArray *)getPlaylistActions:(NSMutableArray *)sheetActions item:(NSDictionary *)item params:(NSMutableDictionary *)parameters{
+    if ([[parameters objectForKey:@"isMusicPlaylist"] boolValue] ||
+        [[parameters objectForKey:@"isVideoPlaylist"] boolValue]){ // NOTE: sheetActions objects must be moved outside from there
         if ([sheetActions isKindOfClass:[NSMutableArray class]]){
             [sheetActions removeAllObjects];
             [sheetActions addObject:NSLocalizedString(@"Queue after current", nil)];
@@ -3006,7 +3007,7 @@ NSIndexPath *selected;
                     }
                     item = [[self.sections valueForKey:[self.sectionArray objectAtIndex:indexPath.section]] objectAtIndex:indexPath.row];
                 }
-                 sheetActions = [self checkMusicPlaylists:sheetActions item:item params:[self indexKeyedMutableDictionaryFromArray:[[self.detailItem mainParameters] objectAtIndex:choosedTab]]];
+                 sheetActions = [self getPlaylistActions:sheetActions item:item params:[self indexKeyedMutableDictionaryFromArray:[[self.detailItem mainParameters] objectAtIndex:choosedTab]]];
 //                if ([[item objectForKey:@"filetype"] isEqualToString:@"directory"]) { // DOESN'T WORK AT THE MOMENT IN XBMC?????
 //                    return;
 //                }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3709,12 +3709,16 @@ NSIndexPath *selected;
     if ([parameters objectForKey:@"thumbWidth"] != nil){
         filemodeThumbWidth = [parameters objectForKey:@"thumbWidth"];
     }
+    NSMutableArray *mutableProperties = [parameters[@"parameters"][@"file_properties"] mutableCopy];
+    if ([[parameters objectForKey:@"FrodoExtraArt"] boolValue] && [AppDelegate instance].serverVersion > 11){
+        [mutableProperties addObject:@"art"];
+    }
     NSMutableArray *newParameters=[NSMutableArray arrayWithObjects:
                                    [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                     [item objectForKey:[mainFields objectForKey:@"row6"]],@"directory",
                                     [[parameters objectForKey:@"parameters"] objectForKey:@"media"], @"media",
                                     [[parameters objectForKey:@"parameters"] objectForKey:@"sort"],@"sort",
-                                    [[parameters objectForKey:@"parameters"] objectForKey:@"file_properties"], @"file_properties",
+                                    mutableProperties, @"file_properties",
                                     nil], @"parameters",
                                    libraryRowHeight, @"rowHeight", libraryThumbWidth, @"thumbWidth",
                                    [parameters objectForKey:@"label"], @"label", @"nocover_filemode.png", @"defaultThumb", filemodeRowHeight, @"rowHeight", filemodeThumbWidth, @"thumbWidth",

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -49,7 +49,7 @@
 "Recently played songs" = "Kürzlich gespielte Lieder";
 "All songs" = "Alle Lieder";
 "Music Add-ons" = "Musik Add-ons";
-"Music Playlists" = "Musik Wiedergabeliste";
+"Music Playlists" = "Musik Wiedergabelisten";
 "Video Playlists" = "Video Wiedergabelisten";
 "Music Roles" = "Musikrollen";
 

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -50,6 +50,7 @@
 "All songs" = "Alle Lieder";
 "Music Add-ons" = "Musik Add-ons";
 "Music Playlists" = "Musik Wiedergabeliste";
+"Video Playlists" = "Video Wiedergabelisten";
 "Music Roles" = "Musikrollen";
 
 "Added Episodes" = "Hinzugefügte Episoden";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -50,6 +50,7 @@
 "Music Add-ons" = "Music Add-ons";
 "Music Playlists" = "Music Playlists";
 "Video Playlists" = "Video Playlists";
+"Music Roles" = "Music Roles";
 
 "Added Episodes" = "Added Episodes";
 

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -49,6 +49,7 @@
 "All songs" = "All songs";
 "Music Add-ons" = "Music Add-ons";
 "Music Playlists" = "Music Playlists";
+"Video Playlists" = "Video Playlists";
 
 "Added Episodes" = "Added Episodes";
 


### PR DESCRIPTION
Feature request was reported as bug in [forum thread](https://forum.kodi.tv/showthread.php?tid=360386).

Most of the code was prepared but still commented. With this PR a new UI entry "Movie Playlists" is added to the "More ..." screen of the Video main menu. The functionality via action sheets is the same as for Music Playlists (for now). Also "art" is used to show the expected thumbs with Kodi 19 and later.