### PR TITLE
Fix shuffle/repeat in overlays not working for iPads

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -405,7 +405,7 @@ int currentItemID;
         thumbnailView.hidden = YES;
     }
     songDetailsView.frame = jewelView.frame;
-    [nowPlayingView addSubview:songDetailsView];
+    songDetailsView.center = [jewelView.superview convertPoint:jewelView.center toView:songDetailsView.superview];
     [nowPlayingView sendSubviewToBack:xbmcOverlayImage];
 }
 


### PR DESCRIPTION
Fixes issue reported in [forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3017071#pid3017071).

Details:
- Instead of adding the overlay view to NowPlaying view as subview we only convert the desired center position