### PR TITLE
Do not show song details if nothing is playing on iPad and iPhone

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1866,6 +1866,9 @@ int currentItemID;
 }
 
 - (void)toggleSongDetails{
+    if (nothingIsPlaying) {
+        return;
+    }
     [UIView beginAnimations:nil context:nil];
     [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
     [UIView setAnimationDuration:0.2];
@@ -1961,7 +1964,7 @@ int currentItemID;
     else if ([itemLogoImage pointInside:viewPoint3 withEvent:event] && songDetailsView.alpha > 0 && itemLogoImage.image != nil) {
         [self updateCurrentLogo];
     }
-    else if (!nothingIsPlaying && ([touch.view isEqual:jewelView] || [touch.view isEqual:songDetailsView])){
+    else if ([touch.view isEqual:jewelView] || [touch.view isEqual:songDetailsView]){
         [self toggleSongDetails];
         [self toggleViewToolBar:volumeSliderView AnimDuration:0.3 Alpha:1.0 YPos:0 forceHide:TRUE];
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/265 only works for iPhone. For iPad the song details are triggered via a different call. This PR now adds the check inside of `toggleSongDetails` which loads and presents the view we do not want show. Now works on both iPhone and iPad devices.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not show song details if nothing is playing on iPad and iPhone