### PR TITLE
Bugfix: Show artist icon for roles

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -882,7 +882,7 @@ NSMutableArray *hostRightMenuItems;
             }, @"parameters",
             LOCALIZED_STR(@"Music Roles"), @"label",
             LOCALIZED_STR(@"Music Roles"), @"morelabel",
-            @"nocover_genre", @"defaultThumb",
+            @"nocover_artist", @"defaultThumb",
             filemodeRowHeight, @"rowHeight",
             filemodeThumbWidth, @"thumbWidth",
             [self itemSizes_Music], @"itemSizes"


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The App shows a not very well matching icon when searching for music roles. This PR changes this icon to the well suitable "artist" icon. The following screenhots show old (left) vs new (right) icons:

<a href="https://abload.de/image.php?img=simulatorscreenshot-ij2jji.png"><img src="https://abload.de/img/simulatorscreenshot-ij2jji.png" /></a> <a href="https://abload.de/image.php?img=simulatorscreenshot-i2bkpt.png"><img src="https://abload.de/img/simulatorscreenshot-i2bkpt.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show artist icon for roles