### PR TITLE
Bugfix: Support XBMC 11 and earlier when checking the API version

### DIFF
--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -240,9 +240,17 @@ NSOutputStream	*outStream;
      withTimeout: SERVER_TIMEOUT
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
          if (!error && !methodError) {
-             [AppDelegate instance].APImajorVersion = [methodResult[@"version"][@"major"] intValue];
-             [AppDelegate instance].APIminorVersion = [methodResult[@"version"][@"minor"] intValue];
-             [AppDelegate instance].APIpatchVersion = [methodResult[@"version"][@"patch"] intValue];
+             // Kodi 11 and earlier do not support "major"/"minor"/"patch" and reply with "version" only
+             if (![methodResult[@"version"] isKindOfClass:[NSNumber class]]) {
+                 [AppDelegate instance].APImajorVersion = [methodResult[@"version"][@"major"] intValue];
+                 [AppDelegate instance].APIminorVersion = [methodResult[@"version"][@"minor"] intValue];
+                 [AppDelegate instance].APIpatchVersion = [methodResult[@"version"][@"patch"] intValue];
+             }
+             else {
+                 [AppDelegate instance].APImajorVersion = [methodResult[@"version"] intValue];
+                 [AppDelegate instance].APIminorVersion = 0;
+                 [AppDelegate instance].APIpatchVersion = 0;
+             }
          }
          // Read the sorttokens
          [self readSorttokens];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/405.

In all Remote App versions from 1.6.2 to 1.8 the App crashes when attempting to connect to a XBMC 11 server. This PR fixes this issue and brings back the support for this quite old server version.

In future it might be a good idea to remove the support for XBMC 11 (and earlier). This allows to remove a good amount of special treatment in the code. Nevertheless, this should be done not only as part of a minor update.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Re-enable support for XBMC 11