### PR TITLE
Avoid searchbar showing after rotation

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5476,6 +5476,15 @@ NSIndexPath *selected;
     [self showSearchBar];
 }
 
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        [activeLayoutView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
+    }
+                                 completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {}];
+}
+
 - (void)updateSearchResultsForSearchController:(UISearchController *)searchController
 {
   NSString *searchString = searchController.searchBar.text;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/213.

When rotating on iPad the implementation of `viewWillTransitionToSize` was missing for `DetailViewController`. This caused the view to scroll to top when the rotating from landscape to portrait as this increases the height. This PR adds `viewWillTransitionToSize` and always keeps the intended default ContentOffset which results in not showing the searchbar after rotation.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
Bugfix: Avoid searchbar showing after rotation on iPad