### PR TITLE
Feature: Introduce Videos main menu entry

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1990,7 +1990,6 @@ NSMutableArray *hostRightMenuItems;
         @"st_movie_genre",
         @"st_movie_set",
         @"st_movie_recently",
-        @"st_music_videos",
         @"st_filemode",
         @"st_addons",
         @"st_playlists"];
@@ -2002,7 +2001,6 @@ NSMutableArray *hostRightMenuItems;
             @[@"VideoLibrary.GetMovieSets", @"method"],
             @[@"VideoLibrary.GetRecentlyAddedMovies", @"method",
               @"VideoLibrary.GetMovieDetails", @"extra_info_method"],
-            @[@"VideoLibrary.GetMusicVideos", @"method"],
             @[@"Files.GetSources", @"method"],
             @[@"Files.GetDirectory", @"method"],
             @[@"Files.GetDirectory", @"method"]
@@ -2142,45 +2140,6 @@ NSMutableArray *hostRightMenuItems;
             @"YES", @"enableLibraryFullScreen",
             [self itemSizes_MovieRecentlyfullscreen], @"itemSizes"
         ],
-              
-        @[
-            @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
-                @"properties": @[
-                        @"artist",
-                        @"year",
-                        @"playcount",
-                        @"thumbnail",
-                        @"genre",
-                        @"runtime",
-                        @"studio",
-                        @"director",
-                        @"plot",
-                        @"file",
-                        @"fanart",
-                        @"resume"]
-            }, @"parameters",
-            @{
-                @"label": @[
-                        LOCALIZED_STR(@"Title"),
-                        LOCALIZED_STR(@"Artist"),
-                        LOCALIZED_STR(@"Genre"),
-                        LOCALIZED_STR(@"Year"),
-                        LOCALIZED_STR(@"Play count")],
-                @"method": @[
-                            @"label",
-                            @"artist",
-                            @"genre",
-                            @"year",
-                            @"playcount"]
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Music Videos"), @"label",
-            LOCALIZED_STR(@"Music Videos"), @"morelabel",
-            @"YES", @"enableCollectionView",
-            @"YES", @"enableLibraryCache",
-            @"YES", @"enableLibraryFullScreen",
-            [self itemSizes_Moviefullscreen], @"itemSizes"
-        ],
 
         @[
             @{
@@ -2308,27 +2267,6 @@ NSMutableArray *hostRightMenuItems;
         },
                       
         @{
-            @"itemid": @"musicvideos",
-            @"row1": @"label",
-            @"row2": @"genre",
-            @"row3": @"year",
-            @"row4": @"runtime",
-            @"row5": @"rating",
-            @"row6": @"musicvideoid",
-            @"playlistid": @1,
-            @"row8": @"musicvideoid",
-            @"row9": @"musicvideoid",
-            @"row10": @"director",
-            @"row11": @"artist",
-            @"row12": @"plot",
-            @"row13": @"playcount",
-            @"row14": @"resume",
-            @"row15": @"votes",
-            @"row16": @"artist",
-            @"row7": @"file"
-        },
-                      
-        @{
             @"itemid": @"sources",
             @"row1": @"label",
             @"row2": @"year",
@@ -2379,7 +2317,6 @@ NSMutableArray *hostRightMenuItems;
         @[],
         [self action_queue_to_play],
         [self action_queue_to_moviedetails], //, LOCALIZED_STR(@"Open with VLC"),
-        [self action_queue_to_musicvideodetails], //, LOCALIZED_STR(@"Open with VLC")
         @[],
         @[],
         [self action_queue_to_showcontent]
@@ -2393,13 +2330,11 @@ NSMutableArray *hostRightMenuItems;
         @YES,
         @YES,
         @YES,
-        @YES,
         @NO];
     
     menu_Movies.watchModes = @[
         [self modes_icons_watched],
         [self modes_icons_empty],
-        [self modes_icons_watched],
         [self modes_icons_watched],
         [self modes_icons_watched],
         [self modes_icons_empty],
@@ -2413,7 +2348,6 @@ NSMutableArray *hostRightMenuItems;
           @"VideoLibrary.GetMovieDetails", @"extra_info_method"],
         @[@"VideoLibrary.GetMovies", @"method",
           @"VideoLibrary.GetMovieDetails", @"extra_info_method"],
-        @[],
         @[],
         @[@"Files.GetDirectory", @"method"],
         @[@"Files.GetDirectory", @"method"],
@@ -2540,7 +2474,6 @@ NSMutableArray *hostRightMenuItems;
         ],
                                   
         @[],
-        @[],
                                   
         @[
             @{
@@ -2655,7 +2588,6 @@ NSMutableArray *hostRightMenuItems;
         },
                               
         @{},
-        @{},
                               
         @{
             @"itemid": @"files",
@@ -2723,7 +2655,6 @@ NSMutableArray *hostRightMenuItems;
         [self action_queue_to_moviedetails], //, LOCALIZED_STR(@"Open with VLC")
         [self action_queue_to_moviedetails], //, LOCALIZED_STR(@"Open with VLC")
         @[],
-        @[],
         [self action_queue_to_play], //, LOCALIZED_STR(@"Open with VLC")
         [self action_queue_to_play],
         [self action_queue_to_moviedetails]
@@ -2736,14 +2667,12 @@ NSMutableArray *hostRightMenuItems;
         @NO,
         @NO,
         @NO,
-        @NO,
         @YES];
     
     menu_Movies.subItem.watchModes = @[
         [self modes_icons_empty],
         [self modes_icons_watched],
         [self modes_icons_watched],
-        [self modes_icons_empty],
         [self modes_icons_empty],
         [self modes_icons_empty],
         [self modes_icons_empty],
@@ -2758,14 +2687,12 @@ NSMutableArray *hostRightMenuItems;
         @[],
         @[],
         @[],
-        @[],
         @[@"Files.GetDirectory", @"method"],
         @[@"Files.GetDirectory", @"method"],
         @[]
     ] mutableCopy];
     
     menu_Movies.subItem.subItem.mainParameters = [@[
-        @[],
         @[],
         @[],
         @[],
@@ -2783,7 +2710,6 @@ NSMutableArray *hostRightMenuItems;
         @{},
         @{},
         @{},
-        @{},
         @{}
     ];
     
@@ -2792,7 +2718,6 @@ NSMutableArray *hostRightMenuItems;
     menu_Movies.subItem.subItem.thumbWidth = 53;
     menu_Movies.subItem.subItem.defaultThumb = @"nocover_filemode";
     menu_Movies.subItem.subItem.sheetActions = @[
-        @[],
         @[],
         @[],
         @[],

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -461,6 +461,7 @@ NSMutableArray *hostRightMenuItems;
     mainMenuItems = [NSMutableArray arrayWithCapacity:1];
     __auto_type menu_Music = [mainMenu new];
     __auto_type menu_Movies = [mainMenu new];
+    __auto_type menu_Videos = [mainMenu new];
     __auto_type menu_TVShows = [mainMenu new];
     __auto_type menu_Pictures = [mainMenu new];
     __auto_type menu_Favourites = [mainMenu new];
@@ -476,6 +477,9 @@ NSMutableArray *hostRightMenuItems;
 
     menu_Movies.subItem = [mainMenu new];
     menu_Movies.subItem.subItem = [mainMenu new];
+    
+    menu_Videos.subItem = [mainMenu new];
+    menu_Videos.subItem.subItem = [mainMenu new];
     
     menu_TVShows.subItem = [mainMenu new];
     menu_TVShows.subItem.subItem = [mainMenu new];
@@ -2798,6 +2802,456 @@ NSMutableArray *hostRightMenuItems;
     ];
     
     menu_Movies.subItem.subItem.widthLabel = 252;
+    
+#pragma mark - Videos
+    menu_Videos.mainLabel = LOCALIZED_STR(@"Videos");
+    menu_Videos.upperLabel = LOCALIZED_STR(@"Watch your");
+    menu_Videos.icon = @"icon_menu_videos";
+    menu_Videos.family = FamilyDetailView;
+    menu_Videos.enableSection = YES;
+    menu_Videos.noConvertTime = YES;
+    menu_Videos.mainButtons = @[
+        @"st_music_videos",
+        @"st_movie_recently",
+        @"st_filemode",
+        @"st_addons",
+        @"st_playlists"];
+    
+    menu_Videos.mainMethod = @[
+            @[@"VideoLibrary.GetMusicVideos", @"method"],
+            @[@"VideoLibrary.GetRecentlyAddedMusicVideos", @"method"],
+            @[@"Files.GetSources", @"method"],
+            @[@"Files.GetDirectory", @"method"],
+            @[@"Files.GetDirectory", @"method"]
+        ];
+    
+    menu_Videos.mainParameters = [@[
+        @[
+            @{
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
+                @"properties": @[
+                        @"artist",
+                        @"year",
+                        @"playcount",
+                        @"thumbnail",
+                        @"genre",
+                        @"runtime",
+                        @"studio",
+                        @"director",
+                        @"plot",
+                        @"file",
+                        @"fanart",
+                        @"resume"]
+            }, @"parameters",
+            @{
+                @"label": @[
+                        LOCALIZED_STR(@"Title"),
+                        LOCALIZED_STR(@"Artist"),
+                        LOCALIZED_STR(@"Genre"),
+                        LOCALIZED_STR(@"Year"),
+                        LOCALIZED_STR(@"Play count")],
+                @"method": @[
+                            @"label",
+                            @"artist",
+                            @"genre",
+                            @"year",
+                            @"playcount"]
+            }, @"available_sort_methods",
+            LOCALIZED_STR(@"Music Videos"), @"label",
+            LOCALIZED_STR(@"Music Videos"), @"morelabel",
+            @"YES", @"enableCollectionView",
+            @"YES", @"enableLibraryCache",
+            @"YES", @"enableLibraryFullScreen",
+            [self itemSizes_Moviefullscreen], @"itemSizes"
+        ],
+              
+        @[
+            @{
+                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
+                @"properties": @[
+                                @"artist",
+                                @"year",
+                                @"playcount",
+                                @"thumbnail",
+                                @"genre",
+                                @"runtime",
+                                @"studio",
+                                @"director",
+                                @"plot",
+                                @"file",
+                                @"fanart",
+                                @"resume"]
+            }, @"parameters",
+            LOCALIZED_STR(@"Added Music Videos"), @"label",
+            @"YES", @"enableCollectionView",
+            @"YES", @"collectionViewRecentlyAdded",
+            @"YES", @"enableLibraryFullScreen",
+            [self itemSizes_MovieRecentlyfullscreen], @"itemSizes"
+        ],
+        
+        @[
+            @{
+                @"media": @"video"
+            }, @"parameters",
+            LOCALIZED_STR(@"Files"), @"label",
+            LOCALIZED_STR(@"Files"), @"morelabel",
+            @"nocover_filemode", @"defaultThumb",
+            filemodeRowHeight, @"rowHeight",
+            filemodeThumbWidth, @"thumbWidth"
+        ],
+              
+        @[
+            @{
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
+                @"media": @"video",
+                @"directory": @"addons://sources/video",
+                @"properties": @[@"thumbnail"]
+            }, @"parameters",
+            LOCALIZED_STR(@"Video Add-ons"), @"label",
+            LOCALIZED_STR(@"Video Add-ons"), @"morelabel",
+            @"nocover_filemode", @"defaultThumb",
+            filemodeRowHeight, @"rowHeight",
+            filemodeThumbWidth, @"thumbWidth",
+            @"YES", @"enableCollectionView",
+            [self itemSizes_Music], @"itemSizes"
+        ],
+
+        @[
+            @{
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
+                @"media": @"video",
+                @"directory": @"special://videoplaylists",
+                @"properties": @[
+                        @"thumbnail",
+                        @"file"],
+                @"file_properties": @[
+                        @"thumbnail",
+                        @"file"]
+            }, @"parameters",
+            LOCALIZED_STR(@"Video Playlists"), @"label",
+            LOCALIZED_STR(@"Video Playlists"), @"morelabel",
+            @"nocover_filemode", @"defaultThumb",
+            filemodeRowHeight, @"rowHeight",
+            filemodeThumbWidth, @"thumbWidth",
+            @"YES", @"isVideoPlaylist"
+        ]
+        
+    ] mutableCopy];
+    
+    menu_Videos.mainFields = @[
+        @{
+            @"itemid": @"musicvideos",
+            @"row1": @"label",
+            @"row2": @"genre",
+            @"row3": @"year",
+            @"row4": @"runtime",
+            @"row5": @"rating",
+            @"row6": @"musicvideoid",
+            @"playlistid": @1,
+            @"row8": @"musicvideoid",
+            @"row9": @"musicvideoid",
+            @"row10": @"director",
+            @"row11": @"artist",
+            @"row12": @"plot",
+            @"row13": @"playcount",
+            @"row14": @"resume",
+            @"row15": @"votes",
+            @"row16": @"artist",
+            @"row7": @"file"
+        },
+        
+        @{
+            @"itemid": @"musicvideos",
+            @"row1": @"label",
+            @"row2": @"genre",
+            @"row3": @"year",
+            @"row4": @"runtime",
+            @"row5": @"rating",
+            @"row6": @"musicvideoid",
+            @"playlistid": @1,
+            @"row8": @"musicvideoid",
+            @"row9": @"musicvideoid",
+            @"row10": @"director",
+            @"row11": @"artist",
+            @"row12": @"plot",
+            @"row13": @"playcount",
+            @"row14": @"resume",
+            @"row15": @"votes",
+            @"row16": @"artist",
+            @"row7": @"file"
+        },
+        
+        @{
+            @"itemid": @"sources",
+            @"row1": @"label",
+            @"row2": @"year",
+            @"row3": @"year",
+            @"row4": @"runtime",
+            @"row5": @"rating",
+            @"row6": @"file",
+            @"playlistid": @1,
+            @"row8": @"file",
+            @"row9": @"file"
+        },
+                      
+        @{
+            @"itemid": @"files",
+            @"row1": @"label",
+            @"row2": @"year",
+            @"row3": @"year",
+            @"row4": @"runtime",
+            @"row5": @"rating",
+            @"row6": @"file",
+            @"playlistid": @1,
+            @"row8": @"file",
+            @"row9": @"file"
+        },
+                      
+        @{
+            @"itemid": @"files",
+            @"row1": @"label",
+            @"row2": @"artist",
+            @"row3": @"year",
+            @"row4": @"duration",
+            @"row5": @"filetype",
+            @"row6": @"file",
+            @"playlistid": @1,
+            @"row8": @"file",
+            @"row9": @"file",
+            @"row10": @"filetype",
+            @"row11": @"type"
+           //@"row11": @"filetype",
+        }
+    ];
+    
+    menu_Videos.rowHeight = 76;
+    menu_Videos.thumbWidth = 53;
+    menu_Videos.defaultThumb = @"nocover_movies";
+    menu_Videos.sheetActions = @[
+        [self action_queue_to_musicvideodetails], //, LOCALIZED_STR(@"Open with VLC")
+        [self action_queue_to_musicvideodetails], //, LOCALIZED_STR(@"Open with VLC")
+        @[],
+        @[],
+        [self action_queue_to_showcontent]
+    ];
+    
+    //    menu_Videos.showInfo = YES;
+    menu_Videos.showInfo = @[
+        @YES,
+        @YES,
+        @YES,
+        @YES,
+        @NO];
+    
+    menu_Videos.watchModes = @[
+        [self modes_icons_watched],
+        [self modes_icons_watched],
+        [self modes_icons_empty],
+        [self modes_icons_empty],
+        [self modes_icons_empty]
+    ];
+    
+    menu_Videos.subItem.mainMethod = [@[
+        @[],
+        @[],
+        @[@"Files.GetDirectory", @"method"],
+        @[@"Files.GetDirectory", @"method"],
+        @[]
+    ] mutableCopy];
+    
+    menu_Videos.subItem.noConvertTime = YES;
+
+    menu_Videos.subItem.mainParameters = [@[
+        @[],
+        @[],
+        
+        @[
+            @{
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
+                @"media": filemodeVideoType
+            }, @"parameters",
+            LOCALIZED_STR(@"Files"), @"label",
+            @"nocover_filemode", @"defaultThumb",
+            filemodeRowHeight, @"rowHeight",
+            filemodeThumbWidth, @"thumbWidth"
+        ],
+                                  
+        @[
+            @{
+                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
+                @"media": @"video",
+                @"file_properties": @[@"thumbnail"]
+            }, @"parameters",
+            LOCALIZED_STR(@"Video Add-ons"), @"label",
+            @"nocover_filemode", @"defaultThumb",
+            filemodeRowHeight, @"rowHeight",
+            filemodeThumbWidth, @"thumbWidth",
+            @"YES", @"enableCollectionView",
+            [self itemSizes_Music], @"itemSizes"
+        ],
+                                  
+        @[
+            @{
+                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
+                @"file_properties": @[
+                        @"year",
+                        @"playcount",
+                        @"rating",
+                        @"thumbnail",
+                        @"genre",
+                        @"runtime",
+                        @"trailer",
+                        @"file",
+                        @"dateadded",
+                        @"uniqueid",
+                        @"studio",
+                        @"director",
+                        @"plot",
+                        @"mpaa",
+                        @"votes",
+                        @"cast",
+                        @"fanart",
+                        @"resume"],
+                @"media": @"video"
+            }, @"parameters",
+            LOCALIZED_STR(@"Files"), @"label",
+            @"nocover_filemode", @"defaultThumb",
+            @"76", @"rowHeight",
+            @"53", @"thumbWidth",
+            @"YES", @"enableCollectionView",
+            @"YES", @"FrodoExtraArt",
+            [self itemSizes_Movie], @"itemSizes"
+        ]
+    ] mutableCopy];
+    
+    menu_Videos.subItem.mainFields = @[
+        @{},
+        @{},
+        
+        @{
+            @"itemid": @"files",
+            @"row1": @"label",
+            @"row2": @"filetype",
+            @"row3": @"filetype",
+            @"row4": @"filetype",
+            @"row5": @"filetype",
+            @"row6": @"file",
+            @"playlistid": @1,
+            @"row8": @"file",
+            @"row9": @"file",
+            @"row10": @"filetype",
+            @"row11": @"type"
+        },
+                              
+        @{
+            @"itemid": @"files",
+            @"row1": @"label",
+            @"row2": @"filetype",
+            @"row3": @"filetype",
+            @"row4": @"filetype",
+            @"row5": @"filetype",
+            @"row6": @"file",
+            @"row7": @"plugin",
+            @"playlistid": @1,
+            @"row8": @"file",
+            @"row9": @"file",
+            @"row10": @"filetype",
+            @"row11": @"type"
+        },
+                              
+        @{
+            @"itemid": @"files",
+            @"row1": @"label",
+            @"row2": @"genre",
+            @"row3": @"year",
+            @"row4": @"runtime",
+            @"row5": @"rating",
+            @"row6": @"file",
+            @"playlistid": @1,
+            @"row8": @"uniqueid",
+            @"row9": @"file",
+            @"row10": @"playcount",
+            @"row11": @"trailer",
+            @"row12": @"plot",
+            @"row13": @"mpaa",
+            @"row14": @"votes",
+            @"row15": @"studio",
+            @"row16": @"cast",
+            @"row7": @"file",
+            @"row17": @"director",
+            @"row18": @"resume",
+            @"row19": @"dateadded"
+            //@"itemid_extra_info": @"moviedetails",
+        }
+    ];
+    
+    menu_Videos.subItem.enableSection = NO;
+    menu_Videos.subItem.rowHeight = 76;
+    menu_Videos.subItem.thumbWidth = 53;
+    menu_Videos.subItem.defaultThumb = @"nocover_movies";
+    menu_Videos.subItem.sheetActions = @[
+        @[],
+        @[],
+        [self action_queue_to_play], //, LOCALIZED_STR(@"Open with VLC")
+        [self action_queue_to_play],
+        [self action_queue_to_moviedetails]
+    ];
+    
+    menu_Videos.subItem.showInfo = @[
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+        @YES];
+    
+    menu_Videos.subItem.watchModes = @[
+        [self modes_icons_empty],
+        [self modes_icons_empty],
+        [self modes_icons_empty],
+        [self modes_icons_empty],
+        [self modes_icons_empty]
+    ];
+
+    menu_Videos.subItem.widthLabel = 252;
+    
+    menu_Videos.subItem.subItem.noConvertTime = YES;
+    menu_Videos.subItem.subItem.mainMethod = [@[
+        @[],
+        @[],
+        @[@"Files.GetDirectory", @"method"],
+        @[@"Files.GetDirectory", @"method"],
+        @[]
+    ] mutableCopy];
+    
+    menu_Videos.subItem.subItem.mainParameters = [@[
+        @[],
+        @[],
+        @[],
+        @[filemodeRowHeight, @"rowHeight",
+          filemodeThumbWidth, @"thumbWidth"],
+        @[]
+    ] mutableCopy];
+    
+    menu_Videos.subItem.subItem.mainFields = @[
+        @{},
+        @{},
+        @{},
+        @{},
+        @{}
+    ];
+    
+    menu_Videos.subItem.subItem.enableSection = NO;
+    menu_Videos.subItem.subItem.rowHeight = 76;
+    menu_Videos.subItem.subItem.thumbWidth = 53;
+    menu_Videos.subItem.subItem.defaultThumb = @"nocover_filemode";
+    menu_Videos.subItem.subItem.sheetActions = @[
+        @[],
+        @[],
+        @[],
+        [self action_queue_to_play]
+    ];
+    
+    menu_Videos.subItem.subItem.widthLabel = 252;
     
 #pragma mark - TV Shows
     menu_TVShows.mainLabel = LOCALIZED_STR(@"TV Shows");
@@ -5140,6 +5594,9 @@ NSMutableArray *hostRightMenuItems;
     }
     if ([self isMenuEntryEnabled:@"menu_movies"]) {
         [mainMenuItems addObject:menu_Movies];
+    }
+    if ([self isMenuEntryEnabled:@"menu_videos"]) {
+        [mainMenuItems addObject:menu_Videos];
     }
     if ([self isMenuEntryEnabled:@"menu_tvshows"]) {
         [mainMenuItems addObject:menu_TVShows];

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3188,16 +3188,17 @@ NSMutableArray *hostRightMenuItems;
         @"st_tv",
         @"st_tv_recently",
         @"st_filemode",
-        @"st_addons"];//@"st_movie_genre",
+        @"st_addons",
+        @"st_playlists"];
     
     menu_TVShows.mainMethod = [@[
         @[@"VideoLibrary.GetTVShows", @"method",
           @"VideoLibrary.GetTVShowDetails", @"extra_info_method",
           @"YES", @"tvshowsView"],
-        //@[@"VideoLibrary.GetGenres", @"method"],
         @[@"VideoLibrary.GetRecentlyAddedEpisodes", @"method",
           @"VideoLibrary.GetEpisodeDetails", @"extra_info_method"],
         @[@"Files.GetSources", @"method"],
+        @[@"Files.GetDirectory", @"method"],
         @[@"Files.GetDirectory", @"method"]
     ] mutableCopy];
     
@@ -3311,6 +3312,26 @@ NSMutableArray *hostRightMenuItems;
             @"YES", @"enableCollectionView",
             [self itemSizes_Music_insets:filemodeThumbWidth], @"itemSizes"
         ],
+        
+        @[
+            @{
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
+                @"media": @"video",
+                @"directory": @"special://videoplaylists",
+                @"properties": @[
+                        @"thumbnail",
+                        @"file"],
+                @"file_properties": @[
+                        @"thumbnail",
+                        @"file"]
+            }, @"parameters",
+            LOCALIZED_STR(@"Video Playlists"), @"label",
+            LOCALIZED_STR(@"Video Playlists"), @"morelabel",
+            @"nocover_filemode", @"defaultThumb",
+            filemodeRowHeight, @"rowHeight",
+            filemodeThumbWidth, @"thumbWidth",
+            @"YES", @"isVideoPlaylist"
+        ]
     ] mutableCopy];
 
     menu_TVShows.mainFields = @[
@@ -3335,19 +3356,7 @@ NSMutableArray *hostRightMenuItems;
             @"row16": @"studio",
             @"itemid_extra_info": @"tvshowdetails"
         },
-/*
-        @{
-            @"itemid": @"genres",
-            @"row1": @"label",
-            @"row2": @"label",
-            @"row3": @"disable",
-            @"row4": @"disable",
-            @"row5": @"disable",
-            @"row6": @"genre",
-            @"playlistid": @1,
-            @"row8": @"genreid",
-        },
-*/
+
         @{
             @"itemid": @"episodes",
             @"row1": @"label",
@@ -3398,6 +3407,22 @@ NSMutableArray *hostRightMenuItems;
             @"playlistid": @1,
             @"row8": @"file",
             @"row9": @"file"
+        },
+        
+        @{
+            @"itemid": @"files",
+            @"row1": @"label",
+            @"row2": @"artist",
+            @"row3": @"year",
+            @"row4": @"duration",
+            @"row5": @"filetype",
+            @"row6": @"file",
+            @"playlistid": @1,
+            @"row8": @"file",
+            @"row9": @"file",
+            @"row10": @"filetype",
+            @"row11": @"type"
+           //@"row11": @"filetype",
         }
     ];
     
@@ -3407,23 +3432,23 @@ NSMutableArray *hostRightMenuItems;
     menu_TVShows.originLabel = 60;
     menu_TVShows.sheetActions = @[
         @[LOCALIZED_STR(@"TV Show Details")],
-        //@[],
         [self action_queue_to_episodedetails],
         @[],
-        @[]
+        @[],
+        [self action_queue_to_showcontent]
     ];
     
     menu_TVShows.showInfo = @[
         @NO,
-        //@NO,
         @YES,
+        @NO,
         @NO,
         @NO];
     
     menu_TVShows.watchModes = @[
         [self modes_icons_watched],
-        //[self modes_icons_empty]
         [self modes_icons_watched],
+        [self modes_icons_empty],
         [self modes_icons_empty],
         [self modes_icons_empty]
     ];
@@ -3433,11 +3458,10 @@ NSMutableArray *hostRightMenuItems;
           @"VideoLibrary.GetEpisodeDetails", @"extra_info_method",
           @"YES", @"episodesView",
           @"VideoLibrary.GetSeasons", @"extra_section_method"],
-        //@[@"VideoLibrary.GetTVShows", @"method",
-        //  @"VideoLibrary.GetTVShowDetails", @"extra_info_method"],
         @[],
         @[@"Files.GetDirectory", @"method"],
-        @[@"Files.GetDirectory", @"method"]
+        @[@"Files.GetDirectory", @"method"],
+        @[]
     ] mutableCopy];
     
     menu_TVShows.subItem.mainParameters = [@[
@@ -3489,41 +3513,7 @@ NSMutableArray *hostRightMenuItems;
             @"YES", @"disableFilterParameter",
             @"YES", @"FrodoExtraArt"
         ],
-/*
-        @[
-            @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
-                @"properties": @[
-                        @"year",
-                        @"playcount",
-                        @"rating",
-                        @"thumbnail",
-                        @"genre",
-                        @"studio"]
-            }, @"parameters",
-            @{
-                @"properties": @[
-                         @"year",
-                         @"playcount",
-                         @"rating",
-                         @"thumbnail",
-                         @"genre",
-                         @"studio",
-                         @"plot",
-                         @"mpaa",
-                         @"votes",
-                         @"cast",
-                         @"premiered",
-                         @"episode",
-                         @"fanart"]
-            }, @"extra_info_parameters",
-            LOCALIZED_STR(@"TV Shows"), @"label",
-            @tvshowHeight, @"rowHeight",
-            @thumbWidth, @"thumbWidth",
-            @"YES", @"blackTableSeparator",
-            @"YES", @"FrodoExtraArt"
-        ],
-*/
+
         @[],
                                     
         @[
@@ -3549,6 +3539,39 @@ NSMutableArray *hostRightMenuItems;
             filemodeThumbWidth, @"thumbWidth",
             @"YES", @"enableCollectionView",
             [self itemSizes_Music], @"itemSizes"
+        ],
+        
+        @[
+            @{
+                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
+                @"file_properties": @[
+                        @"year",
+                        @"playcount",
+                        @"rating",
+                        @"thumbnail",
+                        @"genre",
+                        @"runtime",
+                        @"trailer",
+                        @"file",
+                        @"dateadded",
+                        @"uniqueid",
+                        @"studio",
+                        @"director",
+                        @"plot",
+                        @"mpaa",
+                        @"votes",
+                        @"cast",
+                        @"fanart",
+                        @"resume"],
+                @"media": @"video"
+            }, @"parameters",
+            LOCALIZED_STR(@"Files"), @"label",
+            @"nocover_filemode", @"defaultThumb",
+            @"76", @"rowHeight",
+            @"53", @"thumbWidth",
+            @"YES", @"enableCollectionView",
+            @"YES", @"FrodoExtraArt",
+            [self itemSizes_Movie], @"itemSizes"
         ]
     ] mutableCopy];
     
@@ -3579,29 +3602,7 @@ NSMutableArray *hostRightMenuItems;
             @"itemid_extra_info": @"episodedetails",
             @"itemid_extra_section": @"seasons"
         },
-/*
-        @{
-            @"itemid": @"tvshows",
-            @"row1": @"label",
-            @"row2": @"genre",
-            @"row3": @"blank",
-            @"row4": @"studio",
-            @"row5": @"rating",
-            @"row6": @"tvshowid",
-            @"playlistid": @1,
-            @"row8": @"tvshowid",
-            @"row9": @"playcount",
-            @"row10": @"mpaa",
-            @"row11": @"votes",
-            @"row12": @"cast",
-            @"row13": @"premiered",
-            @"row14": @"episode",
-            @"row7": @"fanart",
-            @"row15": @"plot",
-            @"row16": @"studio",
-            @"itemid_extra_info": @"tvshowdetails"
-        },
-*/
+
         @[],
                                 
         @{
@@ -3633,6 +3634,31 @@ NSMutableArray *hostRightMenuItems;
             @"row9": @"file",
             @"row10": @"filetype",
             @"row11": @"type"
+        },
+        
+        @{
+            @"itemid": @"files",
+            @"row1": @"label",
+            @"row2": @"genre",
+            @"row3": @"year",
+            @"row4": @"runtime",
+            @"row5": @"rating",
+            @"row6": @"file",
+            @"playlistid": @1,
+            @"row8": @"uniqueid",
+            @"row9": @"file",
+            @"row10": @"playcount",
+            @"row11": @"trailer",
+            @"row12": @"plot",
+            @"row13": @"mpaa",
+            @"row14": @"votes",
+            @"row15": @"studio",
+            @"row16": @"cast",
+            @"row7": @"file",
+            @"row17": @"director",
+            @"row18": @"resume",
+            @"row19": @"dateadded"
+            //@"itemid_extra_info": @"moviedetails",
         }
     ];
     
@@ -3642,17 +3668,17 @@ NSMutableArray *hostRightMenuItems;
     menu_TVShows.subItem.defaultThumb = @"nocover_tvshows_episode";
     menu_TVShows.subItem.sheetActions = @[
         [self action_queue_to_episodedetails], //, LOCALIZED_STR(@"Open with VLC")
-        //@[@"TV Show Details"],
         @[],
         [self action_queue_to_play], //, LOCALIZED_STR(@"Open with VLC")
-        [self action_queue_to_play] //, @"Stream to iPhone"
+        [self action_queue_to_play], //, @"Stream to iPhone"
+        [self action_queue_to_moviedetails]
     ];
     
     menu_TVShows.subItem.originYearDuration = 248;
     menu_TVShows.subItem.widthLabel = 208;
     menu_TVShows.subItem.showRuntime = @[
         @NO,
-        //@NO,
+        @NO,
         @NO,
         @NO,
         @NO];
@@ -3660,31 +3686,31 @@ NSMutableArray *hostRightMenuItems;
     menu_TVShows.subItem.noConvertTime = YES;
     menu_TVShows.subItem.showInfo = @[
         @YES,
-        //@NO,
+        @YES,
         @YES,
         @YES,
         @YES];
     
     menu_TVShows.subItem.subItem.mainMethod = [@[
         @[],
-        //@[],
         @[],
         @[@"Files.GetDirectory", @"method"],
-        @[@"Files.GetDirectory", @"method"]
+        @[@"Files.GetDirectory", @"method"],
+        @[]
     ] mutableCopy];
                                         
     menu_TVShows.subItem.subItem.mainParameters = [@[
         @[],
-        //@[],
         @[],
         @[],
         @[filemodeRowHeight, @"rowHeight",
-          filemodeThumbWidth, @"thumbWidth"]
+          filemodeThumbWidth, @"thumbWidth"],
+        @[]
     ] mutableCopy];
     
     menu_TVShows.subItem.subItem.mainFields = @[
         @[],
-        //@[],
+        @[],
         @[],
         @[],
         @[]
@@ -3696,7 +3722,6 @@ NSMutableArray *hostRightMenuItems;
     menu_TVShows.subItem.subItem.defaultThumb = @"nocover_tvshows_episode";
     menu_TVShows.subItem.subItem.sheetActions = @[
         @[],
-        //@[],
         @[],
         [self action_queue_to_play],
         [self action_queue_to_play]

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -2723,6 +2723,7 @@ NSMutableArray *hostRightMenuItems;
         @[],
         @[],
         [self action_queue_to_play],
+        [self action_queue_to_play],
         [self action_queue_to_play]
     ];
     
@@ -3173,6 +3174,7 @@ NSMutableArray *hostRightMenuItems;
         @[],
         @[],
         @[],
+        [self action_queue_to_play],
         [self action_queue_to_play]
     ];
     
@@ -3723,6 +3725,7 @@ NSMutableArray *hostRightMenuItems;
     menu_TVShows.subItem.subItem.sheetActions = @[
         @[],
         @[],
+        [self action_queue_to_play],
         [self action_queue_to_play],
         [self action_queue_to_play]
     ];

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -274,6 +274,16 @@
 			<key>DefaultValue</key>
 			<true/>
 			<key>Key</key>
+			<string>menu_videos</string>
+			<key>Title</key>
+			<string>Show VIDEOS</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<true/>
+			<key>Key</key>
 			<string>menu_tvshows</string>
 			<key>Title</key>
 			<string>Show TV SHOWS</string>

--- a/XBMC Remote/Settings.bundle/de.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/de.lproj/Root.strings
@@ -31,6 +31,7 @@
 "Main Menu changes needs app restart" = "Hauptmenü-Änderungen erfordern einen App-Neustart";
 "Show MUSIC" = "Zeige MUSIK";
 "Show MOVIES" = "Zeige FILME";
+"Show VIDEOS" = "Zeige VIDEOS";
 "Show TV SHOWS" = "Zeige SERIEN";
 "Show PICTURES" = "Zeige BILDER";
 "Show LIVE TV" = "Zeige TV";

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -31,6 +31,7 @@
 "Main Menu changes needs app restart" = "Main Menu changes needs app restart";
 "Show MUSIC" = "Show MUSIC";
 "Show MOVIES" = "Show MOVIES";
+"Show VIDEOS" = "Show VIDEOS";
 "Show TV SHOWS" = "Show TV SHOWS";
 "Show PICTURES" = "Show PICTURES";
 "Show LIVE TV" = "Show LIVE TV";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -30,6 +30,7 @@
 "Radio" = "Radio";
 "Movie Genres" = "Filmgenre";
 "Music Videos" = "Musikvideos";
+"Added Music Videos" = "Hinzugefügte Musikvideos";
 "Added Movies" = "Hinzugefügte Filme";
 "More (%d)" = "Mehr (%d)";
 "Movie Sets" = "Filmreihen";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -32,6 +32,7 @@
 "Radio" = "Radio";
 "Movie Genres" = "Movie Genres";
 "Music Videos" = "Music Videos";
+"Added Music Videos" = "Added Music Videos";
 "Added Movies" = "Added Movies";
 "More (%d)" = "More (%d)";
 "Movie Sets" = "Movie Sets";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/387.

- Have "Videos" main menu entry
- "Videos" toolbar direct access: "Music Videos", "Recently Added Music Videos", "File mode", "Video Add-ons"
- "Videos" toolbar "more menu": "Video Playlists"
- In "Movies" toolbar's "more menu" the entry for "Music Videos" will be removed
- In "TV Show" toolbar's "more menu" an entry for "Video Playlists" will be added

Screenshots:
<a href="https://abload.de/image.php?img=simulatorscreenshot-ieek1d.png"><img src="https://abload.de/img/simulatorscreenshot-ieek1d.png" /></a> <a href="https://abload.de/image.php?img=simulatorscreenshot-itfjsp.png"><img src="https://abload.de/img/simulatorscreenshot-itfjsp.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Introduce Videos main menu entry