### PR TITLE
Correct the position of movie cover in modal view

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1214,7 +1214,7 @@ int h=0;
             int coverWidth = STACKSCROLL_WIDTH;
             CGRect frame;
             frame = jewelView.frame;
-            frame.origin.x = 0;
+            frame.origin.x = (self.view.frame.size.width - STACKSCROLL_WIDTH) / 2;
             frame.size.height = coverHeight;
             frame.size.width = coverWidth;
             jewelView.frame = frame;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The App is not showing the movie covers at the correct position when presenting them in modal view (happens when selecting a movie from fullscreen mode on iPads). This PR corrects the position:

Screenshots (with jewel case):
https://abload.de/img/simulatorscreenshot-ifyjvw.png (iPad 5G, before)
https://abload.de/img/simulatorscreenshot-i2hkqe.png (iPad 5G, after)

Screenshots (without jewel case):
https://abload.de/img/simulatorscreenshot-i65j62.png (iPad 5G, before)
https://abload.de/img/simulatorscreenshot-ia1kj7.png (iPad 5G, after)
https://abload.de/img/simulatorscreenshot-iesjrq.png (iPad Pro 4G, before)
https://abload.de/img/simulatorscreenshot-iezjeb.png (iPad Pro 4G, after)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct the position of movie covers in modal view
