### PR TITLE
Minor correction in cell background color

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2163,6 +2163,7 @@ int originYear = 0;
     frame.size.height = cellHeight;
     cell.urlImageView.frame = frame;
     cell.urlImageView.autoresizingMask = UIViewAutoresizingNone;
+    cell.urlImageView.backgroundColor = [UIColor clearColor];
     
     UILabel *title=(UILabel*) [cell viewWithTag:1];
     UILabel *genre=(UILabel*) [cell viewWithTag:2];
@@ -2344,7 +2345,6 @@ int originYear = 0;
         }
         else {
             [cell.urlImageView setImageWithURL:[NSURL URLWithString:@""] placeholderImage:[UIImage imageNamed:displayThumb]];
-            [cell.urlImageView setBackgroundColor:[Utilities getSystemGray6]];
         }
     }
     else if (albumView){


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
App sets the background color of cells according to Darkmode/Lightmode. It is better to set a transparent background as a default. This resolves a minor glitch when selecting a row, and still supports setting dedicated background colors for transparent TV station logos.

Details:
- Instead of Darkmode/Lightmode background color use clearColor
- Fixes grey selection not shown under transparent image

Screenshot:
<a href="https://abload.de/image.php?img=bildschirmfoto2021-04wsk30.png"><img src="https://abload.de/img/bildschirmfoto2021-04wsk30.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fixes minor glitch not showing selection under transparent thumb image in data cell
