### PR TITLE
Handle sort-by-none

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4931,6 +4931,11 @@ NSIndexPath *selected;
         sortMethodName = nil;
     }
     
+    // In case of sort-by-none set sortMethodName to nil
+    if ([sortMethodName isEqualToString:@"none"]) {
+        sortMethodName = nil;
+    }
+    
     // If a sort method is defined which is not found as key, we select @"label" as sort method.
     // This happens for example when sorting by @"artist".
     if (sortMethodName!=nil && [copyRichResults count]>0 && copyRichResults[0][sortMethodName]==nil) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Expect to close https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/291. Since the rework of sorting to support "ignore articles" the option to sort by method `"none"` fell back to `"label"` (= sort-by-name). This PR will now change the code to skip sorting if the sort method is `"none"`.

Screenshots:
https://abload.de/img/bildschirmfoto2021-059bkr5.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: No sort-by-name when sort method is "none" (e.g. in AddOns, Recently Added)