### PR TITLE
Show correct title in action sheet popup for filtered lists

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2996,7 +2996,6 @@ NSIndexPath *selected;
         CGPoint p;
         CGPoint selectedPoint;
         NSIndexPath *indexPath = nil;
-        NSIndexPath *indexPath2 = nil;
         if (enableCollectionView){
             p = [longPressGesture locationInView:collectionView];
             selectedPoint=[longPressGesture locationInView:self.view];
@@ -3005,11 +3004,9 @@ NSIndexPath *selected;
             p = [lpgr locationInView:dataList];
             selectedPoint=[lpgr locationInView:self.view];
             indexPath = [dataList indexPathForRowAtPoint:p];
-            CGPoint p2 = [longPressGesture locationInView:dataList];
-            indexPath2 = [dataList indexPathForRowAtPoint:p2];
         }
         
-        if (indexPath != nil || indexPath2 != nil ){
+        if (indexPath != nil){
             selected=indexPath;
             
             NSMutableArray *sheetActions = [[self.detailItem sheetActions] objectAtIndex:choosedTab];
@@ -3022,8 +3019,8 @@ NSIndexPath *selected;
             if (numActions){
                 NSDictionary *item = nil;
                 if ([self doesShowSearchResults]){
-                    item = [self.filteredListContent objectAtIndex:indexPath2.row];
-                    [dataList selectRowAtIndexPath:indexPath2 animated:NO scrollPosition:UITableViewScrollPositionNone];
+                    item = self.filteredListContent[indexPath.row];
+                    [dataList selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
                 }
                 else{                    
                     if (enableCollectionView){


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/248

The App uses the wrong path for the selected item when long-pressing on a filtered list. In consequence the wrong title was displayed for the action sheet. This PR lets the App choose the correct item and allows to further reduce complexity. This issue is caused by not-yet fixed wrong code from the intial overhaul of the search behavior which was required to make the App run under iOS 14.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show correct title (taken from item) in action sheet for filtered lists