### PR TITLE
Fix wrong cell dimension after showing recordings

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2157,9 +2157,12 @@ int originYear = 0;
 //        cell.accessoryType =  UITableViewCellAccessoryDisclosureIndicator; 
 //    }
 /* end future */
-    CGRect frame = cell.urlImageView.frame;
+    CGRect frame;
+    frame.origin = CGPointZero;
     frame.size.width = thumbWidth;
+    frame.size.height = cellHeight;
     cell.urlImageView.frame = frame;
+    cell.urlImageView.autoresizingMask = UIViewAutoresizingNone;
     
     UILabel *title=(UILabel*) [cell viewWithTag:1];
     UILabel *genre=(UILabel*) [cell viewWithTag:2];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
After showing the Live TV recording list the thumb frame origin and size was not properly set anymore as it still used the recording list settings. This is fixed with setting the default dimension and origin properly.

Screenshot:
<a href="https://abload.de/image.php?img=bildschirmfoto2021-04bjkpk.png"><img src="https://abload.de/img/bildschirmfoto2021-04bjkpk.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix wrong thumb dimension after showing recording list
