### PR TITLE
Bugfix: Fix "No items found" for Live TV when no PVR add-on is installed

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4383,7 +4383,8 @@ NSIndexPath *selected;
             [mutableParameters removeObjectForKey:@"sort"];
         }
         else if ([mutableParameters[@"channelgroupid"] intValue] == -1) {
-            [self showNoResultsFound:resultStoreArray refresh:forceRefresh];
+            [self alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
+            [activityIndicatorView stopAnimating];
             return;
         }
     }
@@ -4413,7 +4414,8 @@ NSIndexPath *selected;
          // shown via debug message.
          if (error == nil && methodError != nil && [methodToCall containsString:@"PVR."]) {
              if (methodError.code == -32100) {
-                 [self showNoResultsFound:resultStoreArray refresh:forceRefresh];
+                 [self alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
+                 [activityIndicatorView stopAnimating];
                  return;
              }
          }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
In case the App receives and error when accessing the PVR just show "No items found" and stop the animator. This results in same content shown as other empty main menus.

Screensots: https://abload.de/img/bildschirmfoto2021-1076jvq.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix "No items found" for Live TV when no PVR add-on is installed