### PR TITLE
Fix runtime warnings

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3005,7 +3005,14 @@ NSIndexPath *selected;
         UIImageView *isRecordingImageView = (UIImageView*) [cell viewWithTag:104];
         BOOL isRecording = isRecordingImageView == nil ? false : !isRecordingImageView.hidden;
         CGPoint sheetOrigin = CGPointMake(rectOriginX, rectOriginY);
-        [self showActionSheetOptions:title options:sheetActions recording:isRecording point:sheetOrigin fromcontroller:self fromview:self.view];
+        UIViewController *showfromctrl = nil;
+        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+            showfromctrl = self;
+        }
+        else {
+            showfromctrl = self.view.window.rootViewController;
+        }
+        [self showActionSheetOptions:title options:sheetActions recording:isRecording point:sheetOrigin fromcontroller:showfromctrl fromview:self.view];
     }
     else if (indexPath!=nil){ // No actions found, revert back to standard play action
         [self addPlayback:item indexPath:indexPath position:(int)indexPath.row shuffle:NO];
@@ -3086,7 +3093,7 @@ NSIndexPath *selected;
                     showfromview = self.view;
                 }
                 else {
-                    showfromctrl = ([self doesShowSearchResults] || [self getSearchTextField].editing) ? self.searchController : self;
+                    showfromctrl = ([self doesShowSearchResults] || [self getSearchTextField].editing) ? self.searchController : self.view.window.rootViewController;
                     showfromview = enableCollectionView ? collectionView : [showfromctrl.view superview];
                     selectedPoint = enableCollectionView ? p : [lpgr locationInView:showfromview];
                 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3005,14 +3005,14 @@ NSIndexPath *selected;
         UIImageView *isRecordingImageView = (UIImageView*) [cell viewWithTag:104];
         BOOL isRecording = isRecordingImageView == nil ? false : !isRecordingImageView.hidden;
         CGPoint sheetOrigin = CGPointMake(rectOriginX, rectOriginY);
-        UIViewController *showfromctrl = nil;
+        UIViewController *showFromCtrl = nil;
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-            showfromctrl = self;
+            showFromCtrl = self;
         }
         else {
-            showfromctrl = self.view.window.rootViewController;
+            showFromCtrl = self.view.window.rootViewController;
         }
-        [self showActionSheetOptions:title options:sheetActions recording:isRecording point:sheetOrigin fromcontroller:showfromctrl fromview:self.view];
+        [self showActionSheetOptions:title options:sheetActions recording:isRecording point:sheetOrigin fromcontroller:showFromCtrl fromview:self.view];
     }
     else if (indexPath!=nil){ // No actions found, revert back to standard play action
         [self addPlayback:item indexPath:indexPath position:(int)indexPath.row shuffle:NO];
@@ -3086,18 +3086,18 @@ NSIndexPath *selected;
                 }
                 UIImageView *isRecordingImageView = (UIImageView*) [cell viewWithTag:104];
                 BOOL isRecording = isRecordingImageView == nil ? false : !isRecordingImageView.hidden;
-                UIViewController *showfromctrl = nil;
+                UIViewController *showFromCtrl = nil;
                 UIView *showfromview = nil;
                 if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-                    showfromctrl = self;
+                    showFromCtrl = self;
                     showfromview = self.view;
                 }
                 else {
-                    showfromctrl = ([self doesShowSearchResults] || [self getSearchTextField].editing) ? self.searchController : self.view.window.rootViewController;
-                    showfromview = enableCollectionView ? collectionView : [showfromctrl.view superview];
+                    showFromCtrl = ([self doesShowSearchResults] || [self getSearchTextField].editing) ? self.searchController : self.view.window.rootViewController;
+                    showfromview = enableCollectionView ? collectionView : [showFromCtrl.view superview];
                     selectedPoint = enableCollectionView ? p : [lpgr locationInView:showfromview];
                 }
-                [self showActionSheetOptions:title options:sheetActions recording:isRecording point:selectedPoint fromcontroller:showfromctrl fromview:showfromview];
+                [self showActionSheetOptions:title options:sheetActions recording:isRecording point:selectedPoint fromcontroller:showFromCtrl fromview:showfromview];
             }
         }
     }

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -372,7 +372,7 @@
 # pragma mark - ToolBar
 
 -(void)toggleGestureZone:(id)sender{
-    NSString *imageName=@"";
+    NSString *imageName=@"blank";
     BOOL showGesture = (gestureZoneView.alpha == 0);
     if ([sender isKindOfClass:[NSNotification class]]){
         if ([[sender userInfo] isKindOfClass:[NSDictionary class]]){

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -766,7 +766,7 @@
         }
 
         NSString *icon = [item objectForKey:@"icon"];
-        if (icon == nil) icon = @"";
+        if (icon == nil) icon = @"blank";
         
         NSMutableDictionary *action = [item objectForKey:@"action"];
         if (action == nil) action = [[NSMutableDictionary alloc] initWithCapacity:0];
@@ -800,7 +800,7 @@
             NSString *label = [item objectForKey:@"label"];
             if (label == nil) label = @"";
             NSString *icon = [item objectForKey:@"icon"];
-            if (icon == nil) icon = @"";
+            if (icon == nil) icon = @"blank";
             NSString *type = [item objectForKey:@"type"];
             if (type == nil) type = @"";
             NSNumber *isSetting = [item objectForKey:@"isSetting"];

--- a/XBMC Remote/SDWebImage/UIImageView+WebCache.m
+++ b/XBMC Remote/SDWebImage/UIImageView+WebCache.m
@@ -66,7 +66,7 @@ static char operationKey;
 
     self.image = placeholder;
     
-    if (url)
+    if (url && url.path)
     {
         NSDictionary *userInfo = nil;
         if (size.width && size.height){


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The App is throwing several runtime warning when started and while usage. This PR addresses 4 of them.

1. Instead of trying to load an UIImage from `filename = @""` we rather load the invisible `"blank.png"` (happens each start)
Warning:
_Kodi Remote[13395:684990] [framework] CUICatalog: Invalid asset name supplied: ''_

2. Do not try to load images from an empty URL path (e.g. happens when entering music genre menu)
Warning:
_Kodi Remote[13222:678986] nil host used in call to allowsSpecificHTTPSCertificateForHost
2021-04-30 15:50:02.893256+0200 
Kodi Remote[13222:678986] nil host used in call to allowsAnyHTTPSCertificateForHost:
2021-04-30 15:50:02.893425+0200 
Kodi Remote[13222:678986] CFURLRequestSetHTTPCookieStorageAcceptPolicy_block_invoke: no longer implemented and should not be called_

3. Presenting actionsheet popups on iPad throw a warning. Presenting them from `self.view.window.rootViewController` fixes this, but I am not sure if this a good thing to do or we just ignore the warning...
Warning:
_Kodi Remote[13222:678986] [Presentation] Presenting view controller <UIAlertController: 0x7f8bf0008200> from detached view controller <DetailViewController: 0x7f8bf0887800> is discouraged._

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Avoid runtime warnings
