### PR TITLE
Feature: Show artist clearlogos in artist details for Kodi 18 and later

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -549,6 +549,9 @@ NSMutableArray *hostRightMenuItems;
                         @"description",
                         @"albumlabel",
                         @"fanart"],
+                @"kodiExtrasPropertiesMinimumVersion": @{
+                        @"18": @[@"art"]
+                    }
             }, @"extra_info_parameters",
             @{
                 @"label": @[
@@ -593,7 +596,7 @@ NSMutableArray *hostRightMenuItems;
                         @"yearsactive",
                         @"fanart"],
                 @"kodiExtrasPropertiesMinimumVersion": @{
-                        @"18": @[@"roles"]
+                        @"18": @[@"roles", @"art"]
                     }
             }, @"extra_info_parameters",
             LOCALIZED_STR(@"Artists"), @"label",
@@ -644,7 +647,10 @@ NSMutableArray *hostRightMenuItems;
                         @"genre",
                         @"description",
                         @"albumlabel",
-                        @"fanart"]
+                        @"fanart"],
+                @"kodiExtrasPropertiesMinimumVersion": @{
+                        @"18": @[@"art"]
+                    }
             }, @"extra_info_parameters",
            LOCALIZED_STR(@"Added Albums"), @"label",
            @"Album", @"wikitype",
@@ -705,7 +711,10 @@ NSMutableArray *hostRightMenuItems;
                         @"playcount",
                         @"label",
                         @"genre",
-                        @"year"]
+                        @"year"],
+                @"kodiExtrasPropertiesMinimumVersion": @{
+                        @"18": @[@"art"]
+                    }
             }, @"available_sort_methods",
             LOCALIZED_STR(@"Top 100 Albums"), @"label",
             @"Album", @"wikitype",
@@ -1238,7 +1247,10 @@ NSMutableArray *hostRightMenuItems;
                         @"genre",
                         @"description",
                         @"albumlabel",
-                        @"fanart"]
+                        @"fanart"],
+                @"kodiExtrasPropertiesMinimumVersion": @{
+                        @"18": @[@"art"]
+                    }
             }, @"extra_info_parameters",
             @"Albums", @"label",
             @"Album", @"wikitype",
@@ -1263,7 +1275,10 @@ NSMutableArray *hostRightMenuItems;
                         @"genre",
                         @"description",
                         @"albumlabel",
-                        @"fanart"]
+                        @"fanart"],
+                @"kodiExtrasPropertiesMinimumVersion": @{
+                        @"18": @[@"art"]
+                    }
             }, @"extra_info_parameters",
             @{
                 @"label": @[
@@ -1411,7 +1426,7 @@ NSMutableArray *hostRightMenuItems;
                         @"yearsactive",
                         @"fanart"],
                 @"kodiExtrasPropertiesMinimumVersion": @{
-                        @"18": @[@"roles"]
+                        @"18": @[@"roles", @"art"]
                     }
             }, @"extra_info_parameters",
             LOCALIZED_STR(@"Artists"), @"label",
@@ -1729,7 +1744,10 @@ NSMutableArray *hostRightMenuItems;
                         @"genre",
                         @"description",
                         @"albumlabel",
-                        @"fanart"]
+                        @"fanart"],
+                @"kodiExtrasPropertiesMinimumVersion": @{
+                        @"18": @[@"art"]
+                    }
             }, @"extra_info_parameters",
             @"Albums", @"label",
             @"Album", @"wikitype",


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/270.

The `AudioLibrary.GetArtistDetails` and `AudioLibrary.GetAlbumDetails` API allows to request `"art"` from Kodi Leia (18) on. This automatically enables support for clearlogos in the artist and album details.

<a href="https://abload.de/image.php?img=bildschirmfoto2021-107kkz6.png"><img src="https://abload.de/img/bildschirmfoto2021-107kkz6.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Show artist clearlogos in artist and album details for Kodi 18 and later