### PR TITLE
Avoid duplicate code when reading bottom padding

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5593,11 +5593,7 @@ NSIndexPath *selected;
     }
     self.searchController.searchBar.tintColor = searchBarColor;
     [self.searchController.searchBar setBackgroundColor:searchBarColor];
-    bottomPadding = 0;
-    if (@available(iOS 11.0, *)) {
-        UIWindow *window = UIApplication.sharedApplication.keyWindow;
-        bottomPadding = window.safeAreaInsets.bottom;
-    }
+    bottomPadding = [Utilities getBottomPadding];
     if (IS_IPHONE) {
         if (bottomPadding > 0) {
             frame = buttonsView.frame;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -379,11 +379,7 @@ static inline BOOL IsEmpty(id obj) {
     if (IS_IPAD) {
         deltaY = 0;
     }
-    CGFloat bottomPadding = 0;
-    if (@available(iOS 11.0, *)) {
-        UIWindow *window = UIApplication.sharedApplication.keyWindow;
-        bottomPadding = window.safeAreaInsets.bottom;
-    }
+    CGFloat bottomPadding = [Utilities getBottomPadding];
     if (IS_IPAD) {
         bottomPadding = SERVERPOPUP_BOTTOMPADDING;
     }

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -575,11 +575,7 @@
     rightSwipe.direction = UISwipeGestureRecognizerDirectionRight;
     [self.view addGestureRecognizer:rightSwipe];
     
-    CGFloat bottomPadding = 0;
-    if (@available(iOS 11.0, *)) {
-        UIWindow *window = UIApplication.sharedApplication.keyWindow;
-        bottomPadding = window.safeAreaInsets.bottom;
-    }
+    CGFloat bottomPadding = [Utilities getBottomPadding];
     if (IS_IPAD) {
         bottomPadding = SERVERPOPUP_BOTTOMPADDING;
     }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2370,11 +2370,7 @@ int currentItemID;
     CGRect frame;
     
     // Maximum allowed height shall be 90% of visible height in landscape mode
-    CGFloat bottomPadding = 0;
-    if (@available(iOS 11.0, *)) {
-        UIWindow *window = UIApplication.sharedApplication.keyWindow;
-        bottomPadding = window.safeAreaInsets.bottom;
-    }
+    CGFloat bottomPadding = [Utilities getBottomPadding];
     CGFloat maxheight = floor((CGRectGetHeight(UIScreen.mainScreen.bounds) - bottomPadding - playlistToolbar.frame.size.height) * 0.9);
     
     frame = ProgressSlider.frame;
@@ -2810,11 +2806,7 @@ int currentItemID;
     [noItemsLabel setText:LOCALIZED_STR(@"No items found.")];
     [self addSegmentControl];
     cellBackgroundColor = [UIColor whiteColor];
-    bottomPadding = 0;
-    if (@available(iOS 11.0, *)) {
-        UIWindow *window = UIApplication.sharedApplication.keyWindow;
-        bottomPadding = window.safeAreaInsets.bottom;
-    }
+    bottomPadding = [Utilities getBottomPadding];
     [self setIOS7toolbar];
 
     if (bottomPadding > 0) {

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -143,11 +143,7 @@
                     hide: YES];
     }
     // Keep the buttons out of the safe area
-    CGFloat bottomPadding = 0.0;
-    if (@available(iOS 11.0, *)) {
-        UIWindow *window = UIApplication.sharedApplication.keyWindow;
-        bottomPadding = window.safeAreaInsets.bottom;
-    }
+    CGFloat bottomPadding = [Utilities getBottomPadding];
     
     // Place the transitional view in the middle between the two button rows
     CGFloat lowerButtonUpperBorder = CGRectGetMinY([self.view viewWithTag:TAG_BUTTON_MUSIC].frame);
@@ -214,11 +210,7 @@
     }
     else {
         // Used to avoid drawing remote buttons into the safe area
-        CGFloat bottomPadding = 0.0;
-        if (@available(iOS 11.0, *)) {
-            UIWindow *window = UIApplication.sharedApplication.keyWindow;
-            bottomPadding = window.safeAreaInsets.bottom;
-        }
+        CGFloat bottomPadding = [Utilities getBottomPadding];
         // Calculate the maximum possible scaling for the remote
         CGFloat scaleFactorHorizontal = STACKSCROLL_WIDTH / CGRectGetWidth(remoteControlView.frame);
         CGFloat minViewHeight = MIN(CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds), CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds)) - REMOTE_PADDING - bottomPadding;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -624,11 +624,7 @@
                         nil];
     
     mainMenu *menuItems = self.rightMenuItems[0];
-    CGFloat bottomPadding = 0;
-    if (@available(iOS 11.0, *)) {
-        UIWindow *window = UIApplication.sharedApplication.keyWindow;
-        bottomPadding = window.safeAreaInsets.bottom;
-    }
+    CGFloat bottomPadding = [Utilities getBottomPadding];
     CGFloat footerHeight = 0;
     if (menuItems.family == FamilyRemote) {
         footerHeight = TOOLBAR_HEIGHT + bottomPadding;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1856,11 +1856,7 @@ int count = 0;
     [touchOnKenView setNumberOfTouchesRequired:1];
     [fanartView addGestureRecognizer:touchOnKenView];
     self.edgesForExtendedLayout = UIRectEdgeNone;
-    CGFloat bottomPadding = 0;
-    if (@available(iOS 11.0, *)) {
-        UIWindow *window = UIApplication.sharedApplication.keyWindow;
-        bottomPadding = window.safeAreaInsets.bottom;
-    }
+    CGFloat bottomPadding = [Utilities getBottomPadding];
     CGRect frame = arrow_continue_down.frame;
     frame.origin.y -= bottomPadding;
     [arrow_continue_down setFrame:frame];

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -84,5 +84,6 @@ typedef enum {
 + (void)turnTorchOn:(id)sender on:(BOOL)torchOn;
 + (BOOL)isTorchOn;
 + (BOOL)hasRemoteToolBar;
++ (CGFloat)getBottomPadding;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -812,4 +812,13 @@
     return UIScreen.mainScreen.bounds.size.height >= 568;
 }
 
++ (CGFloat)getBottomPadding {
+    CGFloat bottomPadding = 0;
+    if (@available(iOS 11.0, *)) {
+        UIWindow *window = UIApplication.sharedApplication.keyWindow;
+        bottomPadding = window.safeAreaInsets.bottom;
+    }
+    return bottomPadding;
+}
+
 @end

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -494,11 +494,7 @@
         [NSThread detachNewThreadSelector:@selector(startClearAppDiskCache:) toTarget:self withObject:clearView];
     }
 
-    int bottomPadding = 0;
-    if (@available(iOS 11.0, *)) {
-        UIWindow *window = UIApplication.sharedApplication.keyWindow;
-        bottomPadding = window.safeAreaInsets.bottom;
-    }
+    int bottomPadding = [Utilities getBottomPadding];
     
     if (bottomPadding > 0) {
         frame = volumeSliderView.frame;

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -40,6 +40,7 @@
 #import "AppDelegate.h"
 #import "RemoteControllerGestureZoneView.h"
 #import "OBSlider.h"
+#import "Utilities.h"
 #import <QuartzCore/QuartzCore.h>
 
 #define VIEW_TAG 1000
@@ -55,11 +56,7 @@
 	
 	if (self = [super init]) {
 		
-        bottomPadding = 0;
-        if (@available(iOS 11.0, *)) {
-            UIWindow *window = UIApplication.sharedApplication.keyWindow;
-            bottomPadding = window.safeAreaInsets.bottom;
-        }
+        bottomPadding = [Utilities getBottomPadding];
         
 		viewControllersStack = [NSMutableArray new];
         stackViewsFrames = [NSMutableArray new];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/355.

Reading the bottom padding is implemented the same way multiple times in the code. This PR moves the related code to `Utilities` and provides the common method `getBottomPadding`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Avoid duplicated code around reading bottom padding