### PR TITLE
Feature: Enable sorting for PVR recordings/timers

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -95,6 +95,9 @@
 @property (nonatomic, assign) int serverMinorVersion;
 @property (nonatomic, assign) int serverVolume;
 @property (retain, nonatomic) NSString *serverName;
+@property (nonatomic, assign) int APImajorVersion;
+@property (nonatomic, assign) int APIminorVersion;
+@property (nonatomic, assign) int APIpatchVersion;
 @property (nonatomic, retain) GlobalData *obj;
 
 @end

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -2981,7 +2981,15 @@ NSMutableArray *hostRightMenuItems;
 
                           [NSMutableArray arrayWithObjects:
                            [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                            [[NSArray alloc] initWithObjects:@"title", @"starttime", @"endtime", @"plot", @"plotoutline", @"genre", @"playcount",@"resume", @"channel",  @"runtime",@"lifetime", @"icon", @"art", @"streamurl", @"file", @"directory", nil], @"properties",
+                            [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                              @"ascending",@"order",
+                              @"label", @"method",
+                             [NSDictionary dictionaryWithObjectsAndKeys:
+                              [NSMutableArray arrayWithObjects:NSLocalizedString(@"Title", nil), NSLocalizedString(@"Channel", nil), NSLocalizedString(@"Date", nil), NSLocalizedString(@"Runtime", nil), nil], @"label",
+                              [NSArray arrayWithObjects:@"label", @"channel", @"starttime", @"runtime", nil], @"method",
+                              nil], @"available_methods",
+                              nil],@"sort",
+                            [[NSArray alloc] initWithObjects:@"title",@"starttime", @"endtime", @"plot", @"plotoutline", @"genre", @"playcount",@"resume", @"channel",  @"runtime",@"lifetime", @"icon", @"art", @"streamurl", @"file", @"directory", nil], @"properties",
                             nil], @"parameters",
                            [NSDictionary dictionaryWithObjectsAndKeys:
                             [[NSArray alloc] initWithObjects:@"title", @"starttime", @"endtime", @"plot", @"plotoutline", @"genre", @"playcount",@"resume", @"channel",  @"runtime",@"lifetime", @"icon", @"art", @"streamurl", @"file", @"directory", nil], @"properties",
@@ -3001,6 +3009,14 @@ NSMutableArray *hostRightMenuItems;
                           
                           [NSMutableArray arrayWithObjects:
                            [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                            [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                              @"ascending",@"order",
+                              @"label", @"method",
+                            [NSDictionary dictionaryWithObjectsAndKeys:
+                             [NSMutableArray arrayWithObjects:NSLocalizedString(@"Title", nil), NSLocalizedString(@"Channel", nil), NSLocalizedString(@"Date", nil), NSLocalizedString(@"Runtime", nil), nil], @"label",
+                             [NSArray arrayWithObjects:@"label", @"channel", @"starttime", @"runtime", nil], @"method",
+                             nil], @"available_methods",
+                              nil],@"sort",
                             [[NSArray alloc] initWithObjects:@"title", @"summary", @"channelid", @"isradio", @"starttime", @"endtime", @"runtime", @"lifetime", @"firstday",@"weekdays", @"priority", @"startmargin", @"endmargin", @"state", @"file", @"directory", nil], @"properties",
                             nil], @"parameters",
                            [NSDictionary dictionaryWithObjectsAndKeys:

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4540,6 +4540,15 @@ NSIndexPath *selected;
     if ([self loadedDataFromDisk:methodToCall parameters:(sectionParameters == nil) ? mutableParameters : [NSMutableDictionary dictionaryWithDictionary:sectionParameters] refresh:forceRefresh] == YES){
         return;
     }
+    
+    // "sort" in "PVR." methods is only allowed from JSON API 12.1 on, for lower version remove "sort"
+    if ([methodToCall containsString:@"PVR."]) {
+        if (([AppDelegate instance].APImajorVersion < 12) ||
+           (([AppDelegate instance].APImajorVersion == 12) && ([AppDelegate instance].APIminorVersion < 1))) {
+            // remove "sort" from setup
+            [mutableParameters removeObjectForKey:@"sort"];
+        }
+    }
 
     GlobalData *obj=[GlobalData getInstance];
     [self alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5051,11 +5051,11 @@ NSIndexPath *selected;
     else if ([sortMethod isEqualToString:@"rating"]) {
         currentValue = [@(round([currentValue doubleValue])) stringValue];
     }
-    else if ([sortMethod isEqualToString:@"dateadded"] && ![currentValue isEqualToString:@"(null)"]) {
+    else if (([sortMethod isEqualToString:@"dateadded"] || [sortMethod isEqualToString:@"starttime"]) && ![currentValue isEqualToString:@"(null)"]) {
         NSDateComponents *components = [[NSCalendar currentCalendar] components: NSCalendarUnitYear fromDate:[xbmcDateFormatter dateFromString:[NSString stringWithFormat:@"%@ UTC", currentValue]]];
         currentValue = [NSString stringWithFormat:@"%ld", (long)[components year]];
     }
-    else if (([sortMethod isEqualToString:@"label"]  || [sortMethod isEqualToString:@"genre"] || [sortMethod isEqualToString:@"album"]) && [currentValue length]) {
+    else if (([sortMethod isEqualToString:@"label"]  || [sortMethod isEqualToString:@"genre"] || [sortMethod isEqualToString:@"album"] || [sortMethod isEqualToString:@"channel"]) && [currentValue length]) {
         NSCharacterSet * set = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLKMNOPQRSTUVWXYZ"] invertedSet];
         NSCharacterSet * numberset = [[NSCharacterSet characterSetWithCharactersInString:@"0123456789"] invertedSet];
         NSString *c = @"/";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -351,3 +351,7 @@
 "Pull to refresh..." = "Runterziehen zur Aktualisierung...";
 
 "For search switch to list view" = "Zur Suche in Listenansicht wechseln";
+
+"Channel" = "TV Sender";
+"Date" = "Datum";
+"Runtime" = "Laufzeit";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -339,3 +339,7 @@
 "Add window activation button" = "Add window activation button";
 
 "For search switch to list view" = "For search switch to list view";
+
+"Channel" = "TV Station";
+"Date" = "Date";
+"Runtime" = "Runtime";

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -232,6 +232,18 @@ NSOutputStream	*outStream;
              [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
          }
      }];
+    // Read the JSON API version
+    [jsonRPC
+     callMethod:@"JSONRPC.Version"
+     withParameters:nil
+     withTimeout: SERVER_TIMEOUT
+     onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
+         if (!error && !methodError) {
+             [AppDelegate instance].APImajorVersion = [methodResult[@"version"][@"major"] intValue];
+             [AppDelegate instance].APIminorVersion = [methodResult[@"version"][@"minor"] intValue];
+             [AppDelegate instance].APIpatchVersion = [methodResult[@"version"][@"patch"] intValue];
+         }
+    }];
     jsonRPC=nil;
 }
 


### PR DESCRIPTION
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/134.

After a quite some journey through the code and many hints from the community, here is the "sort for PVR recording/timer" feature. In fact, I was initially of the opinion that the Remote App does not sort itself and only displays the items in the order coming from the JSON response. But this is not true. The App requests the items only once with a default sort method/order and in addition collects metadata which can be used for sorting. But: the selectable sorting methods are mingled together with the sort methods in the App -- the logic was a bit obscured.

For the PVR sorting the App now sends a default sort request (sort by label, ascending). This is not sent in case the API does not support this yet. Independent (!) of this the UI now offers the sort options for Title, Channel, Date and Runtime -- meaning: this feature also works for older Kodi versions.

To avoid that the index is taking up to much space it is limited to 10 characters, which allows to display the full date in the format "YYYY-MM-DD".