### PR TITLE
Fix sort-by-playcount for few music album cases

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -643,7 +643,7 @@ NSMutableArray *hostRightMenuItems;
                        @"albumid",@"row6",
                        [NSNumber numberWithInt:0], @"playlistid",
                        @"albumid",@"row8",
-                       @"albumid", @"row9",
+                       @"playcount", @"row9",
                        @"artist", @"row10",
                        @"genre",@"row11",
                        @"description",@"row12",

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -463,6 +463,11 @@ NSMutableArray *hostRightMenuItems;
                             nil], @"parameters", NSLocalizedString(@"All songs", nil), @"label", NSLocalizedString(@"All songs", nil), @"morelabel",
                            @"YES", @"enableLibraryCache",
                            [NSNumber numberWithInt:5], @"numberOfStars",
+                           [NSDictionary dictionaryWithObjectsAndKeys:
+                            NSLocalizedString(@"Not listened", nil), @"notWatched",
+                            NSLocalizedString(@"Listened one time", nil), @"watchedOneTime",
+                            NSLocalizedString(@"Listened %@ times", nil), @"watchedTimes",
+                            nil], @"watchedListenedStrings",
                            nil],
                           
                           [NSMutableArray arrayWithObjects:
@@ -937,7 +942,7 @@ NSMutableArray *hostRightMenuItems;
                                       [NSArray arrayWithObjects:@"label", @"genre", @"year", @"playcount", nil], @"method",
                                       nil], @"available_methods",
                                      nil],@"sort",
-                                    [NSArray arrayWithObjects:@"year", @"thumbnail", @"artist",  nil], @"properties",
+                                    [NSArray arrayWithObjects:@"year", @"thumbnail", @"artist", @"playcount", nil], @"properties",
                                     nil],  @"parameters", @"Albums", @"label", @"Album", @"wikitype",
                                    [NSDictionary dictionaryWithObjectsAndKeys:
                                     [NSArray arrayWithObjects:@"year", @"thumbnail", @"artist", @"genre", @"description", @"albumlabel", @"fanart",
@@ -1114,7 +1119,7 @@ NSMutableArray *hostRightMenuItems;
                                @"albumid",@"row6",
                                [NSNumber numberWithInt:0], @"playlistid",
                                @"albumid",@"row8",
-                               @"albumid", @"row9",
+                               @"playcount", @"row9",
                                @"artist", @"row10",
                                @"genre",@"row11",
                                @"description",@"row12",

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -368,7 +368,7 @@ NSMutableArray *hostRightMenuItems;
                              [NSNumber numberWithBool:FALSE],@"ignorearticle",
                              @"playcount", @"method",
                              [NSDictionary dictionaryWithObjectsAndKeys:
-                              [NSMutableArray arrayWithObjects:NSLocalizedString(@"Play count", nil), NSLocalizedString(@"Album", nil), NSLocalizedString(@"Artist", nil), NSLocalizedString(@"Year", nil), nil], @"label",
+                              [NSMutableArray arrayWithObjects:NSLocalizedString(@"Top 100 Albums", nil), NSLocalizedString(@"Album", nil), NSLocalizedString(@"Artist", nil), NSLocalizedString(@"Year", nil), nil], @"label",
                               [NSArray arrayWithObjects:@"playcount", @"label", @"genre", @"year", nil], @"method",
                               nil], @"available_methods",
                              nil],@"sort",
@@ -401,7 +401,7 @@ NSMutableArray *hostRightMenuItems;
                              [NSNumber numberWithBool:FALSE],@"ignorearticle",
                              @"playcount", @"method",
                              [NSDictionary dictionaryWithObjectsAndKeys:
-                              [NSMutableArray arrayWithObjects:NSLocalizedString(@"Play count", nil), NSLocalizedString(@"Track", nil),NSLocalizedString(@"Title", nil), NSLocalizedString(@"Album", nil), NSLocalizedString(@"Artist", nil), NSLocalizedString(@"Rating", nil), NSLocalizedString(@"Year", nil), nil], @"label",
+                              [NSMutableArray arrayWithObjects:NSLocalizedString(@"Top 100 Songs", nil), NSLocalizedString(@"Track", nil),NSLocalizedString(@"Title", nil), NSLocalizedString(@"Album", nil), NSLocalizedString(@"Artist", nil), NSLocalizedString(@"Rating", nil), NSLocalizedString(@"Year", nil), nil], @"label",
                               [NSArray arrayWithObjects:@"playcount", @"track", @"label", @"album", @"genre", @"rating", @"year", nil], @"method",
                               nil], @"available_methods",
                              nil],@"sort",
@@ -643,7 +643,7 @@ NSMutableArray *hostRightMenuItems;
                        @"albumid",@"row6",
                        [NSNumber numberWithInt:0], @"playlistid",
                        @"albumid",@"row8",
-                       @"playcount", @"row9",
+                       @"albumid", @"row9",
                        @"artist", @"row10",
                        @"genre",@"row11",
                        @"description",@"row12",

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5027,7 +5027,7 @@ NSIndexPath *selected;
         [NSThread detachNewThreadSelector:@selector(backgroundSaveEPGToDisk:) toTarget:self withObject:epgparams];
     }
     else {
-        NSString *defaultSortMethod = [[[parameters objectForKey:@"parameters"] objectForKey:@"sort"] objectForKey:@"method"];
+        NSString *defaultSortMethod = parameters[@"parameters"][@"sort"][@"method"];
         if (sortMethodName != nil && ![sortMethodName isEqualToString:defaultSortMethod]) {
             NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:sortMethodName ascending:sortAscending];
             NSArray *sortDescriptors = [NSArray arrayWithObject:sortDescriptor];
@@ -5054,7 +5054,8 @@ NSIndexPath *selected;
             }
         }
         else {
-            if ([sortAscDesc isEqualToString:@"descending"]) {
+            NSString *defaultSortOrder = parameters[@"parameters"][@"sort"][@"order"];
+            if (![sortAscDesc isEqualToString:defaultSortOrder]) {
                 NSString *methodSort = (sortMethodName == nil) ?  @"label" : sortMethodName;
                 NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:methodSort ascending:sortAscending];
                 NSArray *sortDescriptors = [NSArray arrayWithObject:sortDescriptor];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1083,7 +1083,7 @@
                                        [parameters objectForKey:@"extra_info_parameters"], @"extra_info_parameters",
                                        newSectionParameters, @"extra_section_parameters",
                                        [NSString stringWithFormat:@"%@", [parameters objectForKey:@"defaultThumb"]], @"defaultThumb",
-                                       [parameters objectForKey:@"combinedFilter"], @"combinedFilter",
+                                       [parameters objectForKey:@"watchedListenedStrings"], @"watchedListenedStrings",
                                        nil];
         [[MenuItem.subItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
         MenuItem.subItem.chooseTab=choosedTab;


### PR DESCRIPTION
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/192.

Details:

A) Fixes sorting by playcount for albums in several use cases:
1. Sorting (by playcount) itself now works ins this case, and it is possible to change the sort order.
2. The sections now display the correct tet ("listened" instead of "watched").

B) Allow changing sort order (for sorting by playcount) for Top100 Albums and Top100 Songs. 
Question: Was this intended behaviour? When sorting for playcount the Top100 lists do not show sections or the playcount. Therefor it is not easy to recognize how the display list is sorted, even though the sort-indicator indicates this. Do we want to change the behaviour for consistency (like done with this PR), or shall this keep unchanged?