### PR TITLE
Avoid multiple "Done" buttons when in modal view

### DIFF
--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -80,6 +80,7 @@
     CGFloat dotSize;
     CGFloat dotSizePadding;
     LogoBackgroundType logoBackgroundMode;
+    UIBarButtonItem *doneButton;
 }
 
 - (id)initWithNibName:(NSString *)nibNameOrNil withItem:(NSDictionary *)item withFrame:(CGRect)frame bundle:(NSBundle *)nibBundleOrNil;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1943,10 +1943,12 @@ int h=0;
 //    }
     [actorsTable deselectRowAtIndexPath:[actorsTable indexPathForSelectedRow] animated:YES];
     if ([self isModal]){
-        NSMutableArray *items = [[toolbar items] mutableCopy];
-        UIBarButtonItem *close = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Done", nil) style:UIBarButtonItemStyleDone target:self action:@selector(dismissModal:)];
-        [items insertObject:close atIndex:0];
-        [toolbar setItems:items];
+        if (doneButton == nil) {
+            NSMutableArray *items = [[toolbar items] mutableCopy];
+            doneButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Done", nil) style:UIBarButtonItemStyleDone target:self action:@selector(dismissModal:)];
+            [items insertObject:doneButton atIndex:0];
+            [toolbar setItems:items];
+        }
         [self setIOS7barTintColor:TINT_COLOR];
         viewTitle.textAlignment = NSTextAlignmentCenter;
         bottomShadow.hidden = YES;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in a [forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3036044#pid3036044). On iPad and in fullscreen mode the "Done" button could be inserted multiple times when the modal view was pulled down and flipping back. This PR adds a check if the button was already created and added to the toolbar. Priority for this fix not too high as the issue is in since several years.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid multiple "Done" buttons on ShowInfo screen when in fullscreen mode on iPad