### PR TITLE
Bring back full size for TV Show cover in ShowInfoVC

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -844,6 +844,9 @@ int h=0;
                 int originalHeight = jewelView.frame.size.height;
                 int coverHeight = 560;
                 deltaY = -(coverHeight - originalHeight);
+                frame = jewelView.frame;
+                frame.size.height = coverHeight;
+                jewelView.frame = frame;
             }
             if (enableJewel){
                 jewelView.image = [UIImage imageNamed:@"jewel_dvd.9.png"];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/253

Since 1.6.1 the size of TV show covers was reduced. This PR brings back the original size as in 1.6.0.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Bring back size of TV show cover (same as for movies)