### PR TITLE
Fix recording details

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3486,7 +3486,7 @@ NSMutableArray *hostRightMenuItems;
         @{
             @"itemid": @"recordings",
             @"row1": @"label",
-            @"row2": @"title",
+            @"row2": @"plotoutline",
             @"row3": @"plot",
             @"row4": @"runtime",
             @"row5": @"starttime",

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3025,7 +3025,10 @@ NSIndexPath *selected;
 //                if ([item[@"filetype"] isEqualToString:@"directory"]) { // DOESN'T WORK AT THE MOMENT IN XBMC?????
 //                    return;
 //                }
-                NSString *title = [NSString stringWithFormat:@"%@\n%@", item[@"label"], item[@"genre"]];
+                NSString *title = [NSString stringWithFormat:@"%@", item[@"label"]];
+                if (item[@"genre"] != nil && ![item[@"genre"] isEqualToString:@""]) {
+                    title = [NSString stringWithFormat:@"%@\n%@", title, item[@"genre"]];
+                }
                 id cell = [self getCell:selected];
                 
                 if ([item[@"trailer"] isKindOfClass:[NSString class]]) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/321.

When longpressing on a recording item the actionsheet title shows the recording name twice. This PR changes the actionsheet tilte to either show `"plotoutline"` after the recording name, or only show the recording name without adding a new line.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix actionsheet title for recordings