### PR TITLE
Fix displaying "nocover" images in grid view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1437,7 +1437,7 @@
             [cell.posterThumbnail setImageWithURL:[NSURL URLWithString:@""] placeholderImage:[UIImage imageNamed:displayThumb] ];
             [cell.posterLabel setHidden:NO];
             [cell.labelImageView setHidden:NO];
-            [cell.posterThumbnail setBackgroundColor:[Utilities getSystemGray6]];
+            [cell.posterThumbnail setBackgroundColor:[Utilities getGrayColor:28 alpha:1.0]];
         }
         
         if ([playcount intValue]){

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1379,7 +1379,7 @@
     NSDictionary *item = [[self.sections valueForKey:[self.sectionArray objectAtIndex:indexPath.section]] objectAtIndex:indexPath.row];
     NSString *stringURL = [item objectForKey:@"thumbnail"];
     NSString *fanartURL = [item objectForKey:@"fanart"];
-    NSString *displayThumb=[NSString stringWithFormat:@"%@_wall", defaultThumb];
+    NSString *displayThumb = [NSString stringWithFormat:@"%@_wall", defaultThumb.stringByDeletingPathExtension];
     NSString *playcount = [NSString stringWithFormat:@"%@", [item objectForKey:@"playcount"]];
     
     CGFloat cellthumbWidth = cellGridWidth;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
In case the default thumb needs to be shown in grid view there are two issues. First, the cell background color is using DarkMode/LightMode but needs to be set to a dark background always. Second, adding the extension "_wall" to the image name which already ends with ".png" results in an unresolvable filename. In effect the grid view was showing an empty white field in LightMode and an empty dark field in DarkMode.

Details:
- Choose the dark default color of grid view as background
- Remove .png suffix before adding _wall suffix

Screenshots (taken from Live TV channel groups):
https://abload.de/img/simulatorscreenshot-i6rjwh.png (before)
https://abload.de/img/simulatorscreenshot-i3lk32.png (after)

Remark: I will remove the ".png" treatment with a future PR that moves the images to xcassets, which requires all ".png" suffixes to be removed when using `[UIImage imageNamed:name]`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix displaying "nocover" images in grid view