### PR TITLE
Rework userdefaults and define missing default values

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -382,7 +382,34 @@ NSMutableArray *hostRightMenuItems;
 	
 }
 
+- (void)registerDefaultsFromSettingsBundle {
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+
+    NSString *bundle = [[NSBundle mainBundle] pathForResource:@"Settings" ofType:@"bundle"];
+    if (!bundle) {
+        return;
+    }
+
+    NSDictionary *settings = [NSDictionary dictionaryWithContentsOfFile:[bundle stringByAppendingPathComponent:@"Root.plist"]];
+    NSArray *preferences = settings[@"PreferenceSpecifiers"];
+    NSMutableDictionary *defaultsToRegister = [[NSMutableDictionary alloc] initWithCapacity:preferences.count];
+
+    for (NSDictionary *prefSpecification in preferences) {
+        NSString *key = prefSpecification[@"Key"];
+        if (key) {
+            // We can set defaults here as registerDefaults does not overwrite already defined values
+            defaultsToRegister[key] = prefSpecification[@"DefaultValue"];
+        }
+    }
+
+    // Register defaults
+    [userDefaults registerDefaults:defaultsToRegister];
+}
+
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+    // Load user defaults, if not yet set. Avoids need to check for nil.
+    [self registerDefaultsFromSettingsBundle];
+    
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     UIApplication *xbmcRemote = [UIApplication sharedApplication];
     if ([[userDefaults objectForKey:@"lockscreen_preference"] boolValue]) {

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -126,7 +126,7 @@
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
-			<string></string>
+			<string>auto</string>
 			<key>Key</key>
 			<string>logo_background</string>
 			<key>Title</key>
@@ -176,7 +176,7 @@
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
-			<string></string>
+			<string>position_top</string>
 			<key>Key</key>
 			<string>remote_position</string>
 			<key>Title</key>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/392.

This PR adds the missing definition of two default values for the App settings. In addition, it implements a suggestion by @kambala-decapitator to initialize the user defaults using `registerDefaults`. This will allow to avoid `nil` checks when interpreting the settings.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Default value not shown for 2 settings
Maintenance: Use registerDefaults to set settings for all values