### PR TITLE
Maintenance: Use #defines to improve code readability

### DIFF
--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -287,6 +287,7 @@
 		B1FF37DF1709D1ED005473FF /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C718444525FFD06300F5A060 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		C7478BF8257258E700161C1E /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		C7F28D4826961FE50004B112 /* ConvenienceMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConvenienceMacros.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -531,6 +532,7 @@
 				0F554903151D1187007E633F /* InfoPlist.strings */,
 				0F554906151D1187007E633F /* main.m */,
 				0F554908151D1187007E633F /* Kodi Remote-Prefix.pch */,
+				C7F28D4826961FE50004B112 /* ConvenienceMacros.h */,
 				1A9786C21683D87800B4F3F8 /* Localizable.strings */,
 			);
 			name = "Supporting Files";

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -19,16 +19,6 @@
     GlobalData *obj;
 }
 
-/*
- *  System Versioning Preprocessor Macros
- */
-
-#define SYSTEM_VERSION_EQUAL_TO(v)                  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedSame)
-#define SYSTEM_VERSION_GREATER_THAN(v)              ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedDescending)
-#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
-#define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
-#define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
-
 #define IS_AT_LEAST_IPHONE_X_HEIGHT (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 812)
 #define IS_AT_LEAST_IPAD_1K_WIDTH (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 1024)
 #define IS_IPHONE (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone)

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -19,23 +19,6 @@
     GlobalData *obj;
 }
 
-#define IS_AT_LEAST_IPHONE_X_HEIGHT (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 812)
-#define IS_AT_LEAST_IPAD_1K_WIDTH (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 1024)
-#define IS_IPHONE (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone)
-#define IS_IPAD (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
-#define IS_PORTRAIT UIInterfaceOrientationIsPortrait(UIApplication.sharedApplication.statusBarOrientation)
-#define IS_LANDSCAPE UIInterfaceOrientationIsLandscape(UIApplication.sharedApplication.statusBarOrientation)
-
-#define LOCALIZED_STR(string) NSLocalizedString(string, nil)
-
-#define APP_TINT_COLOR [Utilities getGrayColor:0 alpha:0.3]
-
-#define TINT_COLOR [Utilities getGrayColor:255 alpha:.35]
-
-#define BAR_TINT_COLOR [Utilities getGrayColor:26 alpha:1]
-#define REMOTE_CONTROL_BAR_TINT_COLOR [Utilities getGrayColor:12 alpha:1]
-#define SLIDER_DEFAULT_COLOR [Utilities getSystemTeal]
-
 #define PAD_MENU_HEIGHT 50
 #define PAD_MENU_INFO_HEIGHT 18
 #define PAD_MENU_TABLE_WIDTH 300
@@ -43,10 +26,6 @@
 /* UI items are designed for this screen width */
 #define IPHONE_SCREEN_DESIGN_WIDTH 320.0
 #define IPAD_SCREEN_DESIGN_WIDTH 476.0
-
-#define GET_MAINSCREEN_HEIGHT CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds)
-#define GET_MAINSCREEN_WIDTH CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds)
-#define STACKSCROLL_WIDTH (GET_MAINSCREEN_WIDTH - PAD_MENU_TABLE_WIDTH)
 
 #define PHONE_TV_SHOWS_BANNER_HEIGHT 59
 #define PHONE_TV_SHOWS_POSTER_HEIGHT 76
@@ -59,8 +38,6 @@
 
 #define PAD_TV_SHOWS_BANNER_WIDTH IPAD_SCREEN_DESIGN_WIDTH
 #define PAD_TV_SHOWS_POSTER_WIDTH 53
-
-#define ANCHOR_RIGHT_PEEK (GET_MAINSCREEN_WIDTH/10.0)
 
 + (AppDelegate*)instance;
 

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -33,6 +33,8 @@
 #define IS_AT_LEAST_IPAD_1K_WIDTH (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 1024)
 #define IS_IPHONE (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone)
 #define IS_IPAD (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
+#define IS_PORTRAIT UIInterfaceOrientationIsPortrait(UIApplication.sharedApplication.statusBarOrientation)
+#define IS_LANDSCAPE UIInterfaceOrientationIsLandscape(UIApplication.sharedApplication.statusBarOrientation)
 
 #define LOCALIZED_STR(string) NSLocalizedString(string, nil)
 

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -31,6 +31,8 @@
 
 #define IS_AT_LEAST_IPHONE_X_HEIGHT (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 812)
 #define IS_AT_LEAST_IPAD_1K_WIDTH (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 1024)
+#define IS_IPHONE (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone)
+#define IS_IPAD (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
 
 #define LOCALIZED_STR(string) NSLocalizedString(string, nil)
 

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -415,7 +415,7 @@ NSMutableArray *hostRightMenuItems;
     obj = [GlobalData getInstance];
     
     CGFloat transform = [Utilities getTransformX];
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
         tvshowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
         NSDictionary *navbarTitleTextAttributes = [NSDictionary dictionaryWithObjectsAndKeys:
@@ -4666,7 +4666,7 @@ NSMutableArray *hostRightMenuItems;
     
     // Initialize controllers
     self.serverName = LOCALIZED_STR(@"No connection");
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         InitialSlidingViewController *initialSlidingViewController = [[InitialSlidingViewController alloc] initWithNibName:@"InitialSlidingViewController" bundle:nil];
         initialSlidingViewController.mainMenu = mainMenuItems;
         self.window.rootViewController = initialSlidingViewController;

--- a/XBMC Remote/BDKCollectionIndexView/BDKCollectionIndexView.m
+++ b/XBMC Remote/BDKCollectionIndexView/BDKCollectionIndexView.m
@@ -1,5 +1,6 @@
 #import "BDKCollectionIndexView.h"
 #import "Utilities.h"
+#import "AppDelegate.h"
 #import <QuartzCore/QuartzCore.h>
 
 #define DEFAULT_ALPHA 0.3
@@ -90,7 +91,7 @@
             break;
         case BDKCollectionIndexViewDirectionVertical:
             _theDimension = CGRectGetWidth(self.frame);
-            if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+            if (IS_IPHONE) {
                 maxLength = self.indexLabels.count * INDEX_HEIGHT_IPHONE;
             }
             else {

--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -1,0 +1,44 @@
+//
+//  ConvenienceMacros.h
+//  Kodi Remote
+//
+//  Created by Buschmann on 07.07.21.
+//  Copyright © 2021 joethefox inc. All rights reserved.
+//
+
+#ifndef ConvenienceMacros_h
+#define ConvenienceMacros_h
+
+/*
+ * Device and orientation checks
+ */
+#define IS_AT_LEAST_IPHONE_X_HEIGHT (CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 812)
+#define IS_AT_LEAST_IPAD_1K_WIDTH (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds) >= 1024)
+#define IS_IPHONE (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone)
+#define IS_IPAD (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
+#define IS_PORTRAIT UIInterfaceOrientationIsPortrait(UIApplication.sharedApplication.statusBarOrientation)
+#define IS_LANDSCAPE UIInterfaceOrientationIsLandscape(UIApplication.sharedApplication.statusBarOrientation)
+ 
+/*
+ * Color defines
+ */
+#define APP_TINT_COLOR [Utilities getGrayColor:0 alpha:0.3]
+#define TINT_COLOR [Utilities getGrayColor:255 alpha:.35]
+#define BAR_TINT_COLOR [Utilities getGrayColor:26 alpha:1]
+#define REMOTE_CONTROL_BAR_TINT_COLOR [Utilities getGrayColor:12 alpha:1]
+#define SLIDER_DEFAULT_COLOR [Utilities getSystemTeal]
+
+/*
+ * Dimension and layout macros
+ */
+#define GET_MAINSCREEN_HEIGHT CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds)
+#define GET_MAINSCREEN_WIDTH CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds)
+#define STACKSCROLL_WIDTH (GET_MAINSCREEN_WIDTH - PAD_MENU_TABLE_WIDTH)
+#define ANCHOR_RIGHT_PEEK (GET_MAINSCREEN_WIDTH/10.0)
+
+/*
+ * Other
+ */
+#define LOCALIZED_STR(string) NSLocalizedString(string, nil)
+
+#endif /* ConvenienceMacros_h */

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1400,7 +1400,7 @@
         }
 
         if (![fanartURL isEqualToString:@""]) {
-            [cell.posterFanart setImageWithURL:[NSURL URLWithString:fanartURL] placeholderImage:[UIImage imageNamed:@"blank"]andResize:CGSizeMake(fanartWidth, cellthumbHeight)];
+            [cell.posterFanart setImageWithURL:[NSURL URLWithString:fanartURL] placeholderImage:[UIImage imageNamed:@"blank"] andResize:CGSizeMake(fanartWidth, cellthumbHeight)];
         }
         else {
             [cell.posterFanart setImageWithURL:[NSURL URLWithString:@""] placeholderImage:[UIImage imageNamed:@"blank"]];
@@ -2283,7 +2283,7 @@ int originYear = 0;
             if ([item[@"family"] isEqualToString:@"channelid"] || [item[@"family"] isEqualToString:@"type"]) {
                 [cell.urlImageView setContentMode:UIViewContentModeScaleAspectFit];
             }
-            [cell.urlImageView setImageWithURL:[NSURL URLWithString:stringURL] placeholderImage:[UIImage imageNamed:displayThumb]andResize:CGSizeMake(thumbWidth, cellHeight) completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
+            [cell.urlImageView setImageWithURL:[NSURL URLWithString:stringURL] placeholderImage:[UIImage imageNamed:displayThumb] andResize:CGSizeMake(thumbWidth, cellHeight) completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
                 if (channelListView || channelGuideView || recordingListView) {
                     [Utilities setLogoBackgroundColor:cell.urlImageView mode:logoBackgroundMode];
                 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -570,7 +570,7 @@
 }
 
 - (void)goBack:(id)sender {
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         [self.navigationController popViewControllerAnimated:YES];
     }
     else {
@@ -624,7 +624,7 @@
 
     [self AnimView:moreItemsViewController.view AnimDuration:0.3 Alpha:1.0 XPos:0];
     self.navigationItem.title = [NSString stringWithFormat:LOCALIZED_STR(@"More (%ld)"), (long)(count - MAX_NORMAL_BUTTONS)];
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         [UIView beginAnimations:nil context:nil];
         [UIView setAnimationDuration:0.3];
         topNavigationLabel.alpha = 0;
@@ -857,7 +857,7 @@
     }
     [activeLayoutView setContentOffset:[(UITableView*)activeLayoutView contentOffset] animated:NO];
     self.navigationItem.title = [Utilities indexKeyedDictionaryFromArray:[self.detailItem mainParameters][choosedTab]][@"label"];
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         [UIView beginAnimations:nil context:nil];
         [UIView setAnimationDuration:0.3];
         topNavigationLabel.alpha = 0;
@@ -994,7 +994,7 @@
         [[MenuItem.subItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
         MenuItem.subItem.chooseTab = choosedTab;
         MenuItem.subItem.currentWatchMode = watchMode;
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        if (IS_IPHONE) {
             DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
             detailViewController.detailItem = MenuItem.subItem;
             [self.navigationController pushViewController:detailViewController animated:YES];
@@ -1046,7 +1046,7 @@
                 MenuItem.mainLabel = [NSString stringWithFormat:@"%@", item[@"label"]];
                 [[MenuItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
                 MenuItem.chooseTab = choosedTab;
-                if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+                if (IS_IPHONE) {
                     DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
                     detailViewController.detailItem = MenuItem;
                     [self.navigationController pushViewController:detailViewController animated:YES];
@@ -1108,7 +1108,7 @@
             }
             [[MenuItem.subItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
             MenuItem.subItem.chooseTab = choosedTab;
-            if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+            if (IS_IPHONE) {
                 DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
                 detailViewController.detailItem = MenuItem.subItem;
                 [self.navigationController pushViewController:detailViewController animated:YES];
@@ -1138,7 +1138,7 @@
     int rectOriginX = point.x;
     int rectOriginY = point.y;
     if ([item[@"family"] isEqualToString:@"id"]) {
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        if (IS_IPHONE) {
             SettingsValuesViewController *settingsViewController = [[SettingsValuesViewController alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, self.view.bounds.size.height) withItem:item];
             [self.navigationController pushViewController:settingsViewController animated:YES];
         }
@@ -1659,7 +1659,7 @@
     mainMenu *Menuitem = self.detailItem;
     // Adapt thumbsize if viewing TV Shows and "preferTVPoster" feature is enabled
     if (!tvshowsView) {
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        if (IS_IPAD) {
             Menuitem.thumbWidth = PAD_TV_SHOWS_POSTER_WIDTH;
             Menuitem.rowHeight = PAD_TV_SHOWS_POSTER_HEIGHT;
         }
@@ -1670,7 +1670,7 @@
     }
     else {
         CGFloat transform = [Utilities getTransformX];
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        if (IS_IPAD) {
             Menuitem.thumbWidth = (int)(PAD_TV_SHOWS_BANNER_WIDTH * transform);
             Menuitem.rowHeight = (int)(PAD_TV_SHOWS_BANNER_HEIGHT * transform);
         }
@@ -1734,7 +1734,7 @@ int originYear = 0;
     
     int iOS7offset = 0;
     int iOS7insetSeparator = 0;
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         iOS7offset = 12;
         iOS7insetSeparator = 20;
     }
@@ -2934,7 +2934,7 @@ NSIndexPath *selected;
         BOOL isRecording = isRecordingImageView == nil ? NO : !isRecordingImageView.hidden;
         CGPoint sheetOrigin = CGPointMake(rectOriginX, rectOriginY);
         UIViewController *showFromCtrl = nil;
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        if (IS_IPHONE) {
             showFromCtrl = self;
         }
         else {
@@ -3020,7 +3020,7 @@ NSIndexPath *selected;
                 BOOL isRecording = isRecordingImageView == nil ? NO : !isRecordingImageView.hidden;
                 UIViewController *showFromCtrl = nil;
                 UIView *showfromview = nil;
-                if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+                if (IS_IPHONE) {
                     showFromCtrl = self;
                     showfromview = self.view;
                 }
@@ -3398,7 +3398,7 @@ NSIndexPath *selected;
     [arrayButtons.buttons addObject:button];
     [arrayButtons saveData];
     [messagesView showMessage:LOCALIZED_STR(@"Button added") timeout:2.0 color:[Utilities getSystemGreen:0.95]];
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         [[NSNotificationCenter defaultCenter] postNotificationName: @"UIInterfaceCustomButtonAdded" object: nil];
     }
 }
@@ -3687,7 +3687,7 @@ NSIndexPath *selected;
                                    nil];
     [[MenuItem.subItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
     MenuItem.subItem.chooseTab = choosedTab;
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
         detailViewController.detailItem = MenuItem.subItem;
         [self.navigationController pushViewController:detailViewController animated:YES];
@@ -4066,7 +4066,7 @@ NSIndexPath *selected;
 }
 
 - (void)displayInfoView:(NSDictionary*)item {
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         ShowInfoViewController *showInfoViewController = [[ShowInfoViewController alloc] initWithNibName:@"ShowInfoViewController" bundle:nil];
         showInfoViewController.detailItem = item;
         [self.navigationController pushViewController:showInfoViewController animated:YES];
@@ -5014,7 +5014,7 @@ NSIndexPath *selected;
     if ([self.detailItem enableSection]) {
         // CONDIZIONE DEBOLE!!!
         self.navigationItem.title = [NSString stringWithFormat:@"%@ (%d)", parameters[@"label"], numResults];
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        if (IS_IPAD) {
             if (!stackscrollFullscreen) {
                 [UIView beginAnimations:nil context:nil];
                 [UIView setAnimationDuration:0.3];
@@ -5039,7 +5039,7 @@ NSIndexPath *selected;
         [self alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
     }
     NSDictionary *itemSizes = parameters [@"itemSizes"];
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         [self setIphoneInterface:itemSizes[@"iphone"]];
     }
     else {
@@ -5607,7 +5607,7 @@ NSIndexPath *selected;
         UIWindow *window = UIApplication.sharedApplication.keyWindow;
         bottomPadding = window.safeAreaInsets.bottom;
     }
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         if (bottomPadding > 0) {
             frame = buttonsView.frame;
             frame.size.height += bottomPadding;
@@ -5620,7 +5620,7 @@ NSIndexPath *selected;
     trackCountLabelWidth = 26;
     epgChannelTimeLabelWidth = 48;
     NSDictionary *itemSizes = parameters[@"itemSizes"];
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         [self setIphoneInterface:itemSizes[@"iphone"]];
     }
     else {
@@ -5762,7 +5762,7 @@ NSIndexPath *selected;
 }
 
 - (void)initIpadCornerInfo {
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad && [self.detailItem enableSection]) {
+    if (IS_IPAD && [self.detailItem enableSection]) {
         titleView = [[UIView alloc] initWithFrame:CGRectMake(STACKSCROLL_WIDTH - FIXED_SPACE_WIDTH, 0, FIXED_SPACE_WIDTH - 5, buttonsView.frame.size.height)];
         [titleView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleLeftMargin];
         topNavigationLabel.textAlignment = NSTextAlignmentRight;
@@ -5786,7 +5786,7 @@ NSIndexPath *selected;
 }
 
 - (void)checkFullscreenButton:(BOOL)forceHide {
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad && [self.detailItem enableSection]) {
+    if (IS_IPAD && [self.detailItem enableSection]) {
         NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:[self.detailItem mainParameters][choosedTab]];
         if ([self collectionViewCanBeEnabled] && ([parameters[@"enableLibraryFullScreen"] boolValue] && !forceHide)) {
             int buttonPadding = 1;

--- a/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
+++ b/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "ECSlidingViewController.h"
+#import "AppDelegate.h"
 
 NSString *const ECSlidingViewUnderRightWillAppear    = @"ECSlidingViewUnderRightWillAppear";
 NSString *const ECSlidingViewUnderLeftWillAppear     = @"ECSlidingViewUnderLeftWillAppear";
@@ -45,7 +46,7 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
 - (CGFloat)anchorLeftTopViewCenter;
 - (CGFloat)resettedCenter;
 - (CGFloat)screenWidth;
-- (CGFloat)screenWidthForOrientation:(UIInterfaceOrientation)orientation;
+- (CGFloat)screenWidthForOrientation:(BOOL)isLandscape;
 - (void)underLeftWillAppear;
 - (void)underRightWillAppear;
 - (void)topDidReset;
@@ -496,13 +497,13 @@ CGPoint center = self.topView.center;
 }
 
 - (CGFloat)screenWidth {
-    return [self screenWidthForOrientation:[UIApplication sharedApplication].statusBarOrientation];
+    return [self screenWidthForOrientation:IS_LANDSCAPE];
 }
 
-- (CGFloat)screenWidthForOrientation:(UIInterfaceOrientation)orientation {
+- (CGFloat)screenWidthForOrientation:(BOOL)isLandscape {
     CGSize size = [UIScreen mainScreen].bounds.size;
     UIApplication *application = [UIApplication sharedApplication];
-    if (UIInterfaceOrientationIsLandscape(orientation)) {
+    if (isLandscape) {
         size = CGSizeMake(size.height, size.width);
     }
     if (!application.statusBarHidden) {
@@ -560,7 +561,7 @@ CGPoint center = self.topView.center;
         CGRect frame = self.view.bounds;
         CGFloat newWidth;
 
-        if (UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
+        if (IS_LANDSCAPE) {
             newWidth = [UIScreen mainScreen].bounds.size.height - self.anchorRightPeekAmount;
         }
         else {
@@ -593,7 +594,7 @@ CGPoint center = self.topView.center;
         CGFloat newLeftEdge;
         CGFloat newWidth;
 
-        if (UIInterfaceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) {
+        if (IS_LANDSCAPE) {
             newWidth = [UIScreen mainScreen].bounds.size.height;
         }
         else {

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -347,7 +347,7 @@ static inline BOOL IsEmpty(id obj) {
     self.preferredContentSize = size;
     [super viewWillAppear:animated];
     [self selectIndex:nil reloadData:YES];
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         self.slidingViewController.underRightViewController = nil;
         RightMenuViewController *rightMenuViewController = [[RightMenuViewController alloc] initWithNibName:@"RightMenuViewController" bundle:nil];
         rightMenuViewController.rightMenuItems = [AppDelegate instance].rightMenuItems;
@@ -376,7 +376,7 @@ static inline BOOL IsEmpty(id obj) {
 - (void)viewDidLoad {
     [super viewDidLoad];
     CGFloat deltaY = 44 + [[UIApplication sharedApplication] statusBarFrame].size.height;
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         deltaY = 0;
     }
     CGFloat bottomPadding = 0;
@@ -384,7 +384,7 @@ static inline BOOL IsEmpty(id obj) {
         UIWindow *window = UIApplication.sharedApplication.keyWindow;
         bottomPadding = window.safeAreaInsets.bottom;
     }
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         bottomPadding = SERVERPOPUP_BOTTOMPADDING;
     }
     CGRect frame = bottomToolbar.frame;
@@ -435,7 +435,7 @@ static inline BOOL IsEmpty(id obj) {
     [addHostButton setTitleColor:[UIColor whiteColor] forState:UIControlStateSelected];
     [addHostButton.titleLabel setShadowOffset:CGSizeZero];
     
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         self.edgesForExtendedLayout = 0;
         self.view.tintColor = APP_TINT_COLOR;
         CGRect frame = backgroundImageView.frame;

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -192,7 +192,7 @@
 
 - (void)tailorViewContent:(BOOL)isEditing {
     if (isEditing) {
-        if (IS_IPAD && UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation])) {
+        if (IS_IPAD && IS_LANDSCAPE) {
             tipView.hidden = YES;
         }
         else {

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -192,7 +192,7 @@
 
 - (void)tailorViewContent:(BOOL)isEditing {
     if (isEditing) {
-        if (([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) && UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation])) {
+        if (IS_IPAD && UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation])) {
             tipView.hidden = YES;
         }
         else {
@@ -580,7 +580,7 @@
         UIWindow *window = UIApplication.sharedApplication.keyWindow;
         bottomPadding = window.safeAreaInsets.bottom;
     }
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         bottomPadding = SERVERPOPUP_BOTTOMPADDING;
     }
     if (bottomPadding > 0) {

--- a/XBMC Remote/KenBurns/JBKenBurnsView.m
+++ b/XBMC Remote/KenBurns/JBKenBurnsView.m
@@ -23,6 +23,7 @@
 //
 
 #import "JBKenBurnsView.h"
+#import "AppDelegate.h"
 #include <stdlib.h>
 
 #define enlargeRatio 1.1
@@ -77,7 +78,7 @@
     self.layer.masksToBounds = YES;
     
     newEnlargeRatio = 1.0;
-//    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+//    if (IS_IPAD) {
 //        newEnlargeRatio = 1.0;
 //    }
     
@@ -103,7 +104,7 @@
     self.layer.masksToBounds = YES;
     
     newEnlargeRatio = 1.2;
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         newEnlargeRatio = 2.2;
     }
     

--- a/XBMC Remote/Kodi Remote-Prefix.pch
+++ b/XBMC Remote/Kodi Remote-Prefix.pch
@@ -8,6 +8,8 @@
 #warning "This project uses features only available in iOS SDK 4.0 and later."
 #endif
 
+#import "ConvenienceMacros.h"
+
 #ifdef __OBJC__
     #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>

--- a/XBMC Remote/MessagesView.m
+++ b/XBMC Remote/MessagesView.m
@@ -24,7 +24,7 @@
         [self.layer addSublayer:bottomBorder];
         [self setBackgroundColor:[Utilities getGrayColor:0 alpha:0.9]];
         slideHeight = frame.size.height;
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        if (IS_IPAD) {
             slideHeight += 22.0;
         }
         [self setFrame:CGRectMake(frame.origin.x, -slideHeight, frame.size.width, frame.size.height)];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -519,7 +519,7 @@ int currentItemID;
                                                  backgroundImageView.image = [UIImage imageNamed:@"shiny_black_back"];
                                              }
                                              completion:NULL];
-                             if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+                             if (IS_IPAD) {
                                  NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
                                                          [Utilities getGrayColor:36 alpha:1], @"startColor",
                                                          [Utilities getGrayColor:22 alpha:1], @"endColor",
@@ -540,7 +540,7 @@ int currentItemID;
                                                  backgroundImageView.image = [utils colorizeImage:[UIImage imageNamed:@"shiny_black_back"] withColor:lighterColor];
                                              }
                                              completion:NULL];
-                             if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+                             if (IS_IPAD) {
                                  CGFloat hue, saturation, brightness, alpha;
                                  BOOL ok = [color getHue:&hue saturation:&saturation brightness:&brightness alpha:&alpha];
                                  if (ok) {
@@ -657,7 +657,7 @@ int currentItemID;
                                  NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:nowPlayingInfo useBanner:NO useIcon:NO];
                                  NSString *stringURL = [Utilities formatStringURL:thumbnailPath serverURL:serverURL];
                                  if (![lastThumbnail isEqualToString:stringURL]) {
-                                     if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+                                     if (IS_IPAD) {
                                          NSString *fanart = (NSNull*)nowPlayingInfo[@"fanart"] == [NSNull null] ? @"" : nowPlayingInfo[@"fanart"];
                                          if (![fanart isEqualToString:@""]) {
                                              NSString *fanartURL = [Utilities formatStringURL:fanart serverURL:serverURL];
@@ -1348,7 +1348,7 @@ int currentItemID;
 
 - (void)displayInfoView:(NSDictionary*)item {
     fromItself = YES;
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         ShowInfoViewController *showInfoViewController = [[ShowInfoViewController alloc] initWithNibName:@"ShowInfoViewController" bundle:nil];
         showInfoViewController.detailItem = item;
         [self.navigationController pushViewController:showInfoViewController animated:YES];
@@ -2055,7 +2055,7 @@ int currentItemID;
         [[MenuItem.subItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
         MenuItem.subItem.chooseTab = choosedTab;
         fromItself = YES;
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        if (IS_IPHONE) {
             DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
             detailViewController.detailItem = MenuItem.subItem;
             [self.navigationController pushViewController:detailViewController animated:YES];
@@ -2522,7 +2522,7 @@ int currentItemID;
     seg_video.hidden = YES;
     playlistSegmentedControl = [[UISegmentedControl alloc] initWithItems:@[LOCALIZED_STR(@"Music"), [[LOCALIZED_STR(@"Video ") capitalizedString] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]]];
     CGFloat left_margin = (PAD_MENU_TABLE_WIDTH - SEGMENTCONTROL_WIDTH)/2;
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         left_margin = floor(([self currentScreenBoundsDependOnOrientation].size.width - SEGMENTCONTROL_WIDTH)/2);
     }
     playlistSegmentedControl.frame = CGRectMake(left_margin, (playlistActionView.frame.size.height - SEGMENTCONTROL_HEIGHT)/2, SEGMENTCONTROL_WIDTH, SEGMENTCONTROL_HEIGHT);
@@ -2560,7 +2560,7 @@ int currentItemID;
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         if (self.slidingViewController.panGesture != nil) {
             [self.navigationController.view addGestureRecognizer:self.slidingViewController.panGesture];
         }
@@ -2585,7 +2585,7 @@ int currentItemID;
             playlistToolBarOriginY.origin.y = playlistToolbar.frame.origin.y + playlistToolbar.frame.size.height;
             playlistActionView.frame = playlistToolBarOriginY;
         }
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        if (IS_IPHONE) {
             startFlipDemo = YES;
             UIImage *buttonImage;
             if ([self enableJewelCases]) {
@@ -2685,7 +2685,7 @@ int currentItemID;
     }
     timer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(updateInfo) userInfo:nil repeats:YES];
     fromItself = NO;
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         self.slidingViewController.underRightViewController = nil;
         RightMenuViewController *rightMenuViewController = [[RightMenuViewController alloc] initWithNibName:@"RightMenuViewController" bundle:nil];
         rightMenuViewController.rightMenuItems = [AppDelegate instance].nowPlayingMenuItems;
@@ -2700,7 +2700,7 @@ int currentItemID;
         [self.view insertSubview:iOS7bgEffect atIndex:0];
     }
     // lower half of top area is colored in album color
-    if (iOS7navBarEffect == nil && [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (iOS7navBarEffect == nil && IS_IPHONE) {
         CGFloat effectHeight = CGRectGetMaxY(self.navigationController.navigationBar.frame)/2;
         iOS7navBarEffect = [[UIView alloc] initWithFrame:CGRectMake(0, -effectHeight, self.view.frame.size.width, effectHeight)];
         iOS7navBarEffect.autoresizingMask = UIViewAutoresizingFlexibleTopMargin;
@@ -2817,7 +2817,7 @@ int currentItemID;
     lastSelected = -1;
     storedItemID = -1;
     storeSelection = nil;
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         [self setIphoneInterface];
     }
     else {

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -8,6 +8,7 @@
 
 #import "PosterCell.h"
 #import "Utilities.h"
+#import "AppDelegate.h"
 
 @implementation PosterCell
 
@@ -49,7 +50,7 @@
         [_labelImageView addSubview:_posterLabel];
         [self.contentView addSubview:_labelImageView];
         
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        if (IS_IPAD) {
             _posterLabelFullscreen = [[PosterLabel alloc] initWithFrame:CGRectMake(0, frame.size.height, frame.size.width - borderWidth * 2, labelHeight/2)];
             [_posterLabelFullscreen setAutoresizingMask:UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
             [_posterLabelFullscreen setBackgroundColor:[UIColor clearColor]];

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -8,6 +8,7 @@
 
 #import "RecentlyAddedCell.h"
 #import "Utilities.h"
+#import "AppDelegate.h"
 
 @implementation RecentlyAddedCell
 
@@ -47,7 +48,7 @@
         
         int posterYOffset = 4;
         int labelPadding = 4;
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        if (IS_IPHONE) {
             posterYOffset = 0;
         }
          _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, posterYOffset, fanartWidth - labelPadding -borderWidth * 4, labelHeight - borderWidth)];

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -130,7 +130,7 @@
         self.navigationItem.title = [self.detailItem mainLabel]; 
     }
     quickHelpImageView.image = [UIImage imageNamed:@"remote_quick_help"];
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         CGFloat transform = [Utilities getTransformX];
         CGRect frame = remoteControlView.frame;
         frame.size.height = frame.size.height *transform;
@@ -1119,7 +1119,7 @@ NSInteger buttonAction;
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         self.slidingViewController.underRightViewController = nil;
         RightMenuViewController *rightMenuViewController = [[RightMenuViewController alloc] initWithNibName:@"RightMenuViewController" bundle:nil];
         rightMenuViewController.rightMenuItems = [AppDelegate instance].remoteControlMenuItems;
@@ -1251,7 +1251,7 @@ NSInteger buttonAction;
             }
         }
     }
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         CGRect frame = CGRectMake(self.view.bounds.size.width - TOOLBAR_START, self.view.bounds.size.height - TOOLBAR_ICON_SIZE - TOOLBAR_SPACING, TOOLBAR_ICON_SIZE, TOOLBAR_ICON_SIZE);
         UIButton *settingButton = [UIButton buttonWithType:UIButtonTypeCustom];
         settingButton.frame = frame;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -263,7 +263,7 @@
     [fixedSpace setWidth:50.0];
     UIToolbar *toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, 44)];
     [toolbar setAutoresizingMask: UIViewAutoresizingFlexibleWidth];
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         frame.size.width = STACKSCROLL_WIDTH;
         [fixedSpace setWidth:0.0];
         [toolbar setFrame:CGRectMake(0, 0, frame.size.width, 44)];
@@ -310,7 +310,7 @@
     else {
         DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
         detailViewController.detailItem = [AppDelegate instance].xbmcSettings;
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        if (IS_IPHONE) {
             CustomNavigationController *navController = [[CustomNavigationController alloc] initWithRootViewController:detailViewController];
             UINavigationBar *newBar = navController.navigationBar;
             [newBar setBarStyle:UIBarStyleBlack];
@@ -603,7 +603,7 @@
     self.peekLeftAmount = ANCHOR_RIGHT_PEEK;
     CGRect frame = [[UIScreen mainScreen] bounds];
     CGFloat deltaX = ANCHOR_RIGHT_PEEK;
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         frame.size.width = STACKSCROLL_WIDTH;
         deltaX = 0;
         deltaY = 0;

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -140,7 +140,7 @@
         
         CGFloat deltaY = 0;
         CGRect frame = [[UIScreen mainScreen] bounds];
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        if (IS_IPAD) {
             frame.size.width = STACKSCROLL_WIDTH;
         }
         else {
@@ -290,7 +290,7 @@
     [arrayButtons.buttons addObject:button];
     [arrayButtons saveData];
     [messagesView showMessage:LOCALIZED_STR(@"Button added") timeout:2.0 color:[Utilities getSystemGreen:0.95]];
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         [[NSNotificationCenter defaultCenter] postNotificationName: @"UIInterfaceCustomButtonAdded" object: nil];
     }
 }
@@ -650,7 +650,7 @@
                 self.detailItem[@"definition"][@"value"] = self.detailItem[@"value"];
                 self.detailItem[@"definition"][@"id"] = self.detailItem[@"id"];
                 SettingsValuesViewController *settingsViewController = [[SettingsValuesViewController alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, self.view.bounds.size.height) withItem:self.detailItem[@"definition"]];
-                if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+                if (IS_IPHONE) {
                     [self.navigationController pushViewController:settingsViewController animated:YES];
                 }
                 else {

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -846,7 +846,7 @@
     [_tableView setSeparatorInset:UIEdgeInsetsMake(0, cellLabelOffset, 0, 0)];
     UIEdgeInsets tableViewInsets = UIEdgeInsetsZero;
     tableViewInsets.top = CGRectGetMaxY(self.navigationController.navigationBar.frame);
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    if (@available(iOS 11.0, *)) {
         tableViewInsets.top = 0;
     }
     _tableView.contentInset = tableViewInsets;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -140,7 +140,7 @@ int count = 0;
                 [sheetActions addObject:LOCALIZED_STR(@"Play Trailer")];
             }
         }
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        if (IS_IPAD) {
             toolbar = [UIToolbar new];
             toolbar.barStyle = UIBarStyleBlack;
             toolbar.translucent = YES;
@@ -239,7 +239,7 @@ int count = 0;
 }
 
 - (void)goBack:(id)sender {
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         [self.navigationController popViewControllerAnimated:YES];
     }
     else {
@@ -358,7 +358,7 @@ int count = 0;
         if (![item[@"disableNowPlaying"] boolValue]) {
             choosedMenuItem.disableNowPlaying = NO;
         }
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        if (IS_IPHONE) {
             DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
             detailViewController.detailItem = choosedMenuItem;
             [self.navigationController pushViewController:detailViewController animated:YES];
@@ -411,7 +411,7 @@ int count = 0;
         UIPopoverPresentationController *popPresenter = [actionView popoverPresentationController];
         if (popPresenter != nil) {
             popPresenter.sourceView = self.view;
-            if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+            if (IS_IPAD) {
                 popPresenter.barButtonItem = actionSheetButtonItemIpad;
             }
         }
@@ -593,7 +593,7 @@ int count = 0;
 }
 
 - (void)setTvShowsToolbar {
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         NSInteger count = [toolbar.items count];
         NSMutableArray *newToolbarItems = [toolbar.items mutableCopy];
         [newToolbarItems removeObjectAtIndex:(count - 1)];
@@ -669,7 +669,7 @@ int count = 0;
     CGFloat transform = [Utilities getTransformX];
     int shiftParentalRating = -20;
     NSString *contributorString = @"cast";
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         clearLogoWidth = 457;
         clearLogoHeight = 177;
         thumbWidth = (int)(PAD_TV_SHOWS_BANNER_WIDTH * transform);
@@ -722,7 +722,7 @@ int count = 0;
             GlobalData *obj = [GlobalData getInstance];
             if (!obj.preferTVPosters && [AppDelegate instance].serverVersion < 12) {
                 placeHolderImage = @"blank";
-                if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+                if (IS_IPHONE) {
                     coverHeight = 70;
                 }
                 else {
@@ -731,7 +731,7 @@ int count = 0;
                 deltaY = coverView.frame.size.height - coverHeight;
                 jewelView.hidden = YES;
             }
-            else if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+            else if (IS_IPAD) {
                 int originalHeight = jewelView.frame.size.height;
                 int coverHeight = 560;
                 deltaY = -(coverHeight - originalHeight);
@@ -759,7 +759,7 @@ int count = 0;
             [self setTvShowsToolbar];
         }
         else if ([item[@"family"] isEqualToString:@"episodeid"]) {
-            if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+            if (IS_IPAD) {
                 coverHeight = 280;
             }
             else {
@@ -815,7 +815,7 @@ int count = 0;
     else if ([item[@"family"] isEqualToString:@"albumid"]) {
         // album details
         int coverHeight = 380;
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        if (IS_IPHONE) {
             coverHeight = 290;
         }
         [self moveLabel:@[starsView, voteLabel, numVotesLabel, label1, label2, label3, label4, label5, label6, directorLabel, genreLabel, runtimeLabel, studioLabel, summaryLabel, parentalRatingLabelUp, parentalRatingLabel] posY:40];
@@ -1033,7 +1033,7 @@ int count = 0;
         jeweltype = jewelTypeDVD;
         coverView.autoresizingMask = UIViewAutoresizingNone;
         coverView.contentMode = UIViewContentModeScaleToFill;
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        if (IS_IPAD) {
             int originalHeight = jewelView.frame.size.height;
             int coverHeight = 560;
             int coverWidth = STACKSCROLL_WIDTH;
@@ -1272,7 +1272,7 @@ int count = 0;
         cast = item[contributorString];
         if (actorsTable == nil) {
             int actorsTableWidth = self.view.frame.size.width;
-            if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+            if (IS_IPAD) {
                 actorsTableWidth = pageSize + 40;
             }
             actorsTable = [[UITableView alloc] initWithFrame:CGRectMake(0, startY, actorsTableWidth, [cast count]*(castHeight + 10)) style:UITableViewStylePlain];
@@ -1296,7 +1296,7 @@ int count = 0;
         [clearlogoButton.titleLabel setShadowColor:[Utilities getGrayColor:0 alpha:0.8]];
         [clearlogoButton.titleLabel setShadowOffset:CGSizeMake(0, 1)];
         [clearlogoButton addTarget:self action:@selector(showBackground:) forControlEvents:UIControlEventTouchUpInside];
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        if (IS_IPHONE) {
             [clearlogoButton setAutoresizingMask:UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin];
         }
         if ([item[@"clearlogo"] length] != 0) {
@@ -1350,7 +1350,7 @@ int count = 0;
             [self alphaView:self.kenView AnimDuration:1.5 Alpha:0.2];// cool
         }
         [self.navigationController setNavigationBarHidden:NO animated:YES];
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        if (IS_IPAD) {
             if (![self isModal]) {
                 [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollFullScreenDisabled" object:self.view userInfo:nil];
             }
@@ -1366,7 +1366,7 @@ int count = 0;
     }
     else {
         [self.navigationController setNavigationBarHidden:YES animated:YES];
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        if (IS_IPAD) {
             if (![self isModal]) {
                 NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
                                         @(YES), @"hideToolbar",

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -107,7 +107,7 @@ int count = 0;
         }
         else if ([item[@"family"] isEqualToString:@"artistid"]) {
             UIImage* extraButtonImg = [UIImage imageNamed:@"st_album"];
-            extraButton =[[UIBarButtonItem alloc] initWithImage:extraButtonImg style:UIBarButtonItemStylePlain target:self action:@selector(showContent:)];
+            extraButton = [[UIBarButtonItem alloc] initWithImage:extraButtonImg style:UIBarButtonItemStylePlain target:self action:@selector(showContent:)];
             titleWidth = 350;
         }
         else if ([item[@"family"] isEqualToString:@"tvshowid"]) {

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -301,7 +301,7 @@
 
 + (CGFloat)getTransformX {
     // We scale for iPhone with their different device widths.
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         return (CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds) / IPHONE_SCREEN_DESIGN_WIDTH);
     }
     // For iPad a fixed frame width is used.
@@ -416,7 +416,7 @@
 }
 
 + (CGRect)createXBMCInfoframe:(UIImage*)logo height:(CGFloat)height width:(CGFloat)width {
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+    if (IS_IPHONE) {
         return CGRectMake(width - ANCHOR_RIGHT_PEEK - logo.size.width - XBMC_LOGO_PADDING, (height - logo.size.height)/2, logo.size.width, logo.size.height);
     }
     else {
@@ -497,7 +497,7 @@
     }
     UIViewController *ctrl = fromctrl;
     svc.delegate = fromctrl;
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    if (IS_IPAD) {
         // On iPad presenting from the active ViewController results in blank screen
         ctrl = UIApplication.sharedApplication.keyWindow.rootViewController;
     }

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -42,7 +42,7 @@
         CGRect frame_tmp;
         UIColor *volumeIconColor = nil;
         UIImage *muteBackgroundImage = nil;
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad){
+        if (IS_IPAD){
             volumeLabel.alpha = 1.0;
             volumeView.hidden = YES;
             volumeSlider.hidden = YES;

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -23,7 +23,7 @@
         background_padding = 6;
         alignBottom = 10;
         UIColor *accessoryBackgroundColor = [Utilities getSystemGray4];
-        if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        if (IS_IPAD) {
             accessoryHeight = 74;
             verboseHeight = 34;
             padding = 50;

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -277,8 +277,7 @@
 }
 
 - (void)offView {
-    UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
-    CGFloat posX = (UIInterfaceOrientationIsPortrait(orientation) ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT) - PAD_MENU_TABLE_WIDTH;
+    CGFloat posX = (IS_PORTRAIT ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT) - PAD_MENU_TABLE_WIDTH;
     
     [UIView animateWithDuration:0.2
                      animations:^{ 
@@ -666,8 +665,7 @@
 							viewAtRight = nil;
 							viewAtRight2 = nil;
                             // MODDED BY JOE
-                            UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
-                            CGFloat marginPosX = (UIInterfaceOrientationIsPortrait(orientation) ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT) - PAD_MENU_TABLE_WIDTH - STACK_OVERLAP;
+                            CGFloat marginPosX = (IS_PORTRAIT ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT) - PAD_MENU_TABLE_WIDTH - STACK_OVERLAP;
                             if ((((UIView*)[slideViews subviews][0]).frame.origin.x+marginPosX/2) >= marginPosX) {
                                 posX = marginPosX;
                             }
@@ -882,8 +880,7 @@
 	if (isStackStartView) {
         NSInteger numViews = [[slideViews subviews]count];
         if (numViews == 0) {
-            UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
-            animX = (UIInterfaceOrientationIsPortrait(orientation) ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT) - PAD_MENU_TABLE_WIDTH;
+            animX = (IS_PORTRAIT ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT) - PAD_MENU_TABLE_WIDTH;
         }
         else {
             animX = [[slideViews subviews][0] frame].origin.x;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Use `#define` to improve code readability. 
- for `UIUserInterfaceIdiom` checks
- for `UIInterfaceOrientation` checks

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Use #defines for device type and device orientation checks