### PR TITLE
Do not show posterLabel and labelImageView in fullscreen mode

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1432,7 +1432,7 @@
                     [Utilities setLogoBackgroundColor:cell.posterThumbnail mode:logoBackgroundMode];
                 }
             }];
-            if (hiddenLabel) {
+            if (hiddenLabel || stackscrollFullscreen) {
                 [cell.posterLabel setHidden:YES];
                 [cell.labelImageView setHidden:YES];
             }


### PR DESCRIPTION
- This avoids presenting an unneeded opaque bar over the bottom part of thumbs/covers

## Description
<!--- Detailed info for reviewers and developers -->
Takes care of a valid comment made in a [forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3028203#pid3028203).

The App does still show empty labels and the corresponding "shadow bar" in fullscreen mode, even though they are not required. This PR removes both label and shadow in fullscreen mode, similar to setting "Hide label in wall view".

Screenshots:
https://abload.de/img/simulatorscreenshot-iwajmq.png (movies, before)
https://abload.de/img/simulatorscreenshot-i9kjxp.png (movies, after)
https://abload.de/img/simulatorscreenshot-iswj98.png (music, before)
https://abload.de/img/simulatorscreenshot-in9jvb.png (music, after)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Remove unneeded shadow bar from covers in fullscreen mode