### PR TITLE
Avoid crash DetailViewController:actionSheetHandler

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3197,11 +3197,20 @@ NSIndexPath *selected;
     NSMutableDictionary *item = nil;
     if (selected != nil){
         if ([self.searchController isActive]){
-            item = [self.filteredListContent objectAtIndex:selected.row];
+            if (selected.row < [self.filteredListContent count]) {
+                item = self.filteredListContent[selected.row];
+            }
         }
         else{
-            item = [[self.sections valueForKey:[self.sectionArray objectAtIndex:selected.section]] objectAtIndex:selected.row];
+            if (selected.section < [self.sectionArray count]) {
+                if (selected.row < [self.sections[self.sectionArray[selected.section]] count]) {
+                    item = self.sections[self.sectionArray[selected.section]][selected.row];
+                }
+            }
         }
+    }
+    if (item == nil) {
+        return;
     }
     if ([actiontitle isEqualToString:NSLocalizedString(@"Play", nil)]){
         NSString *songid = [NSString stringWithFormat:@"%@", [item objectForKey:@"songid"]];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2502,19 +2502,6 @@ int currentItemID;
     }
 }
 
--(void)showRemoteController{
-    if (updateProgressBar){
-        if (self.remoteController == nil){
-            self.remoteController = [[RemoteController alloc] initWithNibName:@"RemoteController" bundle:nil];
-        }
-        mainMenu *item = [[mainMenu alloc] init];
-        item.mainLabel = NSLocalizedString(@"Remote Control", nil);
-        self.remoteController.detailItem = item;
-        fromItself = TRUE;
-        [self.navigationController pushViewController:self.remoteController animated:YES];
-    }
-}
-
 #pragma mark - Interface customizations
 
 -(void)setNowPlayingDimension:(int)width height:(int)height YPOS:(int)YPOS {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/220.

Added boundary checks before accessing an array in `actionSheetHandler`. In case `item` cannot be read the return from method. I tested the error case (leaving the method) and this had no negative side effects, just the action was not executed.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid reported crash in DetailViewController:actionSheetHandler
