### PR TITLE
Handle Safari exception

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -470,7 +470,20 @@
 
 + (void)SFloadURL:(NSString*)url fromctrl:(UIViewController<SFSafariViewControllerDelegate> *)fromctrl {
     NSURL *nsurl = [NSURL URLWithString:url];
-    SFSafariViewController *svc = [[SFSafariViewController alloc] initWithURL:nsurl];
+    SFSafariViewController *svc = nil;
+    // Try to load the URL via SFSafariViewController. If this is not possible, check if this is loadable
+    // with other system applications. If so, load it. If not, show an error popup.
+    @try {
+        svc = [[SFSafariViewController alloc] initWithURL:nsurl];
+    } @catch (NSException *exception) {
+        if ([UIApplication.sharedApplication canOpenURL:nsurl])
+            [UIApplication.sharedApplication openURL:nsurl options:@{} completionHandler:nil];
+        else {
+            UIAlertController *alertView = [Utilities createAlertOK:NSLocalizedString(@"Error loading page", nil) message:exception.reason];
+            [fromctrl presentViewController:alertView animated:YES completion:nil];
+        }
+        return;
+    }
     UIViewController *ctrl = fromctrl;
     svc.delegate = fromctrl;
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/245

This PR introduces exception handling via a `@try` / `@catch` block when creating an instance of `SFSafariViewController`. This avoids potential crashes of the App (e.g. when trying to load URL without leading `http://` or `https://`). Instead, the App will present an error message with the non-loadable URL.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid crash of Safari browser