### PR TITLE
Bugfix: Bring back sort for items inside genres and movie sets

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1014,6 +1014,9 @@
                                        [NSString stringWithFormat:@"%@", parameters[@"defaultThumb"]], @"defaultThumb",
                                        parameters[@"watchedListenedStrings"], @"watchedListenedStrings",
                                        nil];
+        if (parameters[@"available_sort_methods"] != nil) {
+            [newParameters addObjectsFromArray:@[parameters[@"available_sort_methods"], @"available_sort_methods"]];
+        }
         [[MenuItem.subItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
         MenuItem.subItem.chooseTab = choosedTab;
         MenuItem.subItem.currentWatchMode = watchMode;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes sort issue reported in https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/414.

The issue is a regression of https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/326 which moved `available_sort_methods`  from the `sort` substructure  to an own key.  I was not recognizing there is a special treatment required for all menu subitems. There are three subitems which were impacted (no sort icon in the toolbar):
1.  Music genres -> Select a gerne -> Could not sort list of results.
2. Movie genres -> Select a gerne -> Could not sort list of results.
3. Movie sets -> Select a set -> Could not sort list of results.

This PR fixes the issue by explicitly adding the `available_sort_methods` key to the parameters when the parameter set is re-built.

Screenshot (movies with genre "Drama"): https://abload.de/img/bildschirmfoto2021-10zxj5h.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Bring back sort for items inside genres and movie sets