### PR TITLE
Searchbar color for seasons always uses color of topmost season

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2452,6 +2452,17 @@ int originYear = 0;
             }];
 }
 
+- (NSInteger)getFirstListedSeason:(NSArray*)array {
+    NSInteger firstSeason = NSNotFound;
+    for (NSDictionary *season in array) {
+        NSInteger index = [season[@"season"] intValue];
+        if (index < firstSeason) {
+            firstSeason = index;
+        }
+    }
+    return firstSeason;
+}
+
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section{
     if (albumView && [self.richResults count]>0){
         __block UIColor *albumFontColor = [UIColor blackColor];
@@ -2671,6 +2682,7 @@ int originYear = 0;
             item = [[self.sections valueForKey:[self.sectionArray objectAtIndex:section]] objectAtIndex:0];
         }
         NSInteger seasonIdx = [self indexOfObjectWithSeason:[NSString stringWithFormat:@"%d",[[item objectForKey:@"season"] intValue]] inArray:self.extraSectionRichResults];
+        NSInteger firstListedSeason = [self getFirstListedSeason:self.extraSectionRichResults];
         CGFloat seasonThumbWidth = (albumViewHeight - (albumViewPadding * 2)) * 0.71;
         if (seasonIdx != NSNotFound){
             CGFloat origin_x = seasonThumbWidth + toggleIconSpace + (albumViewPadding * 2);
@@ -2684,7 +2696,8 @@ int originYear = 0;
             UIImageView *thumbImageView = [[UIImageView alloc] initWithFrame:CGRectMake(albumViewPadding + toggleIconSpace, albumViewPadding, seasonThumbWidth, albumViewHeight - (albumViewPadding * 2))];
             NSString *stringURL = [[self.extraSectionRichResults objectAtIndex:seasonIdx] objectForKey:@"thumbnail"];
             NSString *displayThumb=@"coverbox_back_section.png";
-            if (seasonIdx == 0) {
+            BOOL isFirstListedSeason = [item[@"season"] intValue] == firstListedSeason;
+            if (isFirstListedSeason) {
                 self.searchController.searchBar.backgroundColor = [Utilities getSystemGray6];
                 self.searchController.searchBar.tintColor = tableViewSearchBarColor;
             }
@@ -2701,7 +2714,7 @@ int originYear = 0;
                     seasonFontShadowColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:0 alpha:0.3] darkColor:[Utilities getGrayColor:255 alpha:0.3]];
                     seasonFontColor = [utils updateColor:albumColor lightColor:[Utilities getGrayColor:255 alpha:0.7] darkColor:[Utilities getGrayColor:0 alpha:0.6]];
                     [albumDetailView.layer insertSublayer:gradient atIndex:1];
-                    if (seasonIdx == 0) {
+                    if (isFirstListedSeason) {
                         [self setSearchBarColor:albumColor];
                     }
                     [self setLabelColor:seasonFontColor fontshadow:seasonFontShadowColor label1:artist label2:albumLabel label3:trackCountLabel label4:releasedLabel];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The App is assuming the season shown on top of the list (season with smallest number) would come as `seasonIdx==0`. This assumption is wrong as the season items can be unsorted. There this PR implements a method to identify the smallest season number and use this to set the color of the searchbar.

Details:
- Introduce method to identify the season which is listed on top the list.
- Choose searchbar color based on this season.

Screenshot:
<a href="https://abload.de/image.php?img=bildschirmfoto2021-04tnk5h.png"><img src="https://abload.de/img/bildschirmfoto2021-04tnk5h.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix possibly wrong season view searchbar color