### PR TITLE
Avoid crash when attempting to push same controller again

### DIFF
--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -32,7 +32,6 @@
     IBOutlet UIActivityIndicatorView *activityIndicatorView;
     NSMutableDictionary *sections;  
     IBOutlet UILongPressGestureRecognizer *lpgr;
-    BOOL alreadyPush;
     int choosedTab;
     int numTabs;
     int watchMode;

--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -152,9 +152,6 @@
 @property (nonatomic, retain) NSMutableArray *filteredListContent;
 @property (strong, nonatomic) id detailItem;
 @property(nonatomic,readonly) UIActivityIndicatorView *activityIndicatorView;
-@property (strong, nonatomic) ShowInfoViewController *showInfoViewController;
-@property (strong, nonatomic) DetailViewController *detailViewController;
-@property (strong, nonatomic) NowPlaying *nowPlaying;
 @property (strong, nonatomic) BDKCollectionIndexView *indexView;
 @property (nonatomic,retain) NSMutableDictionary *sections;
 @property (nonatomic,retain) NSMutableArray *richResults;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -38,9 +38,6 @@
 @synthesize detailItem = _detailItem;
 @synthesize activityIndicatorView;
 @synthesize sections;
-@synthesize detailViewController;
-@synthesize nowPlaying;
-@synthesize showInfoViewController;
 @synthesize filteredListContent;
 @synthesize richResults;
 @synthesize sectionArray;
@@ -1005,7 +1002,6 @@
 #pragma mark - Library item didSelect
 
 -(void)viewChild:(NSIndexPath *)indexPath item:(NSDictionary *)item displayPoint:(CGPoint) point{
-    self.detailViewController=nil;
     selected = indexPath;
     mainMenu *MenuItem=self.detailItem;
     NSMutableArray *sheetActions=[[self.detailItem sheetActions] objectAtIndex:choosedTab];
@@ -1089,9 +1085,9 @@
         MenuItem.subItem.chooseTab=choosedTab;
         MenuItem.subItem.currentWatchMode = watchMode;
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone){
-            self.detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
-            self.detailViewController.detailItem = MenuItem.subItem;
-            [self.navigationController pushViewController:self.detailViewController animated:YES];
+            DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
+            detailViewController.detailItem = MenuItem.subItem;
+            [self.navigationController pushViewController:detailViewController animated:YES];
         }
         else{
             if (stackscrollFullscreen == YES){
@@ -1141,9 +1137,9 @@
                 [[MenuItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
                 MenuItem.chooseTab=choosedTab;
                 if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone){
-                    self.detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
-                    self.detailViewController.detailItem = MenuItem;
-                    [self.navigationController pushViewController:self.detailViewController animated:YES];
+                    DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
+                    detailViewController.detailItem = MenuItem;
+                    [self.navigationController pushViewController:detailViewController animated:YES];
                 }
                 else{
                     if (stackscrollFullscreen == YES){
@@ -1204,10 +1200,9 @@
             [[MenuItem.subItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
             MenuItem.subItem.chooseTab=choosedTab;
             if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone){
-                
-                self.detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
-                self.detailViewController.detailItem = MenuItem.subItem;
-                [self.navigationController pushViewController:self.detailViewController animated:YES];
+                DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
+                detailViewController.detailItem = MenuItem.subItem;
+                [self.navigationController pushViewController:detailViewController animated:YES];
             }
             else{
                 if (stackscrollFullscreen == YES){
@@ -1227,7 +1222,6 @@
 }
 
 -(void)didSelectItemAtIndexPath:(NSIndexPath *)indexPath item:(NSDictionary *)item displayPoint:(CGPoint) point{
-    self.detailViewController=nil;
     mainMenu *MenuItem=self.detailItem;
     NSDictionary *methods=[self indexKeyedDictionaryFromArray:[[MenuItem.subItem mainMethod] objectAtIndex:choosedTab]];
     NSMutableArray *sheetActions=[[self.detailItem sheetActions] objectAtIndex:choosedTab];
@@ -3691,9 +3685,9 @@ NSIndexPath *selected;
 
 -(void)showNowPlaying{
     if (!alreadyPush){
-        self.nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
-        self.nowPlaying.detailItem = self.detailItem;
-        [self.navigationController pushViewController:self.nowPlaying animated:YES];
+        NowPlaying *nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
+        nowPlaying.detailItem = self.detailItem;
+        [self.navigationController pushViewController:nowPlaying animated:YES];
         alreadyPush = YES;
     }
 }
@@ -3710,7 +3704,6 @@ NSIndexPath *selected;
 }
 
 -(void)exploreItem:(NSDictionary *)item{
-    self.detailViewController=nil;
     mainMenu *MenuItem=self.detailItem;
     NSDictionary *mainFields=[[MenuItem mainFields] objectAtIndex:choosedTab];
     MenuItem.subItem.mainLabel=[item objectForKey:@"label"];
@@ -3752,10 +3745,9 @@ NSIndexPath *selected;
     [[MenuItem.subItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
     MenuItem.subItem.chooseTab=choosedTab;
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone){
-        
-        self.detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
-        self.detailViewController.detailItem = MenuItem.subItem;
-        [self.navigationController pushViewController:self.detailViewController animated:YES];
+        DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
+        detailViewController.detailItem = MenuItem.subItem;
+        [self.navigationController pushViewController:detailViewController animated:YES];
     }
     else{
         if (stackscrollFullscreen == YES){
@@ -4133,10 +4125,9 @@ NSIndexPath *selected;
 
 -(void)displayInfoView:(NSDictionary *)item {
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-        self.showInfoViewController=nil;
-        self.showInfoViewController = [[ShowInfoViewController alloc] initWithNibName:@"ShowInfoViewController" bundle:nil];
-        self.showInfoViewController.detailItem = item;
-        [self.navigationController pushViewController:self.showInfoViewController animated:YES];
+        ShowInfoViewController *showInfoViewController = [[ShowInfoViewController alloc] initWithNibName:@"ShowInfoViewController" bundle:nil];
+        showInfoViewController.detailItem = item;
+        [self.navigationController pushViewController:showInfoViewController animated:YES];
     }
     else {
         ShowInfoViewController *iPadShowViewController = [[ShowInfoViewController alloc] initWithNibName:@"ShowInfoViewController" withItem:item withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3684,12 +3684,9 @@ NSIndexPath *selected;
 }
 
 -(void)showNowPlaying{
-    if (!alreadyPush){
-        NowPlaying *nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
-        nowPlaying.detailItem = self.detailItem;
-        [self.navigationController pushViewController:nowPlaying animated:YES];
-        alreadyPush = YES;
-    }
+    NowPlaying *nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
+    nowPlaying.detailItem = self.detailItem;
+    [self.navigationController pushViewController:nowPlaying animated:YES];
 }
 
 # pragma mark - Playback Management
@@ -5316,7 +5313,6 @@ NSIndexPath *selected;
         self.slidingViewController.anchorLeftPeekAmount     = 0;
         self.slidingViewController.anchorLeftRevealAmount   = 0;
     }
-    alreadyPush = NO;
     NSIndexPath* selection = [dataList indexPathForSelectedRow];
 	if (selection){
 		[dataList deselectRowAtIndexPath:selection animated:NO];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3691,15 +3691,10 @@ NSIndexPath *selected;
 
 -(void)showNowPlaying{
     if (!alreadyPush){
-        //self.nowPlaying=nil;
-        if (self.nowPlaying == nil){
-            self.nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
-        }
+        self.nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
         self.nowPlaying.detailItem = self.detailItem;
-//        self.nowPlaying.presentedFromNavigation = YES;
-        
         [self.navigationController pushViewController:self.nowPlaying animated:YES];
-        alreadyPush=YES;
+        alreadyPush = YES;
     }
 }
 

--- a/XBMC Remote/HostManagementViewController.h
+++ b/XBMC Remote/HostManagementViewController.h
@@ -38,7 +38,6 @@
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil;
 -(void)selectIndex:(NSIndexPath *)selection reloadData:(BOOL)reload;
 
-@property (strong, nonatomic) HostViewController *hostController;
 @property (nonatomic, strong) NSMutableArray *mainMenu;
 
 @end

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -33,9 +33,7 @@
 #pragma mark - Button Mamagement
 
 -(IBAction)addHost:(id)sender{
-    if (self.hostController == nil) {
-        self.hostController = [[HostViewController alloc] initWithNibName:@"HostViewController" bundle:nil];
-    }
+    self.hostController = [[HostViewController alloc] initWithNibName:@"HostViewController" bundle:nil];
     self.hostController.detailItem = nil;
     [self.navigationController pushViewController:self.hostController animated:YES];
 }
@@ -61,9 +59,7 @@
         }
         [connectingActivityIndicator stopAnimating];
     }
-    if (self.hostController == nil) {
-        self.hostController = [[HostViewController alloc] initWithNibName:@"HostViewController" bundle:nil] ;
-    }
+    self.hostController = [[HostViewController alloc] initWithNibName:@"HostViewController" bundle:nil];
     self.hostController.detailItem = item;
     [self.navigationController pushViewController:self.hostController animated:YES];
 }

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -22,7 +22,6 @@
 
 @implementation HostManagementViewController
 
-@synthesize hostController;
 @synthesize mainMenu;
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil{
@@ -33,9 +32,9 @@
 #pragma mark - Button Mamagement
 
 -(IBAction)addHost:(id)sender{
-    self.hostController = [[HostViewController alloc] initWithNibName:@"HostViewController" bundle:nil];
-    self.hostController.detailItem = nil;
-    [self.navigationController pushViewController:self.hostController animated:YES];
+    HostViewController *hostController = [[HostViewController alloc] initWithNibName:@"HostViewController" bundle:nil];
+    hostController.detailItem = nil;
+    [self.navigationController pushViewController:hostController animated:YES];
 }
 
 -(void)modifyHost:(NSIndexPath *)item{
@@ -59,9 +58,9 @@
         }
         [connectingActivityIndicator stopAnimating];
     }
-    self.hostController = [[HostViewController alloc] initWithNibName:@"HostViewController" bundle:nil];
-    self.hostController.detailItem = item;
-    [self.navigationController pushViewController:self.hostController animated:YES];
+    HostViewController *hostController = [[HostViewController alloc] initWithNibName:@"HostViewController" bundle:nil];
+    hostController.detailItem = item;
+    [self.navigationController pushViewController:hostController animated:YES];
 }
 
 #pragma mark - Table view methods & data source

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -128,8 +128,6 @@
 
 @property (strong, nonatomic) id detailItem;
 @property (strong, nonatomic) RemoteController *remoteController;
-@property (strong, nonatomic) DetailViewController *detailViewController;
-@property (strong, nonatomic) ShowInfoViewController *showInfoViewController;
 @property (strong, nonatomic) UIImageView *jewelView;
 @property (strong, nonatomic) IBOutlet UIImageView *itemLogoImage;
 @property (strong, nonatomic) UIButton *shuffleButton;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -31,13 +31,11 @@
 @synthesize detailItem = _detailItem;
 @synthesize remoteController;
 @synthesize jewelView;
-@synthesize detailViewController;
 @synthesize shuffleButton;
 @synthesize repeatButton;
 @synthesize itemLogoImage;
 @synthesize songDetailsView;
 @synthesize ProgressSlider;
-@synthesize showInfoViewController;
 @synthesize scrabbingView;
 @synthesize itemDescription;
 //@synthesize presentedFromNavigation;
@@ -1455,10 +1453,9 @@ int currentItemID;
 -(void)displayInfoView:(NSDictionary *)item{
     fromItself = TRUE;
     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone){
-        self.showInfoViewController=nil;
-        self.showInfoViewController = [[ShowInfoViewController alloc] initWithNibName:@"ShowInfoViewController" bundle:nil];
-        self.showInfoViewController.detailItem = item;
-        [self.navigationController pushViewController:self.showInfoViewController animated:YES];
+        ShowInfoViewController *showInfoViewController = [[ShowInfoViewController alloc] initWithNibName:@"ShowInfoViewController" bundle:nil];
+        showInfoViewController.detailItem = item;
+        [self.navigationController pushViewController:showInfoViewController animated:YES];
     }
     else{
         ShowInfoViewController *iPadShowViewController = [[ShowInfoViewController alloc] initWithNibName:@"ShowInfoViewController" withItem:item withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
@@ -2235,9 +2232,9 @@ int currentItemID;
         MenuItem.subItem.chooseTab=choosedTab;
         fromItself = TRUE;
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone){
-            self.detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
-            self.detailViewController.detailItem = MenuItem.subItem;
-            [self.navigationController pushViewController:self.detailViewController animated:YES];
+            DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
+            detailViewController.detailItem = MenuItem.subItem;
+            [self.navigationController pushViewController:detailViewController animated:YES];
         }
         else{
             DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:MenuItem.subItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];

--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -87,8 +87,6 @@
 - (id)initWithNibName:(NSString *)nibNameOrNil withItem:(NSDictionary *)item withFrame:(CGRect)frame bundle:(NSBundle *)nibBundleOrNil;
 
 @property (strong, nonatomic) id detailItem;
-@property (strong, nonatomic) NowPlaying *nowPlaying;
-@property (strong, nonatomic) DetailViewController *detailViewController;
 @property (nonatomic, retain) KenBurnsView *kenView;
 
 @end

--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -48,7 +48,6 @@
     IBOutlet UIImageView *jewelView;
     IBOutlet UIImageView *fanartView;
 
-    BOOL alreadyPush;
     BOOL isRecordingDetail;
     UIToolbar *toolbar;
     NSMutableArray *sheetActions;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -602,15 +602,11 @@ int count=0;
 
 -(void)showNowPlaying{
     if (!alreadyPush){
-        //self.nowPlaying=nil;
-        if (self.nowPlaying == nil){
-            self.nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
-        }
+        self.nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
         self.nowPlaying.detailItem = self.detailItem;
-//        self.nowPlaying.presentedFromNavigation = YES;
         [self.navigationController pushViewController:self.nowPlaying animated:YES];
         self.navigationItem.rightBarButtonItem.enabled=YES;
-        alreadyPush=YES;
+        alreadyPush = YES;
     }
 }
 

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -599,13 +599,10 @@ int count=0;
 }
 
 -(void)showNowPlaying{
-    if (!alreadyPush){
-        NowPlaying *nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
-        nowPlaying.detailItem = self.detailItem;
-        [self.navigationController pushViewController:nowPlaying animated:YES];
-        self.navigationItem.rightBarButtonItem.enabled=YES;
-        alreadyPush = YES;
-    }
+    NowPlaying *nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
+    nowPlaying.detailItem = self.detailItem;
+    [self.navigationController pushViewController:nowPlaying animated:YES];
+    self.navigationItem.rightBarButtonItem.enabled = YES;
 }
 
 -(void)moveLabel:(NSArray *)objects posY:(int)y{
@@ -1937,7 +1934,6 @@ int h=0;
 
 -(void)viewWillAppear:(BOOL)animated{
     [super viewWillAppear:animated];
-    alreadyPush=NO;
     self.slidingViewController.underRightViewController = nil;
     self.slidingViewController.anchorLeftPeekAmount     = 0;
     self.slidingViewController.anchorLeftRevealAmount   = 0;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -29,8 +29,6 @@
 @implementation ShowInfoViewController
 
 @synthesize detailItem = _detailItem;
-@synthesize nowPlaying;
-@synthesize detailViewController;
 @synthesize kenView;
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil{
@@ -412,9 +410,9 @@ int count=0;
             choosedMenuItem.disableNowPlaying = NO;
         }
         if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone){
-            self.detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
-            self.detailViewController.detailItem = choosedMenuItem;
-            [self.navigationController pushViewController:self.detailViewController animated:YES];
+            DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
+            detailViewController.detailItem = choosedMenuItem;
+            [self.navigationController pushViewController:detailViewController animated:YES];
         }
         else{
             if (![self isModal]){
@@ -602,9 +600,9 @@ int count=0;
 
 -(void)showNowPlaying{
     if (!alreadyPush){
-        self.nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
-        self.nowPlaying.detailItem = self.detailItem;
-        [self.navigationController pushViewController:self.nowPlaying animated:YES];
+        NowPlaying *nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
+        nowPlaying.detailItem = self.detailItem;
+        [self.navigationController pushViewController:nowPlaying animated:YES];
         self.navigationItem.rightBarButtonItem.enabled=YES;
         alreadyPush = YES;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
There are crashes of `pushViewController` reported from users via AppStore. The call stack can be reproduced in case the same controller is pushed again. Looking in the App's code there are three cases where a singleton constructor is used to create a child view controller instance only once before calling `pushViewController` to show it. In all other places there are simply new view controller instances created. This PR removes the singleton constructor and lets the App create a new instance each time before calling `pushViewController`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix pushViewController crashes reported via AppStore
