### PR TITLE
Fix server popup showing up after rotation

### DIFF
--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -732,11 +732,11 @@
 -(void) willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration{
 	[menuViewController willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
 	[stackScrollViewController willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
-    if ([[AppDelegate instance].navigationController isViewLoaded]) {
+    if (self.hostPickerViewController.isViewLoaded && self.hostPickerViewController.view.window != nil) {
         [[AppDelegate instance].navigationController dismissViewControllerAnimated:NO completion:nil];
         serverPicker = TRUE;
     }
-    if ([self.appInfoView isViewLoaded]) {
+    if (self.appInfoView.isViewLoaded && self.appInfoView.view.window != nil) {
         [self.appInfoView dismissViewControllerAnimated:NO completion:nil];
         appInfo = TRUE;
     }


### PR DESCRIPTION
Fixes an issue reported in [forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3027183#pid3027183). This is a regression caused by replacing deprecated `UIPopoverController` in https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/148.

This fix is also contained in https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/205. In case the latter is not accepted as it is, this PR provides the fix right away. https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/205 can be easily rebased.

Details:
- Correct check for visibility of Server and Info Popup
