### PR TITLE
Remove available sort methods from JSON command parameters

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -347,18 +347,6 @@ NSMutableArray *hostRightMenuItems;
     };
 }
 
-- (NSDictionary*)sortmethod:(NSString*)method order:(NSString*)order ignorearticle:(BOOL)ignore avail_labels:(NSArray*)avail_labels avail_methods:(NSArray*)avail_methods {
-    return @{
-        @"order": order,
-        @"ignorearticle": @(ignore),
-        @"method": method,
-        @"available_methods": @{
-                @"label": avail_labels,
-                @"method": avail_methods
-            }
-    };
-}
-
 #pragma mark -
 #pragma mark init
 
@@ -515,17 +503,7 @@ NSMutableArray *hostRightMenuItems;
     menu_Music.mainParameters = [@[
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO
-                               avail_labels: @[
-                                   LOCALIZED_STR(@"Album"),
-                                   LOCALIZED_STR(@"Artist"),
-                                   LOCALIZED_STR(@"Year"),
-                                   LOCALIZED_STR(@"Play count")]
-                               avail_methods: @[
-                                   @"label",
-                                   @"genre",
-                                   @"year",
-                                   @"playcount"]],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
                         @"thumbnail",
@@ -542,6 +520,18 @@ NSMutableArray *hostRightMenuItems;
                         @"albumlabel",
                         @"fanart"],
             }, @"extra_info_parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Album"),
+                        LOCALIZED_STR(@"Artist"),
+                        LOCALIZED_STR(@"Year"),
+                        LOCALIZED_STR(@"Play count")],
+                @"method": @[
+                        @"label",
+                        @"genre",
+                        @"year",
+                        @"playcount"]
+            }, @"available_sort_methods",
             LOCALIZED_STR(@"Albums"), @"label",
             @"Album", @"wikitype",
             @"YES", @"enableCollectionView",
@@ -654,17 +644,7 @@ NSMutableArray *hostRightMenuItems;
                           
         @[
             @{
-                @"sort": [self sortmethod:@"playcount" order:@"descending" ignorearticle:NO
-                               avail_labels: @[
-                                   LOCALIZED_STR(@"Top 100 Albums"),
-                                   LOCALIZED_STR(@"Album"),
-                                   LOCALIZED_STR(@"Artist"),
-                                   LOCALIZED_STR(@"Year")]
-                               avail_methods: @[
-                                   @"playcount",
-                                   @"label",
-                                   @"genre",
-                                   @"year"]],
+                @"sort": [self sortmethod:@"playcount" order:@"descending" ignorearticle:NO],
                 @"limits": @{
                         @"start": @0,
                         @"end": @100
@@ -685,6 +665,18 @@ NSMutableArray *hostRightMenuItems;
                         @"albumlabel",
                         @"fanart"]
             }, @"extra_info_parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Top 100 Albums"),
+                        LOCALIZED_STR(@"Album"),
+                        LOCALIZED_STR(@"Artist"),
+                        LOCALIZED_STR(@"Year")],
+                @"method": @[
+                        @"playcount",
+                        @"label",
+                        @"genre",
+                        @"year"]
+            }, @"available_sort_methods",
             LOCALIZED_STR(@"Top 100 Albums"), @"label",
             @"Album", @"wikitype",
             LOCALIZED_STR(@"Top 100 Albums"), @"morelabel",
@@ -694,23 +686,7 @@ NSMutableArray *hostRightMenuItems;
             
         @[
             @{
-                @"sort": [self sortmethod:@"playcount" order:@"descending" ignorearticle:NO
-                               avail_labels: @[
-                                   LOCALIZED_STR(@"Top 100 Songs"),
-                                   LOCALIZED_STR(@"Track"),
-                                   LOCALIZED_STR(@"Title"),
-                                   LOCALIZED_STR(@"Album"),
-                                   LOCALIZED_STR(@"Artist"),
-                                   LOCALIZED_STR(@"Rating"),
-                                   LOCALIZED_STR(@"Year")]
-                               avail_methods: @[
-                                   @"playcount",
-                                   @"track",
-                                   @"label",
-                                   @"album",
-                                   @"genre",
-                                   @"rating",
-                                   @"year"]],
+                @"sort": [self sortmethod:@"playcount" order:@"descending" ignorearticle:NO],
                 @"limits": @{
                         @"start": @0,
                         @"end": @100
@@ -728,6 +704,24 @@ NSMutableArray *hostRightMenuItems;
                         @"file",
                         @"album"]
             }, @"parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Top 100 Songs"),
+                        LOCALIZED_STR(@"Track"),
+                        LOCALIZED_STR(@"Title"),
+                        LOCALIZED_STR(@"Album"),
+                        LOCALIZED_STR(@"Artist"),
+                        LOCALIZED_STR(@"Rating"),
+                        LOCALIZED_STR(@"Year")],
+                @"method": @[
+                        @"playcount",
+                        @"track",
+                        @"label",
+                        @"album",
+                        @"genre",
+                        @"rating",
+                        @"year"]
+            }, @"available_sort_methods",
             LOCALIZED_STR(@"Top 100 Songs"), @"label",
             LOCALIZED_STR(@"Top 100 Songs"), @"morelabel",
             @5, @"numberOfStars"
@@ -769,23 +763,7 @@ NSMutableArray *hostRightMenuItems;
                             
         @[
             @{
-                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO
-                               avail_labels: @[
-                                   LOCALIZED_STR(@"Name"),
-                                   LOCALIZED_STR(@"Rating"),
-                                   LOCALIZED_STR(@"Year"),
-                                   LOCALIZED_STR(@"Play count"),
-                                   LOCALIZED_STR(@"Track"),
-                                   LOCALIZED_STR(@"Album"),
-                                   LOCALIZED_STR(@"Artist")]
-                               avail_methods: @[
-                                   @"label",
-                                   @"rating",
-                                   @"year",
-                                   @"playcount",
-                                   @"track",
-                                   @"album",
-                                   @"genre"]],
+                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"genre",
                         @"year",
@@ -798,6 +776,24 @@ NSMutableArray *hostRightMenuItems;
                         @"album",
                         @"file"]
             }, @"parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Name"),
+                        LOCALIZED_STR(@"Rating"),
+                        LOCALIZED_STR(@"Year"),
+                        LOCALIZED_STR(@"Play count"),
+                        LOCALIZED_STR(@"Track"),
+                        LOCALIZED_STR(@"Album"),
+                        LOCALIZED_STR(@"Artist")],
+                @"method": @[
+                        @"label",
+                        @"rating",
+                        @"year",
+                        @"playcount",
+                        @"track",
+                        @"album",
+                        @"genre"]
+            }, @"available_sort_methods",
             LOCALIZED_STR(@"All songs"), @"label",
             LOCALIZED_STR(@"All songs"), @"morelabel",
             @"YES", @"enableLibraryCache",
@@ -1222,17 +1218,7 @@ NSMutableArray *hostRightMenuItems;
                                   
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO
-                               avail_labels: @[
-                                   LOCALIZED_STR(@"Album"),
-                                   LOCALIZED_STR(@"Artist"),
-                                   LOCALIZED_STR(@"Year"),
-                                   LOCALIZED_STR(@"Play count")]
-                               avail_methods: @[
-                                   @"label",
-                                   @"genre",
-                                   @"year",
-                                   @"playcount"]],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
                         @"thumbnail",
@@ -1249,6 +1235,18 @@ NSMutableArray *hostRightMenuItems;
                         @"albumlabel",
                         @"fanart"]
             }, @"extra_info_parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Album"),
+                        LOCALIZED_STR(@"Artist"),
+                        LOCALIZED_STR(@"Year"),
+                        LOCALIZED_STR(@"Play count")],
+                @"method": @[
+                        @"label",
+                        @"genre",
+                        @"year",
+                        @"playcount"]
+            }, @"available_sort_methods",
             @"Albums", @"label",
             @"Album", @"wikitype",
             @"YES", @"enableCollectionView",
@@ -1967,21 +1965,7 @@ NSMutableArray *hostRightMenuItems;
     menu_Movies.mainParameters = [@[
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO
-                             avail_labels: @[
-                                 LOCALIZED_STR(@"Title"),
-                                 LOCALIZED_STR(@"Year"),
-                                 LOCALIZED_STR(@"Rating"),
-                                 LOCALIZED_STR(@"Duration"),
-                                 LOCALIZED_STR(@"Date added"),
-                                 LOCALIZED_STR(@"Play count")]
-                             avail_methods: @[
-                                 @"label",
-                                 @"year",
-                                 @"rating",
-                                 @"runtime",
-                                 @"dateadded",
-                                 @"playcount"]],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
                         @"playcount",
@@ -2012,6 +1996,22 @@ NSMutableArray *hostRightMenuItems;
                         @"resume",
                         @"trailer"]
             }, @"extra_info_parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Title"),
+                        LOCALIZED_STR(@"Year"),
+                        LOCALIZED_STR(@"Rating"),
+                        LOCALIZED_STR(@"Duration"),
+                        LOCALIZED_STR(@"Date added"),
+                        LOCALIZED_STR(@"Play count")],
+                @"method": @[
+                        @"label",
+                        @"year",
+                        @"rating",
+                        @"runtime",
+                        @"dateadded",
+                        @"playcount"]
+            }, @"available_sort_methods",
             LOCALIZED_STR(@"Movies"), @"label",
             @"Movie", @"wikitype",
             @"YES", @"FrodoExtraArt",
@@ -2036,17 +2036,19 @@ NSMutableArray *hostRightMenuItems;
               
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO
-                             avail_labels: @[
-                                 LOCALIZED_STR(@"Name"),
-                                 LOCALIZED_STR(@"Play count")]
-                             avail_methods: @[
-                                 @"label",
-                                 @"playcount"]],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"thumbnail",
                         @"playcount"]
             }, @"parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Name"),
+                        LOCALIZED_STR(@"Play count")],
+                @"method": @[
+                        @"label",
+                        @"playcount"]
+            }, @"available_sort_methods",
             @"YES", @"FrodoExtraArt",
             @"YES", @"enableCollectionView",
             @"YES", @"enableLibraryCache",
@@ -2098,15 +2100,7 @@ NSMutableArray *hostRightMenuItems;
               
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO
-                             avail_labels: @[
-                                 LOCALIZED_STR(@"Name"),
-                                 LOCALIZED_STR(@"Year"),
-                                 LOCALIZED_STR(@"Play count")]
-                             avail_methods: @[
-                                 @"label",
-                                 @"year",
-                                 @"playcount"]],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
                         @"playcount",
@@ -2120,6 +2114,16 @@ NSMutableArray *hostRightMenuItems;
                         @"fanart",
                         @"resume"]
             }, @"parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Name"),
+                        LOCALIZED_STR(@"Year"),
+                        LOCALIZED_STR(@"Play count")],
+                @"method": @[
+                            @"label",
+                            @"year",
+                            @"playcount"]
+            }, @"available_sort_methods",
             LOCALIZED_STR(@"Music Videos"), @"label",
             LOCALIZED_STR(@"Music Videos"), @"morelabel",
             @"Movie", @"wikitype",
@@ -2375,21 +2379,7 @@ NSMutableArray *hostRightMenuItems;
                                   
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO
-                             avail_labels: @[
-                                 LOCALIZED_STR(@"Title"),
-                                 LOCALIZED_STR(@"Year"),
-                                 LOCALIZED_STR(@"Rating"),
-                                 LOCALIZED_STR(@"Duration"),
-                                 LOCALIZED_STR(@"Date added"),
-                                 LOCALIZED_STR(@"Play count")]
-                             avail_methods: @[
-                                 @"label",
-                                 @"year",
-                                 @"rating",
-                                 @"runtime",
-                                 @"dateadded",
-                                 @"playcount"]],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
                         @"playcount",
@@ -2420,6 +2410,22 @@ NSMutableArray *hostRightMenuItems;
                         @"resume",
                         @"trailer"]
             }, @"extra_info_parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Title"),
+                        LOCALIZED_STR(@"Year"),
+                        LOCALIZED_STR(@"Rating"),
+                        LOCALIZED_STR(@"Duration"),
+                        LOCALIZED_STR(@"Date added"),
+                        LOCALIZED_STR(@"Play count")],
+                @"method": @[
+                        @"label",
+                        @"year",
+                        @"rating",
+                        @"runtime",
+                        @"dateadded",
+                        @"playcount"]
+            }, @"available_sort_methods",
             @"Movies", @"label",
             @"Movie", @"wikitype",
             @"nocover_movies", @"defaultThumb",
@@ -2431,21 +2437,7 @@ NSMutableArray *hostRightMenuItems;
                                   
         @[
             @{
-                @"sort": [self sortmethod:@"year" order:@"ascending" ignorearticle:NO
-                             avail_labels: @[
-                                 LOCALIZED_STR(@"Title"),
-                                 LOCALIZED_STR(@"Year"),
-                                 LOCALIZED_STR(@"Rating"),
-                                 LOCALIZED_STR(@"Duration"),
-                                 LOCALIZED_STR(@"Date added"),
-                                 LOCALIZED_STR(@"Play count")]
-                             avail_methods: @[
-                                 @"label",
-                                 @"year",
-                                 @"rating",
-                                 @"runtime",
-                                 @"dateadded",
-                                 @"playcount"]],
+                @"sort": [self sortmethod:@"year" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
                         @"playcount",
@@ -2476,6 +2468,22 @@ NSMutableArray *hostRightMenuItems;
                         @"resume",
                         @"trailer"]
             }, @"extra_info_parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Title"),
+                        LOCALIZED_STR(@"Year"),
+                        LOCALIZED_STR(@"Rating"),
+                        LOCALIZED_STR(@"Duration"),
+                        LOCALIZED_STR(@"Date added"),
+                        LOCALIZED_STR(@"Play count")],
+                @"method": @[
+                        @"label",
+                        @"year",
+                        @"rating",
+                        @"runtime",
+                        @"dateadded",
+                        @"playcount"]
+            }, @"available_sort_methods",
             @"Movies", @"label",
             @"Movie", @"wikitype",
             @"nocover_movies", @"defaultThumb",
@@ -2774,15 +2782,7 @@ NSMutableArray *hostRightMenuItems;
     menu_TVShows.mainParameters = [@[
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO
-                             avail_labels:@[
-                                 LOCALIZED_STR(@"Title"),
-                                 LOCALIZED_STR(@"Year"),
-                                 LOCALIZED_STR(@"Rating")]
-                             avail_methods: @[
-                                 @"label",
-                                 @"year",
-                                 @"rating"]],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
                         @"playcount",
@@ -2807,6 +2807,16 @@ NSMutableArray *hostRightMenuItems;
                         @"episode",
                         @"fanart"]
             }, @"extra_info_parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Title"),
+                        LOCALIZED_STR(@"Year"),
+                        LOCALIZED_STR(@"Rating")],
+                @"method": @[
+                        @"label",
+                        @"year",
+                        @"rating"]
+            }, @"available_sort_methods",
             LOCALIZED_STR(@"TV Shows"), @"label",
             @"TV Show", @"wikitype",
             @"YES", @"blackTableSeparator",
@@ -3340,17 +3350,7 @@ NSMutableArray *hostRightMenuItems;
 
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO
-                             avail_labels: @[
-                                 LOCALIZED_STR(@"Title"),
-                                 LOCALIZED_STR(@"Channel"),
-                                 LOCALIZED_STR(@"Date"),
-                                 LOCALIZED_STR(@"Runtime")]
-                             avail_methods: @[
-                                 @"label",
-                                 @"channel",
-                                 @"starttime",
-                                 @"runtime"]],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"title",
                         @"starttime",
@@ -3388,6 +3388,18 @@ NSMutableArray *hostRightMenuItems;
                         @"file",
                         @"directory"]
             }, @"extra_info_parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Title"),
+                        LOCALIZED_STR(@"Channel"),
+                        LOCALIZED_STR(@"Date"),
+                        LOCALIZED_STR(@"Runtime")],
+                @"method": @[
+                        @"label",
+                        @"channel",
+                        @"starttime",
+                        @"runtime"]
+            }, @"available_sort_methods",
             LOCALIZED_STR(@"Recordings"), @"label",
             LOCALIZED_STR(@"Recordings"), @"morelabel",
             @"nocover_channels", @"defaultThumb",
@@ -3399,17 +3411,7 @@ NSMutableArray *hostRightMenuItems;
                           
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO
-                             avail_labels: @[
-                                 LOCALIZED_STR(@"Title"),
-                                 LOCALIZED_STR(@"Channel"),
-                                 LOCALIZED_STR(@"Date"),
-                                 LOCALIZED_STR(@"Runtime")]
-                             avail_methods: @[
-                                 @"label",
-                                 @"channel",
-                                 @"starttime",
-                                 @"runtime"]],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"title",
                         @"summary",
@@ -3445,6 +3447,18 @@ NSMutableArray *hostRightMenuItems;
                         @"file",
                         @"directory"]
             }, @"extra_info_parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Title"),
+                        LOCALIZED_STR(@"Channel"),
+                        LOCALIZED_STR(@"Date"),
+                        LOCALIZED_STR(@"Runtime")],
+                @"method": @[
+                        @"label",
+                        @"channel",
+                        @"starttime",
+                        @"runtime"]
+            }, @"available_sort_methods",
             LOCALIZED_STR(@"Timers"), @"label",
             LOCALIZED_STR(@"Timers"), @"morelabel",
             @"nocover_timers", @"defaultThumb",

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -307,9 +307,6 @@
 
 -(NSString *)getCacheKey:(NSString *)fieldA parameters:(NSMutableDictionary *)fieldB{
     GlobalData *obj = [GlobalData getInstance];
-//    if ([fieldB[@"sort"] respondsToSelector:@selector(removeObjectForKey:)]) {
-//        [fieldB[@"sort"] removeObjectForKey:@"available_methods"];
-//    }
     return [[NSString stringWithFormat:@"%@%@%@%d%d%@%@", obj.serverIP, obj.serverPort, obj.serverDescription, serverVersion, serverMinorVersion, fieldA, fieldB] MD5String];
 }
 
@@ -507,7 +504,7 @@
     
     // Show sort button when sorting is possible
     button7.hidden = YES;
-    if (parameters[@"parameters"][@"sort"][@"available_methods"] != nil) {
+    if (parameters[@"available_sort_methods"] != nil) {
         button7.hidden = NO;
     }
     
@@ -817,7 +814,7 @@
 }
 
 -(void)setUpSort:(NSDictionary *)methods parameters:(NSDictionary *)parameters{
-    NSDictionary *sortDictionary = parameters[@"parameters"][@"sort"][@"available_methods"];
+    NSDictionary *sortDictionary = parameters[@"available_sort_methods"];
     sortMethodName = [self getCurrentSortMethod:methods withParameters:parameters];
     NSUInteger foundIndex = [sortDictionary[@"method"] indexOfObject:sortMethodName];
     if (foundIndex != NSNotFound) {
@@ -3365,7 +3362,7 @@ NSIndexPath *selected;
     }
     else {
         NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:[self.detailItem mainParameters][choosedTab]];
-        NSMutableDictionary *sortDictionary = parameters[@"parameters"][@"sort"][@"available_methods"];
+        NSMutableDictionary *sortDictionary = parameters[@"available_sort_methods"];
         if (sortDictionary[@"label"] != nil) {
             NSUInteger sort_method_index = [sortDictionary[@"label"] indexOfObject:actiontitle];
             if (sort_method_index != NSNotFound) {
@@ -4441,9 +4438,6 @@ NSIndexPath *selected;
     elapsedTime = 0;
     startTime = [NSDate timeIntervalSinceReferenceDate];
     countExecutionTime = [NSTimer scheduledTimerWithTimeInterval:WARNING_TIMEOUT target:self selector:@selector(checkExecutionTime) userInfo:nil repeats:YES];
-//    if ([mutableParameters[@"sort"] respondsToSelector:@selector(removeObjectForKey:)]) {
-//        [mutableParameters[@"sort"] removeObjectForKey:@"available_methods"];
-//    }
 //    NSLog(@" METHOD %@ PARAMETERS %@", methodToCall, mutableParameters);
     [[Utilities getJsonRPC]
      callMethod:methodToCall
@@ -5898,7 +5892,7 @@ NSIndexPath *selected;
 - (void)handleChangeSortLibrary {
     selected = nil;
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:[self.detailItem mainParameters][choosedTab]];
-    NSDictionary *sortDictionary = parameters[@"parameters"][@"sort"][@"available_methods"];
+    NSDictionary *sortDictionary = parameters[@"available_sort_methods"];
     NSDictionary *item = [NSDictionary dictionaryWithObjectsAndKeys:
                           NSLocalizedString(@"Sort by", nil), @"label",
                           [NSString stringWithFormat:@"\n(%@)", NSLocalizedString(@"tap the selection\nto reverse the sort order", nil)], @"genre",


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/294.

Details:
- Remove available sort methods from JSON command parameters
- Kodi server does not need above information as sorting is done locally in the App. Kodi server might in future even reject these malformed JSON requests.
- Remove unneeded functions and code related to this change.
- Rename key to "available_sort_methods" as it moved from sort section to general parameters.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Clean up malformed sort request via JSON API