### PR TITLE
Fix index width & position for grid view

### DIFF
--- a/XBMC Remote/BDKCollectionIndexView/BDKCollectionIndexView.m
+++ b/XBMC Remote/BDKCollectionIndexView/BDKCollectionIndexView.m
@@ -163,7 +163,7 @@
             UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
             label.text = indexTitle;
             label.font = [UIFont boldSystemFontOfSize:11];
-            label.minimumScaleFactor = 5.0/11.0;
+            label.minimumScaleFactor = 11.0/11.0;
             label.adjustsFontSizeToFitWidth = YES;
             label.backgroundColor = [UIColor clearColor];
             label.textColor = [UIColor systemBlueColor];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1583,11 +1583,8 @@
 
 - (BDKCollectionIndexView *)indexView {
     if (_indexView) return _indexView;
-    CGFloat indexWidth = 26;
-    if ( [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){
-        indexWidth = 32;
-    }
-    CGRect frame = CGRectMake(CGRectGetWidth(dataList.frame) - indexWidth + 2,
+    CGFloat indexWidth = 40;
+    CGRect frame = CGRectMake(CGRectGetWidth(dataList.frame) - indexWidth,
                               CGRectGetMinY(dataList.frame) + dataList.contentInset.top + COLLECTION_HEADER_HEIGHT + 2,
                               indexWidth,
                               CGRectGetHeight(dataList.frame) - dataList.contentInset.top - dataList.contentInset.bottom - 4 -COLLECTION_HEADER_HEIGHT - bottomPadding);


### PR DESCRIPTION
- In grid view (CollectionView) the width was too small to display the possible index text.
- The required width is same for iPad and iPhone.
- Take care the index is fully visible in the frame.