### PR TITLE
Avoid crash when attempting to present popup twice

### DIFF
--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -208,7 +208,9 @@
         popPresenter.sourceView = self.view;
         popPresenter.sourceRect = xbmcInfo.frame;
     }
-    [self presentViewController:[AppDelegate instance].navigationController animated:YES completion:nil];
+    if (![[AppDelegate instance].navigationController isBeingPresented]) {
+        [self presentViewController:[AppDelegate instance].navigationController animated:YES completion:nil];
+    }
 }
 
 -(void) showSetup:(BOOL)show{


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
During startup on iPad a sporadic race condition can result in a crash. This is caused by attempting to present the "serverpicker" popup twice. This PR adds a check to avoid presenting the popup again when it is already presented.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid sporadic crash on iPad at startup