### PR TITLE
Bugfix: Recording details and failed attempts to load images

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1350,11 +1350,12 @@
                             [item[@"family"] isEqualToString:@"recordingid"] ||
                             [item[@"family"] isEqualToString:@"type"] ||
                             [item[@"family"] isEqualToString:@"file"]);
+        BOOL isOnPVR = [item[@"path"] hasPrefix:@"pvr:"];
         cell.posterThumbnail.frame = cell.bounds;
         [Utilities applyRoundedEdgesView:cell.posterThumbnail drawBorder:showBorder];
         if (![stringURL isEqualToString:@""]) {
             [cell.posterThumbnail setImageWithURL:[NSURL URLWithString:stringURL] placeholderImage:[UIImage imageNamed:displayThumb] options:0 andResize:CGSizeMake(cellthumbWidth, cellthumbHeight) withBorder:showBorder progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-                if (channelListView || channelGuideView || recordingListView) {
+                if (channelListView || channelGuideView || recordingListView || isOnPVR) {
                     [Utilities setLogoBackgroundColor:cell.posterThumbnail mode:logoBackgroundMode];
                 }
             }];
@@ -2293,10 +2294,11 @@ int originYear = 0;
                             [item[@"family"] isEqualToString:@"recordingid"] ||
                             [item[@"family"] isEqualToString:@"type"] ||
                             [item[@"family"] isEqualToString:@"file"]);
+        BOOL isOnPVR = [item[@"path"] hasPrefix:@"pvr:"];
         [Utilities applyRoundedEdgesView:cell.urlImageView drawBorder:showBorder];
         if (![stringURL isEqualToString:@""]) {
             [cell.urlImageView setImageWithURL:[NSURL URLWithString:stringURL] placeholderImage:[UIImage imageNamed:displayThumb] options:0 andResize:CGSizeMake(thumbWidth, cellHeight) withBorder:showBorder progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-                if (channelListView || channelGuideView || recordingListView) {
+                if (channelListView || channelGuideView || recordingListView || isOnPVR) {
                     [Utilities setLogoBackgroundColor:cell.urlImageView mode:logoBackgroundMode];
                 }
             }];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -578,6 +578,29 @@
     }
 }
 
+- (void)setCellImageView:(UIImageView*)imgView dictItem:(NSDictionary*)item url:(NSString*)stringURL size:(CGSize)viewSize defaultImg:(NSString*)displayThumb {
+    if ([item[@"family"] isEqualToString:@"channelid"] || [item[@"family"] isEqualToString:@"type"]) {
+        [imgView setContentMode:UIViewContentModeScaleAspectFit];
+    }
+    BOOL showBorder = !([item[@"family"] isEqualToString:@"channelid"] ||
+                        [item[@"family"] isEqualToString:@"recordingid"] ||
+                        [item[@"family"] isEqualToString:@"type"] ||
+                        [item[@"family"] isEqualToString:@"file"]);
+    BOOL isOnPVR = [item[@"path"] hasPrefix:@"pvr:"];
+    [Utilities applyRoundedEdgesView:imgView drawBorder:showBorder];
+    if (![stringURL isEqualToString:@""]) {
+        __auto_type __weak weakImageView = imgView;
+        [imgView setImageWithURL:[NSURL URLWithString:stringURL] placeholderImage:[UIImage imageNamed:displayThumb] options:0 andResize:viewSize withBorder:showBorder progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
+            if (channelListView || channelGuideView || recordingListView || isOnPVR) {
+                [Utilities setLogoBackgroundColor:weakImageView mode:logoBackgroundMode];
+            }
+        }];
+    }
+    else {
+        [imgView setImageWithURL:[NSURL URLWithString:@""] placeholderImage:[UIImage imageNamed:displayThumb]];
+    }
+}
+
 #pragma mark - Tabbar management
 
 - (IBAction)showMore:(id)sender {
@@ -1343,25 +1366,9 @@
         else if (channelListView) {
             [cell setIsRecording:[item[@"isrecording"] boolValue]];
         }
-        if ([item[@"family"] isEqualToString:@"channelid"]) {
-            [cell.posterThumbnail setContentMode:UIViewContentModeScaleAspectFit];
-        }
-        BOOL showBorder = !([item[@"family"] isEqualToString:@"channelid"] ||
-                            [item[@"family"] isEqualToString:@"recordingid"] ||
-                            [item[@"family"] isEqualToString:@"type"] ||
-                            [item[@"family"] isEqualToString:@"file"]);
-        BOOL isOnPVR = [item[@"path"] hasPrefix:@"pvr:"];
         cell.posterThumbnail.frame = cell.bounds;
-        [Utilities applyRoundedEdgesView:cell.posterThumbnail drawBorder:showBorder];
-        if (![stringURL isEqualToString:@""]) {
-            [cell.posterThumbnail setImageWithURL:[NSURL URLWithString:stringURL] placeholderImage:[UIImage imageNamed:displayThumb] options:0 andResize:CGSizeMake(cellthumbWidth, cellthumbHeight) withBorder:showBorder progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-                if (channelListView || channelGuideView || recordingListView || isOnPVR) {
-                    [Utilities setLogoBackgroundColor:cell.posterThumbnail mode:logoBackgroundMode];
-                }
-            }];
-        }
-        else {
-            [cell.posterThumbnail setImageWithURL:[NSURL URLWithString:@""] placeholderImage:[UIImage imageNamed:displayThumb]];
+        [self setCellImageView:cell.posterThumbnail dictItem:item url:stringURL size:CGSizeMake(cellthumbWidth, cellthumbHeight) defaultImg:displayThumb];
+        if ([stringURL isEqualToString:@""]) {
             [cell.posterThumbnail setBackgroundColor:[Utilities getGrayColor:28 alpha:1.0]];
         }
         // Set label visibility based on setting and current view
@@ -2287,25 +2294,7 @@ int originYear = 0;
             genre.hidden = NO;
             runtimeyear.hidden = NO;
         }
-        if ([item[@"family"] isEqualToString:@"channelid"] || [item[@"family"] isEqualToString:@"type"]) {
-            [cell.urlImageView setContentMode:UIViewContentModeScaleAspectFit];
-        }
-        BOOL showBorder = !([item[@"family"] isEqualToString:@"channelid"] ||
-                            [item[@"family"] isEqualToString:@"recordingid"] ||
-                            [item[@"family"] isEqualToString:@"type"] ||
-                            [item[@"family"] isEqualToString:@"file"]);
-        BOOL isOnPVR = [item[@"path"] hasPrefix:@"pvr:"];
-        [Utilities applyRoundedEdgesView:cell.urlImageView drawBorder:showBorder];
-        if (![stringURL isEqualToString:@""]) {
-            [cell.urlImageView setImageWithURL:[NSURL URLWithString:stringURL] placeholderImage:[UIImage imageNamed:displayThumb] options:0 andResize:CGSizeMake(thumbWidth, cellHeight) withBorder:showBorder progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-                if (channelListView || channelGuideView || recordingListView || isOnPVR) {
-                    [Utilities setLogoBackgroundColor:cell.urlImageView mode:logoBackgroundMode];
-                }
-            }];
-        }
-        else {
-            [cell.urlImageView setImageWithURL:[NSURL URLWithString:@""] placeholderImage:[UIImage imageNamed:displayThumb]];
-        }
+        [self setCellImageView:cell.urlImageView dictItem:item url:stringURL size:CGSizeMake(thumbWidth, cellHeight) defaultImg:displayThumb];
     }
     else if (albumView) {
         UILabel *trackNumber = (UILabel*)[cell viewWithTag:101];

--- a/XBMC Remote/SDWebImage/UIImageView+WebCache.m
+++ b/XBMC Remote/SDWebImage/UIImageView+WebCache.m
@@ -74,7 +74,7 @@ static char operationKey;
                 sself.image = [Utilities applyRoundedEdgesImage:image drawBorder:withBorder];
                 [sself setNeedsLayout];
             }
-            if (completedBlock && finished) {
+            if (completedBlock) {
                 completedBlock(image, error, cacheType);
             }
         }];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -622,7 +622,6 @@ int count = 0;
     [activityIndicatorView stopAnimating];
     jewelView.alpha = 0;
     if (isRecordingDetail) {
-        [Utilities setLogoBackgroundColor:jewelView mode:logoBackgroundMode];
         CGRect frame;
         frame.size.width = ceil(TV_LOGO_SIZE_REC_DETAILS * 0.9);
         frame.size.height = ceil(TV_LOGO_SIZE_REC_DETAILS * 0.7);
@@ -633,6 +632,9 @@ int count = 0;
         // Ensure we draw the rounded edges around TV station logo view
         jewelView.image = image;
         jewelView = [Utilities applyRoundedEdgesView:jewelView drawBorder:YES];
+        
+        // Choose correct background color for station logos
+        [Utilities setLogoBackgroundColor:jewelView mode:logoBackgroundMode];
     }
     else {
         // Ensure we draw the rounded edges around thumbnail images

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1069,7 +1069,7 @@ int count = 0;
                 foundTintColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO]];
             }
             [self setIOS7barTintColor:foundTintColor];
-            if (enableJewel) {
+            if (enableJewel && !isRecordingDetail) {
                 coverView.image = image;
                 coverView.frame = [Utilities createCoverInsideJewel:jewelView jewelType:jeweltype];
                 [activityIndicatorView stopAnimating];
@@ -1082,7 +1082,7 @@ int count = 0;
         else {
             __weak ShowInfoViewController *sf = self;
             __block UIColor *newColor = nil;
-            if (enableJewel) {
+            if (enableJewel && !isRecordingDetail) {
                 [coverView setImageWithURL:[NSURL URLWithString:thumbnailPath]
                           placeholderImage:[UIImage imageNamed:placeHolderImage]
                  completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -611,16 +611,17 @@ int count = 0;
     return [[userDefaults objectForKey:@"jewel_preference"] boolValue];
 }
 
-- (void)elaborateImage:(UIImage*)image {
+- (void)elaborateImage:(UIImage*)image fallbackImage:(UIImage*)fallback {
     dispatch_async(dispatch_get_main_queue(), ^{
         [activityIndicatorView startAnimating];
-        [self showImage:image];
+        [self showImage:image fallbackImage:fallback];
     });
 }
 
-- (void)showImage:(UIImage*)image {
+- (void)showImage:(UIImage*)image fallbackImage:(UIImage*)fallback {
     [activityIndicatorView stopAnimating];
     jewelView.alpha = 0;
+    UIImage *imageToShow = image != nil ? image : fallback;
     if (isRecordingDetail) {
         CGRect frame;
         frame.size.width = ceil(TV_LOGO_SIZE_REC_DETAILS * 0.9);
@@ -630,15 +631,17 @@ int count = 0;
         jewelView.frame = frame;
         
         // Ensure we draw the rounded edges around TV station logo view
-        jewelView.image = image;
+        jewelView.image = imageToShow;
         jewelView = [Utilities applyRoundedEdgesView:jewelView drawBorder:YES];
         
         // Choose correct background color for station logos
-        [Utilities setLogoBackgroundColor:jewelView mode:logoBackgroundMode];
+        if (image != nil) {
+            [Utilities setLogoBackgroundColor:jewelView mode:logoBackgroundMode];
+        }
     }
     else {
         // Ensure we draw the rounded edges around thumbnail images
-        jewelView.image = [Utilities applyRoundedEdgesImage:image drawBorder:YES];;
+        jewelView.image = [Utilities applyRoundedEdgesImage:imageToShow drawBorder:YES];;
     }
     [self alphaImage:jewelView AnimDuration:0.1 Alpha:1.0];
 }
@@ -1055,7 +1058,7 @@ int count = 0;
     BOOL inEnableKenBurns = enableKenBurns;
     __weak ShowInfoViewController *sf = self;
     NSString *thumbnailPath = item[@"thumbnail"];
-    if (![item[@"thumbnail"] isEqualToString:@""] && item[@"thumbnail"] != nil) {
+    if (![thumbnailPath isEqualToString:@""] && thumbnailPath != nil) {
         jewelView.alpha = 0;
         [activityIndicatorView startAnimating];
     }
@@ -1076,7 +1079,7 @@ int count = 0;
                 jewelView.alpha = 1;
             }
             else {
-                [self elaborateImage:image];
+                [self elaborateImage:image fallbackImage:[UIImage imageNamed:placeHolderImage]];
             }
         }
         else {
@@ -1108,8 +1111,8 @@ int count = 0;
                                              [sf setIOS7barTintColor:newColor];
                                              foundTintColor = newColor;
                                          }
-                                         [sf elaborateImage:image];
                                      }
+                                     [sf elaborateImage:image fallbackImage:[UIImage imageNamed:placeHolderImage]];
                                  }
                  ];
             }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1055,10 +1055,9 @@ int count = 0;
         runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"runtime" emptyString:@"-"];
         studioLabel.text = [Utilities getStringFromDictionary:item key:@"studio" emptyString:@"-"];
     }
-    BOOL inEnableKenBurns = enableKenBurns;
-    __weak ShowInfoViewController *sf = self;
+    
     NSString *thumbnailPath = item[@"thumbnail"];
-    if (![thumbnailPath isEqualToString:@""] && thumbnailPath != nil) {
+    if (thumbnailPath.length > 0) {
         jewelView.alpha = 0;
         [activityIndicatorView startAnimating];
     }
@@ -1088,15 +1087,13 @@ int count = 0;
             if (enableJewel && !isRecordingDetail) {
                 [coverView setImageWithURL:[NSURL URLWithString:thumbnailPath]
                           placeholderImage:[UIImage imageNamed:placeHolderImage]
-                 completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-                     if (error == nil) {
-                         if (image != nil) {
-                             newColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO]];
-                             [sf setIOS7barTintColor:newColor];
-                             foundTintColor = newColor;
-                         }
-                     }
-                 }];
+                                 completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
+                                    if (image != nil) {
+                                        newColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO]];
+                                        [sf setIOS7barTintColor:newColor];
+                                        foundTintColor = newColor;
+                                    }
+                }];
                 coverView.frame = [Utilities createCoverInsideJewel:jewelView jewelType:jeweltype];
                 [activityIndicatorView stopAnimating];
                 jewelView.alpha = 1;
@@ -1105,25 +1102,24 @@ int count = 0;
                 [jewelView setImageWithURL:[NSURL URLWithString:thumbnailPath]
                           placeholderImage:[UIImage imageNamed:placeHolderImage]
                                  completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-                                     if (image != nil) {
-                                         if (error == nil) {
-                                             newColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO]];
-                                             [sf setIOS7barTintColor:newColor];
-                                             foundTintColor = newColor;
-                                         }
-                                     }
-                                     [sf elaborateImage:image fallbackImage:[UIImage imageNamed:placeHolderImage]];
-                                 }
-                 ];
+                                    if (image != nil) {
+                                        newColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO]];
+                                        [sf setIOS7barTintColor:newColor];
+                                        foundTintColor = newColor;
+                                    }
+                                    [sf elaborateImage:image fallbackImage:[UIImage imageNamed:placeHolderImage]];
+                }];
             }
         }
     }];
     
     NSString *fanartPath = item[@"fanart"];
+    __weak ShowInfoViewController *sf = self;
     [[SDImageCache sharedImageCache] queryDiskCacheForKey:fanartPath done:^(UIImage *image, SDImageCacheType cacheType) {
+        __auto_type strongSelf = sf;
         if (image != nil) {
             fanartView.image = image;
-            if (inEnableKenBurns) {
+            if (strongSelf != nil && strongSelf->enableKenBurns) {
                 fanartView.alpha = 0;
                 [sf elabKenBurns:image];
                 [sf alphaView:sf.kenView AnimDuration:1.5 Alpha:0.2];
@@ -1133,14 +1129,14 @@ int count = 0;
             [fanartView setImageWithURL:[NSURL URLWithString:fanartPath]
                        placeholderImage:[UIImage imageNamed:@"blank"]
                               completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-                                  if (inEnableKenBurns) {
+                                  __auto_type strongSelf = sf;
+                                  if (strongSelf != nil && strongSelf->enableKenBurns) {
                                       [sf elabKenBurns:image];
                                       [sf alphaView:sf.kenView AnimDuration:1.5 Alpha:0.2];
                                   }
                               }
              ];
         }
-        
     }];
 
     [fanartView setClipsToBounds:YES];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR provides several bugfixes and minor refactoring:
1. Recording details shall not show jewel cases. This is consistent with the TV logo in the list views
<a href="https://abload.de/image.php?img=bildschirmfoto2021-09ztkw4.png"><img 
src="https://abload.de/img/bildschirmfoto2021-09ztkw4.png" /></a>

2. Fix automatic background color for TV logos in recording details (regression of rounded corners feature)
<a href="https://abload.de/image.php?img=bildschirmfoto2021-09dhj9v.png"><img src="https://abload.de/img/bildschirmfoto2021-09dhj9v.png" /></a>

3. Provide default images on a failed load attempt (verified with non-existing TV logo images and empty thumbnail paths)
<a href="https://abload.de/image.php?img=bildschirmfoto2021-0939jpa.png"><img src="https://abload.de/img/bildschirmfoto2021-0939jpa.png" /></a>

4. Fix automatic background color for TV logos in Favourites menu
<a href="https://abload.de/image.php?img=bildschirmfoto2021-09pgj6h.png"><img src="https://abload.de/img/bildschirmfoto2021-09pgj6h.png" /></a>

5. Simplify conditions and correct indentations in ShowInfoVC, move variable declarations near their usage

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Recording details shall not show jewel cases
Bugfix: Fix automatic TV logo background for recording details and in Favourites menu
Bugfix: Provide default image on failing attempt to load image