### PR TITLE
Fix longpress actionsheets in fullscreen modal view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3084,7 +3084,18 @@ NSIndexPath *selected;
                     showfromview = self.view;
                 }
                 else {
-                    showFromCtrl = ([self doesShowSearchResults] || [self getSearchTextField].editing) ? self.searchController : self.view.window.rootViewController;
+                    if ([self doesShowSearchResults] || [self getSearchTextField].editing) {
+                        // We are searching an must present from searchController
+                        showFromCtrl = self.searchController;
+                    }
+                    else if ([self isModal]) {
+                        // We are in modal view (e.g. fullscreen) and must present from ourself
+                        showFromCtrl = self;
+                    }
+                    else {
+                        // We are in stackview and must present from rootVC
+                        showFromCtrl = self.view.window.rootViewController;
+                    }
                     showfromview = enableCollectionView ? collectionView : [showFromCtrl.view superview];
                     selectedPoint = enableCollectionView ? p : [lpgr locationInView:showfromview];
                 }
@@ -4125,10 +4136,9 @@ NSIndexPath *selected;
     }
     else {
         ShowInfoViewController *iPadShowViewController = [[ShowInfoViewController alloc] initWithNibName:@"ShowInfoViewController" withItem:item withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
-        if (stackscrollFullscreen == YES) {
+        if (stackscrollFullscreen || [self isModal]) {
             [iPadShowViewController setModalPresentationStyle:UIModalPresentationFormSheet];
-            UIViewController *vc = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
-            [vc presentViewController:iPadShowViewController animated:YES completion:nil];
+            [self presentViewController:iPadShowViewController animated:YES completion:nil];
         }
         else {
             [[AppDelegate instance].windowController.stackScrollViewController addViewInSlider:iPadShowViewController invokeByController:self isStackStartView:FALSE];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes an issues in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3036302#pid3036302). Now the longpress actionsheets are also showing up in the newly added fullscreen mode for Music items.

Details:
- In fullscreen mode the longpress actionsheet was not displayed as the wrong displaying controller was defined.
- In relation to this also corrected the presenting controller for popups being shown as result of selecting an action from the sheet.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Longpress menus were not showing in fullscreen modal view