### PR TITLE
Always choose dark cell color for banner TV Show view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2048,8 +2048,14 @@ int originYear = 0;
     }
 }
 
-- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {    
-	cell.backgroundColor = [Utilities getSystemGray6];
+- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (tvshowsView && choosedTab == 0) {
+        // Gray:28 is similar to systemGray6 in Dark Mode
+        cell.backgroundColor = [Utilities getGrayColor:28 alpha:1.0];
+    }
+    else {
+        cell.backgroundColor = [Utilities getSystemGray6];
+    }
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath{


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/296.

The App's TV Show view for the user looks like a grid / fullscreen view when banners are shown. In the background the cells are still following the iOS color mode (DarkMode / LightMode). The background becomes visible when the index is becoming visible, e.g. when sorting by year, resulting in a white background which does not match user's expectation. This PR will always use a dark cell background for only this view and only when showing banners.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Optimization: Dark cell background for TV Show banner view