### PR TITLE
Adapt NowPlaying to Pictures mode

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1875,7 +1875,7 @@ int currentItemID;
 }
 
 - (void)toggleSongDetails{
-    if (nothingIsPlaying) {
+    if (nothingIsPlaying || playerID==2) {
         return;
     }
     [UIView beginAnimations:nil context:nil];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -965,6 +965,11 @@ int currentItemID;
                                      currentTime.text=actualTime;
                                      ProgressSlider.hidden = NO;
                                  }
+                                 if (playerID == 2) {
+                                     ProgressSlider.hidden = YES;
+                                     currentTime.hidden = YES;
+                                     duration.hidden = YES;
+                                 }
                                  NSIndexPath* selection = [playlistTableView indexPathForSelectedRow];
                                  if (storeSelection)
                                      selection=storeSelection;
@@ -1114,7 +1119,7 @@ int currentItemID;
                  songSampleRate.text = bitrate;
                  songSampleRate.hidden = NO;
              }
-             else if (currentPlayerID==playerID) {
+             else if (playerID==1 && currentPlayerID==playerID) {
                  codec = [[methodResult objectForKey:@"VideoPlayer.VideoResolution"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@", [methodResult objectForKey:@"VideoPlayer.VideoResolution"]] ;
                  songCodec.text = codec;
                  songCodec.hidden = NO;
@@ -1155,6 +1160,12 @@ int currentItemID;
                  if (audioCodecImage != nil){
                      songNumChannels.hidden = YES;
                  }
+             }
+             else {
+                 songCodec.hidden = YES;
+                 songBitRate.hidden = YES;
+                 songSampleRate.hidden = YES;
+                 songNumChannels.hidden = YES;
              }
          }
     }];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The NowPlaying screen was not handling the "Pictures" mode well. While showing pictures there is no need to display the progressbar and runtimes. Also the details screen should be hidden. The only function which is available in this screen while showing picture is to enable shuffle. As you cannot disable shuffle anymore once it was enabled, this PR is simply removing the details screen in picture mode. Picture mode is identified as `playerID==2`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Adapt UI for pictures mode (no progressbar, no details screen)