### PR TITLE
Close SongDetails when playback ends

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -475,6 +475,7 @@ int currentItemID;
             [self fadeView:timePlaying hidden:YES];
     }
     [self showPlaylistTable];
+    [self toggleSongDetails];
 }
 
 -(void)setButtonImageAndStartDemo:(UIImage *)buttonImage{
@@ -1866,7 +1867,7 @@ int currentItemID;
 }
 
 - (void)toggleSongDetails{
-    if (nothingIsPlaying || playerID==2) {
+    if ((nothingIsPlaying && songDetailsView.alpha == 0.0) || playerID==2) {
         return;
     }
     [UIView beginAnimations:nil context:nil];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The App keeps the SongDetails view open when playback ends. In this situation it cannot be closed by the user anymore. This PR allows to close the SongDetails view and automatically closes it when the playback ends.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Close SongDetails when playback ends