### PR TITLE
Fix posterselect

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -148,7 +148,7 @@ NSMutableArray *hostRightMenuItems;
     float itemMovieHeightLargeIpad =  230.0f;
     
     float fullscreenItemMovieWidthIpad = 164.0f;
-    float fullscreenItemMovieHeightIpad = 246.0f;
+    float fullscreenItemMovieHeightIpad = 233.0f;
     
     float itemMovieHeightRecentlyIphone =  132.0f;
     float itemMovieHeightRecentlyIpad =  196.0f;

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -69,7 +69,8 @@
         [self.contentView addSubview:_busyView];
 
         UIView *bgView = [[UIView alloc] initWithFrame:frame];
-        [bgView setBackgroundColor:[Utilities getSystemGreen:1.0]];
+        bgView.layer.borderWidth = borderWidth;
+        bgView.layer.borderColor = [Utilities getSystemGreen:1.0].CGColor;
         self.selectedBackgroundView = bgView;
     }
     return self;

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -92,7 +92,8 @@
         [self.contentView addSubview:_busyView];
         
         UIView *bgView = [[UIView alloc] initWithFrame:frame];
-        [bgView setBackgroundColor:[Utilities getSystemGreen:1.0]];
+        bgView.layer.borderWidth = borderWidth;
+        bgView.layer.borderColor = [Utilities getSystemGreen:1.0].CGColor;
         self.selectedBackgroundView = bgView;
     }
     return self;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The App uses a green frame to highlight a selected item in grid view and fullscreen mode. This is done via drawing a green background which is 2x border width bigger as the image shown. There are two issues with this: First, the dimension for the movie covers was not selected properly in fullscreen mode. In consequence the green frame was not having equal border width (screenshot 1). Second, this looked somehow strange when a cover which does match the expected aspect ratio is drawn (see screenshots 3 and 5).

This PR changes the height of the movie cover cells for fullscreen mode to match the expected aspect ratio. Also it changes the highlighting from using a green background to drawing a green frame.

Screenshots:
https://abload.de/img/simulatorscreenshot-i8jj2t.png (fullscreen, before)
https://abload.de/img/simulatorscreenshot-ij1k6q.png (fullscreen, after)
https://abload.de/img/simulatorscreenshot-iivj4x.png (fullscreen, before)
https://abload.de/img/simulatorscreenshot-iyyk4q.png (fullscreen, after)
https://abload.de/img/simulatorscreenshot-i1hkis.png (grid view, before)
https://abload.de/img/simulatorscreenshot-inok50.png (grid view, after)


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Border instead of background for highlighting selected item