### PR TITLE
Automatic background color for TV logos in recording details

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2704,7 +2704,7 @@ int originYear = 0;
             }
             else {
                 [thumbImageView setImageWithURL:[NSURL URLWithString:@""] placeholderImage:[UIImage imageNamed:displayThumb] ];
-                seasonFontShadowColor = [Utilities getGrayColor:255 alpha:0.3];;
+                seasonFontShadowColor = [Utilities getGrayColor:255 alpha:0.3];
                 seasonFontColor = [Utilities get1stLabelColor];
                 [self setLabelColor:seasonFontColor fontshadow:seasonFontShadowColor label1:artist label2:albumLabel label3:trackCountLabel label4:releasedLabel];
             }            

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -493,13 +493,8 @@
 }
 
 -(void)setLogoBackgroundColor:(UIImageView*)imageview {
-    // adapt color
-    UIImage *image = imageview.image;
-    Utilities *utils = [[Utilities alloc] init];
-    UIColor *imgcolor = [utils averageColor:image inverse:NO];
-    UIColor *bglight = [Utilities getGrayColor:242 alpha:1.0];
-    UIColor *bgdark = [Utilities getGrayColor:28 alpha:1.0];
-    UIColor *bgcolor = [utils updateColor:imgcolor lightColor:bglight darkColor:bgdark trigger:0.4];
+    // get background color and colorize the image background
+    UIColor *bgcolor = [Utilities getLogoBackgroundColor:imageview.image];
     [imageview setBackgroundColor:bgcolor];
 }
 

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -453,7 +453,7 @@
         textInputField.borderStyle = UITextBorderStyleRoundedRect;
         textInputField.textAlignment = NSTextAlignmentCenter;
         textInputField.font = [UIFont systemFontOfSize:15];
-        textInputField.placeholder = NSLocalizedString(@"enter value", nil);;
+        textInputField.placeholder = NSLocalizedString(@"enter value", nil);
         textInputField.autocorrectionType = UITextAutocorrectionTypeNo;
         textInputField.keyboardType = UIKeyboardTypeDefault;
         textInputField.returnKeyType = UIReturnKeyDefault;

--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -48,7 +48,7 @@
     IBOutlet UIImageView *fanartView;
 
     BOOL alreadyPush;
-    
+    BOOL isRecordingDetail;
     UIToolbar *toolbar;
     NSMutableArray *sheetActions;
     UIBarButtonItem *actionSheetButtonItemIpad;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -216,6 +216,12 @@ int count=0;
 
 #pragma mark - Utility 
 
+-(UIImage*)setLogoBackgroundColor:(UIImage*)image{
+    // get background color and colorize the image background
+    UIColor *bgcolor = [Utilities getLogoBackgroundColor:image];
+    return [Utilities colorizeImageBackground:image color:bgcolor];
+}
+
 -(void)dismissModal:(id)sender {
     [self dismissViewControllerAnimated:YES completion:nil];
 }
@@ -709,6 +715,9 @@ int h=0;
 
 -(void)elaborateImage:(UIImage *)image{
     [self performSelectorOnMainThread:@selector(startActivityIndicator) withObject:nil waitUntilDone:YES];
+    if (isRecordingDetail) {
+        image = [self setLogoBackgroundColor:image];
+    }
     UIImage *elabImage = [self imageWithBorderFromImage:image];
     [self performSelectorOnMainThread:@selector(showImage:) withObject:elabImage waitUntilDone:YES];    
 }
@@ -729,6 +738,7 @@ int h=0;
     // NEED TO BE OPTIMIZED. IT WORKS BUT THERE ARE TOO MANY IFS!
     NSMutableDictionary *item = self.detailItem;
     NSString *placeHolderImage = @"coverbox_back.png";
+    isRecordingDetail = item[@"recordingid"] != nil;
 //    NSLog(@"ITEM %@", item);
     eJewelType jeweltype = jewelTypeUnknown;
     castFontSize = 14;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1182,7 +1182,7 @@ int h=0;
             directorLabel.text = @"-";
         }
 //        UIImage *buttonImage = [UIImage imageNamed:@"button_record.png"];
-//        UIButton *recordButton = [UIButton buttonWithType:UIButtonTypeCustom];;
+//        UIButton *recordButton = [UIButton buttonWithType:UIButtonTypeCustom];
 //        recordButton.frame = CGRectMake(0, 0, 200, 29);
 //        [recordButton setImage:buttonImage forState:UIControlStateNormal];
 //        frame = recordButton.frame;

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -25,6 +25,8 @@ typedef enum {
 - (UIColor *)updateColor:(UIColor *) newColor lightColor:(UIColor *)lighter darkColor:(UIColor *)darker;
 - (UIColor *)updateColor:(UIColor *) newColor lightColor:(UIColor *)lighter darkColor:(UIColor *)darker trigger:(CGFloat)trigger;
 - (UIImage*)colorizeImage:(UIImage *)image withColor:(UIColor*)color;
++ (UIImage*)colorizeImageBackground:(UIImage*)image color:(UIColor*)newcolor;
++ (UIColor*)getLogoBackgroundColor:(UIImage*)image;
 + (NSDictionary*)buildPlayerSeekPercentageParams:(int)playerID percentage:(float)percentage;
 + (NSArray*)buildPlayerSeekStepParams:(NSString*)stepmode;
 + (CGFloat)getTransformX;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -157,6 +157,30 @@
     return img;
 }
 
++ (UIImage*)colorizeImageBackground:(UIImage*)image color:(UIColor*)newcolor {
+    CALayer *imageLayer = [CALayer layer];
+    imageLayer.frame = CGRectMake(0, 0, image.size.width, image.size.height);
+    imageLayer.contents = (id)image.CGImage;
+    imageLayer.masksToBounds = YES;
+    imageLayer.backgroundColor = newcolor.CGColor;
+    
+    UIGraphicsBeginImageContext(image.size);
+    [imageLayer renderInContext:UIGraphicsGetCurrentContext()];
+    UIImage *recoloredImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+
+    return recoloredImage;
+}
+
++ (UIColor*)getLogoBackgroundColor:(UIImage*)image {
+    Utilities *utils = [[Utilities alloc] init];
+    UIColor *imgcolor = [utils averageColor:image inverse:NO];
+    UIColor *bglight = [Utilities getGrayColor:242 alpha:1.0];
+    UIColor *bgdark = [Utilities getGrayColor:28 alpha:1.0];
+    UIColor *bgcolor = [utils updateColor:imgcolor lightColor:bglight darkColor:bgdark trigger:0.4];
+    return bgcolor;
+}
+
 + (NSDictionary*)buildPlayerSeekPercentageParams:(int)playerID percentage:(float)percentage{
     NSDictionary *params = nil;
     if ([AppDelegate instance].serverVersion < 15){


### PR DESCRIPTION
Implements missing function report in [forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3027541#pid3027541).

Details:
- Choose different background colors for TV logos
- Processing only done when showing PVR recording details
- Refactoring into Utilities.m to re-use same implementation in different controllers