### PR TITLE
Bugfix: Show correct amount of episodes in Info view

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -784,7 +784,7 @@ int h = 0;
             label1.text = NSLocalizedString(@"EPISODES", nil);
             label3.text = NSLocalizedString(@"GENRE", nil);
             label4.text = NSLocalizedString(@"STUDIO", nil);
-            directorLabel.text = [Utilities getStringFromDictionary:item key:@"showtitle" emptyString:@"-"];
+            directorLabel.text = [Utilities getStringFromDictionary:item key:@"episode" emptyString:@"-"];
             [format setDateFormat:@"yyyy-MM-dd"];
             NSDate *date = [format dateFromString:item[@"premiered"]];
             [format setDateFormat:NSLocalizedString(@"LongDateTimeFormat", nil)];

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -575,6 +575,9 @@
         text = [value componentsJoinedByString:@" / "];
         text = [text length] == 0 ? empty : text;
     }
+    else if ([value isKindOfClass:[NSNumber class]]) {
+        text = [NSString stringWithFormat:@"%@", value];;
+    }
     else {
         text = [value length] == 0 ? empty : value;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The App always shows "-" instead of a TV Shows's amount of episodes. This is caused by using the wrong key `"showtitle"` which is not present. This PR fixes this.

Details:
- Use correct key `"episode"`
- Let `getStringFromDictionary` support `NSNumber`

Screenshot:
https://abload.de/img/bildschirmfoto2021-065ojxk.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show correct amount of episodes in Info view