### PR TITLE
Optimize background color for TV station logos

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -510,9 +510,9 @@
     UIImage *image = imageview.image;
     Utilities *utils = [[Utilities alloc] init];
     UIColor *imgcolor = [utils averageColor:image inverse:NO];
-    UIColor *bglight = [Utilities getGrayColor:28 alpha:1.0];
-    UIColor *bgdark = [Utilities getGrayColor:242 alpha:1.0];
-    UIColor *bgcolor = [utils updateColor:imgcolor lightColor:bglight darkColor:bgdark trigger:0.3];
+    UIColor *bglight = [Utilities getGrayColor:242 alpha:1.0];
+    UIColor *bgdark = [Utilities getGrayColor:28 alpha:1.0];
+    UIColor *bgcolor = [utils updateColor:imgcolor lightColor:bglight darkColor:bgdark trigger:0.4];
     [imageview setBackgroundColor:bgcolor];
 }
 


### PR DESCRIPTION
Implement a better way of calculating the average color and brightness for images with alpha channels. This should fix reports that some dark TV station logos are still drawn on top of dark background ([forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3022986#pid3022986)).

Details:
- Use different methods for images with and without alpha channel
- For images with alpha channel apply higher weighting for non-transparent colors

Now tested with two logo sets provided by a Kodi user.
Set A (monochrome, mainly dark logos):
https://abload.de/img/simulatorscreenshot-i1xjr2.png (before)
https://abload.de/img/simulatorscreenshot-iznjd6.png (with)

Set B (monochrome and color, mainly bright logos):
https://abload.de/img/simulatorscreenshot-idmko8.png (before)
https://abload.de/img/simulatorscreenshot-i6bke4.png (after)