### PR TITLE
Maintenance: iOS 15 migration

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -435,6 +435,16 @@
 }
 
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+    // iOS 15 requires to set the appearance for the navigationbar, otherwise it defaults to unwanted transparency
+    if (@available(iOS 15, *)) {
+        UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
+        [appearance configureWithOpaqueBackground];
+        appearance.titleTextAttributes = @{NSForegroundColorAttributeName : UIColor.whiteColor};
+        appearance.backgroundColor = [Utilities getGrayColor:38 alpha:1.0];
+        [UINavigationBar appearance].standardAppearance = appearance;
+        [UINavigationBar appearance].scrollEdgeAppearance = appearance;
+    }
+    
     // Load user defaults, if not yet set. Avoids need to check for nil.
     [self registerDefaultsFromSettingsBundle];
     

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5692,6 +5692,10 @@ NSIndexPath *selected;
     self.definesPresentationContext = NO;
     iOSYDelta = self.searchController.searchBar.frame.size.height;
 
+    if (@available(iOS 15.0, *)) {
+        dataList.sectionHeaderTopPadding = 0;
+    }
+    
     [button6 addTarget:self action:@selector(handleChangeLibraryView) forControlEvents:UIControlEventTouchUpInside];
 
     [button7 addTarget:self action:@selector(handleChangeSortLibrary) forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/411.

To fix the issue with the padding above new sections the new iOS 15 property `sectionHeaderTopPadding` needs to be set. See https://developer.apple.com/forums/thread/683980.

For the second issue with the navigation bar I do not have a fully satisfying solution yet.
What I want: A translucent navigation bar which blurs the underlying view.
What I got until now: A non-translucent, non-blurred navigation bar background.
Screenshots: https://abload.de/img/bildschirmfoto2021-10atklq.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: iOS 15 and XCode 13 migration