### PR TITLE
Do not fall back to sort-by-label when sort order is nil

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5055,7 +5055,7 @@ NSIndexPath *selected;
         }
         else {
             NSString *defaultSortOrder = parameters[@"parameters"][@"sort"][@"order"];
-            if (![sortAscDesc isEqualToString:defaultSortOrder]) {
+            if (sortAscDesc!=nil && ![sortAscDesc isEqualToString:defaultSortOrder]) {
                 NSString *methodSort = (sortMethodName == nil) ?  @"label" : sortMethodName;
                 NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:methodSort ascending:sortAscending];
                 NSArray *sortDescriptors = [NSArray arrayWithObject:sortDescriptor];


### PR DESCRIPTION
Fixes a regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/194.

Issue:
- When entering the album details view the titles are sorted by label/name and not by track id.

Details:
- Do not fall back to sort-by-label when sort order is nil
- Fixes sort order for songs in album details (was by fault falling back to sort-by-label instead of sort-by-trackid)