### PR TITLE
Improvement: Better usability for iPad mute button

### DIFF
--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -50,7 +50,7 @@
             muteButton.frame = frame_tmp;
             
             frame_tmp = minusButton.frame;
-            frame_tmp.origin.x = CGRectGetMaxX(muteButton.frame);
+            frame_tmp.origin.x = CGRectGetMaxX(muteButton.frame) + VOLUMEICON_PADDING;
             minusButton.frame = frame_tmp;
             
             frame_tmp = volumeLabel.frame;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/436.

Increase the space between mute and minus buttons on iPad for better usability.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Better usability for iPad mute button