### PR TITLE
Bugfix: Fix runtime warning caused by imageNamed:@""

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -340,7 +340,7 @@ NSMutableArray *hostRightMenuItems;
                 @(ViewModeAlbumArtists),
                 @(ViewModeSongArtists)],
         @"icons": @[
-                @"",
+                @"blank",
                 @"st_album_small",
                 @"st_songs_small"]
     };


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Issue was introduced with https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/426 and caused by calling `imageNamed` with an empty string.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix runtime warning caused by imageNamed: with empty string