### PR TITLE
Bugfix: Fix missing actionSheet options

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1182,7 +1182,7 @@
 -(void)didSelectItemAtIndexPath:(NSIndexPath *)indexPath item:(NSDictionary *)item displayPoint:(CGPoint) point{
     mainMenu *MenuItem = self.detailItem;
     NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:[MenuItem.subItem mainMethod][choosedTab]];
-    NSMutableArray *sheetActions = [self.detailItem sheetActions][choosedTab];
+    NSMutableArray *sheetActions = [[self.detailItem sheetActions][choosedTab] mutableCopy];
     NSMutableDictionary *parameters = [Utilities indexKeyedMutableDictionaryFromArray:[MenuItem.subItem mainParameters][choosedTab]];
     int rectOriginX = point.x;
     int rectOriginY = point.y;
@@ -3022,7 +3022,7 @@ NSIndexPath *selected;
         if (indexPath != nil) {
             selected = indexPath;
             
-            NSMutableArray *sheetActions = [self.detailItem sheetActions][choosedTab];
+            NSMutableArray *sheetActions = [[self.detailItem sheetActions][choosedTab] mutableCopy];
             if ([sheetActions isKindOfClass:[NSMutableArray class]]) {
                 [sheetActions removeObject:NSLocalizedString(@"Play Trailer", nil)];
                 [sheetActions removeObject:NSLocalizedString(@"Mark as watched", nil)];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes a regression of the `AppDelegate` rework which was merged with https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/283 (since first 1.7.2 build).

Details:
- `sheetActions` are expected as mutable array to be able to tailor them.
- Use `mutableCopy` as the sheetAction arrays are non-mutable since the `AppDelegate` rework.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix missing actionSheet options for playlists, movies, tv shows and videos