### PR TITLE
Do not show song details if nothing is playing

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1961,7 +1961,7 @@ int currentItemID;
     else if ([itemLogoImage pointInside:viewPoint3 withEvent:event] && songDetailsView.alpha > 0 && itemLogoImage.image != nil) {
         [self updateCurrentLogo];
     }
-    else if([touch.view isEqual:jewelView] || [touch.view isEqual:songDetailsView]){
+    else if (!nothingIsPlaying && ([touch.view isEqual:jewelView] || [touch.view isEqual:songDetailsView])){
         [self toggleSongDetails];
         [self toggleViewToolBar:volumeSliderView AnimDuration:0.3 Alpha:1.0 YPos:0 forceHide:TRUE];
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The App shows an empty overlay view when clicking on the NowPlaying screen if nothing is playing. This PR simply checks for the already available `nothingIsPlaying` variable.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not show song details if nothing is playing