### PR TITLE
Fix defaultthumb border

### DIFF
--- a/XBMC Remote/SDWebImage/UIImageView+WebCache.m
+++ b/XBMC Remote/SDWebImage/UIImageView+WebCache.m
@@ -59,9 +59,8 @@ static char operationKey;
     if (url && url.path) {
         NSDictionary *userInfo = nil;
         if (size.width && size.height) {
-            userInfo = [NSDictionary dictionaryWithObjectsAndKeys:@"resize", @"transformation",
-                                  NSStringFromCGSize(size), @"size",
-                                   nil];
+            userInfo = @{@"transformation": @"resize",
+                         @"size": NSStringFromCGSize(size)};
         }
         __weak UIImageView *wself = self;
         id<SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadWithURL:url options:options userInfo:userInfo progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Minor regression of https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/421 as I was not testing on Light Mode. 

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2021-10zkjgm.png"><img src="https://abload.de/img/bildschirmfoto2021-10zkjgm.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not draw border around default thumbs