### PR TITLE
Use correct array index when reading epg

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4839,7 +4839,7 @@ NSIndexPath *selected;
             [self.richResults removeAllObjects];
         }
         NSDictionary *epgparams = [NSDictionary dictionaryWithObjectsAndKeys:
-                                   [self.detailItem mainParameters][0][0][@"channelid"], @"channelid",
+                                   [self.detailItem mainParameters][choosedTab][0][@"channelid"], @"channelid",
                                    retrievedEPG, @"epgArray",
                                    nil];
         [NSThread detachNewThreadSelector:@selector(backgroundSaveEPGToDisk:) toTarget:self withObject:epgparams];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/453.

The code has a hard coded access pattern instead of using the correct array index. This results in a crash when trying to access a non-existing array index after we moved the channel groups to tab index 1 with https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/386.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix crash when accessing channel guide from channel group list
