### PR TITLE
Feature: Make main menu configurable

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -4580,36 +4580,50 @@ NSMutableArray *hostRightMenuItems;
 //    [UIDevice currentDevice].proximityMonitoringEnabled = YES;
 //    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleProximityChangeNotification:) name:UIDeviceProximityStateDidChangeNotification object:nil];
 
-#pragma mark -
-
-    self.serverName = LOCALIZED_STR(@"No connection");
-    InitialSlidingViewController *initialSlidingViewController;
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-        [mainMenuItems addObject:menu_Server];
+#pragma mark - Build and Initialize menu structure
+    
+    // Build menu
+    [mainMenuItems addObject:menu_Server];
+    if ([self isMenuEntryEnabled:@"menu_music"]) {
         [mainMenuItems addObject:menu_Music];
+    }
+    if ([self isMenuEntryEnabled:@"menu_movies"]) {
         [mainMenuItems addObject:menu_Movies];
+    }
+    if ([self isMenuEntryEnabled:@"menu_tvshows"]) {
         [mainMenuItems addObject:menu_TVShows];
+    }
+    if ([self isMenuEntryEnabled:@"menu_pictures"]) {
         [mainMenuItems addObject:menu_Pictures];
+    }
+    if ([self isMenuEntryEnabled:@"menu_livetv"]) {
         [mainMenuItems addObject:menu_LiveTV];
+    }
+    if ([self isMenuEntryEnabled:@"menu_nowplaying"]) {
         [mainMenuItems addObject:menu_NowPlaying];
+    }
+    if ([self isMenuEntryEnabled:@"menu_remote"]) {
         [mainMenuItems addObject:menu_Remote];
-        initialSlidingViewController = [[InitialSlidingViewController alloc] initWithNibName:@"InitialSlidingViewController" bundle:nil];
+    }
+    
+    // Initialize controllers
+    self.serverName = NSLocalizedString(@"No connection", nil);
+    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        InitialSlidingViewController *initialSlidingViewController = [[InitialSlidingViewController alloc] initWithNibName:@"InitialSlidingViewController" bundle:nil];
         initialSlidingViewController.mainMenu = mainMenuItems;
         self.window.rootViewController = initialSlidingViewController;
     }
     else {
-        [mainMenuItems addObject:menu_Server];
-        [mainMenuItems addObject:menu_Music];
-        [mainMenuItems addObject:menu_Movies];
-        [mainMenuItems addObject:menu_TVShows];
-        [mainMenuItems addObject:menu_Pictures];
-        [mainMenuItems addObject:menu_LiveTV];
-        [mainMenuItems addObject:menu_Remote];
         self.windowController = [[ViewControllerIPad alloc] initWithNibName:@"ViewControllerIPad" bundle:nil];
         self.windowController.mainMenu = mainMenuItems;
         self.window.rootViewController = self.windowController;
     }
     return YES;
+}
+
+-(BOOL)isMenuEntryEnabled:(NSString*)menuItem {
+    id menuEnabled = [[NSUserDefaults standardUserDefaults] objectForKey:menuItem];
+    return (menuEnabled == nil || [menuEnabled boolValue]);
 }
 
 -(NSURL *)getServerJSONEndPoint {

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -212,6 +212,84 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
+		<dict>
+			<key>Title</key>
+			<string>Main Menu</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>FooterText</key>
+			<string>Main Menu changes needs app restart</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<true/>
+			<key>Key</key>
+			<string>menu_music</string>
+			<key>Title</key>
+			<string>Show MUSIC</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<true/>
+			<key>Key</key>
+			<string>menu_movies</string>
+			<key>Title</key>
+			<string>Show MOVIES</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<true/>
+			<key>Key</key>
+			<string>menu_tvshows</string>
+			<key>Title</key>
+			<string>Show TV SHOWS</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<true/>
+			<key>Key</key>
+			<string>menu_pictures</string>
+			<key>Title</key>
+			<string>Show PICTURES</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<true/>
+			<key>Key</key>
+			<string>menu_livetv</string>
+			<key>Title</key>
+			<string>Show LIVE TV</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<true/>
+			<key>Key</key>
+			<string>menu_nowplaying</string>
+			<key>Title</key>
+			<string>Show NOW PLAYING</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<true/>
+			<key>Key</key>
+			<string>menu_remote</string>
+			<key>Title</key>
+			<string>Show REMOTE CONTROL</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
 	</array>
 	<key>StringsTable</key>
 	<string>Root</string>

--- a/XBMC Remote/Settings.bundle/cs.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/cs.lproj/Root.strings
@@ -19,3 +19,12 @@
 "Override Lockscreen" = "Override Lockscreen";
 "Show all files in filemode" = "Show all files in filemode";
 "Filemode changes needs app restart" = "Filemode changes needs app restart";
+"Main Menu" = "Main Menu";
+"Main Menu changes needs app restart" = "Main Menu changes needs app restart";
+"Show MUSIC" = "Show MUSIC";
+"Show MOVIES" = "Show MOVIES";
+"Show TV SHOWS" = "Show TV SHOWS";
+"Show PICTURES" = "Show PICTURES";
+"Show LIVE TV" = "Show LIVE TV";
+"Show NOW PLAYING" = "Show NOW PLAYING";
+"Show REMOTE CONTROL" = "Show REMOTE CONTROL";

--- a/XBMC Remote/Settings.bundle/de.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/de.lproj/Root.strings
@@ -23,3 +23,12 @@
 "Override Lockscreen" = "Sperrbildschirm verhindern";
 "Show all files in filemode" = "Alle Dateien anzeigen";
 "Filemode changes needs app restart" = "Dateimodus-Änderungen erfordern einen App-Neustart";
+"Main Menu" = "Hauptmenü";
+"Main Menu changes needs app restart" = "Hauptmenü-Änderungen erfordern einen App-Neustart";
+"Show MUSIC" = "Zeige MUSIK";
+"Show MOVIES" = "Zeige FILME";
+"Show TV SHOWS" = "Zeige TV-SERIEN";
+"Show PICTURES" = "Zeige BILDER";
+"Show LIVE TV" = "Zeige LIVE TV";
+"Show NOW PLAYING" = "Zeige GERADE LÄUFT";
+"Show REMOTE CONTROL" = "Zeige FERNBEDIENUNG";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/306.

Details:
- Each main menu entry can be switched on/off in Kodi App settings (default is ON for each)
- Added localized strings for English and German
- Minor refactoring when building the menu (iPad per default now also has NowPlaying)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Make main menu configurable