### PR TITLE
Maintenance: Refactor several helper functions

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4235,7 +4235,7 @@ NSIndexPath *selected;
                  NSString *label = [NSString stringWithFormat:@"%@", itemExtraDict[mainFields[@"row1"]]];
                  NSString *genre = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row2"]];
                  
-                 NSString *year = [Utilities getYearFromDictionary:itemExtraDict key:mainFields[@"row3"]];
+                 NSString *year = [Utilities getYearFromItem:itemExtraDict[mainFields[@"row3"]]];
                  
                  NSString *runtime = [Utilities getTimeFromItem:itemExtraDict[mainFields[@"row4"]] sec2min:secondsToMinute];
                  
@@ -4500,7 +4500,7 @@ NSIndexPath *selected;
                          
                          NSString *genre = [Utilities getStringFromDictionary:itemDict[i] key:mainFields[@"row2"]];
                          
-                         NSString *year = [Utilities getYearFromDictionary:itemDict[i] key:mainFields[@"row3"]];
+                         NSString *year = [Utilities getYearFromItem:itemDict[i][mainFields[@"row3"]]];
 
                          NSString *runtime = [Utilities getTimeFromItem:itemDict[i][mainFields[@"row4"]] sec2min:secondsToMinute];
                          

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2185,7 +2185,7 @@ int originYear = 0;
         runtimeyear.text = duration;
     }
     else {
-        runtimeyear.text = [Utilities getDateFromItem:item[@"year"] dateStyle:NSDateFormatterShortStyle emptyString:@""];
+        runtimeyear.text = [Utilities getDateFromItem:item[@"year"] dateStyle:NSDateFormatterShortStyle];
         if (runtimeyear.text.length == 0) {
             runtimeyear.text = item[@"year"];
         }
@@ -2308,8 +2308,8 @@ int originYear = 0;
             [genre sizeToFit];
         }
         else if ([item[@"family"] isEqualToString:@"musicvideoid"]) {
-            genre.text = [Utilities getStringFromDictionary:item key:@"genre" emptyString:@""];
-            runtime.text = [Utilities getStringFromDictionary:item key:@"artist" emptyString:@""];
+            genre.text = [Utilities getStringFromDictionary:item key:@"genre"];
+            runtime.text = [Utilities getStringFromDictionary:item key:@"artist"];
         }
         else {
             genre.hidden = NO;
@@ -2736,7 +2736,7 @@ int originYear = 0;
             releasedLabel.numberOfLines = 1;
             releasedLabel.adjustsFontSizeToFitWidth = YES;
             
-            NSString *aired = [Utilities getDateFromItem:item[@"year"] dateStyle:NSDateFormatterLongStyle emptyString:@""];
+            NSString *aired = [Utilities getDateFromItem:item[@"year"] dateStyle:NSDateFormatterLongStyle];
             
             releasedLabel.text = @"";
             if (aired != nil) {
@@ -4233,7 +4233,7 @@ NSIndexPath *selected;
                      secondsToMinute = 60;
                  }
                  NSString *label = [NSString stringWithFormat:@"%@", itemExtraDict[mainFields[@"row1"]]];
-                 NSString *genre = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row2"] emptyString:@""];
+                 NSString *genre = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row2"]];
                  
                  NSString *year = [Utilities getYearFromDictionary:itemExtraDict key:mainFields[@"row3"]];
                  
@@ -4498,7 +4498,7 @@ NSIndexPath *selected;
                      for (int i = 0; i < total; i++) {
                          NSString *label = [NSString stringWithFormat:@"%@", itemDict[i][mainFields[@"row1"]]];
                          
-                         NSString *genre = [Utilities getStringFromDictionary:itemDict[i] key:mainFields[@"row2"] emptyString:@""];
+                         NSString *genre = [Utilities getStringFromDictionary:itemDict[i] key:mainFields[@"row2"]];
                          
                          NSString *year = [Utilities getYearFromDictionary:itemDict[i] key:mainFields[@"row3"]];
 
@@ -4731,7 +4731,7 @@ NSIndexPath *selected;
 - (NSArray*)applySortTokens:(NSArray*)incomingRichArray sortmethod:(NSString*)sortmethod {
     NSMutableArray *copymutable = [[NSMutableArray alloc] initWithCapacity:incomingRichArray.count];
     for (NSMutableDictionary *mutabledict in incomingRichArray) {
-        NSString *string = [Utilities getStringFromDictionary:mutabledict key:sortmethod emptyString:@""];
+        NSString *string = [Utilities getStringFromDictionary:mutabledict key:sortmethod];
         NSDictionary *dict = @{@"sortby": [self ignoreSorttoken:string]};
         [mutabledict addEntriesFromDictionary:dict];
         [copymutable addObject:mutabledict];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2308,8 +2308,8 @@ int originYear = 0;
             [genre sizeToFit];
         }
         else if ([item[@"family"] isEqualToString:@"musicvideoid"]) {
-            genre.text = [Utilities getStringFromDictionary:item key:@"genre"];
-            runtime.text = [Utilities getStringFromDictionary:item key:@"artist"];
+            genre.text = [Utilities getStringFromItem:item[@"genre"]];
+            runtime.text = [Utilities getStringFromItem:item[@"artist"]];
         }
         else {
             genre.hidden = NO;
@@ -4233,7 +4233,7 @@ NSIndexPath *selected;
                      secondsToMinute = 60;
                  }
                  NSString *label = [NSString stringWithFormat:@"%@", itemExtraDict[mainFields[@"row1"]]];
-                 NSString *genre = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row2"]];
+                 NSString *genre = [Utilities getStringFromItem:itemExtraDict[mainFields[@"row2"]]];
                  
                  NSString *year = [Utilities getYearFromItem:itemExtraDict[mainFields[@"row3"]]];
                  
@@ -4498,7 +4498,7 @@ NSIndexPath *selected;
                      for (int i = 0; i < total; i++) {
                          NSString *label = [NSString stringWithFormat:@"%@", itemDict[i][mainFields[@"row1"]]];
                          
-                         NSString *genre = [Utilities getStringFromDictionary:itemDict[i] key:mainFields[@"row2"]];
+                         NSString *genre = [Utilities getStringFromItem:itemDict[i][mainFields[@"row2"]]];
                          
                          NSString *year = [Utilities getYearFromItem:itemDict[i][mainFields[@"row3"]]];
 
@@ -4731,7 +4731,7 @@ NSIndexPath *selected;
 - (NSArray*)applySortTokens:(NSArray*)incomingRichArray sortmethod:(NSString*)sortmethod {
     NSMutableArray *copymutable = [[NSMutableArray alloc] initWithCapacity:incomingRichArray.count];
     for (NSMutableDictionary *mutabledict in incomingRichArray) {
-        NSString *string = [Utilities getStringFromDictionary:mutabledict key:sortmethod];
+        NSString *string = [Utilities getStringFromItem:mutabledict[sortmethod]];
         NSDictionary *dict = @{@"sortby": [self ignoreSorttoken:string]};
         [mutabledict addEntriesFromDictionary:dict];
         [copymutable addObject:mutabledict];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4239,7 +4239,7 @@ NSIndexPath *selected;
                  
                  NSString *runtime = [Utilities getTimeFromItem:itemExtraDict[mainFields[@"row4"]] sec2min:secondsToMinute];
                  
-                 NSString *rating = [Utilities getRatingFromDictionary:itemExtraDict key:mainFields[@"row5"]];
+                 NSString *rating = [Utilities getRatingFromItem:itemExtraDict[mainFields[@"row5"]]];
                  
                  NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:itemExtraDict useBanner:NO useIcon:methodResult[@"recordingdetails"] != nil];
 
@@ -4504,7 +4504,7 @@ NSIndexPath *selected;
 
                          NSString *runtime = [Utilities getTimeFromItem:itemDict[i][mainFields[@"row4"]] sec2min:secondsToMinute];
                          
-                         NSString *rating = [Utilities getRatingFromDictionary:itemDict[i] key:mainFields[@"row5"]];
+                         NSString *rating = [Utilities getRatingFromItem:itemDict[i][mainFields[@"row5"]]];
                          
                          NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:itemDict[i] useBanner:tvshowsView useIcon:recordingListView];
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4237,7 +4237,7 @@ NSIndexPath *selected;
                  
                  NSString *year = [Utilities getYearFromDictionary:itemExtraDict key:mainFields[@"row3"]];
                  
-                 NSString *runtime = [Utilities getTimeFromDictionary:itemExtraDict key:mainFields[@"row4"] sec2min:secondsToMinute];
+                 NSString *runtime = [Utilities getTimeFromItem:itemExtraDict[mainFields[@"row4"]] sec2min:secondsToMinute];
                  
                  NSString *rating = [Utilities getRatingFromDictionary:itemExtraDict key:mainFields[@"row5"]];
                  
@@ -4502,7 +4502,7 @@ NSIndexPath *selected;
                          
                          NSString *year = [Utilities getYearFromDictionary:itemDict[i] key:mainFields[@"row3"]];
 
-                         NSString *runtime = [Utilities getTimeFromDictionary:itemDict[i] key:mainFields[@"row4"] sec2min:secondsToMinute];
+                         NSString *runtime = [Utilities getTimeFromItem:itemDict[i][mainFields[@"row4"]] sec2min:secondsToMinute];
                          
                          NSString *rating = [Utilities getRatingFromDictionary:itemDict[i] key:mainFields[@"row5"]];
                          

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -643,27 +643,27 @@ int currentItemID;
                                  [self performSelector:@selector(loadCodecView) withObject:nil afterDelay:.5];
                                  itemDescription.text = [nowPlayingInfo[@"description"] length] != 0 ? [NSString stringWithFormat:@"%@", nowPlayingInfo[@"description"]] : [nowPlayingInfo[@"plot"] length] != 0 ? [NSString stringWithFormat:@"%@", nowPlayingInfo[@"plot"]] : @"";
                                  [itemDescription scrollRangeToVisible:NSMakeRange(0, 0)];
-                                 NSString *album = [Utilities getStringFromDictionary:nowPlayingInfo key:@"album" emptyString:@""];
+                                 NSString *album = [Utilities getStringFromDictionary:nowPlayingInfo key:@"album"];
                                  if ([nowPlayingInfo[@"type"] isEqualToString:@"channel"]) {
                                      album = nowPlayingInfo[@"label"];
                                  }
-                                 NSString *title = [Utilities getStringFromDictionary:nowPlayingInfo key:@"title" emptyString:@""];
+                                 NSString *title = [Utilities getStringFromDictionary:nowPlayingInfo key:@"title"];
                                  storeLiveTVTitle = title;
-                                 NSString *artist = [Utilities getStringFromDictionary:nowPlayingInfo key:@"artist" emptyString:@""];
+                                 NSString *artist = [Utilities getStringFromDictionary:nowPlayingInfo key:@"artist"];
                                  if (album.length == 0 && ((NSNull*)nowPlayingInfo[@"showtitle"] != [NSNull null]) && nowPlayingInfo[@"season"] > 0) {
                                      album = [nowPlayingInfo[@"showtitle"] length] != 0 ? [NSString stringWithFormat:@"%@ - %@x%@", nowPlayingInfo[@"showtitle"], nowPlayingInfo[@"season"], nowPlayingInfo[@"episode"]] : @"";
                                  }
                                  if (title.length == 0) {
-                                     title = [Utilities getStringFromDictionary:nowPlayingInfo key:@"label" emptyString:@""];
+                                     title = [Utilities getStringFromDictionary:nowPlayingInfo key:@"label"];
                                  }
 
                                  if (artist.length == 0 && ((NSNull*)nowPlayingInfo[@"studio"] != [NSNull null])) {
-                                     artist = [Utilities getStringFromDictionary:nowPlayingInfo key:@"studio" emptyString:@""];
+                                     artist = [Utilities getStringFromDictionary:nowPlayingInfo key:@"studio"];
                                  }
                                  albumName.text = album;
                                  songName.text = title;
                                  artistName.text = artist;
-                                 NSString *type = [Utilities getStringFromDictionary:nowPlayingInfo key:@"type" emptyString:@"unknown"];
+                                 NSString *type = [Utilities getStringFromDictionary:nowPlayingInfo key:@"type"];
                                  currentType = type;
                                  [self setCoverSize:currentType];
                                  GlobalData *obj = [GlobalData getInstance];
@@ -1287,8 +1287,8 @@ int currentItemID;
                            NSString *label = [NSString stringWithFormat:@"%@", playlistItems[i][@"label"]];
                            NSString *title = [NSString stringWithFormat:@"%@", playlistItems[i][@"title"]];
                            
-                           NSString *artist = [Utilities getStringFromDictionary:playlistItems[i] key:@"artist" emptyString:@""];
-                           NSString *album = [Utilities getStringFromDictionary:playlistItems[i] key:@"album" emptyString:@""];
+                           NSString *artist = [Utilities getStringFromDictionary:playlistItems[i] key:@"artist"];
+                           NSString *album = [Utilities getStringFromDictionary:playlistItems[i] key:@"album"];
                            
                            NSString *runtime = [Utilities getTimeFromDictionary:playlistItems[i] key:@"runtime" sec2min:runtimeInMinute];
                            
@@ -1301,7 +1301,7 @@ int currentItemID;
                            NSString *artistid = [NSString stringWithFormat:@"%@", playlistItems[i][@"artistid"]];
                            NSString *albumid = [NSString stringWithFormat:@"%@", playlistItems[i][@"albumid"]];
                            NSString *movieid = [NSString stringWithFormat:@"%@", playlistItems[i][@"id"]];
-                           NSString *genre = [Utilities getStringFromDictionary:playlistItems[i] key:@"genre" emptyString:@""];
+                           NSString *genre = [Utilities getStringFromDictionary:playlistItems[i] key:@"genre"];
                            NSString *durationTime = @"";
                            if ([playlistItems[i][@"duration"] isKindOfClass:[NSNumber class]]) {
                                durationTime = [Utilities convertTimeFromSeconds:playlistItems[i][@"duration"]];
@@ -1485,11 +1485,11 @@ int currentItemID;
                  }
 
                  NSString *label = [NSString stringWithFormat:@"%@", itemExtraDict[mainFields[@"row1"]]];
-                 NSString *genre = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row2"] emptyString:@""];
+                 NSString *genre = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row2"]];
                  
                  NSString *year = [Utilities getYearFromDictionary:itemExtraDict key:mainFields[@"row3"]];
 
-                 NSString *runtime = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row4"] emptyString:@""];
+                 NSString *runtime = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row4"]];
                  
                  NSString *rating = [Utilities getRatingFromDictionary:itemExtraDict key:mainFields[@"row5"]];
                  

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1487,7 +1487,7 @@ int currentItemID;
                  NSString *label = [NSString stringWithFormat:@"%@", itemExtraDict[mainFields[@"row1"]]];
                  NSString *genre = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row2"]];
                  
-                 NSString *year = [Utilities getYearFromDictionary:itemExtraDict key:mainFields[@"row3"]];
+                 NSString *year = [Utilities getYearFromItem:itemExtraDict[mainFields[@"row3"]]];
 
                  NSString *runtime = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row4"]];
                  

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1290,7 +1290,7 @@ int currentItemID;
                            NSString *artist = [Utilities getStringFromDictionary:playlistItems[i] key:@"artist"];
                            NSString *album = [Utilities getStringFromDictionary:playlistItems[i] key:@"album"];
                            
-                           NSString *runtime = [Utilities getTimeFromDictionary:playlistItems[i] key:@"runtime" sec2min:runtimeInMinute];
+                           NSString *runtime = [Utilities getTimeFromItem:playlistItems[i][@"runtime"] sec2min:runtimeInMinute];
                            
                            NSString *showtitle = playlistItems[i][@"showtitle"];
                          

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -643,27 +643,27 @@ int currentItemID;
                                  [self performSelector:@selector(loadCodecView) withObject:nil afterDelay:.5];
                                  itemDescription.text = [nowPlayingInfo[@"description"] length] != 0 ? [NSString stringWithFormat:@"%@", nowPlayingInfo[@"description"]] : [nowPlayingInfo[@"plot"] length] != 0 ? [NSString stringWithFormat:@"%@", nowPlayingInfo[@"plot"]] : @"";
                                  [itemDescription scrollRangeToVisible:NSMakeRange(0, 0)];
-                                 NSString *album = [Utilities getStringFromDictionary:nowPlayingInfo key:@"album"];
+                                 NSString *album = [Utilities getStringFromItem:nowPlayingInfo[@"album"]];
                                  if ([nowPlayingInfo[@"type"] isEqualToString:@"channel"]) {
                                      album = nowPlayingInfo[@"label"];
                                  }
-                                 NSString *title = [Utilities getStringFromDictionary:nowPlayingInfo key:@"title"];
+                                 NSString *title = [Utilities getStringFromItem:nowPlayingInfo[@"title"]];
                                  storeLiveTVTitle = title;
-                                 NSString *artist = [Utilities getStringFromDictionary:nowPlayingInfo key:@"artist"];
+                                 NSString *artist = [Utilities getStringFromItem:nowPlayingInfo[@"artist"]];
                                  if (album.length == 0 && ((NSNull*)nowPlayingInfo[@"showtitle"] != [NSNull null]) && nowPlayingInfo[@"season"] > 0) {
                                      album = [nowPlayingInfo[@"showtitle"] length] != 0 ? [NSString stringWithFormat:@"%@ - %@x%@", nowPlayingInfo[@"showtitle"], nowPlayingInfo[@"season"], nowPlayingInfo[@"episode"]] : @"";
                                  }
                                  if (title.length == 0) {
-                                     title = [Utilities getStringFromDictionary:nowPlayingInfo key:@"label"];
+                                     title = [Utilities getStringFromItem:nowPlayingInfo[@"label"]];
                                  }
 
                                  if (artist.length == 0 && ((NSNull*)nowPlayingInfo[@"studio"] != [NSNull null])) {
-                                     artist = [Utilities getStringFromDictionary:nowPlayingInfo key:@"studio"];
+                                     artist = [Utilities getStringFromItem:nowPlayingInfo[@"studio"]];
                                  }
                                  albumName.text = album;
                                  songName.text = title;
                                  artistName.text = artist;
-                                 NSString *type = [Utilities getStringFromDictionary:nowPlayingInfo key:@"type"];
+                                 NSString *type = [Utilities getStringFromItem:nowPlayingInfo[@"type"]];
                                  currentType = type;
                                  [self setCoverSize:currentType];
                                  GlobalData *obj = [GlobalData getInstance];
@@ -1287,8 +1287,8 @@ int currentItemID;
                            NSString *label = [NSString stringWithFormat:@"%@", playlistItems[i][@"label"]];
                            NSString *title = [NSString stringWithFormat:@"%@", playlistItems[i][@"title"]];
                            
-                           NSString *artist = [Utilities getStringFromDictionary:playlistItems[i] key:@"artist"];
-                           NSString *album = [Utilities getStringFromDictionary:playlistItems[i] key:@"album"];
+                           NSString *artist = [Utilities getStringFromItem:playlistItems[i][@"artist"]];
+                           NSString *album = [Utilities getStringFromItem:playlistItems[i][@"album"]];
                            
                            NSString *runtime = [Utilities getTimeFromItem:playlistItems[i][@"runtime"] sec2min:runtimeInMinute];
                            
@@ -1301,7 +1301,7 @@ int currentItemID;
                            NSString *artistid = [NSString stringWithFormat:@"%@", playlistItems[i][@"artistid"]];
                            NSString *albumid = [NSString stringWithFormat:@"%@", playlistItems[i][@"albumid"]];
                            NSString *movieid = [NSString stringWithFormat:@"%@", playlistItems[i][@"id"]];
-                           NSString *genre = [Utilities getStringFromDictionary:playlistItems[i] key:@"genre"];
+                           NSString *genre = [Utilities getStringFromItem:playlistItems[i][@"genre"]];
                            NSString *durationTime = @"";
                            if ([playlistItems[i][@"duration"] isKindOfClass:[NSNumber class]]) {
                                durationTime = [Utilities convertTimeFromSeconds:playlistItems[i][@"duration"]];
@@ -1485,11 +1485,11 @@ int currentItemID;
                  }
 
                  NSString *label = [NSString stringWithFormat:@"%@", itemExtraDict[mainFields[@"row1"]]];
-                 NSString *genre = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row2"]];
+                 NSString *genre = [Utilities getStringFromItem:itemExtraDict[mainFields[@"row2"]]];
                  
                  NSString *year = [Utilities getYearFromItem:itemExtraDict[mainFields[@"row3"]]];
 
-                 NSString *runtime = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row4"]];
+                 NSString *runtime = [Utilities getStringFromItem:itemExtraDict[mainFields[@"row4"]]];
                  
                  NSString *rating = [Utilities getRatingFromItem:itemExtraDict[mainFields[@"row5"]]];
                  

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1491,7 +1491,7 @@ int currentItemID;
 
                  NSString *runtime = [Utilities getStringFromDictionary:itemExtraDict key:mainFields[@"row4"]];
                  
-                 NSString *rating = [Utilities getRatingFromDictionary:itemExtraDict key:mainFields[@"row5"]];
+                 NSString *rating = [Utilities getRatingFromItem:itemExtraDict[mainFields[@"row5"]]];
                  
                  NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:itemExtraDict useBanner:NO useIcon:NO];
                  NSDictionary *art = itemExtraDict[@"art"];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -623,11 +623,11 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"SUMMARY");
         label6.text = LOCALIZED_STR(@"CAST");
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [Utilities getStringFromDictionary:item key:@"episode" emptyString:@"-"];
-        genreLabel.text = [Utilities getDateFromItem:item[@"premiered"] dateStyle:NSDateFormatterLongStyle emptyString:@"-"];
-        runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"genre" emptyString:@"-"];
-        studioLabel.text = [Utilities getStringFromDictionary:item key:@"studio" emptyString:@"-"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot" emptyString:@"-"];
+        directorLabel.text = [Utilities getStringFromDictionary:item key:@"episode"];
+        genreLabel.text = [Utilities getDateFromItem:item[@"premiered"] dateStyle:NSDateFormatterLongStyle];
+        runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
+        studioLabel.text = [Utilities getStringFromDictionary:item key:@"studio"];
+        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot"];
         
         [self setTvShowsToolbar];
         
@@ -659,11 +659,11 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"SUMMARY");
         label6.text = LOCALIZED_STR(@"CAST");
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [Utilities getStringFromDictionary:item key:@"showtitle" emptyString:@"-"];
-        genreLabel.text = [Utilities getDateFromItem:item[@"firstaired"] dateStyle:NSDateFormatterLongStyle emptyString:@"-" ];
-        runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"director" emptyString:@"-"];
-        studioLabel.text = [Utilities getStringFromDictionary:item key:@"writer" emptyString:@"-"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot" emptyString:@"-"];
+        directorLabel.text = [Utilities getStringFromDictionary:item key:@"showtitle"];
+        genreLabel.text = [Utilities getDateFromItem:item[@"firstaired"] dateStyle:NSDateFormatterLongStyle];
+        runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"director"];
+        studioLabel.text = [Utilities getStringFromDictionary:item key:@"writer"];
+        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot"];
         
         parentalRatingLabelUp.hidden = YES;
         parentalRatingLabel.hidden = YES;
@@ -691,11 +691,11 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"DESCRIPTION");
         label6.text = @"";
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [Utilities getStringFromDictionary:item key:@"artist" emptyString:@"-"];
-        genreLabel.text = [Utilities getStringFromDictionary:item key:@"year" emptyString:@"-"];
-        runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"genre" emptyString:@"-"];
-        studioLabel.text = [Utilities getStringFromDictionary:item key:@"label" emptyString:@"-"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"description" emptyString:@"-"];
+        directorLabel.text = [Utilities getStringFromDictionary:item key:@"artist"];
+        genreLabel.text = [Utilities getStringFromDictionary:item key:@"year"];
+        runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
+        studioLabel.text = [Utilities getStringFromDictionary:item key:@"label"];
+        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"description"];
         
         starsView.hidden = YES;
         voteLabel.hidden = YES;
@@ -723,13 +723,13 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"SUMMARY");
         label6.text = @"";
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [Utilities getStringFromDictionary:item key:@"artist" emptyString:@"-"];
-        genreLabel.text = [Utilities getStringFromDictionary:item key:@"genre" emptyString:@"-"];
-        NSString *director = [Utilities getStringFromDictionary:item key:@"director" emptyString:@"-"];
+        directorLabel.text = [Utilities getStringFromDictionary:item key:@"artist"];
+        genreLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
+        NSString *director = [Utilities getStringFromDictionary:item key:@"director"];
         NSString *year = [Utilities getYearFromDictionary:item key:@"year"];
         runtimeLabel.text = [item[@"year"] length] == 0 ? director : [NSString stringWithFormat:@"%@ (%@)", director, year];
-        studioLabel.text = [Utilities getStringFromDictionary:item key:@"studio" emptyString:@"-"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot" emptyString:@"-"];
+        studioLabel.text = [Utilities getStringFromDictionary:item key:@"studio"];
+        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot"];
         
         if (enableJewel) {
             jewelView.image = [UIImage imageNamed:@"jewel_cd.9"];
@@ -751,12 +751,12 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"DESCRIPTION");
         label6.text = LOCALIZED_STR(@"MUSIC ROLES");
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [Utilities getStringFromDictionary:item key:@"genre" emptyString:@"-"];
-        genreLabel.text = [Utilities getStringFromDictionary:item key:@"style" emptyString:@"-"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"description" emptyString:@"-"];
-        NSString *born = [Utilities getStringFromDictionary:item key:@"born" emptyString:@"-"];
-        NSString *formed = [Utilities getStringFromDictionary:item key:@"formed" emptyString:@"-"];
-        studioLabel.text = [formed isEqualToString:@"-"] ? born : formed;
+        directorLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
+        genreLabel.text = [Utilities getStringFromDictionary:item key:@"style"];
+        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"description"];
+        NSString *born = [Utilities getStringFromDictionary:item key:@"born"];
+        NSString *formed = [Utilities getStringFromDictionary:item key:@"formed"];
+        studioLabel.text = formed.length ? formed : born;
         
         parentalRatingLabelUp.hidden = YES;
         parentalRatingLabel.hidden = YES;
@@ -786,10 +786,10 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"SUMMARY");
         label6.text = @"";
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [self formatBroadcastTime:item emptyString:@"-"];
-        genreLabel.text = [Utilities getStringFromDictionary:item key:@"genre" emptyString:@"-"];
+        directorLabel.text = [self formatBroadcastTime:item];
+        genreLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
         numVotesLabel.text = item[@"channel"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot" emptyString:@"-"];
+        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot"];
         
         coverView.hidden = YES;
         starsView.hidden = YES;
@@ -819,10 +819,10 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"SUMMARY");
         label6.text = @"";
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [self formatBroadcastTime:item emptyString:@"-"];
-        genreLabel.text = [Utilities getStringFromDictionary:self.detailItem key:@"plotoutline" emptyString:@"-"];
+        directorLabel.text = [self formatBroadcastTime:item];
+        genreLabel.text = [Utilities getStringFromDictionary:self.detailItem key:@"plotoutline"];
         numVotesLabel.text = item[@"pvrExtraInfo"][@"channel_name"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"genre" emptyString:@"-"];
+        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
         
         coverView.hidden = YES;
         starsView.hidden = YES;
@@ -847,13 +847,13 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"SUMMARY");
         label6.text = LOCALIZED_STR(@"CAST");
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        NSString *director = [Utilities getStringFromDictionary:item key:@"director" emptyString:@"-"];
+        NSString *director = [Utilities getStringFromDictionary:item key:@"director"];
         NSString *year = [Utilities getYearFromDictionary:item key:@"year"];
         directorLabel.text = [item[@"year"] length] == 0 ? director : [NSString stringWithFormat:@"%@ (%@)", director, year];
-        genreLabel.text = [Utilities getStringFromDictionary:item key:@"genre" emptyString:@"-"];
-        runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"runtime" emptyString:@"-"];
-        studioLabel.text = [Utilities getStringFromDictionary:item key:@"studio" emptyString:@"-"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot" emptyString:@"-"];
+        genreLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
+        runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"runtime"];
+        studioLabel.text = [Utilities getStringFromDictionary:item key:@"studio"];
+        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot"];
         
         if (enableJewel) {
             jewelView.image = [UIImage imageNamed:@"jewel_dvd.9"];
@@ -873,15 +873,15 @@ double round(double d) {
     
     [self loadFanart:item[@"fanart"]];
     
-    voteLabel.text = [Utilities getStringFromDictionary:item key:@"rating" emptyString:@"N.A."];
+    voteLabel.text = [Utilities getStringFromDictionary:item key:@"rating"];
     starsView.image = [UIImage imageNamed:[NSString stringWithFormat:@"stars_%.0f", roundf([item[@"rating"] floatValue])]];
-    NSString *numVotes = [Utilities getStringFromDictionary:item key:@"votes" emptyString:@""];
+    NSString *numVotes = [Utilities getStringFromDictionary:item key:@"votes"];
     if (numVotes.length != 0) {
         NSString *numVotesPlus = LOCALIZED_STR(([numVotes isEqualToString:@"1"]) ? @"vote" : @"votes");
         numVotesLabel.text = [NSString stringWithFormat:@"(%@ %@)", numVotes, numVotesPlus];
     }
 
-    parentalRatingLabel.text = [Utilities getStringFromDictionary:item key:@"mpaa" emptyString:@"-"];
+    parentalRatingLabel.text = [Utilities getStringFromDictionary:item key:@"mpaa"];
     
     if ([item[@"trailer"] isKindOfClass:[NSString class]]) {
         [self processTrailerFromString:item[@"trailer"]];
@@ -896,32 +896,32 @@ double round(double d) {
     }
     
     // Hide empty labels
-    if ([voteLabel.text isEqualToString:@"N.A."]) {
+    if (voteLabel.text.length == 0) {
         starsView.hidden = YES;
         voteLabel.hidden = YES;
         numVotesLabel.hidden = YES;
     }
-    if ([directorLabel.text isEqualToString:@"-"]) {
+    if (directorLabel.text.length == 0) {
         directorLabel.hidden = YES;
         label1.hidden = YES;
     }
-    if ([genreLabel.text isEqualToString:@"-"]) {
+    if (genreLabel.text.length == 0) {
         genreLabel.hidden = YES;
         label2.hidden = YES;
     }
-    if ([runtimeLabel.text isEqualToString:@"-"]) {
+    if (runtimeLabel.text.length == 0) {
         runtimeLabel.hidden = YES;
         label3.hidden = YES;
     }
-    if ([studioLabel.text isEqualToString:@"-"]) {
+    if (studioLabel.text.length == 0) {
         studioLabel.hidden = YES;
         label4.hidden = YES;
     }
-    if ([summaryLabel.text isEqualToString:@"-"]) {
+    if (summaryLabel.text.length == 0) {
         summaryLabel.hidden = YES;
         label5.hidden = YES;
     }
-    if ([parentalRatingLabel.text isEqualToString:@"-"]) {
+    if (parentalRatingLabel.text.length == 0) {
         parentalRatingLabel.hidden = YES;
         parentalRatingLabelUp.hidden = YES;
     }
@@ -1085,8 +1085,8 @@ double round(double d) {
     return offset;
 }
 
-- (NSString*)formatBroadcastTime:(NSDictionary*)item emptyString:(NSString*)empty {
-    NSString *broadcastTime = empty;
+- (NSString*)formatBroadcastTime:(NSDictionary*)item {
+    NSString *broadcastTime = @"";
     NSDate *startTime = [xbmcDateFormatter dateFromString:item[@"starttime"]];
     NSDate *endTime = [xbmcDateFormatter dateFromString:item[@"endtime"]];
     if (startTime != nil && endTime != nil) {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -726,7 +726,7 @@ double round(double d) {
         directorLabel.text = [Utilities getStringFromDictionary:item key:@"artist"];
         genreLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
         NSString *director = [Utilities getStringFromDictionary:item key:@"director"];
-        NSString *year = [Utilities getYearFromDictionary:item key:@"year"];
+        NSString *year = [Utilities getYearFromItem:item[@"year"]];
         runtimeLabel.text = [item[@"year"] length] == 0 ? director : [NSString stringWithFormat:@"%@ (%@)", director, year];
         studioLabel.text = [Utilities getStringFromDictionary:item key:@"studio"];
         summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot"];
@@ -848,7 +848,7 @@ double round(double d) {
         label6.text = LOCALIZED_STR(@"CAST");
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
         NSString *director = [Utilities getStringFromDictionary:item key:@"director"];
-        NSString *year = [Utilities getYearFromDictionary:item key:@"year"];
+        NSString *year = [Utilities getYearFromItem:item[@"year"]];
         directorLabel.text = [item[@"year"] length] == 0 ? director : [NSString stringWithFormat:@"%@ (%@)", director, year];
         genreLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
         runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"runtime"];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -623,11 +623,11 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"SUMMARY");
         label6.text = LOCALIZED_STR(@"CAST");
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [Utilities getStringFromDictionary:item key:@"episode"];
+        directorLabel.text = [Utilities getStringFromItem:item[@"episode"]];
         genreLabel.text = [Utilities getDateFromItem:item[@"premiered"] dateStyle:NSDateFormatterLongStyle];
-        runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
-        studioLabel.text = [Utilities getStringFromDictionary:item key:@"studio"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot"];
+        runtimeLabel.text = [Utilities getStringFromItem:item[@"genre"]];
+        studioLabel.text = [Utilities getStringFromItem:item[@"studio"]];
+        summaryLabel.text = [Utilities getStringFromItem:item[@"plot"]];
         
         [self setTvShowsToolbar];
         
@@ -659,11 +659,11 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"SUMMARY");
         label6.text = LOCALIZED_STR(@"CAST");
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [Utilities getStringFromDictionary:item key:@"showtitle"];
+        directorLabel.text = [Utilities getStringFromItem:item[@"showtitle"]];
         genreLabel.text = [Utilities getDateFromItem:item[@"firstaired"] dateStyle:NSDateFormatterLongStyle];
-        runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"director"];
-        studioLabel.text = [Utilities getStringFromDictionary:item key:@"writer"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot"];
+        runtimeLabel.text = [Utilities getStringFromItem:item[@"director"]];
+        studioLabel.text = [Utilities getStringFromItem:item[@"writer"]];
+        summaryLabel.text = [Utilities getStringFromItem:item[@"plot"]];
         
         parentalRatingLabelUp.hidden = YES;
         parentalRatingLabel.hidden = YES;
@@ -691,11 +691,11 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"DESCRIPTION");
         label6.text = @"";
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [Utilities getStringFromDictionary:item key:@"artist"];
-        genreLabel.text = [Utilities getStringFromDictionary:item key:@"year"];
-        runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
-        studioLabel.text = [Utilities getStringFromDictionary:item key:@"label"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"description"];
+        directorLabel.text = [Utilities getStringFromItem:item[@"artist"]];
+        genreLabel.text = [Utilities getStringFromItem:item[@"year"]];
+        runtimeLabel.text = [Utilities getStringFromItem:item[@"genre"]];
+        studioLabel.text = [Utilities getStringFromItem:item[@"label"]];
+        summaryLabel.text = [Utilities getStringFromItem:item[@"description"]];
         
         starsView.hidden = YES;
         voteLabel.hidden = YES;
@@ -723,13 +723,13 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"SUMMARY");
         label6.text = @"";
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [Utilities getStringFromDictionary:item key:@"artist"];
-        genreLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
-        NSString *director = [Utilities getStringFromDictionary:item key:@"director"];
+        directorLabel.text = [Utilities getStringFromItem:item[@"artist"]];
+        genreLabel.text = [Utilities getStringFromItem:item[@"genre"]];
+        NSString *director = [Utilities getStringFromItem:item[@"director"]];
         NSString *year = [Utilities getYearFromItem:item[@"year"]];
         runtimeLabel.text = [item[@"year"] length] == 0 ? director : [NSString stringWithFormat:@"%@ (%@)", director, year];
-        studioLabel.text = [Utilities getStringFromDictionary:item key:@"studio"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot"];
+        studioLabel.text = [Utilities getStringFromItem:item[@"studio"]];
+        summaryLabel.text = [Utilities getStringFromItem:item[@"plot"]];
         
         if (enableJewel) {
             jewelView.image = [UIImage imageNamed:@"jewel_cd.9"];
@@ -751,11 +751,11 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"DESCRIPTION");
         label6.text = LOCALIZED_STR(@"MUSIC ROLES");
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
-        genreLabel.text = [Utilities getStringFromDictionary:item key:@"style"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"description"];
-        NSString *born = [Utilities getStringFromDictionary:item key:@"born"];
-        NSString *formed = [Utilities getStringFromDictionary:item key:@"formed"];
+        directorLabel.text = [Utilities getStringFromItem:item[@"genre"]];
+        genreLabel.text = [Utilities getStringFromItem:item[@"style"]];
+        summaryLabel.text = [Utilities getStringFromItem:item[@"description"]];
+        NSString *born = [Utilities getStringFromItem:item[@"born"]];
+        NSString *formed = [Utilities getStringFromItem:item[@"formed"]];
         studioLabel.text = formed.length ? formed : born;
         
         parentalRatingLabelUp.hidden = YES;
@@ -787,9 +787,9 @@ double round(double d) {
         label6.text = @"";
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
         directorLabel.text = [self formatBroadcastTime:item];
-        genreLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
+        genreLabel.text = [Utilities getStringFromItem:item[@"genre"]];
         numVotesLabel.text = item[@"channel"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot"];
+        summaryLabel.text = [Utilities getStringFromItem:item[@"plot"]];
         
         coverView.hidden = YES;
         starsView.hidden = YES;
@@ -820,9 +820,9 @@ double round(double d) {
         label6.text = @"";
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
         directorLabel.text = [self formatBroadcastTime:item];
-        genreLabel.text = [Utilities getStringFromDictionary:self.detailItem key:@"plotoutline"];
+        genreLabel.text = [Utilities getStringFromItem:self.detailItem[@"plotoutline"]];
         numVotesLabel.text = item[@"pvrExtraInfo"][@"channel_name"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
+        summaryLabel.text = [Utilities getStringFromItem:item[@"genre"]];
         
         coverView.hidden = YES;
         starsView.hidden = YES;
@@ -847,13 +847,13 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"SUMMARY");
         label6.text = LOCALIZED_STR(@"CAST");
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        NSString *director = [Utilities getStringFromDictionary:item key:@"director"];
+        NSString *director = [Utilities getStringFromItem:item[@"director"]];
         NSString *year = [Utilities getYearFromItem:item[@"year"]];
         directorLabel.text = [item[@"year"] length] == 0 ? director : [NSString stringWithFormat:@"%@ (%@)", director, year];
-        genreLabel.text = [Utilities getStringFromDictionary:item key:@"genre"];
-        runtimeLabel.text = [Utilities getStringFromDictionary:item key:@"runtime"];
-        studioLabel.text = [Utilities getStringFromDictionary:item key:@"studio"];
-        summaryLabel.text = [Utilities getStringFromDictionary:item key:@"plot"];
+        genreLabel.text = [Utilities getStringFromItem:item[@"genre"]];
+        runtimeLabel.text = [Utilities getStringFromItem:item[@"runtime"]];
+        studioLabel.text = [Utilities getStringFromItem:item[@"studio"]];
+        summaryLabel.text = [Utilities getStringFromItem:item[@"plot"]];
         
         if (enableJewel) {
             jewelView.image = [UIImage imageNamed:@"jewel_dvd.9"];
@@ -873,15 +873,15 @@ double round(double d) {
     
     [self loadFanart:item[@"fanart"]];
     
-    voteLabel.text = [Utilities getStringFromDictionary:item key:@"rating"];
+    voteLabel.text = [Utilities getStringFromItem:item[@"rating"]];
     starsView.image = [UIImage imageNamed:[NSString stringWithFormat:@"stars_%.0f", roundf([item[@"rating"] floatValue])]];
-    NSString *numVotes = [Utilities getStringFromDictionary:item key:@"votes"];
+    NSString *numVotes = [Utilities getStringFromItem:item[@"votes"]];
     if (numVotes.length != 0) {
         NSString *numVotesPlus = LOCALIZED_STR(([numVotes isEqualToString:@"1"]) ? @"vote" : @"votes");
         numVotesLabel.text = [NSString stringWithFormat:@"(%@ %@)", numVotes, numVotesPlus];
     }
 
-    parentalRatingLabel.text = [Utilities getStringFromDictionary:item key:@"mpaa"];
+    parentalRatingLabel.text = [Utilities getStringFromItem:item[@"mpaa"]];
     
     if ([item[@"trailer"] isKindOfClass:[NSString class]]) {
         [self processTrailerFromString:item[@"trailer"]];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -727,7 +727,7 @@ double round(double d) {
         genreLabel.text = [Utilities getStringFromItem:item[@"genre"]];
         NSString *director = [Utilities getStringFromItem:item[@"director"]];
         NSString *year = [Utilities getYearFromItem:item[@"year"]];
-        runtimeLabel.text = [item[@"year"] length] == 0 ? director : [NSString stringWithFormat:@"%@ (%@)", director, year];
+        runtimeLabel.text = [self formatDirectorYear:director year:year];
         studioLabel.text = [Utilities getStringFromItem:item[@"studio"]];
         summaryLabel.text = [Utilities getStringFromItem:item[@"plot"]];
         
@@ -849,7 +849,7 @@ double round(double d) {
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
         NSString *director = [Utilities getStringFromItem:item[@"director"]];
         NSString *year = [Utilities getYearFromItem:item[@"year"]];
-        directorLabel.text = [item[@"year"] length] == 0 ? director : [NSString stringWithFormat:@"%@ (%@)", director, year];
+        directorLabel.text = [self formatDirectorYear:director year:year];
         genreLabel.text = [Utilities getStringFromItem:item[@"genre"]];
         runtimeLabel.text = [Utilities getStringFromItem:item[@"runtime"]];
         studioLabel.text = [Utilities getStringFromItem:item[@"studio"]];
@@ -1083,6 +1083,20 @@ double round(double d) {
     clearlogoButton.frame = frame;
     offset += frame.size.height;
     return offset;
+}
+
+- (NSString*)formatDirectorYear:(NSString*)director year:(NSString*)year {
+    NSString *text = @"";
+    if (director.length && year.length) {
+        text = [NSString stringWithFormat:@"%@ (%@)", director, year];
+    }
+    else if (year.length) {
+        text = [NSString stringWithFormat:@"(%@)", year];
+    }
+    else if (director.length) {
+        text = director;
+    }
+    return text;
 }
 
 - (NSString*)formatBroadcastTime:(NSDictionary*)item {

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -72,7 +72,7 @@ typedef enum {
 + (NSString*)getItemIconFromDictionary:(NSDictionary*)dict mainFields:(NSDictionary*)mainFields;
 + (NSString*)getStringFromDictionary:(NSDictionary*)dict key:(NSString*)key;
 + (NSString*)getTimeFromItem:(id)item sec2min:(int)secondsToMinute;
-+ (NSString*)getYearFromDictionary:(NSDictionary*)dict key:(NSString*)key;
++ (NSString*)getYearFromItem:(id)item;
 + (NSString*)getRatingFromDictionary:(NSDictionary*)dict key:(NSString*)key;
 + (NSString*)getClearArtFromDictionary:(NSDictionary*)dict type:(NSString*)type;
 + (NSString*)getThumbnailFromDictionary:(NSDictionary*)dict useBanner:(BOOL)useBanner useIcon:(BOOL)useIcon;

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -73,7 +73,7 @@ typedef enum {
 + (NSString*)getStringFromDictionary:(NSDictionary*)dict key:(NSString*)key;
 + (NSString*)getTimeFromItem:(id)item sec2min:(int)secondsToMinute;
 + (NSString*)getYearFromItem:(id)item;
-+ (NSString*)getRatingFromDictionary:(NSDictionary*)dict key:(NSString*)key;
++ (NSString*)getRatingFromItem:(id)item;
 + (NSString*)getClearArtFromDictionary:(NSDictionary*)dict type:(NSString*)type;
 + (NSString*)getThumbnailFromDictionary:(NSDictionary*)dict useBanner:(BOOL)useBanner useIcon:(BOOL)useIcon;
 + (NSString*)getDateFromItem:(id)item dateStyle:(NSDateFormatterStyle)dateStyle;

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -70,7 +70,7 @@ typedef enum {
 + (NSMutableDictionary*)indexKeyedMutableDictionaryFromArray:(NSArray*)array;
 + (NSString*)convertTimeFromSeconds:(NSNumber*)seconds;
 + (NSString*)getItemIconFromDictionary:(NSDictionary*)dict mainFields:(NSDictionary*)mainFields;
-+ (NSString*)getStringFromDictionary:(NSDictionary*)dict key:(NSString*)key;
++ (NSString*)getStringFromItem:(id)item;
 + (NSString*)getTimeFromItem:(id)item sec2min:(int)secondsToMinute;
 + (NSString*)getYearFromItem:(id)item;
 + (NSString*)getRatingFromItem:(id)item;

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -70,13 +70,13 @@ typedef enum {
 + (NSMutableDictionary*)indexKeyedMutableDictionaryFromArray:(NSArray*)array;
 + (NSString*)convertTimeFromSeconds:(NSNumber*)seconds;
 + (NSString*)getItemIconFromDictionary:(NSDictionary*)dict mainFields:(NSDictionary*)mainFields;
-+ (NSString*)getStringFromDictionary:(NSDictionary*)dict key:(NSString*)key emptyString:(NSString*)empty;
++ (NSString*)getStringFromDictionary:(NSDictionary*)dict key:(NSString*)key;
 + (NSString*)getTimeFromDictionary:(NSDictionary*)dict key:(NSString*)key sec2min:(int)secondsToMinute;
 + (NSString*)getYearFromDictionary:(NSDictionary*)dict key:(NSString*)key;
 + (NSString*)getRatingFromDictionary:(NSDictionary*)dict key:(NSString*)key;
 + (NSString*)getClearArtFromDictionary:(NSDictionary*)dict type:(NSString*)type;
 + (NSString*)getThumbnailFromDictionary:(NSDictionary*)dict useBanner:(BOOL)useBanner useIcon:(BOOL)useIcon;
-+ (NSString*)getDateFromItem:(id)item dateStyle:(NSDateFormatterStyle)dateStyle emptyString:(NSString*)empty;
++ (NSString*)getDateFromItem:(id)item dateStyle:(NSDateFormatterStyle)dateStyle;
 + (NSString*)formatStringURL:(NSString*)path serverURL:(NSString*)serverURL;
 + (CGFloat)getHeightOfLabel:(UILabel*)label;
 + (UIImage*)roundedCornerImage:(UIImage*)image drawBorder:(BOOL)drawBorder;

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -71,7 +71,7 @@ typedef enum {
 + (NSString*)convertTimeFromSeconds:(NSNumber*)seconds;
 + (NSString*)getItemIconFromDictionary:(NSDictionary*)dict mainFields:(NSDictionary*)mainFields;
 + (NSString*)getStringFromDictionary:(NSDictionary*)dict key:(NSString*)key;
-+ (NSString*)getTimeFromDictionary:(NSDictionary*)dict key:(NSString*)key sec2min:(int)secondsToMinute;
++ (NSString*)getTimeFromItem:(id)item sec2min:(int)secondsToMinute;
 + (NSString*)getYearFromDictionary:(NSDictionary*)dict key:(NSString*)key;
 + (NSString*)getRatingFromDictionary:(NSDictionary*)dict key:(NSString*)key;
 + (NSString*)getClearArtFromDictionary:(NSDictionary*)dict type:(NSString*)type;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -639,7 +639,7 @@
             year = @"";
         }
     }
-    else {
+    else if ([item integerValue] > 0) {
         year = item;
     }
     return year;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -646,8 +646,8 @@
     return year;
 }
 
-+ (NSString*)getRatingFromDictionary:(NSDictionary*)dict key:(NSString*)key {
-    NSString *rating = [NSString stringWithFormat:@"%.1f", [(NSNumber*)dict[key] floatValue]];
++ (NSString*)getRatingFromItem:(id)item {
+    NSString *rating = [NSString stringWithFormat:@"%.1f", [(NSNumber*)item floatValue]];
     if ([rating isEqualToString:@"0.0"]) {
         rating = @"";
     }

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -627,27 +627,21 @@
     return runtime;
 }
 
-+ (NSString*)getYearFromDictionary:(NSDictionary*)dict key:(NSString*)key {
++ (NSString*)getYearFromItem:(id)item {
     NSString *year = @"";
-    id value = dict[key];
-    if (value == nil) {
+    if (item == nil) {
         year = @"";
     }
-    else if ([value isKindOfClass:[NSNumber class]]) {
-        if ([value integerValue] > 0) {
-            year = [value stringValue];
+    else if ([item isKindOfClass:[NSNumber class]]) {
+        if ([item integerValue] > 0) {
+            year = [item stringValue];
         }
         else {
             year = @"";
         }
     }
     else {
-        if ([key isEqualToString:@"blank"]) {
-            year = @"";
-        }
-        else {
-            year = value;
-        }
+        year = item;
     }
     return year;
 }

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -593,21 +593,21 @@
     return iconName;
 }
 
-+ (NSString*)getStringFromDictionary:(NSDictionary*)dict key:(NSString*)key emptyString:(NSString*)empty {
-    NSString *text = empty;
++ (NSString*)getStringFromDictionary:(NSDictionary*)dict key:(NSString*)key {
+    NSString *text = @"";
     id value = dict[key];
     if (value == nil) {
-        text = empty;
+        text = @"";
     }
     else if ([value isKindOfClass:[NSArray class]]) {
         text = [value componentsJoinedByString:@" / "];
-        text = text.length == 0 ? empty : text;
+        text = text.length == 0 ? @"" : text;
     }
     else if ([value isKindOfClass:[NSNumber class]]) {
         text = [NSString stringWithFormat:@"%@", value];
     }
     else {
-        text = [value length] == 0 ? empty : value;
+        text = [value length] == 0 ? @"" : value;
     }
     return text;
 }
@@ -687,8 +687,8 @@
     return thumbnailPath;
 }
 
-+ (NSString*)getDateFromItem:(id)item dateStyle:(NSDateFormatterStyle)dateStyle emptyString:(NSString*)empty {
-    NSString *dateString = empty;
++ (NSString*)getDateFromItem:(id)item dateStyle:(NSDateFormatterStyle)dateStyle {
+    NSString *dateString = @"";
     if ([item length] > 0) {
         NSDateFormatter *format = [NSDateFormatter new];
         format.locale = [NSLocale currentLocale];

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -593,21 +593,20 @@
     return iconName;
 }
 
-+ (NSString*)getStringFromDictionary:(NSDictionary*)dict key:(NSString*)key {
++ (NSString*)getStringFromItem:(id)item {
     NSString *text = @"";
-    id value = dict[key];
-    if (value == nil) {
+    if (item == nil) {
         text = @"";
     }
-    else if ([value isKindOfClass:[NSArray class]]) {
-        text = [value componentsJoinedByString:@" / "];
+    else if ([item isKindOfClass:[NSArray class]]) {
+        text = [item componentsJoinedByString:@" / "];
         text = text.length == 0 ? @"" : text;
     }
-    else if ([value isKindOfClass:[NSNumber class]]) {
-        text = [NSString stringWithFormat:@"%@", value];
+    else if ([item isKindOfClass:[NSNumber class]]) {
+        text = [NSString stringWithFormat:@"%@", item];
     }
     else {
-        text = [value length] == 0 ? @"" : value;
+        text = [item length] == 0 ? @"" : item;
     }
     return text;
 }

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -612,17 +612,16 @@
     return text;
 }
 
-+ (NSString*)getTimeFromDictionary:(NSDictionary*)dict key:(NSString*)key sec2min:(int)secondsToMinute {
++ (NSString*)getTimeFromItem:(id)item sec2min:(int)secondsToMinute {
     NSString *runtime = @"";
-    id value = dict[key];
-    if (value == nil) {
+    if (item == nil) {
         runtime = @"";
     }
-    else if ([value isKindOfClass:[NSArray class]]) {
-        runtime = [NSString stringWithFormat:@"%@", [value componentsJoinedByString:@" / "]];
+    else if ([item isKindOfClass:[NSArray class]]) {
+        runtime = [NSString stringWithFormat:@"%@", [item componentsJoinedByString:@" / "]];
     }
     else {
-        int minutes = [value intValue] / secondsToMinute;
+        int minutes = [item intValue] / secondsToMinute;
         runtime = minutes ? [NSString stringWithFormat:@"%d min", minutes] : runtime;
     }
     return runtime;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Since the rework of `ShowInfoViewController` (see https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/438) it is not required anymore to differentiate the way how to represent non-existing data. Formerly, the detail screens where using `"-"`, whereas all other screen simply used `""`. This rework now allows to remove the parameter `emptyString:` from several helper functions, and to simplify the check for non-existing data in `ShowInfoViewController`. 

In addition, this PR changes the helper function's parameters to directly use `id` objects instead of separate dictionary and key parameters. This simplifies the calls itself.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Refactor several helper functions
