### PR TITLE
Bring back volume up/down button functionality on iPhone

### DIFF
--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -67,7 +67,6 @@
             img = [UIImage imageNamed:@"volume_slash"];
             img = [utils colorizeImage:img withColor:muteForeground];
             [muteButton setImage:img forState:UIControlStateNormal];
-            [muteButton setShowsTouchWhenHighlighted:YES];
             
             img = [UIImage imageNamed:@"button_metal_down"];
             [minusButton setBackgroundImage:img forState:UIControlStateNormal];
@@ -83,8 +82,6 @@
             self.frame = frame_tmp;
         }
         else {
-            minusButton.hidden = YES;
-            plusButton.hidden = YES;
             volumeView.hidden = YES;
             volumeLabel.hidden = YES;
 
@@ -94,10 +91,18 @@
             frame_tmp.origin.x = VOLUMEICON_PADDING;
             muteButton.frame = frame_tmp;
             
-            frame_tmp = volumeSlider.frame;
+            frame_tmp = minusButton.frame;
             frame_tmp.origin.x = muteButton.frame.origin.x + muteButton.frame.size.width + VOLUMEICON_PADDING;
-            frame_tmp.size.width = self.frame.size.width - frame_tmp.origin.x - ANCHORRIGHTPEEK - VOLUMEICON_PADDING;
+            minusButton.frame = frame_tmp;
+            
+            frame_tmp = volumeSlider.frame;
+            frame_tmp.origin.x = minusButton.frame.origin.x + minusButton.frame.size.width;
+            frame_tmp.size.width = self.frame.size.width - frame_tmp.origin.x - ANCHORRIGHTPEEK - 3*VOLUMEICON_PADDING - volumeLabel.frame.size.width;
             volumeSlider.frame = frame_tmp;
+            
+            frame_tmp = plusButton.frame;
+            frame_tmp.origin.x = volumeSlider.frame.origin.x + volumeSlider.frame.size.width + VOLUMEICON_PADDING;
+            plusButton.frame = frame_tmp;
             
             muteForeground = [UIColor blackColor];
             img = [UIImage imageNamed:@"button_metal_up"];
@@ -107,15 +112,24 @@
             img = [UIImage imageNamed:@"volume_slash"];
             img = [utils colorizeImage:img withColor:muteForeground];
             [muteButton setImage:img forState:UIControlStateNormal];
-            [muteButton setShowsTouchWhenHighlighted:YES];
             
             img = [UIImage imageNamed:@"volume_1"];
             img = [utils colorizeImage:img withColor:[UIColor grayColor]];
-            [volumeSlider setMinimumValueImage:img];
+            [minusButton setImage:img forState:UIControlStateNormal];
+            [minusButton setImage:img forState:UIControlStateHighlighted];
+            [minusButton setBackgroundImage:nil forState:UIControlStateNormal];
+            [minusButton setBackgroundImage:nil forState:UIControlStateHighlighted];
+            [minusButton setTitle:nil forState:UIControlStateNormal];
+            [minusButton setTitle:nil forState:UIControlStateHighlighted];
             
             img = [UIImage imageNamed:@"volume_3"];
             img = [utils colorizeImage:img withColor:[UIColor grayColor]];
-            [volumeSlider setMaximumValueImage:img];
+            [plusButton setImage:img forState:UIControlStateNormal];
+            [plusButton setImage:img forState:UIControlStateHighlighted];
+            [plusButton setBackgroundImage:nil forState:UIControlStateNormal];
+            [plusButton setBackgroundImage:nil forState:UIControlStateHighlighted];
+            [plusButton setTitle:nil forState:UIControlStateNormal];
+            [plusButton setTitle:nil forState:UIControlStateHighlighted];
         }
         [self checkMuteServer];
         

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -49,15 +49,15 @@
             muteButton.frame = frame_tmp;
             
             frame_tmp = minusButton.frame;
-            frame_tmp.origin.x = muteButton.frame.origin.x + muteButton.frame.size.width;
+            frame_tmp.origin.x = CGRectGetMaxX(muteButton.frame);
             minusButton.frame = frame_tmp;
             
             frame_tmp = volumeLabel.frame;
-            frame_tmp.origin.x = minusButton.frame.origin.x + minusButton.frame.size.width;
+            frame_tmp.origin.x = CGRectGetMaxX(minusButton.frame);
             volumeLabel.frame= frame_tmp;
             
             frame_tmp = plusButton.frame;
-            frame_tmp.origin.x = volumeLabel.frame.origin.x + volumeLabel.frame.size.width;
+            frame_tmp.origin.x = CGRectGetMaxX(volumeLabel.frame);
             plusButton.frame = frame_tmp;
             
             muteForeground = [UIColor darkGrayColor];
@@ -78,7 +78,7 @@
             
             // set final used width for this view
             frame_tmp = frame;
-            frame_tmp.size.width = plusButton.frame.origin.x + plusButton.frame.size.width;
+            frame_tmp.size.width = CGRectGetMaxX(plusButton.frame);
             self.frame = frame_tmp;
         }
         else {
@@ -92,16 +92,16 @@
             muteButton.frame = frame_tmp;
             
             frame_tmp = minusButton.frame;
-            frame_tmp.origin.x = muteButton.frame.origin.x + muteButton.frame.size.width + VOLUMEICON_PADDING;
+            frame_tmp.origin.x = CGRectGetMaxX(muteButton.frame) + VOLUMEICON_PADDING;
             minusButton.frame = frame_tmp;
             
             frame_tmp = volumeSlider.frame;
-            frame_tmp.origin.x = minusButton.frame.origin.x + minusButton.frame.size.width;
+            frame_tmp.origin.x = CGRectGetMaxX(minusButton.frame);
             frame_tmp.size.width = self.frame.size.width - frame_tmp.origin.x - ANCHORRIGHTPEEK - 3*VOLUMEICON_PADDING - volumeLabel.frame.size.width;
             volumeSlider.frame = frame_tmp;
             
             frame_tmp = plusButton.frame;
-            frame_tmp.origin.x = volumeSlider.frame.origin.x + volumeSlider.frame.size.width + VOLUMEICON_PADDING;
+            frame_tmp.origin.x = CGRectGetMaxX(volumeSlider.frame) + VOLUMEICON_PADDING;
             plusButton.frame = frame_tmp;
             
             muteForeground = [UIColor blackColor];

--- a/XBMC Remote/VolumeSliderView.xib
+++ b/XBMC Remote/VolumeSliderView.xib
@@ -37,11 +37,11 @@
                         <action selector="stopVolume:" destination="3" eventType="touchUpInside" id="dB6-Nz-aJM"/>
                     </connections>
                 </slider>
-                <button opaque="NO" tag="2" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="15">
+                <button opaque="NO" tag="2" contentMode="scaleAspectFit" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="15">
                     <rect key="frame" x="307" y="6" width="36" height="36"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                    <inset key="contentEdgeInsets" minX="1" minY="3" maxX="0.0" maxY="7"/>
+                    <fontDescription key="fontDescription" name="Optima-ExtraBlack" family="Optima" pointSize="22"/>
+                    <inset key="titleEdgeInsets" minX="1" minY="3" maxX="0.0" maxY="7"/>
                     <size key="titleShadowOffset" width="1" height="1"/>
                     <state key="normal" title="-" backgroundImage="button_metal_down">
                         <color key="titleColor" red="0.25" green="0.25" blue="0.25" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -63,11 +63,11 @@
                         <action selector="stopVolume:" destination="-2" eventType="touchDragExit" id="40"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UWD-at-bvG" userLabel="Mute Button">
+                <button opaque="NO" contentMode="scaleAspectFit" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UWD-at-bvG" userLabel="Mute Button">
                     <rect key="frame" x="28" y="6" width="36" height="36"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <size key="titleShadowOffset" width="1" height="1"/>
-                    <state key="normal" backgroundImage="button_metal_up">
+                    <state key="normal" image="volume_slash" backgroundImage="button_metal_up">
                         <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <color key="titleShadowColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </state>
@@ -76,11 +76,11 @@
                         <action selector="toggleMute:" destination="3" eventType="touchUpInside" id="qgZ-f2-8Pl"/>
                     </connections>
                 </button>
-                <button opaque="NO" tag="1" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14">
+                <button opaque="NO" tag="1" contentMode="scaleAspectFit" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14">
                     <rect key="frame" x="60" y="6" width="36" height="36"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <fontDescription key="fontDescription" name="Optima-ExtraBlack" family="Optima" pointSize="20"/>
-                    <inset key="contentEdgeInsets" minX="0.0" minY="-1" maxX="0.0" maxY="1"/>
+                    <fontDescription key="fontDescription" name="Optima-ExtraBlack" family="Optima" pointSize="22"/>
+                    <inset key="titleEdgeInsets" minX="0.0" minY="-1" maxX="0.0" maxY="1"/>
                     <size key="titleShadowOffset" width="1" height="1"/>
                     <state key="normal" title="+" backgroundImage="button_metal_up">
                         <color key="titleColor" red="0.25" green="0.25" blue="0.25" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -122,5 +122,6 @@
         <image name="button_metal_down.png" width="36" height="36"/>
         <image name="button_metal_up" width="36" height="36"/>
         <image name="shiny_black_volume" width="65" height="210"/>
+        <image name="volume_slash" width="28" height="28"/>
     </resources>
 </document>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Takes care of feedback from [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3036679#pid3036679). This PR brings back the volume up/down button functionality for iPhone.

Details:
- Re-enable volume plus/minus button for iPhone
- Ensure correct position and aspect ratios of title (iPad) and image (iPhone)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Bring back volume up/down button functionality on iPhone