### PR TITLE
Bugfix: Pan gesture not working when showing Remote's underRight screen

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1068,7 +1068,7 @@ NSInteger buttonAction;
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer*)gestureRecognizer shouldReceiveTouch:(UITouch*)touch {
     BOOL isGestureViewActive = (gestureZoneView.alpha > 0);
-    return !isGestureViewActive;
+    return !isGestureViewActive || self.slidingViewController.underRightShowing;
 }
 
 # pragma mark - Gestures

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -448,11 +448,8 @@
     if (showGesture && gestureZoneView.alpha == 1) {
         return;
     }
+    [self setPanGestureFullArea:!showGesture];
     if (showGesture) {
-        // Only allow panning gesture for navigation bar to not interfere with gesture area
-        [self.navigationController.view removeGestureRecognizer:self.slidingViewController.panGesture];
-        [self.navigationController.navigationBar addGestureRecognizer:self.slidingViewController.panGesture];
-        
         CGRect frame;
         frame = [gestureZoneView frame];
         frame.origin.x = -self.view.frame.size.width;
@@ -475,10 +472,6 @@
         imageName = @"circle";
     }
     else {
-        // Allow panning gesture for full view
-        [self.navigationController.navigationBar removeGestureRecognizer:self.slidingViewController.panGesture];
-        [self.navigationController.view addGestureRecognizer:self.slidingViewController.panGesture];
-        
         CGRect frame;
         [UIView beginAnimations:nil context:nil];
         [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
@@ -1072,6 +1065,19 @@ NSInteger buttonAction;
 }
 
 # pragma mark - Gestures
+
+- (void)setPanGestureFullArea:(BOOL)allowFullArea {
+    if (allowFullArea) {
+        // Allow panning gesture for full view
+        [self.navigationController.navigationBar removeGestureRecognizer:self.slidingViewController.panGesture];
+        [self.navigationController.view addGestureRecognizer:self.slidingViewController.panGesture];
+    }
+    else {
+        // Only allow panning gesture for navigation bar to not interfere with gesture area
+        [self.navigationController.view removeGestureRecognizer:self.slidingViewController.panGesture];
+        [self.navigationController.navigationBar addGestureRecognizer:self.slidingViewController.panGesture];
+    }
+}
 
 - (IBAction)handleButtonLongPress:(UILongPressGestureRecognizer*)gestureRecognizer {
     if (gestureRecognizer.state == UIGestureRecognizerStateBegan) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in a [forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3069607#pid3069607). When the remote screen has the gesture zone active the pan gestures were blocked even if the App was showing the remote's `underRight` screen (remote was swiped left to show the custom button screen). This PR allows the pan gesture in this case now.

In addition, a minor refactoring is done to introduce a helper function for setting the area of the pan gesture (no functional change).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Pan gesture not working when showing Remote's underRight screen