### PR TITLE
Fix overlay position for DetailView in NowPlaying screen

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -399,13 +399,13 @@ int currentItemID;
         thumbnailView.frame = [Utilities createCoverInsideJewel:jewelView jewelType:jeweltype];
         [nowPlayingView bringSubviewToFront:jewelView];
         thumbnailView.hidden = NO;
-        songDetailsView.frame = thumbnailView.frame;
     }
     else {
         [nowPlayingView sendSubviewToBack:jewelView];
         thumbnailView.hidden = YES;
-        songDetailsView.frame = jewelView.frame;
     }
+    songDetailsView.frame = jewelView.frame;
+    [nowPlayingView addSubview:songDetailsView];
     [nowPlayingView sendSubviewToBack:xbmcOverlayImage];
 }
 


### PR DESCRIPTION
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/171 (newly reported overlay problem).

The view for detailed infos was not set as subview of the NowPlaying screen and was in consequence displaced on iPads. I corrected this and decided to use the same frame dimension as for the "jewel" frame. This results in a frame which always uses the full width of the NowPlaying screen and might be larger than the underlying thumb. I feel this way we make best use of the available space, especially when there is a lot of details available to display. Screenshots:

https://abload.de/img/simulatorscreenshot-i5hkvk.png
https://abload.de/img/simulatorscreenshot-ik4k6h.png
https://abload.de/img/simulatorscreenshot-icojls.png
https://abload.de/img/simulatorscreenshot-il2kea.png
https://abload.de/img/simulatorscreenshot-io1j8o.png
https://abload.de/img/simulatorscreenshot-iymkf1.png
https://abload.de/img/simulatorscreenshot-ikkj16.png
https://abload.de/img/simulatorscreenshot-i3mjji.png
https://abload.de/img/simulatorscreenshot-iswkl7.png
https://abload.de/img/simulatorscreenshot-i06jhb.png