### PR TITLE
Feature: Music fullscreen also loads ShowInfo view

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -852,6 +852,23 @@ NSMutableArray *hostRightMenuItems;
                         [NSMutableArray array],
                         nil];
     
+    item1.showInfo = [NSArray arrayWithObjects:
+                      [NSNumber numberWithBool:YES],
+                      [NSNumber numberWithBool:YES],
+                      [NSNumber numberWithBool:NO],
+                      [NSNumber numberWithBool:NO],
+                      [NSNumber numberWithBool:NO],
+                      [NSNumber numberWithBool:NO],
+                      [NSNumber numberWithBool:NO],
+                      [NSNumber numberWithBool:NO],
+                      [NSNumber numberWithBool:NO],
+                      [NSNumber numberWithBool:NO],
+                      [NSNumber numberWithBool:NO],
+                      [NSNumber numberWithBool:NO],
+                      [NSNumber numberWithBool:NO],
+                      [NSNumber numberWithBool:NO],
+                      nil];
+    
     item1.subItem.mainMethod=[NSMutableArray arrayWithObjects:
                               
                               [NSArray arrayWithObjects:@"AudioLibrary.GetSongs", @"method", @"YES", @"albumView", nil],

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1248,7 +1248,8 @@
             }
         }
     }
-    else if ([methods objectForKey:@"method"]!=nil && ![[parameters objectForKey:@"forceActionSheet"] boolValue]){ // THERE IS A CHILD
+    else if (methods[@"method"]!=nil && ![parameters[@"forceActionSheet"] boolValue] && !stackscrollFullscreen){
+        // There is a child and we want to show it (only when not in fullscreen)
         [self viewChild:indexPath item:item displayPoint:point];
     }
     else {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1102,6 +1102,11 @@
 
                 });
             }
+            else if ([self isModal]) {
+                DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:MenuItem.subItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
+                [iPadDetailViewController setModalPresentationStyle:UIModalPresentationFormSheet];
+                [self presentViewController:iPadDetailViewController animated:YES completion:nil];
+            }
             else {
                 DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:MenuItem.subItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
                 [[AppDelegate instance].windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:FALSE];
@@ -2631,6 +2636,7 @@ int originYear = 0;
         albumInfoButton.tag = 0;
         [albumInfoButton addTarget:self action:@selector(prepareShowAlbumInfo:) forControlEvents:UIControlEventTouchUpInside];
         [albumDetailView addSubview:albumInfoButton];
+        albumInfoButton.hidden = [self isModal];
         
 //        UIButton *albumPlaybackButton =  [UIButton buttonWithType:UIButtonTypeCustom];
 //        albumPlaybackButton.tag = 0;
@@ -2801,6 +2807,7 @@ int originYear = 0;
             albumInfoButton.tag = 1;
             [albumInfoButton addTarget:self action:@selector(prepareShowAlbumInfo:) forControlEvents:UIControlEventTouchUpInside];
             [albumDetailView addSubview:albumInfoButton];
+            albumInfoButton.hidden = [self isModal];
         }
         return albumDetailView;
     }
@@ -5453,6 +5460,10 @@ NSIndexPath *selected;
     }
 }
 
+-(BOOL)isModal {
+    return [self presentingViewController] != nil;
+}
+
 -(void)setIphoneInterface:(NSDictionary *)itemSizes {
     viewWidth = [self currentScreenBoundsDependOnOrientation].size.width;
     albumViewHeight = 116;
@@ -5473,6 +5484,9 @@ NSIndexPath *selected;
 
 -(void)setIpadInterface:(NSDictionary *)itemSizes{
     viewWidth = STACKSCROLL_WIDTH;
+    // ensure modal views are forced to width = STACKSCROLL_WIDTH, this eases the layout
+    CGSize size = CGSizeMake(STACKSCROLL_WIDTH, self.view.frame.size.height);
+    self.preferredContentSize = size;
     albumViewHeight = 166;
     if (episodesView){
         albumViewHeight = 120;
@@ -5594,6 +5608,7 @@ NSIndexPath *selected;
 -(void)viewWillLayoutSubviews {
     [super viewWillLayoutSubviews];
     [self showSearchBar];
+    viewWidth = self.view.bounds.size.width;
 }
 
 - (void)willPresentSearchController:(UISearchController *)controller {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5340,7 +5340,7 @@ NSIndexPath *selected;
 
     [self choseParams];
 
-    if ([self presentingViewController] != nil) {
+    if ([self isModal]) {
         UIBarButtonItem * doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismissAddAction:)];
         self.navigationItem.rightBarButtonItem = doneButton;
     }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -774,10 +774,7 @@ int h=0;
         size = 6;
         castWidth = 75;
         castHeight = 105;
-        pageSize = STACKSCROLL_WIDTH - 40;
-        if ([self isModal]){
-            pageSize = 540 - 40;
-        }
+        pageSize = self.view.bounds.size.width - 40;
         [starsView setFrame:
          CGRectMake(
                     starsView.frame.origin.x, 

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -423,6 +423,11 @@ int count=0;
                 [[AppDelegate instance].windowController.stackScrollViewController enablePanGestureRecognizer];
                 [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object: nil];
             }
+            else {
+                DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:choosedMenuItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
+                [iPadDetailViewController setModalPresentationStyle:UIModalPresentationFormSheet];
+                [self presentViewController:iPadDetailViewController animated:YES completion:nil];
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The App since 1.6.2 support fullscreen for music albums and artists. But when selecting a music album or an artists the fullscreen mode is stopped and the App falls back into the normal list/grid view. This is not happening when selecting a movie from the fullscreen mode. In this case a detail view (ShowInfoViewController) is presented in modal view.

This PR changes the music behavior to the same as for movies. When an album is selected a modal view of the album details is presented, skipping the track list for the album. When an artists is selected a modal view of the artist details is presented, skipping all albums of this artist. This is not fully consistent to the behavior in list/grid view, but keeps the fullscreen look&feel. You can still reach the skipped view via the upper right buttons in the artist/album detail view which will open the track list or artists' albums. All of these screen are presented in modal view until the user leaves fullscreen mode.

Screenshots:
https://abload.de/img/simulatorscreenshot-ix1kvd.png
https://abload.de/img/simulatorscreenshot-is6kdo.png
https://abload.de/img/simulatorscreenshot-i9oj7h.png
https://abload.de/img/simulatorscreenshot-itzkul.png
https://abload.de/img/simulatorscreenshot-i6xjas.png
https://abload.de/img/simulatorscreenshot-ii0kei.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Align look and feel of music fullscreen to movie fullscreen