### PR TITLE
Bugfix: Correctly detect swipe left

### DIFF
--- a/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
+++ b/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
@@ -283,7 +283,7 @@ BOOL moved;
         if ([self underLeftShowing] && currentVelocityX > 100) {
             [self anchorTopViewTo:ECRight];
         }
-        else if ([self underRightShowing] && currentVelocityX < 100) {
+        else if ([self underRightShowing] && currentVelocityX < -100) {
             [self anchorTopViewTo:ECLeft];
         }
         else {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
When swiping left, the velocity is < 0. To detect a swipe gesture to the left we need to check for a minimum velocity which is smaller than a certain negative value.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correctly detect swipe left