### PR TITLE
Desaturate season background and choose top most background color for searchbar

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2699,6 +2699,7 @@ int originYear = 0;
                     CAGradientLayer *gradient = [CAGradientLayer layer];
                     gradient.frame = albumDetailView.bounds;
                     albumColor = [utils averageColor:image inverse:NO];
+                    albumColor = [utils limitSaturation:albumColor satmax:0.33];
                     gradient.colors = [NSArray arrayWithObjects:(id)[albumColor CGColor], (id)[[utils lighterColorForColor:albumColor] CGColor], nil];
                     seasonFontShadowColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:0 alpha:0.3] darkColor:[Utilities getGrayColor:255 alpha:0.3]];
                     seasonFontColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:255 alpha:0.7] darkColor:[Utilities getGrayColor:0 alpha:0.6]];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -481,6 +481,22 @@
 
 #pragma mark - Utility
 
+-(void)setSearchBarColor:(UIColor*)albumColor {
+    UITextField *searchTextField = [self getSearchTextField];
+    UIColor *lightAlbumColor = [utils lighterColorForColor:albumColor];
+    if (searchTextField != nil) {
+        UIImageView *iconView = (id)searchTextField.leftView;
+        iconView.image = [iconView.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        iconView.tintColor = lightAlbumColor;
+        searchTextField.textColor = lightAlbumColor;
+        searchTextField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.searchController.searchBar.placeholder attributes: @{NSForegroundColorAttributeName: lightAlbumColor}];
+    }
+    self.searchController.searchBar.backgroundColor = albumColor;
+    self.searchController.searchBar.tintColor = lightAlbumColor;
+    self.searchController.searchBar.barTintColor = lightAlbumColor;
+    self.searchController.searchBar.barStyle = UIBarStyleBlack;
+}
+
 -(void)setLabelColor:(UIColor*)text fontshadow:(UIColor*)shadow label1:(UILabel*)label1 label2:(UILabel*)label2 label3:(UILabel*)label3 label4:(UILabel*)label4{
     [label1 setShadowColor:shadow];
     [label1 setTextColor:text];
@@ -2511,11 +2527,9 @@ int originYear = 0;
                                           albumColor = [utils averageColor:image inverse:NO];
                                           UIColor *lightAlbumColor = [utils lighterColorForColor:albumColor];
                                           self.navigationController.navigationBar.tintColor = lightAlbumColor;
-                                          self.searchController.searchBar.tintColor = lightAlbumColor;
                                           if ([[[self.searchController.searchBar subviews] objectAtIndex:0] isKindOfClass:[UIImageView class]]){
                                               [[[self.searchController.searchBar subviews] objectAtIndex:0] removeFromSuperview];
                                           }
-                                          [self.searchController.searchBar setBackgroundColor:albumColor];
                                           CAGradientLayer *gradient = [CAGradientLayer layer];
                                           gradient.frame = albumDetailView.bounds;
                                           gradient.colors = [NSArray arrayWithObjects:(id)[albumColor CGColor], (id)[[utils lighterColorForColor:albumColor] CGColor], nil];
@@ -2524,16 +2538,7 @@ int originYear = 0;
                                           albumFontShadowColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:0 alpha:0.3] darkColor:[Utilities getGrayColor:255 alpha:0.3]];
                                           albumDetailsColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:255 alpha:0.7] darkColor:[Utilities getGrayColor:0 alpha:0.6]];
                                           [self setLabelColor:albumFontColor fontshadow:albumFontShadowColor label1:artist label2:albumLabel label3:trackCountLabel label4:releasedLabel];
-                                          UITextField *searchTextField = [self getSearchTextField];
-                                          if (searchTextField != nil) {
-                                              if ([searchTextField respondsToSelector:@selector(setAttributedPlaceholder:)]) {
-                                                  UIImageView *iconView = (id)searchTextField.leftView;
-                                                  iconView.image = [iconView.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-                                                  iconView.tintColor = lightAlbumColor;
-                                                  searchTextField.textColor = lightAlbumColor;
-                                                  searchTextField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.searchController.searchBar.placeholder attributes: @{NSForegroundColorAttributeName: lightAlbumColor}];
-                                              }
-                                          }
+                                          [self setSearchBarColor:albumColor];
                                       }
                                   }];
         }
@@ -2656,7 +2661,6 @@ int originYear = 0;
         gradient.frame = albumDetailView.bounds;
         gradient.colors = [NSArray arrayWithObjects:(id)[[Utilities getSystemGray5] CGColor], (id)[[Utilities getSystemGray1] CGColor], nil];
         [albumDetailView.layer insertSublayer:gradient atIndex:0];
-        [self.searchController.searchBar setBackgroundColor:[Utilities getSystemGray5]];
         if (section>0){
             UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, -1, viewWidth, 1)];
             [lineView setBackgroundColor:[Utilities getGrayColor:242 alpha:1]];
@@ -2691,6 +2695,10 @@ int originYear = 0;
             UIImageView *thumbImageView = [[UIImageView alloc] initWithFrame:CGRectMake(albumViewPadding + toggleIconSpace, albumViewPadding, seasonThumbWidth, albumViewHeight - (albumViewPadding * 2))];
             NSString *stringURL = [[self.extraSectionRichResults objectAtIndex:seasonIdx] objectForKey:@"thumbnail"];
             NSString *displayThumb=@"coverbox_back_section.png";
+            if (seasonIdx == 0) {
+                self.searchController.searchBar.backgroundColor = [Utilities getSystemGray6];
+                self.searchController.searchBar.tintColor = tableViewSearchBarColor;
+            }
             if ([[item objectForKey:@"filetype"] length]!=0){
                 displayThumb=stringURL;
             }
@@ -2704,7 +2712,9 @@ int originYear = 0;
                     seasonFontShadowColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:0 alpha:0.3] darkColor:[Utilities getGrayColor:255 alpha:0.3]];
                     seasonFontColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:255 alpha:0.7] darkColor:[Utilities getGrayColor:0 alpha:0.6]];
                     [albumDetailView.layer insertSublayer:gradient atIndex:1];
-                    [self.searchController.searchBar setBackgroundColor:albumColor];
+                    if (seasonIdx == 0) {
+                        [self setSearchBarColor:albumColor];
+                    }
                     [self setLabelColor:seasonFontColor fontshadow:seasonFontShadowColor label1:artist label2:albumLabel label3:trackCountLabel label4:releasedLabel];
                 }];
             }

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -19,6 +19,7 @@ typedef enum {
 @interface Utilities : NSObject
 
 - (UIColor *)averageColor:(UIImage *)image inverse:(BOOL)inverse;
+- (UIColor *)limitSaturation:(UIColor *)c satmax:(CGFloat)satmax;
 - (UIColor *)slightLighterColorForColor:(UIColor *)c;
 - (UIColor *)lighterColorForColor:(UIColor *)c;
 - (UIColor *)darkerColorForColor:(UIColor *)c;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -75,6 +75,17 @@
 	return [UIColor colorWithRed:f * red  green:f * green blue:f * blue alpha:1];
 }
 
+- (UIColor *)limitSaturation:(UIColor *)color_in satmax:(CGFloat)satmax {
+    CGFloat hue, sat, bright, alpha;
+    UIColor *color_out = nil;
+    if ([color_in getHue:&hue saturation:&sat brightness:&bright alpha:&alpha]) {
+        // limit saturation
+        sat = MIN(MAX(sat, 0), satmax);
+        color_out = [UIColor colorWithHue:hue saturation:sat brightness:bright alpha:alpha];
+    }
+    return color_out;
+}
+
 + (UIColor *)tailorColor:(UIColor *)color_in satscale:(CGFloat)satscale brightscale:(CGFloat)brightscale brightmin:(CGFloat)brightmin brightmax:(CGFloat)brightmax{
     CGFloat hue, sat, bright, alpha;
     UIColor *color_out = nil;


### PR DESCRIPTION
As brought up in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3027133#pid3027133) the current implementation for the Season View background can become a bit aggressive (not to say "froggy" :) ). This PR limits the saturation of the chosen background color for a smoother coloring. In addition, it lets the searchbar have the color of the topmost season background color.

Screenshots:
https://abload.de/img/simulatorscreenshot-isqjef.png (Dexter, before)
https://abload.de/img/simulatorscreenshot-ijkjwl.png (Dexter, after)
https://abload.de/img/simulatorscreenshot-i5xj9x.png (Sherlock, before)
https://abload.de/img/simulatorscreenshot-ismj51.png (Sherlock, after)
https://abload.de/img/simulatorscreenshot-incjzm.png (Muppets, before)
https://abload.de/img/simulatorscreenshot-i7wko4.png (Muppets, after)

It is of course possible to change this further, in case the de-saturation is not sufficient. Initially I took this over from the album view -- but this will only show a single album at a time.
