### PR TITLE
More robust handling of empty channel groups in Live TV

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4545,6 +4545,10 @@ NSIndexPath *selected;
             // remove "sort" from setup
             [mutableParameters removeObjectForKey:@"sort"];
         }
+        else if ([mutableParameters[@"channelgroupid"] intValue] == -1) {
+            [self showNoResultsFound:resultStoreArray refresh:forceRefresh];
+            return;
+        }
     }
 
     GlobalData *obj=[GlobalData getInstance];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5163,11 +5163,17 @@ NSIndexPath *selected;
 }
 
 -(void)updateChannelListTableCell {
-    [dataList beginUpdates];
-    [dataList reloadRowsAtIndexPaths:[dataList indexPathsForVisibleRows] withRowAnimation:UITableViewRowAnimationNone];
-    [dataList endUpdates];
+    NSArray* indexPaths = [dataList indexPathsForVisibleRows];
+    if ([dataList numberOfSections]>0 && [indexPaths count]>0) {
+        [dataList beginUpdates];
+        [dataList reloadRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationNone];
+        [dataList endUpdates];
+    }
 
-    [collectionView reloadItemsAtIndexPaths:[collectionView indexPathsForVisibleItems]];
+    indexPaths = [collectionView indexPathsForVisibleItems];
+    if ([collectionView numberOfSections]>0 && [indexPaths count]>0) {
+        [collectionView reloadItemsAtIndexPaths:indexPaths];
+    }
 }
 
 -(NSComparisonResult)alphaNumericCompare:(id)firstObject secondObject:(id)secondObject{


### PR DESCRIPTION
Possibly fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/161.

Changes:
1. When requesting the channel list for an empty channel group (`channelgroupid` == -1) Kodi server reacts with an error. The updated implementation now does not request the channel list in this case and simply shows "No results found".
2. The last non-fixed crash reported in https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/161 is reproducible when entering the situation described above (`channelgroupid` == -1). I added a potential fix for this in the 2nd commit.
