### PR TITLE
Enforce specific image formats before analyzing them

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -86,10 +86,10 @@
     BOOL isRGB = infoMask == kCGImageAlphaNone;
     */
     
-    unsigned int red   = 0;
-    unsigned int green = 0;
-    unsigned int blue  = 0;
-    unsigned int alpha = 0;
+    UInt64 red   = 0;
+    UInt64 green = 0;
+    UInt64 blue  = 0;
+    UInt64 alpha = 0;
     CGFloat f = 1.0;
     
     if (anyNonAlpha) {
@@ -121,7 +121,7 @@
         f = 1.0 / (255.0 * alpha);
     }
     if (inverse) {
-        unsigned int tmp = red;
+        UInt64 tmp = red;
         red = blue;
         blue = tmp;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The App analyzes images for their colors and brightness to decide on background colors. Especially for lately implemented background detection for transparent TV station logos it is important to know the exact format before running the analysis. To ensure the calculations are done accurately this PR forces images into two certain formats: one for images with alpha channel (32 bpp ARGB) and one for images without (32 bpp RGBx). These match the typical formats, conversions were seen rarely during my tests. As an advantage the analysis implementation is reduced as well.

This should finally resolve problems with unreadable TV station logos.

Details:
- Forcing images into certain format before analyzing
- 32 bits per pixel
- If with alpha: kCGImageAlphaPremultipliedFirst (ARGB)
- If without alpha: kCGImageAlphaNoneSkipLast (RGBx)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct analysis of different image formats for background color detection