### PR TITLE
Fixes around UI behavior while searching

### DIFF
--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -143,6 +143,7 @@
     BOOL showbar;
     dispatch_queue_t epglockqueue;
     LogoBackgroundType logoBackgroundMode;
+    BOOL showkeyboard;
 }
 
 - (id)initWithFrame:(CGRect)frame;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -561,9 +561,8 @@
     [self hideButtonListWhenEmpty];
 }
 
--(void)hideButtonListWhenEmpty {
-    // Hide the toolbar when no button is shown at all
-    if (button1.hidden && button2.hidden && button3.hidden && button4.hidden && button5.hidden && button6.hidden && button7.hidden) {
+-(void)hideButtonList:(BOOL)hide {
+    if (hide) {
         buttonsView.hidden = YES;
         
         UIEdgeInsets tableViewInsets = dataList.contentInset;
@@ -583,6 +582,13 @@
         collectionView.contentInset = tableViewInsets;
         collectionView.scrollIndicatorInsets = tableViewInsets;
     }
+}
+
+-(void)hideButtonListWhenEmpty {
+    // Hide the toolbar when no button is shown at all
+    BOOL hide = button1.hidden && button2.hidden && button3.hidden && button4.hidden &&
+                button5.hidden && button6.hidden && button7.hidden;
+    [self hideButtonList:hide];
 }
 
 -(void)toggleOpen:(UITapGestureRecognizer *)sender {
@@ -5467,10 +5473,14 @@ NSIndexPath *selected;
 
 - (void)searchBarCancelButtonClicked:(UISearchBar*)searchbar {
     showkeyboard = NO;
+    // Restore the toolbar when search became inactive
+    [self hideButtonListWhenEmpty];
 }
 
 - (void)searchBarSearchButtonClicked:(UISearchBar*)searchbar {
     showkeyboard = NO;
+    // Hide the toolbar while search is active
+    [self hideButtonList:YES];
 }
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar*)searchbar {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5279,6 +5279,10 @@ NSIndexPath *selected;
         [self updateChannelListTableCell];
         channelListUpdateTimer = [NSTimer scheduledTimerWithTimeInterval:(60.0 - [[outputFormatter stringFromDate:now] floatValue]) target:self selector:@selector(startChannelListUpdateTimer) userInfo:nil repeats:NO];
     }
+    // Show the keyboard if it was active when the view was shown last time. Remark: Only works with dalay!
+    if (showkeyboard) {
+        [[self getSearchTextField] performSelector:@selector(becomeFirstResponder) withObject:nil afterDelay:0.1];
+    }
     [self setButtonViewContent];
 }
 
@@ -5457,6 +5461,20 @@ NSIndexPath *selected;
         }
     }
     return sortMethod;
+}
+
+#pragma mark - UISearchBarDelegate
+
+- (void)searchBarCancelButtonClicked:(UISearchBar*)searchbar {
+    showkeyboard = NO;
+}
+
+- (void)searchBarSearchButtonClicked:(UISearchBar*)searchbar {
+    showkeyboard = NO;
+}
+
+- (void)searchBarTextDidBeginEditing:(UISearchBar*)searchbar {
+    showkeyboard = YES;
 }
 
 #pragma mark UISearchController Delegate Methods


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/241.

1. Restore keyboard visibility
When coming back to a filtered list (e.g. filtering for music albums, then select one to go into the detail view, then go back) the App is never showing the keyboard and the search text field is not firstResponder anymore. This PR aligns the behavior with other iOS Apps: The keyboard visibility / editing mode is saved and restored when re-entering the menu.
2. Avoid misbehavior
When a filtered list is shown (e.g. filtering for music albums) and the user hits "Search" the keyboard becomes invisible and allows to touch the toolbar items. Hitting any of these buttons now leads to uncontrolled behavior which can only be fixed via re-entering the whole music menu. This PR avoids this situation by simply hiding the toolbar when the keyboard is made invisible (pressing "Search" button on the keyboard), and making it visible again when the search is ended (pressing "Cancel" button next to search text field). I chose this solution over ignoring touch of each toolbar item for its simplicity.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Restore keyboard visibility while searching after selecting item from search list and returning back
Bugfix: Avoid misbehavior when selecting toolbar items during search list is presented