### PR TITLE
Rework date formatting

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2122,17 +2122,9 @@ int originYear = 0;
         [runtimeyear setText:duration];
     }
     else {
-        NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:LOCALIZED_STR(@"LocaleIdentifier")];
-        NSDateFormatter *format = [NSDateFormatter new];
-        [format setLocale:locale];
-        [format setDateFormat:@"yyyy-MM-dd"];
-        NSDate *date = [format dateFromString:item[@"year"]];
-        if (date == nil) {
-            [runtimeyear setText:item[@"year"]];
-        }
-        else {
-            [format setDateFormat:LOCALIZED_STR(@"ShortDateTimeFormat")];
-            [runtimeyear setText:[format stringFromDate:date]];
+        runtimeyear.text = [Utilities getDateFromItem:item[@"year"] dateStyle:NSDateFormatterShortStyle emptyString:@""];
+        if (runtimeyear.text.length == 0) {
+            runtimeyear.text = item[@"year"];
         }
     }
     frame = runtime.frame;
@@ -2666,7 +2658,7 @@ int originYear = 0;
             [releasedLabel setNumberOfLines:1];
             [releasedLabel setAdjustsFontSizeToFitWidth:YES];
             
-            NSString *aired = [Utilities getDateFromItem:item[@"year"] emptyString:@""];
+            NSString *aired = [Utilities getDateFromItem:item[@"year"] dateStyle:NSDateFormatterLongStyle emptyString:@""];
             
             releasedLabel.text = @"";
             if (aired != nil) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2666,14 +2666,8 @@ int originYear = 0;
             [releasedLabel setNumberOfLines:1];
             [releasedLabel setAdjustsFontSizeToFitWidth:YES];
             
-            NSLocale *usLocale = [[NSLocale alloc] initWithLocaleIdentifier:LOCALIZED_STR(@"LocaleIdentifier")];
-            NSString *aired = @"";
-            NSDateFormatter *format = [NSDateFormatter new];
-            [format setLocale:usLocale];
-            [format setDateFormat:@"yyyy-MM-dd"];
-            NSDate *date = [format dateFromString:item[@"year"]];
-            [format setDateFormat:LOCALIZED_STR(@"LongDateTimeFormat")];
-            aired = [format stringFromDate:date];
+            NSString *aired = [Utilities getDateFromItem:item[@"year"] emptyString:@""];
+            
             releasedLabel.text = @"";
             if (aired != nil) {
                 releasedLabel.text = [NSString stringWithFormat:LOCALIZED_STR(@"First aired on %@"), aired];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -626,7 +626,7 @@ double round(double d) {
         label6.text = LOCALIZED_STR(@"CAST");
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
         directorLabel.text = [Utilities getStringFromDictionary:item key:@"episode" emptyString:@"-"];
-        genreLabel.text = [Utilities getDateFromItem:item[@"premiered"] emptyString:@"-"];
+        genreLabel.text = [Utilities getDateFromItem:item[@"premiered"] dateStyle:NSDateFormatterLongStyle emptyString:@"-"];
         runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"genre" emptyString:@"-"];
         studioLabel.text = [Utilities getStringFromDictionary:item key:@"studio" emptyString:@"-"];
         summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot" emptyString:@"-"];
@@ -662,7 +662,7 @@ double round(double d) {
         label6.text = LOCALIZED_STR(@"CAST");
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
         directorLabel.text = [Utilities getStringFromDictionary:item key:@"showtitle" emptyString:@"-"];
-        genreLabel.text = [Utilities getDateFromItem:item[@"firstaired"] emptyString:@"-" ];
+        genreLabel.text = [Utilities getDateFromItem:item[@"firstaired"] dateStyle:NSDateFormatterLongStyle emptyString:@"-" ];
         runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"director" emptyString:@"-"];
         studioLabel.text = [Utilities getStringFromDictionary:item key:@"writer" emptyString:@"-"];
         summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot" emptyString:@"-"];

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -76,7 +76,7 @@ typedef enum {
 + (NSString*)getRatingFromDictionary:(NSDictionary*)dict key:(NSString*)key;
 + (NSString*)getClearArtFromDictionary:(NSDictionary*)dict type:(NSString*)type;
 + (NSString*)getThumbnailFromDictionary:(NSDictionary*)dict useBanner:(BOOL)useBanner useIcon:(BOOL)useIcon;
-+ (NSString*)getDateFromItem:(id)item emptyString:(NSString*)empty;
++ (NSString*)getDateFromItem:(id)item dateStyle:(NSDateFormatterStyle)dateStyle emptyString:(NSString*)empty;
 + (NSString*)formatStringURL:(NSString*)path serverURL:(NSString*)serverURL;
 + (CGFloat)getHeightOfLabel:(UILabel*)label;
 + (UIImage*)roundedCornerImage:(UIImage*)image drawBorder:(BOOL)drawBorder;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -682,7 +682,7 @@
     return thumbnailPath;
 }
 
-+ (NSString*)getDateFromItem:(id)item emptyString:(NSString*)empty {
++ (NSString*)getDateFromItem:(id)item dateStyle:(NSDateFormatterStyle)dateStyle emptyString:(NSString*)empty {
     NSString *dateString = empty;
     if ([item length] > 0) {
         NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:LOCALIZED_STR(@"LocaleIdentifier")];
@@ -690,7 +690,7 @@
         [format setLocale:locale];
         [format setDateFormat:@"yyyy-MM-dd"];
         NSDate *date = [format dateFromString:item];
-        [format setDateFormat:LOCALIZED_STR(@"LongDateTimeFormat")];
+        [format setDateStyle:dateStyle];
         dateString = [format stringFromDate:date];
     }
     return dateString;

--- a/XBMC Remote/cs.lproj/Localizable.strings
+++ b/XBMC Remote/cs.lproj/Localizable.strings
@@ -150,8 +150,6 @@
 "Subtitles not available" = "Titulky nejsou dostupné";
 "Audiostream not available" = "Audio stream není dostupný";
 "Audiostreams not available" = "Audio streams není dostupný";
-"LongDateTimeFormat" = "dd.MM.yyyy";
-"ShortDateTimeFormat" = "d.MM.yyyy";
 "LocaleIdentifier" = "cs_CS";
 "Yes" = "Ano";
 "No" = "Ne";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Cancel" = "Abbrechen";
 "Resume from %@" = "Fortsetzen von %@";
 "Resume from" = "Fortsetzen von";
-"First aired on %@" = "Erstausstrahlung auf %@";
+"First aired on %@" = "Erstausstrahlung am %@";
 "Episodes: %@" = "Episoden: %@";
 "1 result" = "1 Ergebnis";
 "%d results" = "%d Ergebnisse";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -157,8 +157,6 @@
 "Subtitles not available" = "Keine Untertitel verfügbar";
 "Audiostream not available" = "Audiospur nicht verfügbar";
 "Audiostreams not available" = "Keine Audiospuren verfügbar";
-"LongDateTimeFormat" = "d. MMMM YYYY";
-"ShortDateTimeFormat" = "dd.MM.YYYY";
 "LocaleIdentifier" = "de_DE";
 "Yes" = "Ja";
 "No" = "Nein";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -172,8 +172,6 @@
 "Audiostream not available" = "Audio stream not available";
 "Audiostreams not available" = "Audio streams not available";
 
-"LongDateTimeFormat" = "MMMM d, yyyy";
-"ShortDateTimeFormat" = "yyyy-MM-dd";
 "LocaleIdentifier" = "en_US";
 
 "Yes" = "Yes";

--- a/XBMC Remote/es.lproj/Localizable.strings
+++ b/XBMC Remote/es.lproj/Localizable.strings
@@ -150,8 +150,6 @@
 "Subtitles not available" = "Subtítulos no disponibles";
 "Audiostream not available" = "Flujo de Audio no disponible";
 "Audiostreams not available" = "Flujos de Audio no disponibles";
-"LongDateTimeFormat" = "dd MM yyyy";
-"ShortDateTimeFormat" = "dd-MM-yy";
 "LocaleIdentifier" = "es_ES";
 "Yes" = "Si";
 "No" = "No";

--- a/XBMC Remote/fr.lproj/Localizable.strings
+++ b/XBMC Remote/fr.lproj/Localizable.strings
@@ -149,8 +149,6 @@
 "Subtitles not available" = "Sous-titres non disponibles";
 "Audiostream not available" = "Audiostreams non disponibles";
 "Audiostreams not available" = "Audiostreams non disponibles";
-"LongDateTimeFormat" = "dd MMMM, YYYY";
-"ShortDateTimeFormat" = "yyyy-MM-dd";
 "LocaleIdentifier" = "fr_FR";
 "Yes" = "Oui";
 "No" = "Non";

--- a/XBMC Remote/it.lproj/Localizable.strings
+++ b/XBMC Remote/it.lproj/Localizable.strings
@@ -150,8 +150,6 @@
 "Subtitles not available" = "Sottotitoli non disponibili";
 "Audiostream not available" = "Traccia audio non disponibile";
 "Audiostreams not available" = "Tracce audio non disponibili";
-"LongDateTimeFormat" = "dd MMMM yyyy";
-"ShortDateTimeFormat" = "dd-MMM-yyyy";
 "LocaleIdentifier" = "it_IT";
 "Yes" = "Si";
 "No" = "No";

--- a/XBMC Remote/nl.lproj/Localizable.strings
+++ b/XBMC Remote/nl.lproj/Localizable.strings
@@ -152,8 +152,6 @@
 "Subtitles not available" = "Ondertitels niet beschikbaar";
 "Audiostream not available" = "Audiospoor niet beschikbaar";
 "Audiostreams not available" = "Geen audiosporen beschikbaar";
-"LongDateTimeFormat" = "d. MMMM YYYY";
-"ShortDateTimeFormat" = "dd.MM.YYYY";
 "LocaleIdentifier" = "nl_NL";
 "Yes" = "Ja";
 "No" = "Nee";

--- a/XBMC Remote/pl.lproj/Localizable.strings
+++ b/XBMC Remote/pl.lproj/Localizable.strings
@@ -150,8 +150,6 @@
 "Subtitles not available" = "Napisy niedostępne";
 "Audiostream not available" = "Strumień audio niedostępna";
 "Audiostreams not available" = "Strumienie audio niedostępne";
-"LongDateTimeFormat" = "dd.MM.yyyy";
-"ShortDateTimeFormat" = "d.MM.yyyy";
 "LocaleIdentifier" = "pl_PL";
 "Yes" = "Tak";
 "No" = "Nie";

--- a/XBMC Remote/pt-PT.lproj/Localizable.strings
+++ b/XBMC Remote/pt-PT.lproj/Localizable.strings
@@ -152,8 +152,6 @@
 "Subtitles not available" = "Legendas não disponíveis";
 "Audiostream not available" = "Pista de áudio não disponível";
 "Audiostreams not available" = "Pistas de áudio não disponíveis";
-"LongDateTimeFormat" = "d' de 'MMMM' de 'yyyy";
-"ShortDateTimeFormat" = "yyyy-MM-dd";
 "LocaleIdentifier" = "pt_PT";
 "Yes" = "Sim";
 "No" = "Não";

--- a/XBMC Remote/sv.lproj/Localizable.strings
+++ b/XBMC Remote/sv.lproj/Localizable.strings
@@ -153,8 +153,6 @@
 "Subtitles not available" = "Undertexter inte tillgängliga";
 "Audiostream not available" = "Ljudström inte tillgänglig";
 "Audiostreams not available" = "Ljudströmmar inte tillgängliga";
-"LongDateTimeFormat" = "yyyy-MM-dd";
-"ShortDateTimeFormat" = "yyyy-MM-dd";
 "LocaleIdentifier" = "sv_SE";
 "Yes" = "Ja";
 "No" = "Nej";

--- a/XBMC Remote/tr.lproj/Localizable.strings
+++ b/XBMC Remote/tr.lproj/Localizable.strings
@@ -149,8 +149,6 @@
 "Subtitles not available" = "Altyazı yok";
 "Audiostream not available" = "Ses akışı yok";
 "Audiostreams not available" = "Ses akışları yok";
-"LongDateTimeFormat" = "dd MMMM, YYYY";
-"ShortDateTimeFormat" = "yyyy-MM-dd";
 "LocaleIdentifier" = "tr_TR";
 "Yes" = "Evet";
 "No" = "Hayır";

--- a/XBMC Remote/zh-Hans.lproj/Localizable.strings
+++ b/XBMC Remote/zh-Hans.lproj/Localizable.strings
@@ -150,8 +150,6 @@
 "Subtitles not available" = "字幕不可用";
 "Audiostream not available" = "音频流不可用";
 "Audiostreams not available" = "音频流不可用";
-"LongDateTimeFormat" = "YYYY年M月d日";
-"ShortDateTimeFormat" = "年年年年-月月-日日";
 "LocaleIdentifier" = "zh_CN";
 "Yes" = "是";
 "No" = "否";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Should be merged after #440.

This PR avoids code duplication via tailoring `getDateFromItem` and changes date formatting to make use of `NSDateFormatterStyle` instead of localized strings. This solves the `setDateStyle`-part of https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/442.

In Addition, the German translation of "First aired on" is corrected. It details a _date_, and not a _channel_.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct German translation for "First aired on"
Maintenance: Simplify date formatting