### PR TITLE
Bugfix: Fix reduced resolution for thumbnails

### DIFF
--- a/XBMC Remote/SDWebImage/UIImageView+WebCache.m
+++ b/XBMC Remote/SDWebImage/UIImageView+WebCache.m
@@ -27,7 +27,6 @@ static char operationKey;
 }
 
 - (void)setImageWithURL:(NSURL*)url placeholderImage:(UIImage*)placeholder andResize:(CGSize)size {
-    size = [self doubleSizeIfRetina:size];
     [self setImageWithURL:url placeholderImage:placeholder options:0 andResize:size withBorder:YES progress:nil completed:nil];
 }
 
@@ -40,7 +39,6 @@ static char operationKey;
 }
 
 - (void)setImageWithURL:(NSURL*)url placeholderImage:(UIImage*)placeholder andResize:(CGSize)size completed:(SDWebImageCompletedBlock)completedBlock {
-    size = [self doubleSizeIfRetina:size];
     [self setImageWithURL:url placeholderImage:placeholder options:0 andResize:size withBorder:YES progress:nil completed:completedBlock];
 }
 
@@ -53,6 +51,7 @@ static char operationKey;
 }
 
 - (void)setImageWithURL:(NSURL*)url placeholderImage:(UIImage*)placeholder options:(SDWebImageOptions)options andResize:(CGSize)size withBorder:(BOOL)withBorder progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletedBlock)completedBlock {
+    size = [self doubleSizeIfRetina:size];
     [self cancelCurrentImageLoad];
 
     self.image = placeholder;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->

Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/394.

Since we now directly call  `setImageWithURL:placeholderImage:options:andResize:withBorder:progress:completed:` from DetailViewController `size` must be scaled up to the native resolution _in_ this function. Before, this was only done for helper functions which are now not called anymore.

Screenshot:
<a href="https://abload.de/image.php?img=bildschirmfoto2021-092gk6y.png"><img src="https://abload.de/img/bildschirmfoto2021-092gk6y.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix reduced resolution for thumbnails