### PR TITLE
Fix longpress on filtered list for iPad

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3043,7 +3043,8 @@ NSIndexPath *selected;
                     [action showInView:self.view];
                 }
                 else{
-                   [action showFromRect:CGRectMake(selectedPoint.x, selectedPoint.y, 1, 1) inView:[self.view superview] animated:YES];
+                    selectedPoint = [lpgr locationInView:[self.view superview]];
+                    [action showFromRect:CGRectMake(selectedPoint.x, selectedPoint.y, 1, 1) inView:[self.view superview] animated:YES];
                 }
             }
         }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2997,7 +2997,6 @@ NSIndexPath *selected;
             if (numActions){
                 NSDictionary *item = nil;
                 if ([self doesShowSearchResults]){
-                    selectedPoint=[longPressGesture locationInView:self.view];
                     item = [self.filteredListContent objectAtIndex:indexPath2.row];
                     [dataList selectRowAtIndexPath:indexPath2 animated:NO scrollPosition:UITableViewScrollPositionNone];
                 }
@@ -3044,7 +3043,7 @@ NSIndexPath *selected;
                     [action showInView:self.view];
                 }
                 else{
-                   [action showFromRect:CGRectMake(selectedPoint.x, selectedPoint.y, 1, 1) inView:self.view animated:YES];
+                   [action showFromRect:CGRectMake(selectedPoint.x, selectedPoint.y, 1, 1) inView:[self.view superview] animated:YES];
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/170

Details:
- iPad behaves different than iPhone
- For iPad the action sheet after longpress on a filtered list must be shown from `[self.view superview]`

Need some guidance if the right way to fix this...