### PR TITLE
More fixes for 1.6 issues (crashes)

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2015,7 +2015,7 @@ int currentItemID;
         NSIndexPath *indexPath = [playlistTableView indexPathForRowAtPoint:p];
         if (indexPath != nil){
             [sheetActions removeAllObjects];
-            NSDictionary *item = [playlistData objectAtIndex:indexPath.row];
+            NSDictionary *item = ([playlistData count]>indexPath.row) ? playlistData[indexPath.row] : nil;
             selected = indexPath;
             CGPoint selectedPoint = [gestureRecognizer locationInView:self.view];
             if ([[item objectForKey:@"albumid"] intValue]>0){
@@ -2275,7 +2275,7 @@ int currentItemID;
         [(UILabel*) [cell viewWithTag:2] setTextColor:[Utilities get2ndLabelColor]];
         [(UILabel*) [cell viewWithTag:3] setTextColor:[Utilities get2ndLabelColor]];
     }
-    NSDictionary *item = [playlistData objectAtIndex:indexPath.row];
+    NSDictionary *item = ([playlistData count]>indexPath.row) ? playlistData[indexPath.row] : nil;
     UIImageView *thumb = (UIImageView*) [cell viewWithTag:4];
     
     UILabel *mainLabel = (UILabel*) [cell viewWithTag:1];


### PR DESCRIPTION
Details:
- Fixes one of crashes from https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/161: out-of-bounds crash in `cellForRowAtIndexPath`
