### PR TITLE
Bugfix: Do not change thumbsize when editing a playlist

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2289,6 +2289,7 @@ int originYear = 0;
                             [item[@"family"] isEqualToString:@"recordingid"] ||
                             [item[@"family"] isEqualToString:@"type"] ||
                             [item[@"family"] isEqualToString:@"file"]);
+        [Utilities applyRoundedEdgesView:cell.urlImageView drawBorder:showBorder];
         if (![stringURL isEqualToString:@""]) {
             [cell.urlImageView setImageWithURL:[NSURL URLWithString:stringURL] placeholderImage:[UIImage imageNamed:displayThumb] options:0 andResize:CGSizeMake(thumbWidth, cellHeight) withBorder:showBorder progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
                 if (channelListView || channelGuideView || recordingListView) {
@@ -2298,9 +2299,7 @@ int originYear = 0;
         }
         else {
             [cell.urlImageView setImageWithURL:[NSURL URLWithString:@""] placeholderImage:[UIImage imageNamed:displayThumb]];
-            showBorder = NO;
         }
-        [Utilities applyRoundedEdgesView:cell.urlImageView drawBorder:showBorder];
     }
     else if (albumView) {
         UILabel *trackNumber = (UILabel*)[cell viewWithTag:101];

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -721,16 +721,17 @@
 + (UIImageView*)roundedCornerView:(UIImageView*)view drawBorder:(BOOL)drawBorder {
     CALayer *imageLayer = view.layer;
     
-    // Shrink view to ensure a bit of space between thumbnails in list views
-    view.frame = CGRectInset(view.frame, 0.5, 0.5);
-    
     // Set radius for corners
-    imageLayer.cornerRadius = GET_ROUNDED_EDGES_RADIUS(imageLayer.frame.size);
+    CGFloat radius = GET_ROUNDED_EDGES_RADIUS(imageLayer.frame.size);
     // Create a mask layer
     CAShapeLayer *maskLayer = [CAShapeLayer new];
-    maskLayer.frame = imageLayer.bounds;
+    CGFloat freeAreaWidth = 1.0 / UIScreen.mainScreen.scale;
+    CGRect maskFrame = CGRectInset(imageLayer.bounds, freeAreaWidth, freeAreaWidth);
+    maskFrame.origin.x /= 2;
+    maskFrame.origin.y /= 2;
+    maskLayer.frame = maskFrame;
     // Define our path, capitalizing on UIKit's corner rounding magic
-    UIBezierPath *newPath = GET_ROUNDED_EDGES_PATH(imageLayer.bounds, imageLayer.cornerRadius);
+    UIBezierPath *newPath = GET_ROUNDED_EDGES_PATH(maskLayer.frame, radius);
     maskLayer.path = newPath.CGPath;
     // Apply the mask
     imageLayer.mask = maskLayer;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3055992#pid3055992)

Details:
- Do not alter the views dimensions as the rounded corner function can be called multiple times per cell (e.g. when editing a playlist).
- Keep using `CGRectInset` to have minimum free space around the thumbs (`1.0 / UIScreen.mainScreen.scale`). This looks more convenient even though it eats some space from the image content.

Screenshot: https://abload.de/img/bildschirmfoto2021-08hnj5h.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not change thumbsize when editing a playlist