### PR TITLE
Feature: Add volume slider to remote screen

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -23,6 +23,7 @@
 #define TOOLBAR_ICON_SIZE 36
 #define TOOLBAR_FIXED_OFFSET 8
 #define TOOLBAR_HEIGHT (TOOLBAR_ICON_SIZE + TOOLBAR_FIXED_OFFSET)
+#define TOOLBAR_PARENT_HEIGHT 50
 #define TAG_BUTTON_FULLSCREEN 1
 #define TAG_BUTTON_SEEK_BACKWARD 2
 #define TAG_BUTTON_PLAY_PAUSE 3
@@ -123,7 +124,7 @@
                        nil]
                 hide:YES];
     if ([Utilities hasRemoteToolBar]) {
-        shift = [self.view viewWithTag:TAG_BUTTON_MUSIC].frame.size.height;
+        shift = CGRectGetMinY(TransitionalView.frame) - CGRectGetMinY([self.view viewWithTag:TAG_BUTTON_NEXT].frame);
         [self moveButton: [NSArray arrayWithObjects:
                            (UIButton*)[self.view viewWithTag:TAG_BUTTON_MUSIC],
                            (UIButton*)[self.view viewWithTag:TAG_BUTTON_MOVIES],
@@ -133,7 +134,7 @@
                     ypos: -shift];
     }
     else {
-        shift = 2.0 * [self.view viewWithTag:TAG_BUTTON_MUSIC].frame.size.height;
+        shift = CGRectGetMinY(TransitionalView.frame) - CGRectGetMinY([self.view viewWithTag:TAG_BUTTON_STOP].frame);
         [self hideButton: [NSArray arrayWithObjects:
                            [(UIButton*)self.view viewWithTag:TAG_BUTTON_MUSIC],
                            [(UIButton*)self.view viewWithTag:TAG_BUTTON_MOVIES],
@@ -150,8 +151,9 @@
     TransitionalView.frame = CGRectMake(frame.origin.x, transViewY, frame.size.width, frame.size.height);
     
     // Maintain aspect ratio
-    CGFloat newHeight = remoteControlView.frame.size.height * newWidth / remoteControlView.frame.size.width;
-    CGFloat offset = [self getOriginYForRemote:shift - newHeight];
+    CGFloat transform = newWidth / remoteControlView.frame.size.width;
+    CGFloat newHeight = remoteControlView.frame.size.height * transform;
+    CGFloat offset = [self getOriginYForRemote:shift * transform - newHeight + TOOLBAR_PARENT_HEIGHT - TOOLBAR_HEIGHT];
     remoteControlView.frame = CGRectMake(0, offset, newWidth, newHeight);
     
     frame = remoteControlView.frame;
@@ -166,7 +168,7 @@
     
     [self setupGestureView];
     if ([Utilities hasRemoteToolBar]) {
-        [self createRemoteToolbar:gestureImage width:newWidth xMin:ANCHOR_RIGHT_PEEK yMax:TOOLBAR_HEIGHT isEmbedded:YES];
+        [self createRemoteToolbar:gestureImage width:newWidth xMin:ANCHOR_RIGHT_PEEK yMax:TOOLBAR_PARENT_HEIGHT isEmbedded:YES];
     }
     else {
         // Overload "stop" button with gesture icon in case the toolbar cannot be displayed (e.g. iPhone 4S)
@@ -186,7 +188,7 @@
     if (self.detailItem) {
         self.navigationItem.title = [self.detailItem mainLabel]; 
     }
-    CGFloat toolbarPadding = TOOLBAR_ICON_SIZE + TOOLBAR_FIXED_OFFSET;
+    CGFloat toolbarPadding = TOOLBAR_HEIGHT;
     if (![Utilities hasRemoteToolBar]) {
         toolbarPadding = 0;
     }

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -142,8 +142,6 @@
                            nil]
                     hide: YES];
     }
-    // Keep the buttons out of the safe area
-    CGFloat bottomPadding = [Utilities getBottomPadding];
     
     // Place the transitional view in the middle between the two button rows
     CGFloat lowerButtonUpperBorder = CGRectGetMinY([self.view viewWithTag:TAG_BUTTON_MUSIC].frame);

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -193,11 +193,21 @@
         toolbarPadding = 0;
     }
     if (IS_IPHONE) {
+        VolumeSliderView *volumeSliderView = nil;
         CGFloat transform = [Utilities getTransformX];
         CGRect frame = remoteControlView.frame;
         frame.size.height *= transform;
         frame.size.width *= transform;
         frame.origin.y = [self getOriginYForRemote:remoteControlView.frame.size.height - frame.size.height - toolbarPadding];
+        
+        if ([Utilities hasRemoteToolBar]) {
+            volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectZero leftAnchor:0.0];
+            [volumeSliderView startTimer];
+            [self.view addSubview:volumeSliderView];
+            if (frame.origin.y == 0) {
+                frame.origin.y = volumeSliderView.frame.size.height;
+            }
+        }
         remoteControlView.frame = frame;
         
         frame.origin.y = 0;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -38,11 +38,15 @@
 #pragma mark Table view data source
 
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
-    if ([tableData[indexPath.row][@"label"] isEqualToString:@"ServerInfo"]) {
+    NSString *rowContent = tableData[indexPath.row][@"label"];
+    if ([rowContent isEqualToString:@"ServerInfo"]) {
         return SERVER_INFO_HEIGHT;
     }
-    else if ([tableData[indexPath.row][@"label"] isEqualToString:@"RemoteControl"]) {
+    else if ([rowContent isEqualToString:@"RemoteControl"]) {
         return UIScreen.mainScreen.bounds.size.height - [self getRemoteViewOffsetY];
+    }
+    else if ([rowContent isEqualToString:@"VolumeControl"]) {
+        return volumeSliderView.frame.size.height;
     }
     return RIGHT_MENU_ITEM_HEIGHT;
 }

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -120,10 +120,9 @@
     }
     else if ([tableData[indexPath.row][@"label"] isEqualToString:@"VolumeControl"]) {
         [cell setSelectionStyle:UITableViewCellSelectionStyleNone];
-
         [title setText:@""];
         if (volumeSliderView == nil) {
-            volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectMake(0, 0, 0, 0)];
+            volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectZero leftAnchor:ANCHOR_RIGHT_PEEK];
             [volumeSliderView startTimer];
         }
         [cell.contentView addSubview:volumeSliderView];
@@ -635,7 +634,7 @@
         [self.view addSubview:[self createTableFooterView: footerHeight]];
     }
     if (menuItems.family == FamilyNowPlaying || menuItems.family == FamilyRemote) {
-        volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectMake(0, 0, 0, 0)];
+        volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectZero leftAnchor:ANCHOR_RIGHT_PEEK];
         [volumeSliderView startTimer];
     }
     menuTableView = [[UITableView alloc] initWithFrame:CGRectMake(self.peekLeftAmount, deltaY, frame.size.width - self.peekLeftAmount, self.view.frame.size.height - deltaY - footerHeight - 1) style:UITableViewStylePlain];

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -438,7 +438,7 @@
     [self.view addSubview:rootView];
     
     // left most element
-    volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectMake(leftMenuView.frame.size.width, self.view.frame.size.height - TOOLBAR_HEIGHT, 0, TOOLBAR_HEIGHT)];
+    volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectMake(leftMenuView.frame.size.width, self.view.frame.size.height - TOOLBAR_HEIGHT, 0, TOOLBAR_HEIGHT) leftAnchor:0.0];
     volumeSliderView.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
     [self.view addSubview:volumeSliderView];
     

--- a/XBMC Remote/VolumeSliderView.h
+++ b/XBMC Remote/VolumeSliderView.h
@@ -20,6 +20,8 @@
     UIColor *muteIconColor;
 }
 
+- (id)initWithFrame:(CGRect)frame leftAnchor:(CGFloat)leftAnchor;
+
 - (IBAction)slideVolume:(id)sender;
 
 - (void)startTimer;

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -14,7 +14,6 @@
 
 #define VOLUMEICON_PADDING 10 /* space left/right from volume icons */
 #define VOLUMELABEL_PADDING 5 /* space left/right from volume label */
-#define VOLUMEVIEW_OFFSET 8 /* vertical offset to match menu */
 #define VOLUMESLIDER_HEIGHT 44
 #define SERVER_TIMEOUT 3.0
 
@@ -22,7 +21,7 @@
 
 @synthesize timer, holdVolumeTimer;
 
-- (id)initWithFrame:(CGRect)frame {
+- (id)initWithFrame:(CGRect)frame leftAnchor:(CGFloat)leftAnchor {
     self = [super initWithFrame:frame];
     if (self) {
         NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"VolumeSliderView" owner:self options:nil];
@@ -67,11 +66,6 @@
             muteIconColor = [UIColor grayColor];
             volumeIconColor = [UIColor lightGrayColor];
             
-            // Move all buttons to vertical center of view
-            for (UIView *subView in [self subviews]) {
-                subView.center = CGPointMake(subView.center.x, frame.size.height / 2);
-            }
-            
             // set final used width for this view
             frame_tmp = frame;
             frame_tmp.size.width = CGRectGetMaxX(plusButton.frame);
@@ -81,7 +75,7 @@
             volumeView.hidden = YES;
             volumeLabel.hidden = YES;
 
-            self.frame = CGRectMake(0, VOLUMEVIEW_OFFSET, [self currentScreenBoundsDependOnOrientation].size.width, VOLUMESLIDER_HEIGHT);
+            self.frame = CGRectMake(0, 0, [self currentScreenBoundsDependOnOrientation].size.width - leftAnchor, VOLUMESLIDER_HEIGHT);
             
             frame_tmp = muteButton.frame;
             frame_tmp.origin.x = VOLUMEICON_PADDING;
@@ -93,7 +87,7 @@
             
             frame_tmp = volumeSlider.frame;
             frame_tmp.origin.x = CGRectGetMaxX(minusButton.frame) + VOLUMEICON_PADDING;
-            frame_tmp.size.width = self.frame.size.width - frame_tmp.origin.x - ANCHOR_RIGHT_PEEK - 3*VOLUMEICON_PADDING - volumeLabel.frame.size.width;
+            frame_tmp.size.width = self.frame.size.width - frame_tmp.origin.x - 3 * VOLUMEICON_PADDING - volumeLabel.frame.size.width;
             volumeSlider.frame = frame_tmp;
             
             frame_tmp = plusButton.frame;
@@ -105,6 +99,12 @@
             muteBackgroundImage = [Utilities colorizeImage:img withColor:[UIColor darkGrayColor]];
             volumeIconColor = [UIColor grayColor];
         }
+        // Move all buttons to vertical center of view
+        CGFloat center_y = self.frame.size.height / 2;
+        for (UIView *subView in self.subviews) {
+            subView.center = CGPointMake(subView.center.x, center_y);
+        }
+        
         [muteButton setBackgroundImage:muteBackgroundImage forState:UIControlStateNormal];
         [muteButton setBackgroundImage:muteBackgroundImage forState:UIControlStateHighlighted];
         img = [UIImage imageNamed:@"volume_slash"];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/358.

Add volume slider to remote screen:
- When screen size allows (`height >= 568`) add the volume bar on top.
- Use `leftAnchor` to differentiate between embedded and full screen.
- Align both iPad/iPhone volume elements in vertical center of screen.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Show volume slider on remote screen (not working for iPhone 4S)