### PR TITLE
Bugfix: Fix issues with automatic TV station background while rounded corners are enabled

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -57,11 +57,11 @@
                         infoMask == kCGImageAlphaNoneSkipLast);
 //    if (!anyNonAlpha) return [UIColor clearColor];
     
-    // Enforce images are converted to ARGB or RGB 32bpp before analyzing them
-    if (anyNonAlpha && (infoMask != kCGImageAlphaNoneSkipLast || CGImageGetBitsPerPixel(rawImageRef) != 32)) {
+    // Enforce images are converted to default (ARGB or RGB, 32bpp, ByteOrderDefault)  before analyzing them
+    if (anyNonAlpha && (bitmapInfo != kCGImageAlphaNoneSkipLast || CGImageGetBitsPerPixel(rawImageRef) != 32)) {
         rawImageRef = [Utilities create32bppImage:rawImageRef format:kCGImageAlphaNoneSkipLast];
     }
-    else if (!anyNonAlpha && (infoMask != kCGImageAlphaPremultipliedFirst || CGImageGetBitsPerPixel(rawImageRef) != 32)) {
+    else if (!anyNonAlpha && (bitmapInfo != kCGImageAlphaPremultipliedFirst || CGImageGetBitsPerPixel(rawImageRef) != 32)) {
         rawImageRef = [Utilities create32bppImage:rawImageRef format:kCGImageAlphaPremultipliedFirst];
     }
     if (rawImageRef == NULL) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/366.

Force images to desired format before analyzing the average color:
- Desired format: `kCGImageAlphaNoneSkipLast` or `kCGImageAlphaPremultipliedFirst`, 32bpp, `kCGBitmapByteOrderDefault`
- ByteOrder was not taken into account when checking for the need to re-format an image.
- Check unmasked CGBitmapInfo against desired format.
- Fixes issues with automatic background color selection for TV station logos when rounded corners are enabled.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix issues with automatic TV station background while rounded corners are enabled