### PR TITLE
Bugfix: Properly display NowPlaying details with enabled jewel case

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -342,6 +342,7 @@ int currentItemID;
     }
     songDetailsView.frame = jewelView.frame;
     songDetailsView.center = [jewelView.superview convertPoint:jewelView.center toView:songDetailsView.superview];
+    [nowPlayingView bringSubviewToFront:songDetailsView];
     [nowPlayingView sendSubviewToBack:xbmcOverlayImage];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
With v1.6.2 a regression came in which resulted in the jewel case being drawn on top of the NowPlaying details view. This PR fixes this and moves the `songDetailsView` back on top.

Screenshots: https://abload.de/img/bildschirmfoto2021-08qhk5a.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Properly display NowPlaying details with enabled jewel case