### PR TITLE
Fix longpress when search textfield active but empty

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3067,7 +3067,7 @@ NSIndexPath *selected;
                     showfromview = self.view;
                 }
                 else {
-                    showfromctrl = [self doesShowSearchResults] ? self.searchController : self;
+                    showfromctrl = ([self doesShowSearchResults] || [self getSearchTextField].editing) ? self.searchController : self;
                     showfromview = enableCollectionView ? collectionView : [showfromctrl.view superview];
                     selectedPoint = enableCollectionView ? p : [lpgr locationInView:showfromview];
                 }
@@ -3205,7 +3205,7 @@ NSIndexPath *selected;
 - (void)actionSheetHandler:(NSString*)actiontitle {
     NSMutableDictionary *item = nil;
     if (selected != nil){
-        if ([self.searchController isActive]){
+        if ([self doesShowSearchResults]){
             if (selected.row < [self.filteredListContent count]) {
                 item = self.filteredListContent[selected.row];
             }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/250

Details:
- On iPad we need to present from searchController not only when a non-empty filtered list is available, but also when we have an active but empty searchbar textfield.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix longpress on filtered list not showing in case of active but empty searchbar textfield