### PR TITLE
Fix regression which caused sorting to not work at all

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3208,9 +3208,9 @@ NSIndexPath *selected;
                 }
             }
         }
-    }
-    if (item == nil) {
-        return;
+        if (item == nil) {
+            return;
+        }
     }
     if ([actiontitle isEqualToString:NSLocalizedString(@"Play", nil)]){
         NSString *songid = [NSString stringWithFormat:@"%@", [item objectForKey:@"songid"]];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This fixes a major regression I was not observing because I was mainly testing around the possible reset case.

Details:
- Only return on empty item in case an item should be selected
- Before we returned without any further action also when sorting shall be changed

Sorry for any inconvenience. 

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix regression caused by fix for crash in DetailViewController:actionSheetHandler