### PR TITLE
Feature: Easier access to Remote and NowPlaying

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3463,18 +3463,9 @@ NSIndexPath *selected;
         topNavigationLabel.opaque = YES;
         topNavigationLabel.text = [self.detailItem mainLabel];
         self.navigationItem.title = [self.detailItem mainLabel];
+        
+        // Set up gestures
         if (![self.detailItem disableNowPlaying]) {
-            UIBarButtonItem *nowPlayingButtonItem = [[UIBarButtonItem alloc] initWithTitle:LOCALIZED_STR(@"Now Playing") style:UIBarButtonItemStylePlain target:self action:@selector(showNowPlaying)];
-            [nowPlayingButtonItem setTitleTextAttributes:
-             [NSDictionary dictionaryWithObjectsAndKeys:
-              [UIFont systemFontOfSize:12], NSFontAttributeName,
-              nil] forState:UIControlStateNormal];
-            [nowPlayingButtonItem setTitleTextAttributes:
-             [NSDictionary dictionaryWithObjectsAndKeys:
-              [UIFont systemFontOfSize:12], NSFontAttributeName,
-              nil] forState:UIControlStateHighlighted];
-            self.navigationItem.rightBarButtonItem = nowPlayingButtonItem;
-            
             UISwipeGestureRecognizer *leftSwipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFromLeft:)];
             leftSwipe.numberOfTouchesRequired = 1;
             leftSwipe.cancelsTouchesInView = NO;
@@ -3486,6 +3477,19 @@ NSIndexPath *selected;
         rightSwipe.cancelsTouchesInView = NO;
         rightSwipe.direction = UISwipeGestureRecognizerDirectionRight;
         [self.view addGestureRecognizer:rightSwipe];
+        
+        // Set up navigation bar items on upper right
+        UIImage *remoteButtonImage = [UIImage imageNamed:@"icon_menu_remote"];
+        UIBarButtonItem *remoteButton = [[UIBarButtonItem alloc] initWithImage:remoteButtonImage style:UIBarButtonItemStylePlain target:self action:@selector(showRemote)];
+        UIImage *nowPlayingButtonImage = [UIImage imageNamed:@"icon_menu_playing"];
+        UIBarButtonItem *nowPlayingButton = [[UIBarButtonItem alloc] initWithImage:nowPlayingButtonImage style:UIBarButtonItemStylePlain target:self action:@selector(showNowPlaying)];
+         if (![self.detailItem disableNowPlaying]) {
+             self.navigationItem.rightBarButtonItems = @[remoteButton,
+                                                         nowPlayingButton];
+         }
+         else {
+             self.navigationItem.rightBarButtonItems = @[remoteButton];
+         }
    }
 }
 
@@ -3620,6 +3624,11 @@ NSIndexPath *selected;
     NowPlaying *nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
     nowPlaying.detailItem = self.detailItem;
     [self.navigationController pushViewController:nowPlaying animated:YES];
+}
+
+- (void)showRemote {
+    RemoteController *remote = [[RemoteController alloc] initWithNibName:@"RemoteController" bundle:nil];
+    [self.navigationController pushViewController:remote animated:YES];
 }
 
 # pragma mark - Playback Management

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -186,9 +186,7 @@
 }
 
 - (void)configureView {
-    if (self.detailItem) {
-        self.navigationItem.title = [self.detailItem mainLabel]; 
-    }
+    self.navigationItem.title = LOCALIZED_STR(@"Remote Control");
     CGFloat toolbarPadding = TOOLBAR_HEIGHT;
     if (![Utilities hasRemoteToolBar]) {
         toolbarPadding = 0;


### PR DESCRIPTION
Allows to reach both the NowPlaying screen and the Remote from nearly all menus.
Add Remote and NowPlaying button to NavigationBar

## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/243.
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/373.

Feedback from users point to a a lack of usability when Remote or NowPlaying's controls (e.g. time slider, play/pause, ...) shall be accessed while browsing the database or file tree. This PR adds access buttons for both the Remote and the NowPlaying screen to the navigation bar. This allows to switch to Remote/NowPlaying from the current menu and back, without losing the context. Exceptions are the remote screen and the settings menu itself.

Remark: This change only impacts iPhone. For iPad there is no navigation bar used, and the Remote and NowPlaying can be accessed from the always reachable main menu. In this case the context of an ongoing browse activity is lost though.

New Navigation bar: 
<a href="https://abload.de/image.php?img=bildschirmfoto2021-1051ka0.png"><img src="https://abload.de/img/bildschirmfoto2021-1051ka0.png" /></a>

Menu logic: 
https://abload.de/img/bildschirmfoto2021-1010kh4.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Easier access to Remote and NowPlaying