### PR TITLE
Bugfix: Resolve issues around playlist

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4237,8 +4237,8 @@ NSIndexPath *selected;
                  else {
                      return; // something goes wrong
                  }
-                 NSDictionary *videoLibraryMovieDetail = methodResult[itemid_extra_info];
-                 if (((NSNull*)videoLibraryMovieDetail == [NSNull null]) || videoLibraryMovieDetail == nil) {
+                 NSDictionary *itemExtraDict = methodResult[itemid_extra_info];
+                 if (((NSNull*)itemExtraDict == [NSNull null]) || itemExtraDict == nil) {
                      return; // something goes wrong
                  }
                  NSString *serverURL = @"";
@@ -4248,34 +4248,34 @@ NSIndexPath *selected;
                      serverURL = [NSString stringWithFormat:@"%@:%@/image/", obj.serverIP, obj.serverPort];
                      secondsToMinute = 60;
                  }
-                 NSString *label = [NSString stringWithFormat:@"%@", videoLibraryMovieDetail[mainFields[@"row1"]]];
-                 NSString *genre = [Utilities getStringFromDictionary:videoLibraryMovieDetail key:mainFields[@"row2"] emptyString:@""];
+                 NSString *label = [NSString stringWithFormat:@"%@", itemExtraDict[mainFields[@"row1"]]];
+                 NSString *genre = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row2"] emptyString:@""];
                  
-                 NSString *year = [Utilities getYearFromDictionary:videoLibraryMovieDetail key:mainFields[@"row3"]];
+                 NSString *year = [Utilities getYearFromDictionary:itemExtraDict key:mainFields[@"row3"]];
                  
-                 NSString *runtime = [Utilities getTimeFromDictionary:videoLibraryMovieDetail key:mainFields[@"row4"] sec2min:secondsToMinute];
+                 NSString *runtime = [Utilities getTimeFromDictionary:itemExtraDict key:mainFields[@"row4"] sec2min:secondsToMinute];
                  
-                 NSString *rating = [Utilities getRatingFromDictionary:videoLibraryMovieDetail key:mainFields[@"row5"]];
+                 NSString *rating = [Utilities getRatingFromDictionary:itemExtraDict key:mainFields[@"row5"]];
                  
-                 NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:videoLibraryMovieDetail useBanner:NO useIcon:methodResult[@"recordingdetails"] != nil];
+                 NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:itemExtraDict useBanner:NO useIcon:methodResult[@"recordingdetails"] != nil];
 
-                 NSDictionary *art = videoLibraryMovieDetail[@"art"];
+                 NSDictionary *art = itemExtraDict[@"art"];
                  NSString *clearlogo = [Utilities getClearArtFromDictionary:art type:@"clearlogo"];
                  NSString *clearart = [Utilities getClearArtFromDictionary:art type:@"clearart"];
 //                 if ([art count] && [art[@"banner"] length] != 0 && [AppDelegate instance].serverVersion > 11 && ![AppDelegate instance].obj.preferTVPosters) {
 //                     thumbnailPath = art[@"banner"];
 //                 }
                  NSString *stringURL = [Utilities formatStringURL:thumbnailPath serverURL:serverURL];
-                 NSString *fanartURL = [Utilities formatStringURL:videoLibraryMovieDetail[@"fanart"] serverURL:serverURL];
+                 NSString *fanartURL = [Utilities formatStringURL:itemExtraDict[@"fanart"] serverURL:serverURL];
                  if ([stringURL isEqualToString:@""]) {
-                     stringURL = [Utilities getItemIconFromDictionary:videoLibraryMovieDetail mainFields:mainFields];
+                     stringURL = [Utilities getItemIconFromDictionary:itemExtraDict mainFields:mainFields];
                  }
                  BOOL disableNowPlaying = NO;
                  if ([self.detailItem disableNowPlaying]) {
                      disableNowPlaying = YES;
                  }
                  
-                 NSObject *row11 = videoLibraryMovieDetail[mainFields[@"row11"]];
+                 NSObject *row11 = itemExtraDict[mainFields[@"row11"]];
                  if (row11 == nil) {
                      row11 = @(0);
                  }
@@ -4284,7 +4284,7 @@ NSIndexPath *selected;
                      row11key = @"";
                  }
                  
-                 NSObject *row7 = videoLibraryMovieDetail[mainFields[@"row7"]];
+                 NSObject *row7 = itemExtraDict[mainFields[@"row7"]];
                  if (row7 == nil) {
                      row7 = @(0);
                  }
@@ -4307,23 +4307,23 @@ NSIndexPath *selected;
                   fanartURL, @"fanart",
                   runtime, @"runtime",
                   row7, row7key,
-                  videoLibraryMovieDetail[mainFields[@"row6"]], mainFields[@"row6"],
-                  videoLibraryMovieDetail[mainFields[@"row8"]], mainFields[@"row8"],
+                  itemExtraDict[mainFields[@"row6"]], mainFields[@"row6"],
+                  itemExtraDict[mainFields[@"row8"]], mainFields[@"row8"],
                   year, @"year",
                   rating, @"rating",
                   mainFields[@"playlistid"], @"playlistid",
                   mainFields[@"row8"], @"family",
-                  @([[NSString stringWithFormat:@"%@", videoLibraryMovieDetail[mainFields[@"row9"]]] intValue]), mainFields[@"row9"],
-                  videoLibraryMovieDetail[mainFields[@"row10"]], mainFields[@"row10"],
+                  @([[NSString stringWithFormat:@"%@", itemExtraDict[mainFields[@"row9"]]] intValue]), mainFields[@"row9"],
+                  itemExtraDict[mainFields[@"row10"]], mainFields[@"row10"],
                   row11, row11key,
-                  videoLibraryMovieDetail[mainFields[@"row12"]], mainFields[@"row12"],
-                  videoLibraryMovieDetail[mainFields[@"row13"]], mainFields[@"row13"],
-                  videoLibraryMovieDetail[mainFields[@"row14"]], mainFields[@"row14"],
-                  videoLibraryMovieDetail[mainFields[@"row15"]], mainFields[@"row15"],
-                  videoLibraryMovieDetail[mainFields[@"row16"]], mainFields[@"row16"],
-                  videoLibraryMovieDetail[mainFields[@"row17"]], mainFields[@"row17"],
-                  videoLibraryMovieDetail[mainFields[@"row18"]], mainFields[@"row18"],
-                  videoLibraryMovieDetail[mainFields[@"row20"]], mainFields[@"row20"],
+                  itemExtraDict[mainFields[@"row12"]], mainFields[@"row12"],
+                  itemExtraDict[mainFields[@"row13"]], mainFields[@"row13"],
+                  itemExtraDict[mainFields[@"row14"]], mainFields[@"row14"],
+                  itemExtraDict[mainFields[@"row15"]], mainFields[@"row15"],
+                  itemExtraDict[mainFields[@"row16"]], mainFields[@"row16"],
+                  itemExtraDict[mainFields[@"row17"]], mainFields[@"row17"],
+                  itemExtraDict[mainFields[@"row18"]], mainFields[@"row18"],
+                  itemExtraDict[mainFields[@"row20"]], mainFields[@"row20"],
                   nil];
                  [self displayInfoView:newItem];
              }
@@ -4465,7 +4465,7 @@ NSIndexPath *selected;
                  else {
                      recordingListView = NO;
                  }
-                 NSArray *videoLibraryMovies = methodResult[itemid];
+                 NSArray *itemDict = methodResult[itemid];
                  NSString *serverURL = @"";
                  serverURL = [NSString stringWithFormat:@"%@:%@/vfs/", obj.serverIP, obj.serverPort];
                  int secondsToMinute = 1;
@@ -4475,35 +4475,35 @@ NSIndexPath *selected;
                          secondsToMinute = 60;
                      }
                  }
-                 if ([videoLibraryMovies isKindOfClass:[NSArray class]]) {
-                     if (((NSNull*)videoLibraryMovies != [NSNull null])) {
-                         total = (int)[videoLibraryMovies count];
+                 if ([itemDict isKindOfClass:[NSArray class]]) {
+                     if (((NSNull*)itemDict != [NSNull null])) {
+                         total = (int)[itemDict count];
                      }
                      for (int i = 0; i < total; i++) {
-                         NSString *label = [NSString stringWithFormat:@"%@", videoLibraryMovies[i][mainFields[@"row1"]]];
+                         NSString *label = [NSString stringWithFormat:@"%@", itemDict[i][mainFields[@"row1"]]];
                          
-                         NSString *genre = [Utilities getStringFromDictionary:videoLibraryMovies[i] key:mainFields[@"row2"] emptyString:@""];
+                         NSString *genre = [Utilities getStringFromDictionary:itemDict[i] key:mainFields[@"row2"] emptyString:@""];
                          
-                         NSString *year = [Utilities getYearFromDictionary:videoLibraryMovies[i] key:mainFields[@"row3"]];
+                         NSString *year = [Utilities getYearFromDictionary:itemDict[i] key:mainFields[@"row3"]];
 
-                         NSString *runtime = [Utilities getTimeFromDictionary:videoLibraryMovies[i] key:mainFields[@"row4"] sec2min:secondsToMinute];
+                         NSString *runtime = [Utilities getTimeFromDictionary:itemDict[i] key:mainFields[@"row4"] sec2min:secondsToMinute];
                          
-                         NSString *rating = [Utilities getRatingFromDictionary:videoLibraryMovies[i] key:mainFields[@"row5"]];
+                         NSString *rating = [Utilities getRatingFromDictionary:itemDict[i] key:mainFields[@"row5"]];
                          
-                         NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:videoLibraryMovies[i] useBanner:tvshowsView useIcon:recordingListView];
+                         NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:itemDict[i] useBanner:tvshowsView useIcon:recordingListView];
 
                          NSString *stringURL = [Utilities formatStringURL:thumbnailPath serverURL:serverURL];
-                         NSString *fanartURL = [Utilities formatStringURL:videoLibraryMovies[i][@"fanart"] serverURL:serverURL];
+                         NSString *fanartURL = [Utilities formatStringURL:itemDict[i][@"fanart"] serverURL:serverURL];
                          if ([stringURL isEqualToString:@""]) {
-                             stringURL = [Utilities getItemIconFromDictionary:videoLibraryMovies[i] mainFields:mainFields];
+                             stringURL = [Utilities getItemIconFromDictionary:itemDict[i] mainFields:mainFields];
                          }
                          NSString *key = @"none";
                          NSString *value = @"";
                          if ((mainFields[@"row7"] != nil)) {
                              key = mainFields[@"row7"];
-                             value = [NSString stringWithFormat:@"%@", videoLibraryMovies[i][mainFields[@"row7"]]];
+                             value = [NSString stringWithFormat:@"%@", itemDict[i][mainFields[@"row7"]]];
                          }
-                         NSString *seasonNumber = [NSString stringWithFormat:@"%@", videoLibraryMovies[i][mainFields[@"row10"]]];
+                         NSString *seasonNumber = [NSString stringWithFormat:@"%@", itemDict[i][mainFields[@"row10"]]];
                          
                          NSString *family = [NSString stringWithFormat:@"%@", mainFields[@"row8"]];
                          
@@ -4512,17 +4512,17 @@ NSIndexPath *selected;
                              row19key = @"episode";
                          }
                          id episodeNumber = @"";
-                         if ([videoLibraryMovies[i][mainFields[@"row19"]] isKindOfClass:[NSDictionary class]]) {
-                             episodeNumber = [videoLibraryMovies[i][mainFields[@"row19"]] mutableCopy];
+                         if ([itemDict[i][mainFields[@"row19"]] isKindOfClass:[NSDictionary class]]) {
+                             episodeNumber = [itemDict[i][mainFields[@"row19"]] mutableCopy];
                          }
                          else {
-                             episodeNumber = [NSString stringWithFormat:@"%@", videoLibraryMovies[i][mainFields[@"row19"]]];
+                             episodeNumber = [NSString stringWithFormat:@"%@", itemDict[i][mainFields[@"row19"]]];
                          }
-                         id row13obj = [mainFields[@"row13"] isEqualToString:@"options"] ? videoLibraryMovies[i][mainFields[@"row13"]] == nil ? @"" : videoLibraryMovies[i][mainFields[@"row13"]] : videoLibraryMovies[i][mainFields[@"row13"]];
+                         id row13obj = [mainFields[@"row13"] isEqualToString:@"options"] ? itemDict[i][mainFields[@"row13"]] == nil ? @"" : itemDict[i][mainFields[@"row13"]] : itemDict[i][mainFields[@"row13"]];
                          
-                         id row14obj = [mainFields[@"row14"] isEqualToString:@"allowempty"] ? videoLibraryMovies[i][mainFields[@"row14"]] == nil ? @"" : videoLibraryMovies[i][mainFields[@"row14"]] : videoLibraryMovies[i][mainFields[@"row14"]];
+                         id row14obj = [mainFields[@"row14"] isEqualToString:@"allowempty"] ? itemDict[i][mainFields[@"row14"]] == nil ? @"" : itemDict[i][mainFields[@"row14"]] : itemDict[i][mainFields[@"row14"]];
                          
-                         id row15obj = [mainFields[@"row15"] isEqualToString:@"addontype"] ? videoLibraryMovies[i][mainFields[@"row15"]] == nil ? @"" : videoLibraryMovies[i][mainFields[@"row15"]] : videoLibraryMovies[i][mainFields[@"row15"]];
+                         id row15obj = [mainFields[@"row15"] isEqualToString:@"addontype"] ? itemDict[i][mainFields[@"row15"]] == nil ? @"" : itemDict[i][mainFields[@"row15"]] : itemDict[i][mainFields[@"row15"]];
                          
                          NSMutableDictionary *newDict = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                                       label, @"label",
@@ -4533,22 +4533,22 @@ NSIndexPath *selected;
                                                       seasonNumber, @"season",
                                                       episodeNumber, row19key,
                                                       family, @"family",
-                                                      videoLibraryMovies[i][mainFields[@"row6"]], mainFields[@"row6"],
-                                                      videoLibraryMovies[i][mainFields[@"row8"]], mainFields[@"row8"],
+                                                      itemDict[i][mainFields[@"row6"]], mainFields[@"row6"],
+                                                      itemDict[i][mainFields[@"row8"]], mainFields[@"row8"],
                                                       year, @"year",
                                                       [NSString stringWithFormat:@"%@", rating], @"rating",
                                                       mainFields[@"playlistid"], @"playlistid",
                                                       value, key,
-                                                      videoLibraryMovies[i][mainFields[@"row9"]], mainFields[@"row9"],
-                                                      videoLibraryMovies[i][mainFields[@"row10"]], mainFields[@"row10"],
-                                                      videoLibraryMovies[i][mainFields[@"row11"]], mainFields[@"row11"],
-                                                      videoLibraryMovies[i][mainFields[@"row12"]], mainFields[@"row12"],
+                                                      itemDict[i][mainFields[@"row9"]], mainFields[@"row9"],
+                                                      itemDict[i][mainFields[@"row10"]], mainFields[@"row10"],
+                                                      itemDict[i][mainFields[@"row11"]], mainFields[@"row11"],
+                                                      itemDict[i][mainFields[@"row12"]], mainFields[@"row12"],
                                                       row13obj, mainFields[@"row13"],
                                                       row14obj, mainFields[@"row14"],
                                                       row15obj, mainFields[@"row15"],
-                                                      videoLibraryMovies[i][mainFields[@"row16"]], mainFields[@"row16"],
-                                                      videoLibraryMovies[i][mainFields[@"row17"]], mainFields[@"row17"],
-                                                      videoLibraryMovies[i][mainFields[@"row18"]], mainFields[@"row18"],
+                                                      itemDict[i][mainFields[@"row16"]], mainFields[@"row16"],
+                                                      itemDict[i][mainFields[@"row17"]], mainFields[@"row17"],
+                                                      itemDict[i][mainFields[@"row18"]], mainFields[@"row18"],
                                                       nil];
                          
                          // Postprocessing of movie sets lists to ignore 1-movie-sets
@@ -4558,7 +4558,7 @@ NSIndexPath *selected;
                                  [storeRichResults removeAllObjects];
                              }
                              NSString *newMethodToCall = @"VideoLibrary.GetMovieSetDetails";
-                             NSDictionary *newParameter = @{@"setid": @([videoLibraryMovies[i][@"setid"] intValue])};
+                             NSDictionary *newParameter = @{@"setid": @([itemDict[i][@"setid"] intValue])};
                              [[Utilities getJsonRPC]
                               callMethod:newMethodToCall
                               withParameters:newParameter
@@ -4584,13 +4584,13 @@ NSIndexPath *selected;
                          }
                      }
                  }
-                 else if ([videoLibraryMovies isKindOfClass:[NSDictionary class]]) {
+                 else if ([itemDict isKindOfClass:[NSDictionary class]]) {
                      NSDictionary *dictVideoLibraryMovies = methodResult[itemid];
                      if ([dictVideoLibraryMovies[mainFields[@"typename"]] isKindOfClass:[NSDictionary class]]) {
                          if ([dictVideoLibraryMovies[mainFields[@"typename"]][mainFields[@"fieldname"]] isKindOfClass:[NSArray class]]) {
-                             videoLibraryMovies = dictVideoLibraryMovies[mainFields[@"typename"]][mainFields[@"fieldname"]];
-                             if (((NSNull*)videoLibraryMovies != [NSNull null])) {
-                                 total = (int)[videoLibraryMovies count];
+                             itemDict = dictVideoLibraryMovies[mainFields[@"typename"]][mainFields[@"fieldname"]];
+                             if (((NSNull*)itemDict != [NSNull null])) {
+                                 total = (int)[itemDict count];
                              }
                              NSString *sublabel = [Utilities indexKeyedDictionaryFromArray:[self.detailItem mainParameters][choosedTab]][@"morelabel"];
                              if (!sublabel || [sublabel isKindOfClass:[NSNull class]]) {
@@ -4598,7 +4598,7 @@ NSIndexPath *selected;
                              }
                              for (int i = 0; i < total; i++) {
                                  [resultStoreArray addObject:[NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                                              videoLibraryMovies[i], @"label",
+                                                              itemDict[i], @"label",
                                                               sublabel, @"genre",
                                                               @"file", @"family",
                                                               mainFields[@"thumbnail"], @"thumbnail",

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1441,7 +1441,7 @@ int currentItemID;
                  
                  NSString *rating = [Utilities getRatingFromDictionary:videoLibraryMovieDetail key:mainFields[@"row5"]];
                  
-                 NSString *thumbnailPath = videoLibraryMovieDetail[@"thumbnail"];
+                 NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:videoLibraryMovieDetail useBanner:NO useIcon:NO];
                  NSDictionary *art = videoLibraryMovieDetail[@"art"];
                  NSString *clearlogo = [Utilities getClearArtFromDictionary:art type:@"clearlogo"];
                  NSString *clearart = [Utilities getClearArtFromDictionary:art type:@"clearart"];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2108,7 +2108,7 @@ int currentItemID;
     [(UILabel*)[cell viewWithTag:2] setText:@""];
     if ([item[@"type"] isEqualToString:@"episode"]) {
         if ([item[@"season"] intValue] != 0 || [item[@"episode"] intValue] != 0) {
-            [mainLabel setText:[NSString stringWithFormat:@"%@x%02i. %@", item[@"season"], [item[@"episode"] intValue], item[@"label"]]];
+            [mainLabel setText:[NSString stringWithFormat:@"%@x%02i. %@", item[@"season"], [item[@"episode"] intValue], item[@"title"]]];
         }
         [subLabel setText:[NSString stringWithFormat:@"%@", item[@"showtitle"]]];
     }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1412,14 +1412,14 @@ int currentItemID;
                  if ([AppDelegate instance].serverVersion > 11 && [methodToCall isEqualToString:@"AudioLibrary.GetArtists"]) {// WORKAROUND due the lack of the artistid with Playlist.GetItems
                      itemid_extra_info = @"artists";
                  }
-                 NSDictionary *videoLibraryMovieDetail = methodResult[itemid_extra_info];
-                 if (((NSNull*)videoLibraryMovieDetail == [NSNull null]) || videoLibraryMovieDetail == nil) {
+                 NSDictionary *itemExtraDict = methodResult[itemid_extra_info];
+                 if (((NSNull*)itemExtraDict == [NSNull null]) || itemExtraDict == nil) {
                      [self somethingGoesWrong:LOCALIZED_STR(@"Details not found")];
                      return;
                  }
                  if ([AppDelegate instance].serverVersion > 11 && [methodToCall isEqualToString:@"AudioLibrary.GetArtists"]) {// WORKAROUND due the lack of the artistid with Playlist.GetItems
                      if ([methodResult[itemid_extra_info] count]) {
-                         videoLibraryMovieDetail = methodResult[itemid_extra_info][0];
+                         itemExtraDict = methodResult[itemid_extra_info][0];
                      }
                      else {
                          [self somethingGoesWrong:LOCALIZED_STR(@"Details not found")];
@@ -1432,29 +1432,29 @@ int currentItemID;
                      serverURL = [NSString stringWithFormat:@"%@:%@/image/", obj.serverIP, obj.serverPort];
                  }
 
-                 NSString *label = [NSString stringWithFormat:@"%@", videoLibraryMovieDetail[mainFields[@"row1"]]];
-                 NSString *genre = [Utilities getStringFromDictionary:videoLibraryMovieDetail key:mainFields[@"row2"] emptyString:@""];
+                 NSString *label = [NSString stringWithFormat:@"%@", itemExtraDict[mainFields[@"row1"]]];
+                 NSString *genre = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row2"] emptyString:@""];
                  
-                 NSString *year = [Utilities getYearFromDictionary:videoLibraryMovieDetail key:mainFields[@"row3"]];
+                 NSString *year = [Utilities getYearFromDictionary:itemExtraDict key:mainFields[@"row3"]];
 
-                 NSString *runtime = [Utilities getStringFromDictionary:videoLibraryMovieDetail key:mainFields[@"row4"] emptyString:@""];
+                 NSString *runtime = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row4"] emptyString:@""];
                  
-                 NSString *rating = [Utilities getRatingFromDictionary:videoLibraryMovieDetail key:mainFields[@"row5"]];
+                 NSString *rating = [Utilities getRatingFromDictionary:itemExtraDict key:mainFields[@"row5"]];
                  
-                 NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:videoLibraryMovieDetail useBanner:NO useIcon:NO];
-                 NSDictionary *art = videoLibraryMovieDetail[@"art"];
+                 NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:itemExtraDict useBanner:NO useIcon:NO];
+                 NSDictionary *art = itemExtraDict[@"art"];
                  NSString *clearlogo = [Utilities getClearArtFromDictionary:art type:@"clearlogo"];
                  NSString *clearart = [Utilities getClearArtFromDictionary:art type:@"clearart"];
 //                 if ([art count] && [art[@"banner"] length] != 0 && [AppDelegate instance].serverVersion > 11 && ![AppDelegate instance].obj.preferTVPosters) {
 //                     thumbnailPath = art[@"banner"];
 //                 }
                  NSString *stringURL = [Utilities formatStringURL:thumbnailPath serverURL:serverURL];
-                 NSString *fanartURL = [Utilities formatStringURL:videoLibraryMovieDetail[@"fanart"] serverURL:serverURL];
+                 NSString *fanartURL = [Utilities formatStringURL:itemExtraDict[@"fanart"] serverURL:serverURL];
                  if ([stringURL isEqualToString:@""]) {
-                     stringURL = [Utilities getItemIconFromDictionary:videoLibraryMovieDetail mainFields:mainFields];
+                     stringURL = [Utilities getItemIconFromDictionary:itemExtraDict mainFields:mainFields];
                  }
                  BOOL disableNowPlaying = YES;
-                 NSObject *row11 = videoLibraryMovieDetail[mainFields[@"row11"]];
+                 NSObject *row11 = itemExtraDict[mainFields[@"row11"]];
                  if (row11 == nil) {
                      row11 = @(0);
                  }
@@ -1468,23 +1468,23 @@ int currentItemID;
                   stringURL, @"thumbnail",
                   fanartURL, @"fanart",
                   runtime, @"runtime",
-                  videoLibraryMovieDetail[mainFields[@"row6"]], mainFields[@"row6"],
-                  videoLibraryMovieDetail[mainFields[@"row8"]], mainFields[@"row8"],
+                  itemExtraDict[mainFields[@"row6"]], mainFields[@"row6"],
+                  itemExtraDict[mainFields[@"row8"]], mainFields[@"row8"],
                   year, @"year",
                   rating, @"rating",
                   mainFields[@"playlistid"], @"playlistid",
                   mainFields[@"row8"], @"family",
-                  @([[NSString stringWithFormat:@"%@", videoLibraryMovieDetail[mainFields[@"row9"]]] intValue]), mainFields[@"row9"],
-                  videoLibraryMovieDetail[mainFields[@"row10"]], mainFields[@"row10"],
+                  @([[NSString stringWithFormat:@"%@", itemExtraDict[mainFields[@"row9"]]] intValue]), mainFields[@"row9"],
+                  itemExtraDict[mainFields[@"row10"]], mainFields[@"row10"],
                   row11, mainFields[@"row11"],
-                  videoLibraryMovieDetail[mainFields[@"row12"]], mainFields[@"row12"],
-                  videoLibraryMovieDetail[mainFields[@"row13"]], mainFields[@"row13"],
-                  videoLibraryMovieDetail[mainFields[@"row14"]], mainFields[@"row14"],
-                  videoLibraryMovieDetail[mainFields[@"row15"]], mainFields[@"row15"],
-                  videoLibraryMovieDetail[mainFields[@"row16"]], mainFields[@"row16"],
-                  videoLibraryMovieDetail[mainFields[@"row17"]], mainFields[@"row17"],
-                  videoLibraryMovieDetail[mainFields[@"row18"]], mainFields[@"row18"],
-                  videoLibraryMovieDetail[mainFields[@"row20"]], mainFields[@"row20"],
+                  itemExtraDict[mainFields[@"row12"]], mainFields[@"row12"],
+                  itemExtraDict[mainFields[@"row13"]], mainFields[@"row13"],
+                  itemExtraDict[mainFields[@"row14"]], mainFields[@"row14"],
+                  itemExtraDict[mainFields[@"row15"]], mainFields[@"row15"],
+                  itemExtraDict[mainFields[@"row16"]], mainFields[@"row16"],
+                  itemExtraDict[mainFields[@"row17"]], mainFields[@"row17"],
+                  itemExtraDict[mainFields[@"row18"]], mainFields[@"row18"],
+                  itemExtraDict[mainFields[@"row20"]], mainFields[@"row20"],
                   nil];
                  [self displayInfoView:newItem];
              }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -254,12 +254,10 @@
 	if (image.imageOrientation == UIImageOrientationLeft) {
 		CGContextRotateCTM (bitmap, M_PI/2);
 		CGContextTranslateCTM (bitmap, 0, -height);
-		
 	}
     else if (image.imageOrientation == UIImageOrientationRight) {
 		CGContextRotateCTM (bitmap, -M_PI/2);
 		CGContextTranslateCTM (bitmap, -width, 0);
-		
 	}
     else if (image.imageOrientation == UIImageOrientationUp) {
 		
@@ -939,7 +937,6 @@ int currentItemID;
                                          else {
                                              NSIndexPath* selection = [playlistTableView indexPathForSelectedRow];
                                              if (selection) {
-                                                 
                                                  [playlistTableView deselectRowAtIndexPath:selection animated:YES];
                                                  UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:selection];
                                                  UIView *timePlaying = (UIView*)[cell viewWithTag:5];
@@ -1983,7 +1980,6 @@ int currentItemID;
         else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Album Tracks")]) {
             choosedTab = 0;
             MenuItem.subItem.mainLabel = item[@"album"];
-
         }
         else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Artist Details")]) {
             choosedTab = 1;
@@ -2123,10 +2119,16 @@ int currentItemID;
     else if ([item[@"type"] isEqualToString:@"movie"]) {
         [subLabel setText:[NSString stringWithFormat:@"%@", item[@"genre"]]];
     }
-    if (playerID == 0)
-        [cornerLabel setText:item[@"duration"]];
-    if (playerID == 1)
-        [cornerLabel setText:item[@"runtime"]];
+    switch (playerID) {
+        case 0:
+            [cornerLabel setText:item[@"duration"]];
+            break;
+        case 1:
+            [cornerLabel setText:item[@"runtime"]];
+            break;
+        default:
+            break;
+    }
     NSString *stringURL = item[@"thumbnail"];
     [thumb setImageWithURL:[NSURL URLWithString:stringURL] placeholderImage:[UIImage imageNamed:@"nocover_music"]];
     // andResize:CGSizeMake(thumb.frame.size.width, thumb.frame.size.height)
@@ -2143,8 +2145,9 @@ int currentItemID;
     coverView.alpha = 1.0;
     UIView *timePlaying = (UIView*)[cell viewWithTag:5];
     storeSelection = nil;
-    if (!timePlaying.hidden)
+    if (!timePlaying.hidden) {
         [self fadeView:timePlaying hidden:YES];
+    }
 }
 
 - (void)checkPartyMode {
@@ -2189,9 +2192,7 @@ int currentItemID;
 }
 
 - (BOOL)tableView:(UITableView*)tableView canEditRowAtIndexPath:(NSIndexPath*)indexPath {
-    if (storeSelection && storeSelection.row == indexPath.row)
-        return NO;
-    return YES;
+    return !(storeSelection && storeSelection.row == indexPath.row);
 }
 
 - (BOOL)tableView:(UITableView*)tableview canMoveRowAtIndexPath:(NSIndexPath*)indexPath {
@@ -2289,7 +2290,6 @@ int currentItemID;
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer*)gestureRecognizer {
     if (playlistTableView.editing) {
         return NO;
-        
     }
     else {
         return YES;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -277,7 +277,6 @@ int count = 0;
         MenuItem = [[AppDelegate instance].playlistArtistAlbums copy];
         choosedMenuItem = MenuItem.subItem;
         choosedMenuItem.mainLabel = [NSString stringWithFormat:@"%@", item[@"label"]];
-
     }
     else if ([item[@"family"] isEqualToString:@"movieid"] && [AppDelegate instance].serverVersion > 11) {
         if ([sender isKindOfClass:[NSString class]]) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR applies follwing changes. 

- First change fixes an issue described in a [forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3049725#pid3049725), which results in double `1x01` (or whatever season/episode is played) shown in the App's playlist when the playback was started via the Kodi UI. 
Screenshot: https://abload.de/img/a5137fe2-9c4b-4309-ap0k3p.jpeg

- Second change fixes missing or wrong thumbnails when calling the info screen via longpress on the playlist item.
Screenshots:
https://abload.de/img/simulatorscreenshot-i6iku0.png (TVShow before)
https://abload.de/img/simulatorscreenshot-i5lkam.png (TVShow after)
https://abload.de/img/simulatorscreenshot-it5ksx.png (Movie before)
https://abload.de/img/simulatorscreenshot-iqjkie.png (Movie after)
 
- Last changes are some coding style changes and the renaming of three main variables to match its content, which is not only Video based.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not show double "1x01" in playlist for TVShow episodes
Bugfix: Show thumbnails for Movies/TVShows when calling info via playlist's longpress menu