### PR TITLE
Add kodi.tv as marketing URL for AppStore

### DIFF
--- a/fastlane/metadata/en-US/marketing_url.txt
+++ b/fastlane/metadata/en-US/marketing_url.txt
@@ -1,1 +1,1 @@
-
+https://kodi.tv


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Adding [https://kodi.tv](https://kodi.tv) as marketing URL for AppStore.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
[no app] Add kodi.tv as marketing URL for AppStore