### PR TITLE
Bugfix: Apply rounded edges to fallback images

### DIFF
--- a/XBMC Remote/SDWebImage/UIImageView+WebCache.m
+++ b/XBMC Remote/SDWebImage/UIImageView+WebCache.m
@@ -54,7 +54,7 @@ static char operationKey;
     size = [self doubleSizeIfRetina:size];
     [self cancelCurrentImageLoad];
 
-    self.image = placeholder;
+    self.image = [Utilities applyRoundedEdgesImage:placeholder drawBorder:withBorder];;
     
     if (url && url.path) {
         NSDictionary *userInfo = nil;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes rounded edges for fallback thumbnails in some cases. Example is an artist without a thumbnail/art:

<a href="https://abload.de/image.php?img=simulatorscreenshot-idljbo.png"><img src="https://abload.de/img/simulatorscreenshot-idljbo.png" /></a> <a href="https://abload.de/image.php?img=simulatorscreenshot-ijcjky.png"><img src="https://abload.de/img/simulatorscreenshot-ijcjky.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Apply rounded edges to fallback images