### PR TITLE
Features and fixes around TV station logos

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -508,12 +508,6 @@
     [label4 setTextColor:text];
 }
 
--(void)setLogoBackgroundColor:(UIImageView*)imageview {
-    // get background color and colorize the image background
-    UIColor *bgcolor = [Utilities getLogoBackgroundColor:imageview.image];
-    [imageview setBackgroundColor:bgcolor];
-}
-
 -(BOOL)doesShowSearchResults {
     BOOL result = NO;
     if (@available(iOS 13.0, *)) {
@@ -1427,7 +1421,7 @@
             }
             [cell.posterThumbnail setImageWithURL:[NSURL URLWithString:stringURL] placeholderImage:[UIImage imageNamed:displayThumb] andResize:CGSizeMake(cellthumbWidth, cellthumbHeight) completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
                 if (channelListView || channelGuideView || recordingListView) {
-                    [self setLogoBackgroundColor:cell.posterThumbnail];
+                    [Utilities setLogoBackgroundColor:cell.posterThumbnail];
                 }
             }];
             if (hiddenLabel) {
@@ -2341,7 +2335,7 @@ int originYear = 0;
             }
             [cell.urlImageView setImageWithURL:[NSURL URLWithString:stringURL] placeholderImage:[UIImage imageNamed:displayThumb]andResize:CGSizeMake(thumbWidth, cellHeight) completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
                 if (channelListView || channelGuideView || recordingListView) {
-                    [self setLogoBackgroundColor:cell.urlImageView];
+                    [Utilities setLogoBackgroundColor:cell.urlImageView];
                 }
             }];
         }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -214,13 +214,7 @@ int count=0;
     }
 }
 
-#pragma mark - Utility 
-
--(UIImage*)setLogoBackgroundColor:(UIImage*)image{
-    // get background color and colorize the image background
-    UIColor *bgcolor = [Utilities getLogoBackgroundColor:image];
-    return [Utilities colorizeImageBackground:image color:bgcolor];
-}
+#pragma mark - Utility
 
 -(void)dismissModal:(id)sender {
     [self dismissViewControllerAnimated:YES completion:nil];
@@ -715,10 +709,7 @@ int h=0;
 
 -(void)elaborateImage:(UIImage *)image{
     [self performSelectorOnMainThread:@selector(startActivityIndicator) withObject:nil waitUntilDone:YES];
-    if (isRecordingDetail) {
-        image = [self setLogoBackgroundColor:image];
-    }
-    UIImage *elabImage = [self imageWithBorderFromImage:image];
+    UIImage *elabImage = isRecordingDetail ? image : [self imageWithBorderFromImage:image];
     [self performSelectorOnMainThread:@selector(showImage:) withObject:elabImage waitUntilDone:YES];    
 }
 
@@ -726,6 +717,9 @@ int h=0;
     [activityIndicatorView stopAnimating];
     jewelView.alpha = 0;
     jewelView.image = image;
+    if (isRecordingDetail) {
+        [Utilities setLogoBackgroundColor:jewelView];
+    }
     [self alphaImage:jewelView AnimDuration:0.1 Alpha:1.0];
 }
 

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -21,6 +21,7 @@
 #import "Utilities.h"
 
 #define PLAY_BUTTON_SIZE 20
+#define TV_LOGO_SIZE_REC_DETAILS 72
 
 @interface ShowInfoViewController ()
 @end
@@ -719,6 +720,12 @@ int h=0;
     jewelView.image = image;
     if (isRecordingDetail) {
         [Utilities setLogoBackgroundColor:jewelView];
+        CGRect frame;
+        frame.size.width = ceil(TV_LOGO_SIZE_REC_DETAILS * 0.9);
+        frame.size.height = ceil(TV_LOGO_SIZE_REC_DETAILS * 0.7);
+        frame.origin.x = jewelView.frame.origin.x + (jewelView.frame.size.width - frame.size.width)/2;
+        frame.origin.y = jewelView.frame.origin.y + 4;
+        jewelView.frame = frame;
     }
     [self alphaImage:jewelView AnimDuration:0.1 Alpha:1.0];
 }

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -26,8 +26,7 @@ typedef enum {
 - (UIColor *)updateColor:(UIColor *) newColor lightColor:(UIColor *)lighter darkColor:(UIColor *)darker;
 - (UIColor *)updateColor:(UIColor *) newColor lightColor:(UIColor *)lighter darkColor:(UIColor *)darker trigger:(CGFloat)trigger;
 - (UIImage*)colorizeImage:(UIImage *)image withColor:(UIColor*)color;
-+ (UIImage*)colorizeImageBackground:(UIImage*)image color:(UIColor*)newcolor;
-+ (UIColor*)getLogoBackgroundColor:(UIImage*)image;
++ (void)setLogoBackgroundColor:(UIImageView*)imageview;
 + (NSDictionary*)buildPlayerSeekPercentageParams:(int)playerID percentage:(float)percentage;
 + (NSArray*)buildPlayerSeekStepParams:(NSString*)stepmode;
 + (CGFloat)getTransformX;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -210,28 +210,14 @@
     return img;
 }
 
-+ (UIImage*)colorizeImageBackground:(UIImage*)image color:(UIColor*)newcolor {
-    CALayer *imageLayer = [CALayer layer];
-    imageLayer.frame = CGRectMake(0, 0, image.size.width, image.size.height);
-    imageLayer.contents = (id)image.CGImage;
-    imageLayer.masksToBounds = YES;
-    imageLayer.backgroundColor = newcolor.CGColor;
-    
-    UIGraphicsBeginImageContext(image.size);
-    [imageLayer renderInContext:UIGraphicsGetCurrentContext()];
-    UIImage *recoloredImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-
-    return recoloredImage;
-}
-
-+ (UIColor*)getLogoBackgroundColor:(UIImage*)image {
++ (void)setLogoBackgroundColor:(UIImageView*)imageview {
+    // get background color and colorize the image background
     Utilities *utils = [[Utilities alloc] init];
-    UIColor *imgcolor = [utils averageColor:image inverse:NO];
+    UIColor *imgcolor = [utils averageColor:imageview.image inverse:NO];
     UIColor *bglight = [Utilities getGrayColor:242 alpha:1.0];
     UIColor *bgdark = [Utilities getGrayColor:28 alpha:1.0];
     UIColor *bgcolor = [utils updateColor:imgcolor lightColor:bglight darkColor:bgdark trigger:0.4];
-    return bgcolor;
+    [imageview setBackgroundColor:bgcolor];
 }
 
 + (NSDictionary*)buildPlayerSeekPercentageParams:(int)playerID percentage:(float)percentage{

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -40,28 +40,70 @@
     
     if (anyNonAlpha) {
         // no alpha channel present
-        for (int row = 0; row < imageHeight; row++) {
-            const UInt8 *rowPtr = rawPixelData + bytesPerRow * row;
-            for (int column = 0; column < imageWidth; column++) {
-                red    += rowPtr[0];
-                green  += rowPtr[1];
-                blue   += rowPtr[2];
-                rowPtr += stride;
-            }
+        switch (stride) {
+            case 4:
+                // standard RGB
+                for (int row = 0; row < imageHeight; row++) {
+                    const UInt8 *rowPtr = rawPixelData + bytesPerRow * row;
+                    for (int column = 0; column < imageWidth; column++) {
+                        red    += rowPtr[0];
+                        green  += rowPtr[1];
+                        blue   += rowPtr[2];
+                        rowPtr += stride;
+                    }
+                }
+                break;
+            case 1:
+                // monochrome
+                for (int row = 0; row < imageHeight; row++) {
+                    const UInt8 *rowPtr = rawPixelData + bytesPerRow * row;
+                    for (int column = 0; column < imageWidth; column++) {
+                        blue   += rowPtr[0];
+                        rowPtr += stride;
+                    }
+                }
+                red = green = blue;
+                break;
+            default:
+                // should not happen, return rgb=0
+                red = green = blue = 0;
+                break;
         }
         f = 1.0 / (255.0 * imageWidth * imageHeight);
     }
     else {
         // weight color with alpha to ignore transparent sections
-        for (int row = 0; row < imageHeight; row++) {
-            const UInt8 *rowPtr = rawPixelData + bytesPerRow * row;
-            for (int column = 0; column < imageWidth; column++) {
-                red    += rowPtr[0] * rowPtr[3];
-                green  += rowPtr[1] * rowPtr[3];
-                blue   += rowPtr[2] * rowPtr[3];
-                alpha  += rowPtr[3];
-                rowPtr += stride;
-            }
+        switch (stride) {
+            case 4:
+                // standard RGBA
+                for (int row = 0; row < imageHeight; row++) {
+                    const UInt8 *rowPtr = rawPixelData + bytesPerRow * row;
+                    for (int column = 0; column < imageWidth; column++) {
+                        red    += rowPtr[0] * rowPtr[3];
+                        green  += rowPtr[1] * rowPtr[3];
+                        blue   += rowPtr[2] * rowPtr[3];
+                        alpha  += rowPtr[3];
+                        rowPtr += stride;
+                    }
+                }
+                break;
+            case 2:
+                // monochrome with alpha
+                for (int row = 0; row < imageHeight; row++) {
+                    const UInt8 *rowPtr = rawPixelData + bytesPerRow * row;
+                    for (int column = 0; column < imageWidth; column++) {
+                        blue   += rowPtr[0] * rowPtr[1];
+                        alpha  += rowPtr[1];
+                        rowPtr += stride;
+                    }
+                }
+                red = green = blue;
+                break;
+            default:
+                // should not happen, return rgb=0 and alpha=1
+                red = green = blue = 0;
+                alpha = 1;
+                break;
         }
         f = 1.0 / (255.0 * alpha);
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR resolves an issue report from a [forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3027965#pid3027965).

1. Monochrome images were not properly analyzed for their average color / brightness causing an inadequate choice of background color. This PR reworks the calculation method.
2. The TV station logs for channel list, recording list and recording details now use same aspect ratios for improved UI consistency.

Screenshots:
https://abload.de/img/simulatorscreenshot-ia2k9f.png (monochrome before, recording + channel list)
https://abload.de/img/simulatorscreenshot-i53jr8.png (monochrome before, recording list + details)
https://abload.de/img/simulatorscreenshot-i96j2c.png (monochrome after, recording + channel list)
https://abload.de/img/simulatorscreenshot-ih3kp4.png (monochrome after, recording list + details)
https://abload.de/img/simulatorscreenshot-ibqjxp.png (RGBA after, recording + channel list)
https://abload.de/img/simulatorscreenshot-iehkbr.png (RGBA after, recording list + details)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
Bugfix: Correct handling of monochrome TV station logos with alpha channel
Feature: Align aspect ratio of TV station logos for channel list, recording list and recording details
