### PR TITLE
Bugfix: Fix potential crash in canEditRowAtIndexPath

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -399,7 +399,12 @@
 }
 
 - (BOOL)tableView:(UITableView*)tableView canEditRowAtIndexPath:(NSIndexPath*)indexPath {
-    return ([tableData[indexPath.row][@"isSetting"] boolValue]);
+    if (indexPath.row < tableData.count) {
+        return [tableData[indexPath.row][@"isSetting"] boolValue];
+    }
+    else {
+        return NO;
+    }
 }
 
 - (void)tableView:(UITableView*)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath*)indexPath {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/465.

Avoid possible out-of-bounds access in `canEditRowAtIndexPath`. In case we are out of bounds, respond with `NO` (= not editable).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix potential crash in canEditRowAtIndexPath