### PR TITLE
Maintenance: Rework handling of language and locale

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -412,8 +412,7 @@
             NSDateFormatter *dateFormatter = [NSDateFormatter new];
             [dateFormatter setDateStyle:NSDateFormatterLongStyle];
             [dateFormatter setTimeStyle:NSDateFormatterMediumStyle];
-            NSLocale *userLocale = [[NSLocale alloc] initWithLocaleIdentifier:LOCALIZED_STR(@"LocaleIdentifier")];
-            [dateFormatter setLocale:userLocale];
+            [dateFormatter setLocale:[NSLocale currentLocale]];
             NSString *dateString = [dateFormatter stringFromDate:[attributes fileModificationDate]];
             NSString *title = [NSString stringWithFormat:@"%@: %@", LOCALIZED_STR(@"Last sync"), dateString];
             [dataList.pullToRefreshView setSubtitle:title forState: SVPullToRefreshStateStopped];
@@ -1798,9 +1797,8 @@ int originYear = 0;
         NSString *sectionName = self.sectionArray[section];
         if (channelGuideView) {
             NSString *dateString = @"";
-            NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:LOCALIZED_STR(@"LocaleIdentifier")];
             NSDateFormatter *format = [NSDateFormatter new];
-            [format setLocale:locale];
+            [format setLocale:[NSLocale currentLocale]];
             [format setDateFormat:@"yyyy-MM-dd"];
             NSDate *date = [format dateFromString:sectionName];
             [format setDateStyle:NSDateFormatterLongStyle];
@@ -1967,9 +1965,8 @@ int originYear = 0;
                 NSMutableArray *channelGuideTableIndexTitles = [NSMutableArray new];
                 for (NSString *label in self.sectionArray) {
                         NSString *dateString = label;
-                        NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:LOCALIZED_STR(@"LocaleIdentifier")];
                         NSDateFormatter *format = [NSDateFormatter new];
-                        [format setLocale:locale];
+                        [format setLocale:[NSLocale currentLocale]];
                         [format setDateFormat:@"yyyy-MM-dd"];
                         NSDate *date = [format dateFromString:label];
                         [format setDateFormat:@"EEE"];

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -542,7 +542,7 @@
                                      for (int i = 0; i < numSubs; i++) {
                                          NSString *language = @"?";
                                          if (((NSNull*)subtitles[i][@"language"] != [NSNull null])) {
-                                             NSLocale *currentLocale = [[NSLocale alloc] initWithLocaleIdentifier:LOCALIZED_STR(@"LocaleIdentifier")];
+                                             NSLocale *currentLocale = [NSLocale currentLocale];
                                              NSString *canonicalID = [NSLocale canonicalLanguageIdentifierFromString:subtitles[i][@"language"]];
                                              NSString *displayNameString = [currentLocale displayNameForKey:NSLocaleIdentifier value:canonicalID];
                                              if ([displayNameString length] > 0) {
@@ -609,7 +609,7 @@
                                      for (int i = 0; i < numAudio; i++) {
                                          NSString *language = @"?";
                                          if (((NSNull*)audiostreams[i][@"language"] != [NSNull null])) {
-                                             NSLocale *currentLocale = [[NSLocale alloc] initWithLocaleIdentifier:LOCALIZED_STR(@"LocaleIdentifier")];
+                                             NSLocale *currentLocale = [NSLocale currentLocale];
                                              NSString *canonicalID = [NSLocale canonicalLanguageIdentifierFromString:audiostreams[i][@"language"]];
                                              NSString *displayNameString = [currentLocale displayNameForKey:NSLocaleIdentifier value:canonicalID];
                                              if ([displayNameString length] > 0) {

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -9,50 +9,6 @@
 			<string>General</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
-			<key>FooterText</key>
-			<string>Language changes needs app restart</string>
-		</dict>
-		<dict>
-			<key>DefaultValue</key>
-			<string></string>
-			<key>Key</key>
-			<string>lang_preference</string>
-			<key>Title</key>
-			<string>Language</string>
-			<key>Type</key>
-			<string>PSMultiValueSpecifier</string>
-			<key>Titles</key>
-			<array>
-				<string>Automatic</string>
-				<string>English</string>
-				<string>Français</string>
-				<string>Italiano</string>
-				<string>Deutsch</string>
-				<string>简体中文</string>
-				<string>Polski</string>
-				<string>Português</string>
-				<string>Español</string>
-				<string>Czech</string>
-				<string>Nederlands</string>
-				<string>Türkçe</string>
-				<string>Svenska</string>
-			</array>
-			<key>Values</key>
-			<array>
-				<string></string>
-				<string>en</string>
-				<string>fr</string>
-				<string>it</string>
-				<string>de</string>
-				<string>zh-Hans</string>
-				<string>pl</string>
-				<string>pt-PT</string>
-				<string>es</string>
-				<string>cs</string>
-				<string>nl</string>
-				<string>tr</string>
-				<string>sv</string>
-			</array>
 		</dict>
 		<dict>
 			<key>DefaultValue</key>

--- a/XBMC Remote/Settings.bundle/cs.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/cs.lproj/Root.strings
@@ -1,9 +1,7 @@
 /* A single strings file, whose title is specified in your preferences schema. The strings files provide the localized content to display to the user for each of your preferences. */
 
 "General" = "General";
-"Language" = "Jazyk";
 "Automatic" = "Automatické";
-"Language changes needs app restart" = "Language changes needs app restart";
 "Show connection notice" = "Show connection notice";
 "Direct Play mode" = "Direct Play mode";
 "Ken Burns effect" = "Ken Burns effect";

--- a/XBMC Remote/Settings.bundle/de.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/de.lproj/Root.strings
@@ -1,9 +1,7 @@
 /* A single strings file, whose title is specified in your preferences schema. The strings files provide the localized content to display to the user for each of your preferences. */
 
 "General" = "Allgemein";
-"Language" = "Sprache";
 "Automatic" = "Automatisch";
-"Language changes needs app restart" = "Sprachänderungen erfordern einen App-Neustart";
 "Show connection notice" = "Zeige Verbindungshinweis";
 "Direct Play mode" = "\"Sofort abspielen\"-Modus";
 "Ken Burns effect" = "Ken Burns Effekt";

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -1,9 +1,7 @@
 /* A single strings file, whose title is specified in your preferences schema. The strings files provide the localized content to display to the user for each of your preferences. */
 
 "General" = "General";
-"Language" = "Language";
 "Automatic" = "Automatic";
-"Language changes needs app restart" = "Language changes needs app restart";
 "Show connection notice" = "Show connection notice";
 "Direct Play mode" = "Direct Play mode";
 "Ken Burns effect" = "Ken Burns effect";

--- a/XBMC Remote/Settings.bundle/es.lprj/Root.strings
+++ b/XBMC Remote/Settings.bundle/es.lprj/Root.strings
@@ -1,9 +1,7 @@
 /* A single strings file, whose title is specified in your preferences schema. The strings files provide the localized content to display to the user for each of your preferences. */
 
 "General" = "General";
-"Language" = "Idioma";
 "Automatic" = "Automático";
-"Language changes needs app restart" = "El cambio de idioma necesita reinicio de la app";
 "Show connection notice" = "Show connection notice";
 "Direct Play mode" = "Modo Reproducción Directa";
 "Ken Burns effect" = "Efecto Ken Burns";

--- a/XBMC Remote/Settings.bundle/fr.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/fr.lproj/Root.strings
@@ -1,9 +1,7 @@
 /* A single strings file, whose title is specified in your preferences schema. The strings files provide the localized content to display to the user for each of your preferences. */
 
 "General" = "General";
-"Language" = "Langue";
 "Automatic" = "Automatique";
-"Language changes needs app restart" = "Language changes needs app restart";
 "Show connection notice" = "Show connection notice";
 "Direct Play mode" = "Direct Play mode";
 "Ken Burns effect" = "Ken Burns effect";

--- a/XBMC Remote/Settings.bundle/it.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/it.lproj/Root.strings
@@ -1,9 +1,7 @@
 /* A single strings file, whose title is specified in your preferences schema. The strings files provide the localized content to display to the user for each of your preferences. */
 
 "General" = "Generali";
-"Language" = "Lingua";
 "Automatic" = "Automatica";
-"Language changes needs app restart" = "Il cambio della lingua richiede il riavvio dell'app";
 "Show connection notice" = "Mostra avviso collegamento";
 "Direct Play mode" = "Modalità Direct Play";
 "Ken Burns effect" = "Effetto Ken Burns";

--- a/XBMC Remote/Settings.bundle/nl.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/nl.lproj/Root.strings
@@ -1,9 +1,7 @@
 /* A single strings file, whose title is specified in your preferences schema. The strings files provide the localized content to display to the user for each of your preferences. */
 
 "General" = "Algemeen";
-"Language" = "Taal";
 "Automatic" = "Automatisch";
-"Language changes needs app restart" = "Herstart de app als je de taalinstellingen verandert";
 "Show connection notice" = "Toon verbindingsbericht";
 "Direct Play mode" = "Direct Play modus";
 "Ken Burns effect" = "Ken Burns effect";

--- a/XBMC Remote/Settings.bundle/pl.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/pl.lproj/Root.strings
@@ -1,9 +1,7 @@
 /* A single strings file, whose title is specified in your preferences schema. The strings files provide the localized content to display to the user for each of your preferences. */
 
 "General" = "Ogólne";
-"Language" = "Język";
 "Automatic" = "Automatycznie";
-"Language changes needs app restart" = "Zmiana języka wymaga ponownego uruchomienia aplikacji";
 "Show connection notice" = "Pokaż powiadomienie o połączeniu";
 "Direct Play mode" = "Tryb Direct Play";
 "Ken Burns effect" = "Efekt Ken Burns";

--- a/XBMC Remote/Settings.bundle/pt-PT.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/pt-PT.lproj/Root.strings
@@ -2,6 +2,5 @@
 "Light" = "Leve";
 "Dark" = "Escuro";
 "Automatic" = "Automático";
-"Language" = "Idioma";
 "General" = "Geral";
 "Remote Control" = "Controlo remoto";

--- a/XBMC Remote/Settings.bundle/sv.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/sv.lproj/Root.strings
@@ -2,9 +2,7 @@
 /* Swedish translation by Daniel Nylander 2017-01-15 */
 
 "General" = "Allmänt";
-"Language" = "Språk";
 "Automatic" = "Automatiskt";
-"Language changes needs app restart" = "Ändring av språk kräver omstart";
 "Show connection notice" = "Show connection notice";
 "Direct Play mode" = "Direct Play-läge";
 "Ken Burns effect" = "Ken Burns-effekt";

--- a/XBMC Remote/Settings.bundle/tr.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/tr.lproj/Root.strings
@@ -1,9 +1,7 @@
 /* A single strings file, whose title is specified in your preferences schema. The strings files provide the localized content to display to the user for each of your preferences. */
 
 "General" = "Genel";
-"Language" = "Dil";
 "Automatic" = "Otomatik";
-"Language changes needs app restart" = "Dil değişimi yeniden başlatma gerekir";
 "Show connection notice" = "Show connection notice";
 "Direct Play mode" = "Direct Play modu";
 "Ken Burns effect" = "Ken Burns efekti";

--- a/XBMC Remote/Settings.bundle/zh-Hans.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/zh-Hans.lproj/Root.strings
@@ -1,9 +1,7 @@
 /* A single strings file, whose title is specified in your preferences schema. The strings files provide the localized content to display to the user for each of your preferences. */
 
 "General" = "常规";
-"Language" = "语言";
 "Automatic" = "自动";
-"Language changes needs app restart" = "变更语言需要重启应用";
 "Show connection notice" = "显示连接通知";
 "Direct Play mode" = "直接播放模式";
 "Ken Burns effect" = "Ken Burns特效";

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -685,9 +685,8 @@
 + (NSString*)getDateFromItem:(id)item dateStyle:(NSDateFormatterStyle)dateStyle emptyString:(NSString*)empty {
     NSString *dateString = empty;
     if ([item length] > 0) {
-        NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:LOCALIZED_STR(@"LocaleIdentifier")];
         NSDateFormatter *format = [NSDateFormatter new];
-        [format setLocale:locale];
+        [format setLocale:[NSLocale currentLocale]];
         [format setDateFormat:@"yyyy-MM-dd"];
         NSDate *date = [format dateFromString:item];
         [format setDateStyle:dateStyle];

--- a/XBMC Remote/cs.lproj/Localizable.strings
+++ b/XBMC Remote/cs.lproj/Localizable.strings
@@ -150,7 +150,6 @@
 "Subtitles not available" = "Titulky nejsou dostupné";
 "Audiostream not available" = "Audio stream není dostupný";
 "Audiostreams not available" = "Audio streams není dostupný";
-"LocaleIdentifier" = "cs_CS";
 "Yes" = "Ano";
 "No" = "Ne";
 "Authentication Failed" = "Ověření se nezdařilo";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -157,7 +157,6 @@
 "Subtitles not available" = "Keine Untertitel verfügbar";
 "Audiostream not available" = "Audiospur nicht verfügbar";
 "Audiostreams not available" = "Keine Audiospuren verfügbar";
-"LocaleIdentifier" = "de_DE";
 "Yes" = "Ja";
 "No" = "Nein";
 "Authentication Failed" = "Authentifizierung fehlgeschlagen";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -172,8 +172,6 @@
 "Audiostream not available" = "Audio stream not available";
 "Audiostreams not available" = "Audio streams not available";
 
-"LocaleIdentifier" = "en_US";
-
 "Yes" = "Yes";
 "No" = "No";
 "Authentication Failed" = "Authentication Failed";

--- a/XBMC Remote/es.lproj/Localizable.strings
+++ b/XBMC Remote/es.lproj/Localizable.strings
@@ -150,7 +150,6 @@
 "Subtitles not available" = "Subtítulos no disponibles";
 "Audiostream not available" = "Flujo de Audio no disponible";
 "Audiostreams not available" = "Flujos de Audio no disponibles";
-"LocaleIdentifier" = "es_ES";
 "Yes" = "Si";
 "No" = "No";
 "Authentication Failed" = "Fallo de Autentificación";

--- a/XBMC Remote/fr.lproj/Localizable.strings
+++ b/XBMC Remote/fr.lproj/Localizable.strings
@@ -149,7 +149,6 @@
 "Subtitles not available" = "Sous-titres non disponibles";
 "Audiostream not available" = "Audiostreams non disponibles";
 "Audiostreams not available" = "Audiostreams non disponibles";
-"LocaleIdentifier" = "fr_FR";
 "Yes" = "Oui";
 "No" = "Non";
 "Authentication Failed" = "Authentication Failed";

--- a/XBMC Remote/it.lproj/Localizable.strings
+++ b/XBMC Remote/it.lproj/Localizable.strings
@@ -150,7 +150,6 @@
 "Subtitles not available" = "Sottotitoli non disponibili";
 "Audiostream not available" = "Traccia audio non disponibile";
 "Audiostreams not available" = "Tracce audio non disponibili";
-"LocaleIdentifier" = "it_IT";
 "Yes" = "Si";
 "No" = "No";
 "Authentication Failed" = "Autenticazione Fallita";

--- a/XBMC Remote/main.m
+++ b/XBMC Remote/main.m
@@ -12,13 +12,6 @@
 
 int main(int argc, char *argv[]) {
     @autoreleasepool {
-        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-        if ([[userDefaults objectForKey:@"lang_preference"] length]) {
-            [userDefaults setObject:[NSArray arrayWithObjects:[userDefaults objectForKey:@"lang_preference"], nil] forKey:@"AppleLanguages"];
-        }
-        else {
-            [userDefaults removeObjectForKey:@"AppleLanguages"];
-        }
         return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
     }
 }

--- a/XBMC Remote/nl.lproj/Localizable.strings
+++ b/XBMC Remote/nl.lproj/Localizable.strings
@@ -152,7 +152,6 @@
 "Subtitles not available" = "Ondertitels niet beschikbaar";
 "Audiostream not available" = "Audiospoor niet beschikbaar";
 "Audiostreams not available" = "Geen audiosporen beschikbaar";
-"LocaleIdentifier" = "nl_NL";
 "Yes" = "Ja";
 "No" = "Nee";
 "Authentication Failed" = "Authenticatie mislukt";

--- a/XBMC Remote/pl.lproj/Localizable.strings
+++ b/XBMC Remote/pl.lproj/Localizable.strings
@@ -150,7 +150,6 @@
 "Subtitles not available" = "Napisy niedostępne";
 "Audiostream not available" = "Strumień audio niedostępna";
 "Audiostreams not available" = "Strumienie audio niedostępne";
-"LocaleIdentifier" = "pl_PL";
 "Yes" = "Tak";
 "No" = "Nie";
 "Authentication Failed" = "Identyfikacja nie powiodła się";

--- a/XBMC Remote/pt-PT.lproj/Localizable.strings
+++ b/XBMC Remote/pt-PT.lproj/Localizable.strings
@@ -152,7 +152,6 @@
 "Subtitles not available" = "Legendas não disponíveis";
 "Audiostream not available" = "Pista de áudio não disponível";
 "Audiostreams not available" = "Pistas de áudio não disponíveis";
-"LocaleIdentifier" = "pt_PT";
 "Yes" = "Sim";
 "No" = "Não";
 "Authentication Failed" = "Falha ao autenticar";

--- a/XBMC Remote/sv.lproj/Localizable.strings
+++ b/XBMC Remote/sv.lproj/Localizable.strings
@@ -153,7 +153,6 @@
 "Subtitles not available" = "Undertexter inte tillgängliga";
 "Audiostream not available" = "Ljudström inte tillgänglig";
 "Audiostreams not available" = "Ljudströmmar inte tillgängliga";
-"LocaleIdentifier" = "sv_SE";
 "Yes" = "Ja";
 "No" = "Nej";
 "Authentication Failed" = "Autentisering misslyckades";

--- a/XBMC Remote/tr.lproj/Localizable.strings
+++ b/XBMC Remote/tr.lproj/Localizable.strings
@@ -149,7 +149,6 @@
 "Subtitles not available" = "Altyazı yok";
 "Audiostream not available" = "Ses akışı yok";
 "Audiostreams not available" = "Ses akışları yok";
-"LocaleIdentifier" = "tr_TR";
 "Yes" = "Evet";
 "No" = "Hayır";
 "Authentication Failed" = "Doğrulama Başarısız";

--- a/XBMC Remote/zh-Hans.lproj/Localizable.strings
+++ b/XBMC Remote/zh-Hans.lproj/Localizable.strings
@@ -150,7 +150,6 @@
 "Subtitles not available" = "字幕不可用";
 "Audiostream not available" = "音频流不可用";
 "Audiostreams not available" = "音频流不可用";
-"LocaleIdentifier" = "zh_CN";
 "Yes" = "是";
 "No" = "否";
 "Authentication Failed" = "验证失败";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/442.

Current implementation for language selection ignores the iOS preferred language, and only the Remote App language is used (see screenshots below). This App-specific implementation lets the selected language define the locale via the localized string `LocaleIdentifier`.

This PR uses the preferred language as provided by iOS and reads `currentLocale` from the system settings. The language can still be selected for the App specifically by the user (see screenshots below), but `currentLocale` is used. All settings and translations related to the former language selection are removed.
 

[![](https://camo.githubusercontent.com/af017c1f93d94fa9be59b115a0b3297b04a22c2298d35db33068528672d7701c/68747470733a2f2f61626c6f61642e64652f696d672f62696c6473636869726d666f746f323032312d313138676a6a772e706e67)](https://abload.de/image.php?img=bildschirmfoto2021-118gjjw.png)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Custom language selector was removed from app settings: use the one provided by iOS or configure system-wide preferred languages appropriately.
Maintenance: Follow iOS preferred languages