### PR TITLE
Show musepack icon also for video playback

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1148,6 +1148,7 @@ int currentItemID;
                  }
                  
                  numchan = [[methodResult objectForKey:@"VideoPlayer.AudioCodec"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@", [methodResult objectForKey:@"VideoPlayer.AudioCodec"]];
+                 numchan = [self processSongCodecName:numchan];
                  songNumChannels.text = numchan;
                  songNumChannels.hidden = NO;
                  songNumChanImage.image = nil;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
For the musepack audio codec a mapping method was introduced to map the codec name provided by Kodi server to the provided icons. The App only uses this for audio playback. This PR introduces the same for video playback. The App will now also show the correct audio codec icon in case a video is using a musepack encoded audio stream.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show musepack icon in codec details of videos