### PR TITLE
Improve song details screen

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1074,6 +1074,23 @@ int currentItemID;
     }];
 }
 
+-(NSString*)reformatSamplerate:(NSString*)rate {
+    NSString *reg = @"0+$";
+    NSRange range = [rate rangeOfString:@"."];
+    NSMutableString *newrate = [rate mutableCopy];
+    
+    // Removal of trailing "0" only needed for strings showing float numbers with "."
+    if (range.location != NSNotFound) {
+        // Remove all trailing "0"
+        newrate = [[rate stringByReplacingOccurrencesOfString:reg withString:@"" options:NSRegularExpressionSearch range:NSMakeRange(0, rate.length)] mutableCopy];
+        // Remove "." in case this is the last character
+        if (range.location == newrate.length-1) {
+            [newrate deleteCharactersInRange:range];
+        }
+    }
+    return newrate;
+}
+
 -(void)loadCodecView {
     [[Utilities getJsonRPC]
      callMethod:@"XBMC.GetInfoLabels" 
@@ -1111,7 +1128,8 @@ int currentItemID;
                      songBitRate.hidden = YES;
                  }
         
-                 samplerate = [[methodResult objectForKey:@"MusicPlayer.SampleRate"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@\nkHz", [methodResult objectForKey:@"MusicPlayer.SampleRate"]];
+                 samplerate = [self reformatSamplerate:methodResult[@"MusicPlayer.SampleRate"]];
+                 samplerate = [samplerate isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@\nkHz", samplerate];
                  songNumChannels.text = samplerate;
                  songNumChannels.hidden = NO;
                  


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR avoids mis-reading the sample rate. The App always uses the unit "kHz" for the values sent by Kodi server. For older versions of Kodi (e.g. 17.6) the sample rate was given like "44.1". Newer versions (e.g. 19) will send "44.100" for the same sample rate. The App shows "44.100 kHz" in this case, which ca be mis-interpreted as 44.1 MHz due to reading the "." as thousands separator in many countries. This PR reformats the sample rate by removing the trailing "0"s after the "." which will result in displaying "44.1 kHz" again. The problem stays unresolved for sample rates which use three digits after the "." like "11.025 kHz" -- in my opinion this not too much of relevance, but suggestions are of course welcome.

Screenshots:
https://abload.de/img/bildschirmfoto2021-05bmkxi.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Present sample rate in less-mistakable form