### PR TITLE
Bugfix: Open/close episode section

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -557,8 +557,6 @@
         [dataList deleteRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationTop];
         [dataList endUpdates];
         if (section > 0) {
-            //            NSIndexPath *indexPathToScroll = [NSIndexPath indexPathForRow:NSNotFound inSection:section];
-            //            [dataList scrollToRowAtIndexPath:indexPathToScroll atScrollPosition:UITableViewScrollPositionBottom animated:YES];
             CGRect sectionRect = [dataList rectForSection:section - 1];
             [dataList scrollRectToVisible:sectionRect animated:YES];
         }
@@ -2583,7 +2581,6 @@ int originYear = 0;
             button.frame = CGRectMake(3, (int)(albumViewHeight / 2) - 6, 11, 11);
             [button setImage:[UIImage imageNamed:@"arrow_close"] forState:UIControlStateNormal];
             [button setImage:[UIImage imageNamed:@"arrow_open"] forState:UIControlStateSelected];
-//            [button addTarget:self action:@selector(toggleOpen:) forControlEvents:UIControlEventTouchUpInside];
             if ([self.sectionArrayOpen[section] boolValue]) {
                 [button setSelected:YES];
             }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Opening or closing a section in the episode view shall not make the searchbar visible.

<a href="https://abload.de/image.php?img=bildschirmfoto2021-105hjw7.png"><img src="https://abload.de/img/bildschirmfoto2021-105hjw7.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid searchbar becoming visible when open/close an episode section