### PR TITLE
Bugfix: Avoid presentViewController crash

### DIFF
--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -183,18 +183,14 @@
 }
 
 - (void)toggleSetup {
-    if (_hostPickerViewController == nil) {
-        [self initHostManagemetPopOver];
-    }
+    [self initHostManagemetPopOver];
     [[AppDelegate instance].navigationController setModalPresentationStyle:UIModalPresentationPopover];
     UIPopoverPresentationController *popPresenter = [[AppDelegate instance].navigationController popoverPresentationController];
     if (popPresenter != nil) {
         popPresenter.sourceView = self.view;
         popPresenter.sourceRect = xbmcInfo.frame;
     }
-    if (![[AppDelegate instance].navigationController isBeingPresented]) {
-        [self presentViewController:[AppDelegate instance].navigationController animated:YES completion:nil];
-    }
+    [self presentViewController:[AppDelegate instance].navigationController animated:YES completion:nil];
 }
 
 - (void)showSetup:(BOOL)show {
@@ -570,8 +566,6 @@
                                              selector: @selector(handleChangeBackgroundImage:)
                                                  name: @"UIViewChangeBackgroundImage"
                                                object: nil];
-    
-    [self initHostManagemetPopOver];
     
     [(gradientUIView*)self.view setColoursWithCGColors:[Utilities getGrayColor:36 alpha:1].CGColor
                                                endColor:[Utilities getGrayColor:22 alpha:1].CGColor];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes 1 out of 4 reported crashes in App version 1.8 (also see https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/401).

Creating a new instance of `HostManagementViewController` before calling `presentViewController` avoids possible crash.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid presentViewController crash