### PR TITLE
Bugfix: Go back to  %d formatting to use existing translations

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -623,13 +623,13 @@
     }
 
     [self AnimView:moreItemsViewController.view AnimDuration:0.3 Alpha:1.0 XPos:0];
-    self.navigationItem.title = [NSString stringWithFormat:LOCALIZED_STR(@"More (%ld)"), (long)(count - MAX_NORMAL_BUTTONS)];
+    self.navigationItem.title = [NSString stringWithFormat:LOCALIZED_STR(@"More (%d)"), (int)(count - MAX_NORMAL_BUTTONS)];
     if (IS_IPAD) {
         [UIView beginAnimations:nil context:nil];
         [UIView setAnimationDuration:0.3];
         topNavigationLabel.alpha = 0;
         [UIView commitAnimations];
-        topNavigationLabel.text = [NSString stringWithFormat:LOCALIZED_STR(@"More (%ld)"), (long)(count - MAX_NORMAL_BUTTONS)];
+        topNavigationLabel.text = [NSString stringWithFormat:LOCALIZED_STR(@"More (%d)"), (int)(count - MAX_NORMAL_BUTTONS)];
         [UIView beginAnimations:nil context:nil];
         [UIView setAnimationDuration:0.1];
         topNavigationLabel.alpha = 1;
@@ -1807,7 +1807,7 @@ int originYear = 0;
         int numResult = (int)[self.filteredListContent count];
         if (numResult) {
             if (numResult != 1) {
-                return [NSString stringWithFormat:LOCALIZED_STR(@"%lu results"), (unsigned long)[self.filteredListContent count]];
+                return [NSString stringWithFormat:LOCALIZED_STR(@"%d results"), (int)self.filteredListContent.count];
             }
             else {
                 return LOCALIZED_STR(@"1 result");

--- a/XBMC Remote/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/XBMC Remote/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -348,7 +348,6 @@ static char UIScrollViewPullToRefreshView;
 - (UILabel*)titleLabel {
     if (!_titleLabel) {
         _titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 210, 20)];
-        _titleLabel.text = LOCALIZED_STR(@"Pull to refresh...");
         _titleLabel.font = [UIFont boldSystemFontOfSize:13];
         _titleLabel.numberOfLines = 1;
         _titleLabel.minimumScaleFactor = 12.0/13.0;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
While reviewing https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/380 I recognized a regression which was caused when removing compile warnings during the initial iOS 14 migration end of 2020. This caused two texts -- displaying the amount of search results and the amount of "more" items -- not being translated correctly anymore as the related localized strings contain the formatting `"%d"`. This PR goes back to the old formatting and resolves the warnings through casting to `int`. As a result the existing translations are again in use.

Screenshots (French): https://abload.de/img/bildschirmfoto2021-09kwkad.png

Second change removes a superfluous string which is not needed as the text is overwritten with the desired text for the current state of the pull-down-sync menu when displayed. This allows to remove the related translation for German as well.

Remark: I am not removing the superfluous text strings in the German localized file as this is done as part of the cleanup inside https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/380.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix some translations while search and in more items view