### PR TITLE
Bugfix: Fix broadcast detail view

### DIFF
--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -49,7 +49,7 @@
     IBOutlet UIImageView *jewelView;
     IBOutlet UIImageView *fanartView;
 
-    BOOL isRecordingDetail;
+    BOOL isPvrDetail;
     UIToolbar *toolbar;
     NSMutableArray *sheetActions;
     UIBarButtonItem *actionSheetButtonItemIpad;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1228,7 +1228,7 @@ double round(double d) {
         if (image != nil) {
             foundTintColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO]];
             [self setIOS7barTintColor:foundTintColor];
-            if (enableJewel && !isPvrDetail) {
+            if (enableJewel) {
                 coverView.image = image;
                 coverView.frame = [Utilities createCoverInsideJewel:jewelView jewelType:jewelType];
                 [activityIndicatorView stopAnimating];
@@ -1241,7 +1241,7 @@ double round(double d) {
         else {
             __weak ShowInfoViewController *sf = self;
             __block UIColor *newColor = nil;
-            if (enableJewel && !isPvrDetail) {
+            if (enableJewel) {
                 [coverView setImageWithURL:[NSURL URLWithString:thumbnailPath]
                           placeholderImage:[UIImage imageNamed:placeHolderImage]
                                  completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -540,7 +540,7 @@ double round(double d) {
     [activityIndicatorView stopAnimating];
     jewelView.alpha = 0;
     UIImage *imageToShow = image != nil ? image : fallback;
-    if (isRecordingDetail) {
+    if (isPvrDetail) {
         CGRect frame;
         frame.size.width = ceil(TV_LOGO_SIZE_REC_DETAILS * 0.9);
         frame.size.height = ceil(TV_LOGO_SIZE_REC_DETAILS * 0.7);
@@ -573,7 +573,7 @@ double round(double d) {
     // NEED TO BE OPTIMIZED. IT WORKS BUT THERE ARE TOO MANY IFS!
     NSMutableDictionary *item = self.detailItem;
     NSString *placeHolderImage = @"coverbox_back";
-    isRecordingDetail = item[@"recordingid"] != nil;
+    isPvrDetail = item[@"recordingid"] != nil || item[@"broadcastid"] != nil;
 //    NSLog(@"ITEM %@", item);
     eJewelType jeweltype = jewelTypeUnknown;
     lineSpacing = IS_IPAD ? 2 : 0;
@@ -1228,7 +1228,7 @@ double round(double d) {
         if (image != nil) {
             foundTintColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO]];
             [self setIOS7barTintColor:foundTintColor];
-            if (enableJewel && !isRecordingDetail) {
+            if (enableJewel && !isPvrDetail) {
                 coverView.image = image;
                 coverView.frame = [Utilities createCoverInsideJewel:jewelView jewelType:jewelType];
                 [activityIndicatorView stopAnimating];
@@ -1241,7 +1241,7 @@ double round(double d) {
         else {
             __weak ShowInfoViewController *sf = self;
             __block UIColor *newColor = nil;
-            if (enableJewel && !isRecordingDetail) {
+            if (enableJewel && !isPvrDetail) {
                 [coverView setImageWithURL:[NSURL URLWithString:thumbnailPath]
                           placeholderImage:[UIImage imageNamed:placeHolderImage]
                                  completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
In the details view for a broadcast (TV > All channels > Select channel > Channel guide > Select broadcast) the channel logo background is not set. This PR fixes this minor issue.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix channel logo background in broadcast detail view