### PR TITLE
Bugfix: Avoid crash by blocked stringWithContentsOfURL:encoding:error:

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -182,11 +182,7 @@
     if ([AppDelegate instance].serverVersion == 11) {
         storedItemID = -1;
         [PartyModeButton setSelected:YES];
-        GlobalData *obj = [GlobalData getInstance];
-        NSString *userPassword = [obj.serverPass isEqualToString:@""] ? @"" : [NSString stringWithFormat:@":%@", obj.serverPass];
-        NSString *serverHTTP = [NSString stringWithFormat:@"http://%@%@@%@:%@/xbmcCmds/xbmcHttp?command=ExecBuiltIn&parameter=PlayerControl(Partymode('music'))", obj.serverUser, userPassword, obj.serverIP, obj.serverPort];
-        NSURL *url = [NSURL URLWithString:serverHTTP];
-        [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding error:NULL];
+        [Utilities sendXbmcHttp:@"ExecBuiltIn&parameter=PlayerControl(Partymode('music'))"];
         playerID = -1;
         selectedPlayerID = -1;
         [self createPlaylist:NO animTableView:YES];

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -674,18 +674,9 @@
 //            NSLog(@"method error %@ %@", methodError, error);
 //        }
         if ((methodError != nil || error != nil) && callback != nil) { // Backward compatibility
-            [self sendXbmcHttp:callback];
+            [Utilities sendXbmcHttp:callback];
         }
     }];
-}
-
-- (void)sendXbmcHttp:(NSString*)command {
-    GlobalData *obj = [GlobalData getInstance];
-    NSString *userPassword = [obj.serverPass isEqualToString:@""] ? @"" : [NSString stringWithFormat:@":%@", obj.serverPass];
-
-    NSString *serverHTTP = [NSString stringWithFormat:@"http://%@%@@%@:%@/xbmcCmds/xbmcHttp?command=%@", obj.serverUser, userPassword, obj.serverIP, obj.serverPort, command];
-    NSURL *url = [NSURL URLWithString:serverHTTP];
-    [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding error:NULL];
 }
 
 - (void)volumeInfo {

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -85,5 +85,6 @@ typedef enum {
 + (BOOL)isTorchOn;
 + (BOOL)hasRemoteToolBar;
 + (CGFloat)getBottomPadding;
++ (void)sendXbmcHttp:(NSString*)command;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -820,4 +820,13 @@
     return bottomPadding;
 }
 
++ (void)sendXbmcHttp:(NSString*)command {
+    GlobalData *obj = [GlobalData getInstance];
+    NSString *userPassword = [obj.serverPass isEqualToString:@""] ? @"" : [NSString stringWithFormat:@":%@", obj.serverPass];
+
+    NSString *serverHTTP = [NSString stringWithFormat:@"http://%@%@@%@:%@/xbmcCmds/xbmcHttp?command=%@", obj.serverUser, userPassword, obj.serverIP, obj.serverPort, command];
+    NSURL *url = [NSURL URLWithString:serverHTTP];
+    [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding error:NULL];
+}
+
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -823,10 +823,8 @@
 + (void)sendXbmcHttp:(NSString*)command {
     GlobalData *obj = [GlobalData getInstance];
     NSString *userPassword = [obj.serverPass isEqualToString:@""] ? @"" : [NSString stringWithFormat:@":%@", obj.serverPass];
-
     NSString *serverHTTP = [NSString stringWithFormat:@"http://%@%@@%@:%@/xbmcCmds/xbmcHttp?command=%@", obj.serverUser, userPassword, obj.serverIP, obj.serverPort, command];
-    NSURL *url = [NSURL URLWithString:serverHTTP];
-    [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding error:NULL];
+    [[NSURLSession.sharedSession dataTaskWithURL:[NSURL URLWithString:serverHTTP]] resume];
 }
 
 @end

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -169,7 +169,7 @@
 - (BOOL)textField:(UITextField*)theTextField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString*)string {
     if ([AppDelegate instance].serverVersion == 11) {
         if (range.location == 0) { //BACKSPACE
-            [self sendXbmcHttp:@"SendKey(0xf108)"];
+            [Utilities sendXbmcHttp:@"SendKey(0xf108)"];
         }
         else { // CHARACTER
             int x = (unichar) [string characterAtIndex: 0];
@@ -179,7 +179,7 @@
                 [xbmcVirtualKeyboard resignFirstResponder];
             }
             else if (x < 1000) {
-                [self sendXbmcHttp:[NSString stringWithFormat:@"SendKey(0xf1%x)", x]];
+                [Utilities sendXbmcHttp:[NSString stringWithFormat:@"SendKey(0xf1%x)", x]];
             }
         }
         return NO;
@@ -212,18 +212,9 @@
 - (void)GUIAction:(NSString*)action params:(NSDictionary*)params httpAPIcallback:(NSString*)callback {
     [[Utilities getJsonRPC] callMethod:action withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
         if ((methodError != nil || error != nil) && callback != nil) { // Backward compatibility
-            [self sendXbmcHttp:callback];
+            [Utilities sendXbmcHttp:callback];
         }
     }];
-}
-
-- (void)sendXbmcHttp:(NSString*)command {
-    GlobalData *obj = [GlobalData getInstance];
-    NSString *userPassword = [obj.serverPass isEqualToString:@""] ? @"" : [NSString stringWithFormat:@":%@", obj.serverPass];
-    
-    NSString *serverHTTP = [NSString stringWithFormat:@"http://%@%@@%@:%@/xbmcCmds/xbmcHttp?command=%@", obj.serverUser, userPassword, obj.serverIP, obj.serverPort, command];
-    NSURL *url = [NSURL URLWithString:serverHTTP];
-    [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding error:NULL];
 }
 
 #pragma mark - lifecycle


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes 2 out of 4 reported crashes in App version 1.8 (also see #401).

Calling `stringWithContentsOfURL:encoding:error:` could block the main thread. This PR asynchronously calls`NSUrlSession` to fix it. In addition, some code duplication is resolved.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid crash when sending HTTP request to Kodi