### PR TITLE
Fix position of jewelview when jewel case is disabled

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -826,11 +826,11 @@ int h=0;
         CGFloat transform = [Utilities getTransformX];
         thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
         tvshowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
-        if (!enableJewel) {
-            CGRect frame = jewelView.frame;
-            frame.origin.x = frame.origin.x + 4;
-            jewelView.frame = frame;
-        }
+    }
+    if (!enableJewel) {
+        CGRect frame = jewelView.frame;
+        frame.origin.x = 0;
+        jewelView.frame = frame;
     }
     if ([[item objectForKey:@"family"] isEqualToString:@"episodeid"] || [[item objectForKey:@"family"] isEqualToString:@"tvshowid"]){
         int deltaY=0;


### PR DESCRIPTION
Minor UI fix. The position of the season´s coverView (depends on the jewelView) was a bit too far left when "Show jewel case" is disabled.

<a href="https://abload.de/image.php?img=bildschirmfoto2021-02i0jia.png"><img src="https://abload.de/img/bildschirmfoto2021-02i0jia.png" /></a>