### PR TITLE
Enable fullscreen for music albums and artists

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -255,6 +255,7 @@ NSMutableArray *hostRightMenuItems;
                             nil], @"extra_info_parameters",
                            @"YES", @"enableCollectionView",
                            @"YES", @"enableLibraryCache",
+                           @"YES", @"enableLibraryFullScreen",
                            [NSDictionary dictionaryWithObjectsAndKeys:
                             NSLocalizedString(@"Not listened", nil), @"notWatched",
                             NSLocalizedString(@"Listened one time", nil), @"watchedOneTime",
@@ -288,6 +289,7 @@ NSMutableArray *hostRightMenuItems;
                             nil], @"extra_info_parameters",
                            @"YES", @"enableCollectionView",
                            @"YES", @"enableLibraryCache",
+                           @"YES", @"enableLibraryFullScreen",
                            [NSDictionary dictionaryWithObjectsAndKeys:
                             [NSDictionary dictionaryWithObjectsAndKeys:
                              [NSNumber numberWithFloat:itemMusicWidthIphone], @"width",


### PR DESCRIPTION
With this PR the fullscreen option for music albums and artists is enabled. 

Screenshots:
https://abload.de/img/simulatorscreenshot-i60jn1.png
https://abload.de/img/simulatorscreenshot-ii3jxg.png
https://abload.de/img/simulatorscreenshot-iqajlt.png
https://abload.de/img/simulatorscreenshot-i8wjms.png