### PR TITLE
Replace magic numbers with enum for property "family"

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -462,7 +462,7 @@ NSMutableArray *hostRightMenuItems;
     menu_Music.mainLabel = LOCALIZED_STR(@"Music");
     menu_Music.upperLabel = LOCALIZED_STR(@"Listen to");
     menu_Music.icon = @"icon_menu_music";
-    menu_Music.family = 1;
+    menu_Music.family = FamilyDetailView;
     menu_Music.enableSection = YES;
     menu_Music.mainButtons = @[
         @"st_album",
@@ -1937,7 +1937,7 @@ NSMutableArray *hostRightMenuItems;
     menu_Movies.mainLabel = LOCALIZED_STR(@"Movies");
     menu_Movies.upperLabel = LOCALIZED_STR(@"Watch your");
     menu_Movies.icon = @"icon_menu_movies";
-    menu_Movies.family = 1;
+    menu_Movies.family = FamilyDetailView;
     menu_Movies.enableSection = YES;
     menu_Movies.noConvertTime = YES;
     menu_Movies.mainButtons = @[
@@ -2762,7 +2762,7 @@ NSMutableArray *hostRightMenuItems;
     menu_TVShows.mainLabel = LOCALIZED_STR(@"TV Shows");
     menu_TVShows.upperLabel = LOCALIZED_STR(@"Watch your");
     menu_TVShows.icon = @"icon_menu_tvshows";
-    menu_TVShows.family = 1;
+    menu_TVShows.family = FamilyDetailView;
     menu_TVShows.enableSection = YES;
     menu_TVShows.mainButtons = @[
         @"st_tv",
@@ -3305,7 +3305,7 @@ NSMutableArray *hostRightMenuItems;
     menu_LiveTV.mainLabel = LOCALIZED_STR(@"Live TV");
     menu_LiveTV.upperLabel = LOCALIZED_STR(@"Watch");
     menu_LiveTV.icon = @"icon_menu_livetv";
-    menu_LiveTV.family = 1;
+    menu_LiveTV.family = FamilyDetailView;
     menu_LiveTV.enableSection = YES;
     menu_LiveTV.noConvertTime = YES;
     menu_LiveTV.mainButtons = @[
@@ -3794,7 +3794,7 @@ NSMutableArray *hostRightMenuItems;
     menu_Pictures.mainLabel = LOCALIZED_STR(@"Pictures");
     menu_Pictures.upperLabel = LOCALIZED_STR(@"Browse your");
     menu_Pictures.icon = @"icon_menu_pictures";
-    menu_Pictures.family = 1;
+    menu_Pictures.family = FamilyDetailView;
     menu_Pictures.enableSection = YES;
     menu_Pictures.mainButtons = @[
         @"st_filemode",
@@ -3956,7 +3956,7 @@ NSMutableArray *hostRightMenuItems;
         menu_Favourites.mainLabel = LOCALIZED_STR(@"Favourites");
         menu_Favourites.upperLabel = LOCALIZED_STR(@"Choose your");
         menu_Favourites.icon = @"icon_menu_favourites";
-        menu_Favourites.family = 1;
+        menu_Favourites.family = FamilyDetailView;
         menu_Favourites.enableSection = YES;
         menu_Favourites.mainButtons = @[@"st_filemode"];
         
@@ -4008,19 +4008,19 @@ NSMutableArray *hostRightMenuItems;
     menu_NowPlaying.mainLabel = LOCALIZED_STR(@"Now Playing");
     menu_NowPlaying.upperLabel = LOCALIZED_STR(@"See what's");
     menu_NowPlaying.icon = @"icon_menu_playing";
-    menu_NowPlaying.family = 2;
+    menu_NowPlaying.family = FamilyNowPlaying;
     
 #pragma mark - Remote Control
     menu_Remote.mainLabel = LOCALIZED_STR(@"Remote Control");
     menu_Remote.upperLabel = LOCALIZED_STR(@"Use as");
     menu_Remote.icon = @"icon_menu_remote";
-    menu_Remote.family = 3;
+    menu_Remote.family = FamilyRemote;
     
 #pragma mark - XBMC Server Management
     menu_Server.mainLabel = LOCALIZED_STR(@"XBMC Server");
     menu_Server.upperLabel = @"";
     menu_Server.icon = @"";
-    menu_Server.family = 4;
+    menu_Server.family = FamilyServer;
     
 #pragma mark - Playlist Artist Albums
     playlistArtistAlbums = [menu_Music copy];
@@ -4044,7 +4044,7 @@ NSMutableArray *hostRightMenuItems;
     
     xbmcSettings.mainLabel = LOCALIZED_STR(@"XBMC Settings");
     xbmcSettings.icon = @"icon_menu_settings";
-    xbmcSettings.family = 1;
+    xbmcSettings.family = FamilyDetailView;
     xbmcSettings.enableSection = YES;
     xbmcSettings.rowHeight = 65;
     xbmcSettings.thumbWidth = 44;
@@ -4379,7 +4379,7 @@ NSMutableArray *hostRightMenuItems;
     rightMenuItems = [NSMutableArray arrayWithCapacity:1];
     __auto_type rightItem1 = [mainMenu new];
     rightItem1.mainLabel = LOCALIZED_STR(@"XBMC Server");
-    rightItem1.family = 1;
+    rightItem1.family = FamilyDetailView;
     rightItem1.enableSection = YES;
     rightItem1.mainMethod = @[
         @{
@@ -4538,7 +4538,7 @@ NSMutableArray *hostRightMenuItems;
     nowPlayingMenuItems = [NSMutableArray arrayWithCapacity:1];
     __auto_type nowPlayingItem1 = [mainMenu new];
     nowPlayingItem1.mainLabel = @"VolumeControl";
-    nowPlayingItem1.family = 2;
+    nowPlayingItem1.family = FamilyNowPlaying;
     nowPlayingItem1.mainMethod = @[
         @{
             @"offline": @[
@@ -4578,7 +4578,7 @@ NSMutableArray *hostRightMenuItems;
     remoteControlMenuItems = [NSMutableArray arrayWithCapacity:1];
     __auto_type remoteControlItem1 = [mainMenu new];
     remoteControlItem1.mainLabel = @"RemoteControl";
-    remoteControlItem1.family = 3;
+    remoteControlItem1.family = FamilyRemote;
     remoteControlItem1.enableSection = YES;
 
     remoteControlItem1.mainMethod = @[

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -178,7 +178,7 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath{
     mainMenu *item = self.mainMenu[indexPath.row];
-    if (![AppDelegate instance].serverOnLine && item.family != 4) {
+    if (![AppDelegate instance].serverOnLine && item.family != FamilyServer) {
         [menuList selectRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:indexPath.section] animated:YES scrollPosition:UITableViewScrollPositionNone];
         return;
     }
@@ -189,37 +189,39 @@
     UIViewController *object;
     BOOL setBarTintColor = NO;
     BOOL hideBottonLine = NO;
-    if (item.family == 2) {
-        if (self.nowPlaying == nil) {
-            self.nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
-        }
-        self.nowPlaying.detailItem = item;
-        object = self.nowPlaying;
-    }
-    else if (item.family == 3) {
-        if (self.remoteController == nil) {
-            self.remoteController = [[RemoteController alloc] initWithNibName:@"RemoteController" bundle:nil];
-        }
-        else {
-            [self.remoteController resetRemote];
-        }
-        self.remoteController.detailItem = item;
-        object = self.remoteController;
-    }
-    else if (item.family == 4) {
-        if (self.hostController == nil) {
-            self.hostController = [[HostManagementViewController alloc] initWithNibName:@"HostManagementViewController" bundle:nil];
-        }
-        object = self.hostController;
-        setBarTintColor = YES;
-        hideBottonLine = YES;
-    }
-    else if (item.family == 1) {
-        self.detailViewController = nil;
-        self.detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
-        self.detailViewController.detailItem = item;
-        object = self.detailViewController;
-        hideBottonLine = YES;
+    switch (item.family) {
+        case FamilyNowPlaying:
+            if (self.nowPlaying == nil) {
+                self.nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
+            }
+            self.nowPlaying.detailItem = item;
+            object = self.nowPlaying;
+            break;
+        case FamilyRemote:
+            if (self.remoteController == nil) {
+                self.remoteController = [[RemoteController alloc] initWithNibName:@"RemoteController" bundle:nil];
+            }
+            else {
+                [self.remoteController resetRemote];
+            }
+            self.remoteController.detailItem = item;
+            object = self.remoteController;
+            break;
+        case FamilyServer:
+            if (self.hostController == nil) {
+                self.hostController = [[HostManagementViewController alloc] initWithNibName:@"HostManagementViewController" bundle:nil];
+            }
+            object = self.hostController;
+            setBarTintColor = YES;
+            hideBottonLine = YES;
+            break;
+        case FamilyDetailView:
+            self.detailViewController = nil;
+            self.detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
+            self.detailViewController.detailItem = item;
+            object = self.detailViewController;
+            hideBottonLine = YES;
+            break;
     }
     navController = nil;
     navController = [[CustomNavigationController alloc] initWithRootViewController:object];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -650,11 +650,11 @@
         bottomPadding = window.safeAreaInsets.bottom;
     }
     CGFloat footerHeight = 0;
-    if (menuItems.family == 3) {
+    if (menuItems.family == FamilyRemote) {
         footerHeight = 44 + bottomPadding;
         [self.view addSubview:[self createTableFooterView: footerHeight]];
     }
-    if (menuItems.family == 2 || menuItems.family == 3) {
+    if (menuItems.family == FamilyNowPlaying || menuItems.family == FamilyRemote) {
         volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectMake(0, 0, 0, 0)];
         [volumeSliderView startTimer];
     }
@@ -799,7 +799,7 @@
                             nil]];
     }
     editableRowStartAt = [tableData count];
-    if ([key isEqualToString:@"online"] && menuItems.family == 3) {
+    if ([key isEqualToString:@"online"] && menuItems.family == FamilyRemote) {
         customButton *arrayButtons = [[customButton alloc] init];
         if ([arrayButtons.buttons count] == 0) {
             [editTableButton setEnabled:NO];

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -296,7 +296,7 @@
         return;
     }
     mainMenu *item = mainMenuItems[indexPath.row];
-    if (item.family == 2) {
+    if (item.family == FamilyNowPlaying) {
         [[AppDelegate instance].windowController.stackScrollViewController offView];
     }
     else {
@@ -307,12 +307,12 @@
             return;
         }
         [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollOnScreen" object: nil]; 
-        if (item.family == 1) {
+        if (item.family == FamilyDetailView) {
             DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:item withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
             [[AppDelegate instance].windowController.stackScrollViewController addViewInSlider:detailViewController invokeByController:self isStackStartView:YES];
             [[AppDelegate instance].windowController.stackScrollViewController enablePanGestureRecognizer];
         }   
-        else if (item.family == 3) {
+        else if (item.family == FamilyRemote) {
             RemoteController *remoteController = [[RemoteController alloc] initWithNibName:@"RemoteController" bundle:nil]; 
             [remoteController.view setFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height)];
             [[AppDelegate instance].windowController.stackScrollViewController addViewInSlider:remoteController invokeByController:self isStackStartView:YES];

--- a/XBMC Remote/mainMenu.h
+++ b/XBMC Remote/mainMenu.h
@@ -8,11 +8,18 @@
 
 #import <Foundation/Foundation.h>
 
+typedef enum {
+    FamilyDetailView,
+    FamilyNowPlaying,
+    FamilyRemote,
+    FamilyServer
+} MenuItemFamilyType;
+
 @interface mainMenu : NSObject
 
 @property (nonatomic, copy) NSString *mainLabel;
 @property (nonatomic, copy) NSString *upperLabel;
-@property int family;
+@property MenuItemFamilyType family;
 @property BOOL enableSection;
 @property (nonatomic, copy) NSString *icon;
 @property (nonatomic, copy) NSArray *mainMethod;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Use enum instead of magic number for "family" property.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Use enum instead of magic number for "family" property