### PR TITLE
Fix: Update App playlist when it changed on server

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2789,6 +2789,21 @@ int currentItemID;
                                              selector: @selector(handleXBMCPlaylistHasChanged:)
                                                  name: @"XBMCPlaylistHasChanged"
                                                object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handleXBMCPlaylistHasChanged:)
+                                                 name: @"Playlist.OnAdd"
+                                               object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handleXBMCPlaylistHasChanged:)
+                                                 name: @"Playlist.OnClear"
+                                               object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handleXBMCPlaylistHasChanged:)
+                                                 name: @"Playlist.OnRemove"
+                                               object: nil];
 
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(revealMenu:)


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/304.

The App is not updating the playlist if this changed from server side (e.g. adding an album to the playlist). This PR adds listeners to the `"Playlist.On"`-notifications and calls the already implemented method to update the playlist in the App. Verified with Kodi 20 Alpha.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Update App playlist when the playlist changed on server