### PR TITLE
Maintenance: Use smaller NavigationBar font size

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -445,9 +445,8 @@ NSMutableArray *hostRightMenuItems;
     if (IS_IPHONE) {
         thumbWidth = (int)(PHONE_TV_SHOWS_BANNER_WIDTH * transform);
         tvshowHeight = (int)(PHONE_TV_SHOWS_BANNER_HEIGHT * transform);
-        NSDictionary *navbarTitleTextAttributes = [NSDictionary dictionaryWithObjectsAndKeys:
-                                                   [UIColor whiteColor], NSForegroundColorAttributeName,
-                                                   [UIFont boldSystemFontOfSize:16], NSFontAttributeName, nil];
+        NSDictionary *navbarTitleTextAttributes = @{NSForegroundColorAttributeName: [UIColor whiteColor],
+                                                    NSFontAttributeName: [UIFont boldSystemFontOfSize:16]};
         [[UINavigationBar appearance] setTitleTextAttributes:navbarTitleTextAttributes];
     }
     else {
@@ -4743,7 +4742,7 @@ NSMutableArray *hostRightMenuItems;
     NSData *authCredential = [[NSString stringWithFormat:@"%@:%@", obj.serverUser, obj.serverPass] dataUsingEncoding:NSUTF8StringEncoding];
     NSString *base64AuthCredentials = [authCredential base64EncodedStringWithOptions:(NSDataBase64EncodingOptions)0];
     NSString *authValue = [NSString stringWithFormat:@"Basic %@", base64AuthCredentials];
-    NSDictionary *httpHeaders = [NSDictionary dictionaryWithObjectsAndKeys:authValue, @"Authorization", nil];
+    NSDictionary *httpHeaders = @{@"Authorization": authValue};
     return httpHeaders;
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Since adding the 2nd button to `rightBarButtonItems` several strings are not fitting into the NavigationBar's text field anymore. This PR sets a slightly smaller font size to compensate for the reduced width. In addition, it migrates last two occurances of `dictionaryWithObjectsAndKeys` in AppDelegate.m to literals.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Use smaller NavigationBar font size