### PR TITLE
Bugfix: Pan gestures and gesture view conflicted when remote screen was opened via navigation bar button

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -521,8 +521,22 @@ static inline BOOL IsEmpty(id obj) {
                                              selector: @selector(tcpJSONRPCConnectionError:)
                                                  name: @"tcpJSONRPCConnectionError"
                                                object: nil];
-    
-    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(disablePopGestureRecognizer:)
+                                                 name: @"ECSlidingViewUnderRightWillAppear"
+                                               object: nil];
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(enablePopGestureRecognizer:)
+                                                 name: @"ECSlidingViewTopDidReset"
+                                               object: nil];
+}
+
+- (void)enablePopGestureRecognizer:(id)sender {
+    self.navigationController.interactivePopGestureRecognizer.enabled = YES;
+}
+
+- (void)disablePopGestureRecognizer:(id)sender {
+    self.navigationController.interactivePopGestureRecognizer.enabled = NO;
 }
 
 - (void)tcpJSONRPCConnectionError:(NSNotification*)note {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2630,11 +2630,11 @@ int currentItemID;
                                                object: nil];
     
     [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(disableInteractivePopGestureRecognizer:)
+                                             selector: @selector(disablePopGestureRecognizer:)
                                                  name: @"ECSlidingViewUnderRightWillAppear"
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(disableInteractivePopGestureRecognizer:)
+                                             selector: @selector(enablePopGestureRecognizer:)
                                                  name: @"ECSlidingViewTopDidReset"
                                                object: nil];
     
@@ -2653,13 +2653,12 @@ int currentItemID;
     [self viewWillDisappear:YES];
 }
 
-- (void)disableInteractivePopGestureRecognizer:(id)sender {
-    if ([[sender name] isEqualToString:@"ECSlidingViewUnderRightWillAppear"]) {
-        self.navigationController.interactivePopGestureRecognizer.enabled = NO;
-    }
-    else {
-        self.navigationController.interactivePopGestureRecognizer.enabled = YES;
-    }
+- (void)enablePopGestureRecognizer:(id)sender {
+    self.navigationController.interactivePopGestureRecognizer.enabled = YES;
+}
+
+- (void)disablePopGestureRecognizer:(id)sender {
+    self.navigationController.interactivePopGestureRecognizer.enabled = NO;
 }
 
 - (void)revealMenu:(id)sender {

--- a/XBMC Remote/RemoteController.h
+++ b/XBMC Remote/RemoteController.h
@@ -10,7 +10,7 @@
 #import "DSJSONRPC.h"
 //#import "RightMenuViewController.h"
 
-@interface RemoteController : UIViewController {
+@interface RemoteController : UIViewController <UIGestureRecognizerDelegate> {
     IBOutlet UIView *remoteControlView;
     IBOutlet UILabel *subsInfoLabel;
     NSTimer *fadeoutTimer;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1210,6 +1210,22 @@ NSInteger buttonAction;
                                              selector: @selector(hideKeyboard:)
                                                  name: @"ECSlidingViewUnderLeftWillAppear"
                                                object: nil];
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(disablePopGestureRecognizer:)
+                                                 name: @"ECSlidingViewUnderRightWillAppear"
+                                               object: nil];
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(enablePopGestureRecognizer:)
+                                                 name: @"ECSlidingViewTopDidReset"
+                                               object: nil];
+}
+
+- (void)enablePopGestureRecognizer:(id)sender {
+    self.navigationController.interactivePopGestureRecognizer.enabled = YES;
+}
+
+- (void)disablePopGestureRecognizer:(id)sender {
+    self.navigationController.interactivePopGestureRecognizer.enabled = NO;
 }
 
 - (void)revealMenu:(id)sender {

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1064,6 +1064,13 @@ NSInteger buttonAction;
     [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputFinished" object:nil userInfo:nil];
 }
 
+#pragma mark - GestureRecognizer delegate
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer*)gestureRecognizer shouldReceiveTouch:(UITouch*)touch {
+    BOOL isGestureViewActive = (gestureZoneView.alpha > 0);
+    return !isGestureViewActive;
+}
+
 # pragma mark - Gestures
 
 - (IBAction)handleButtonLongPress:(UILongPressGestureRecognizer*)gestureRecognizer {
@@ -1175,6 +1182,7 @@ NSInteger buttonAction;
             self.slidingViewController.underRightViewController = nil;
             self.slidingViewController.anchorLeftPeekAmount   = 0;
             self.slidingViewController.anchorLeftRevealAmount = 0;
+            self.slidingViewController.panGesture.delegate = self;
         }
         RightMenuViewController *rightMenuViewController = [[RightMenuViewController alloc] initWithNibName:@"RightMenuViewController" bundle:nil];
         rightMenuViewController.rightMenuItems = [AppDelegate instance].remoteControlMenuItems;
@@ -1246,6 +1254,7 @@ NSInteger buttonAction;
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     [self resetRemote];
+    self.slidingViewController.panGesture.delegate = nil;
 }
 
 - (void)turnTorchOn:(id)sender {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/456.

For TF build 1.8.2-b4  it was reported that the remote screen behaved strange when the remote screen was entered via the newly added navigation bar remote-button. In this case the pan gesture was not handled properly. This PR fixes this and follows the behaviour of the `NowPlaying` screen.

First issue was caused by a missing reaction to the signals `"ECSlidingViewUnderRightWillAppear"` (attempting to show the so-called underRight menu, in the remote's case this is the settings menu with the custom buttons) and `"ECSlidingViewTopDidReset"` (when the underRight menu was closed again) from `ECSlidingViewController`. This fixes a problem where you could see other screens scrolled in a small frame on the left side of the screen.

Second issue was missing blockage of pan gesture when the remote's gesture view as active _and_ the screen was entered from another menu. To fix this a`UIGestureRecognizerDelegate`-method needed to be implemented.

With above changes there is still a debatable behaviour left: Pan left gesture (moving back to higher/last menu) still is not blocked when gesture view is active and the remote screen was entered via the navigation bar button. This seems to be connected to the `ECSlidingViewController` implementation.

Edit: Same problem was reported for another use case related to the `HostManagementViewController`. This was now fixed in this PR as well.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Pan gestures and gesture view conflicted when remote screen was via navigation bar button