### PR TITLE
Implement support for sort tokens

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -103,6 +103,7 @@
 @property (nonatomic, assign) int APImajorVersion;
 @property (nonatomic, assign) int APIminorVersion;
 @property (nonatomic, assign) int APIpatchVersion;
+@property (nonatomic, copy) NSArray *KodiSorttokens;
 @property (nonatomic, retain) GlobalData *obj;
 
 @end

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -103,6 +103,7 @@
 @property (nonatomic, assign) int APImajorVersion;
 @property (nonatomic, assign) int APIminorVersion;
 @property (nonatomic, assign) int APIpatchVersion;
+@property (nonatomic, assign) BOOL isIgnoreArticlesEnabled;
 @property (nonatomic, copy) NSArray *KodiSorttokens;
 @property (nonatomic, retain) GlobalData *obj;
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4927,9 +4927,13 @@ NSIndexPath *selected;
 
 -(BOOL)isSortDifferentToDefault {
     BOOL isDifferent = NO;
-    NSDictionary *parameters=[self indexKeyedDictionaryFromArray:[[self.detailItem mainParameters] objectAtIndex:choosedTab]];
+    NSDictionary *parameters=[self indexKeyedDictionaryFromArray:[self.detailItem mainParameters][choosedTab]];
     NSString *defaultSortMethod = parameters[@"parameters"][@"sort"][@"method"];
+    NSString *defaultSortOrder = parameters[@"parameters"][@"sort"][@"order"];
     if (sortMethodName != nil && ![sortMethodName isEqualToString:defaultSortMethod]) {
+        isDifferent = YES;
+    }
+    else if (sortAscDesc != nil && ![sortAscDesc isEqualToString:defaultSortOrder]) {
         isDifferent = YES;
     }
     // Exception: genre is misused for artist for app-internal reasons

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4936,10 +4936,6 @@ NSIndexPath *selected;
     else if (sortAscDesc != nil && ![sortAscDesc isEqualToString:defaultSortOrder]) {
         isDifferent = YES;
     }
-    // Exception: genre is misused for artist for app-internal reasons
-    else if ([sortMethodName isEqualToString:@"genre"] && [defaultSortMethod isEqualToString:@"artist"]) {
-        isDifferent = NO;
-    }
     return isDifferent;
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1638,21 +1638,27 @@
         if (sectionNameOverlayView == nil && stackscrollFullscreen == YES){
             [self initSectionNameOverlayView];
         }
+        // Ensure the sort tokens are respected as well when using the index in fullscreen mode
+        NSString *sortbymethod = sortMethodName;
+        if ([self isEligibleForSorttokenSort]) {
+            sortbymethod = @"sortby";
+        }
+        
         sectionNameLabel.text = [self buildSortInfo:[storeSectionArray objectAtIndex:sender.currentIndex]];
         NSString *value = [storeSectionArray objectAtIndex:sender.currentIndex];
-        NSPredicate *predExists = [NSPredicate predicateWithFormat: @"SELF.%@ BEGINSWITH[c] %@", sortMethodName, value];
+        NSPredicate *predExists = [NSPredicate predicateWithFormat: @"SELF.%@ BEGINSWITH[c] %@", sortbymethod, value];
         if ([value isEqual:@"#"]) {
-            predExists = [NSPredicate predicateWithFormat: @"SELF.%@ MATCHES[c] %@", sortMethodName, @"^[0-9].*"];
+            predExists = [NSPredicate predicateWithFormat: @"SELF.%@ MATCHES[c] %@", sortbymethod, @"^[0-9].*"];
         }
-        else if ([sortMethodName isEqualToString:@"rating"] && [value isEqualToString:@"0"]){
-            predExists = [NSPredicate predicateWithFormat: @"SELF.%@.length == 0", sortMethodName];
+        else if ([sortbymethod isEqualToString:@"rating"] && [value isEqualToString:@"0"]){
+            predExists = [NSPredicate predicateWithFormat: @"SELF.%@.length == 0", sortbymethod];
         }
-        else if ([sortMethodName isEqualToString:@"runtime"]){
+        else if ([sortbymethod isEqualToString:@"runtime"]){
              [NSPredicate predicateWithFormat: @"attributeName BETWEEN %@", @[@1, @10]];
-            predExists = [NSPredicate predicateWithFormat: @"SELF.%@.intValue BETWEEN %@", sortMethodName, [NSArray arrayWithObjects:[NSNumber numberWithInt:[value intValue] - 15],[NSNumber numberWithInt:[value intValue]], nil]];
+            predExists = [NSPredicate predicateWithFormat: @"SELF.%@.intValue BETWEEN %@", sortbymethod, [NSArray arrayWithObjects:[NSNumber numberWithInt:[value intValue] - 15],[NSNumber numberWithInt:[value intValue]], nil]];
         }
-        else if ([sortMethodName isEqualToString:@"playcount"]){
-            predExists = [NSPredicate predicateWithFormat: @"SELF.%@.intValue == %d", sortMethodName, [value intValue]];
+        else if ([sortbymethod isEqualToString:@"playcount"]){
+            predExists = [NSPredicate predicateWithFormat: @"SELF.%@.intValue == %d", sortbymethod, [value intValue]];
         }
         NSUInteger index = [[sections objectForKey:@""] indexOfObjectPassingTest:
                             ^(id obj, NSUInteger idx, BOOL *stop) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4869,15 +4869,15 @@ NSIndexPath *selected;
 }
 
 -(NSString*)ignoreSorttoken:(NSString*)text {
+    if ([[AppDelegate instance].KodiSorttokens count] == 0) {
+        return text;
+    }
     NSMutableString *string = [text mutableCopy];
-    NSString *token = @"";
-    NSInteger token_count = [[AppDelegate instance].KodiSorttokens count];
-    if (token_count > 0) {
-        for (token in [AppDelegate instance].KodiSorttokens) {
-            NSRange range = [string rangeOfString:token];
-            if (range.location==0 && range.length > 0) {
-                [string deleteCharactersInRange:range];
-            }
+    for (NSString *token in [AppDelegate instance].KodiSorttokens) {
+        NSRange range = [string rangeOfString:token];
+        if (range.location==0 && range.length > 0) {
+            [string deleteCharactersInRange:range];
+            break; // We want to leave the loop after we removed the sort token
         }
     }
     return [string copy];

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -244,6 +244,19 @@ NSOutputStream	*outStream;
              [AppDelegate instance].APIpatchVersion = [methodResult[@"version"][@"patch"] intValue];
          }
     }];
+    // Read the sorttokens
+    [jsonRPC
+     callMethod:@"Application.GetProperties"
+     withParameters:@{@"properties":@[@"sorttokens"]}
+     withTimeout: SERVER_TIMEOUT
+     onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
+         if (!error && !methodError) {
+             [AppDelegate instance].KodiSorttokens = methodResult[@"sorttokens"];
+         }
+         else {
+             [AppDelegate instance].KodiSorttokens = nil;
+         }
+    }];
     jsonRPC=nil;
 }
 

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -257,6 +257,19 @@ NSOutputStream	*outStream;
              [AppDelegate instance].KodiSorttokens = nil;
          }
     }];
+    // Check if ignorearticles is enabled
+    [jsonRPC
+     callMethod:@"Settings.GetSettingValue"
+     withParameters:@{@"setting": @"filelists.ignorethewhensorting"}
+     withTimeout: SERVER_TIMEOUT
+     onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
+         if (!error && !methodError) {
+             [AppDelegate instance].isIgnoreArticlesEnabled = [methodResult[@"value"] boolValue];
+         }
+         else {
+             [AppDelegate instance].isIgnoreArticlesEnabled = NO;
+         }
+    }];
     jsonRPC=nil;
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/97

This PR implements support for sort tokens for the Remote App. When connecting to the Kodi server the App requests the server´s sort tokens and the server´s setting for "ignore articles when sorting" via the JSON API. As older versions of Kodi do not provide the sort tokens a default set (`"The"`, `"The_"` and `"The."`) is defined -- following the same default Kodi uses.

Remark: The web interface also applies `"A"` and `"An"` as sort tokens. As the Kodi UI does not use this, which most users here compare the App behavior with, and several native speakers voted to only use `"The"` I am sticking to the reduced sort token set.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Ignore articles based on Kodi sort tokens (e.g. "The")