### PR TITLE
Bugfix: Correct vertical position of volume control on iPad

### DIFF
--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -68,6 +68,11 @@
             muteIconColor = [UIColor grayColor];
             volumeIconColor = [UIColor lightGrayColor];
             
+            // Move all buttons to vertical center of view
+            for (UIView *subView in [self subviews]) {
+                subView.center = CGPointMake(subView.center.x, frame.size.height / 2);
+            }
+            
             // set final used width for this view
             frame_tmp = frame;
             frame_tmp.size.width = CGRectGetMaxX(plusButton.frame);


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR corrects the vertical position of the volume control elements for iPads.

<a href="https://abload.de/image.php?img=bildschirmfoto2021-07gljs0.png"><img src="https://abload.de/img/bildschirmfoto2021-07gljs0.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct vertical position of volume control on iPad