### PR TITLE
Read setting to show 1-movie-sets and ignore such sets when disabled

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -104,6 +104,7 @@
 @property (nonatomic, assign) int APIminorVersion;
 @property (nonatomic, assign) int APIpatchVersion;
 @property (nonatomic, assign) BOOL isIgnoreArticlesEnabled;
+@property (nonatomic, assign) BOOL isGroupSingleItemSetsEnabled;
 @property (nonatomic, copy) NSArray *KodiSorttokens;
 @property (nonatomic, retain) GlobalData *obj;
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4466,6 +4466,9 @@ NSIndexPath *selected;
                  return;
              }
          }
+         // If the feature to also show movies sets with only 1 movie is disabled and the current results
+         // are movie sets, enable the postprocessing to ignore movies sets with only 1 movie.
+         BOOL ignoreSingleMovieSets = ![AppDelegate instance].isGroupSingleItemSetsEnabled && [methodToCall isEqualToString:@"VideoLibrary.GetMovieSets"];
          if (error == nil && methodError == nil) {
              callBack = NO;
 //             debugText.text = [NSString stringWithFormat:@"%@\n*DATA: %@", debugText.text, methodResult];
@@ -4557,7 +4560,7 @@ NSIndexPath *selected;
                          
                          id row15obj = [mainFields[@"row15"] isEqualToString:@"addontype"] ? videoLibraryMovies[i][mainFields[@"row15"]] == nil ? @"" : videoLibraryMovies[i][mainFields[@"row15"]] : videoLibraryMovies[i][mainFields[@"row15"]];
                          
-                         [resultStoreArray addObject:[NSMutableDictionary dictionaryWithObjectsAndKeys:
+                         NSMutableDictionary *newDict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                                       label, @"label",
                                                       genre, @"genre",
                                                       stringURL, @"thumbnail",
@@ -4582,7 +4585,39 @@ NSIndexPath *selected;
                                                       videoLibraryMovies[i][mainFields[@"row16"]], mainFields[@"row16"],
                                                       videoLibraryMovies[i][mainFields[@"row17"]], mainFields[@"row17"],
                                                       videoLibraryMovies[i][mainFields[@"row18"]], mainFields[@"row18"],
-                                                      nil]];
+                                                      nil];
+                         
+                         // Postprocessing of movie sets lists to ignore 1-movie-sets
+                         if (ignoreSingleMovieSets) {
+                             BOOL isLastItem = i == total-1;
+                             if (i==0) {
+                                 [storeRichResults removeAllObjects];
+                             }
+                             NSString *newMethodToCall = @"VideoLibrary.GetMovieSetDetails";
+                             NSDictionary *newParameter = @{@"setid": @([videoLibraryMovies[i][@"setid"] intValue])};
+                             [[Utilities getJsonRPC]
+                              callMethod:newMethodToCall
+                              withParameters:newParameter
+                              onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
+                                 if (error==nil && methodError==nil) {
+                                     if ([methodResult[@"setdetails"][@"movies"] count]>1) {
+                                         [storeRichResults addObject:newDict];
+                                     }
+                                 }
+                                 if (isLastItem) {
+                                     self.richResults = [storeRichResults mutableCopy];
+                                     if (forceRefresh == YES){
+                                         [((UITableView *)activeLayoutView).pullToRefreshView stopAnimating];
+                                         [activeLayoutView setUserInteractionEnabled:YES];
+                                     }
+                                     [self saveData:mutableParameters];
+                                     [self indexAndDisplayData];
+                                 }
+                             }];
+                         }
+                         else {
+                             [resultStoreArray addObject:newDict];
+                         }
                      }
                  }
                  else if ([videoLibraryMovies isKindOfClass:[NSDictionary class]]) {
@@ -4612,6 +4647,10 @@ NSIndexPath *selected;
                  }
 //                 NSLog(@"END STORE");
 //                 NSLog(@"RICH RESULTS %@", resultStoreArray);
+                 // Leave as all necessary steps are handled in callbacks of the postprocessing for 1-movie-sets
+                 if (ignoreSingleMovieSets) {
+                     return;
+                 }
                  if (!extraSectionCallBool) {
                      storeRichResults = [resultStoreArray mutableCopy];
                  }

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -260,6 +260,19 @@ NSOutputStream	*outStream;
              [AppDelegate instance].isIgnoreArticlesEnabled = NO;
          }
     }];
+    // Check if groupsingleitemsets is enabled
+    [[Utilities getJsonRPC]
+     callMethod:@"Settings.GetSettingValue"
+     withParameters:@{@"setting": @"videolibrary.groupsingleitemsets"}
+     withTimeout: SERVER_TIMEOUT
+     onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
+         if (!error && !methodError) {
+             [AppDelegate instance].isGroupSingleItemSetsEnabled = [methodResult[@"value"] boolValue];
+         }
+         else {
+             [AppDelegate instance].isGroupSingleItemSetsEnabled = NO;
+         }
+    }];
 }
 
 - (void)readSorttokens {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/308.

The App always shows **all** movie sets, independent of the Kodi server user setting to only show movie sets with >1 movie. This PR will enable the App to respect the Kodi server user setting. It will read `videolibrary.groupsingleitemsets` at connect, so in case you change the setting you need to re-connect once. If the user wants to ignore 1-movie sets, a post-processing is applied to remove the irrelevant movie sets from the list provided via the API.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Respect setting to show/ignore 1-movie sets