### PR TITLE
Improvement: Ignore year <= 0 and show empty string instead

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -635,7 +635,12 @@
         year = @"";
     }
     else if ([value isKindOfClass:[NSNumber class]]) {
-        year = [(NSNumber*)value stringValue];
+        if ([value integerValue] > 0) {
+            year = [value stringValue];
+        }
+        else {
+            year = @"";
+        }
     }
     else {
         if ([key isEqualToString:@"blank"]) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Suggestion from [forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3069432#pid3069432): Do not show years <= 0.

<a href="https://abload.de/image.php?img=bildschirmfoto2021-11juj93.png"><img src="https://abload.de/img/bildschirmfoto2021-11juj93.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Ignore year <= 0 and show empty string instead