### PR TITLE
Bugfix: Do not draw unwanted borders for several icon types

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -620,7 +620,11 @@
     }
     BOOL showBorder = !([item[@"family"] isEqualToString:@"channelid"] ||
                         [item[@"family"] isEqualToString:@"recordingid"] ||
+                        [item[@"family"] isEqualToString:@"channelgroupid"] ||
+                        [item[@"family"] isEqualToString:@"timerid"] ||
                         [item[@"family"] isEqualToString:@"genreid"] ||
+                        [item[@"family"] isEqualToString:@"sectionid"] ||
+                        [item[@"family"] isEqualToString:@"categoryid"] ||
                         [item[@"family"] isEqualToString:@"type"] ||
                         [item[@"family"] isEqualToString:@"file"]);
     BOOL isOnPVR = [item[@"path"] hasPrefix:@"pvr:"];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
As I wrote in a forum post alley, the common handling of thumbnails and icons is a nightmare. Here are some more icon/thumbnail types which should not have borders around them.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not draw unwanted borders for several icon types