### PR TITLE
Use same icon for power menu on iPad and iPhone

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -475,7 +475,7 @@ static inline BOOL IsEmpty(id obj) {
         self.navigationItem.titleView = xbmcLogo;
         UIImage* menuImg = [UIImage imageNamed:@"button_menu.png"];
         self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:menuImg style:UIBarButtonItemStylePlain target:nil action:@selector(revealMenu:)];
-        UIImage* settingsImg = [UIImage imageNamed:@"button_settings.png"];
+        UIImage* settingsImg = [UIImage imageNamed:@"icon_power_up.png"];
         self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithImage:settingsImg style:UIBarButtonItemStylePlain target:nil action:@selector(revealUnderRight:)];
     }
     doRevealMenu = YES;


### PR DESCRIPTION
Have consistent UI icons for both iPad and iPhone. With this change on iPhones (as already for iPads) you reach the "Power Action Menu" via the same icon (upper right side on the screen shot).

<a href="https://abload.de/image.php?img=simulatorscreenshot-ixbkay.png"><img src="https://abload.de/img/simulatorscreenshot-ixbkay.png" /></a>