### PR TITLE
Rework pan gesture for iPhone, re-using iPad's solution

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -14,6 +14,7 @@
 #import "AppDelegate.h"
 #import "ViewControllerIPad.h"
 #import "StackScrollViewController.h"
+#import "RemoteControllerGestureZoneView.h"
 #import "RightMenuViewController.h"
 #import "DetailViewController.h"
 #import "Utilities.h"
@@ -448,7 +449,6 @@
     if (showGesture && gestureZoneView.alpha == 1) {
         return;
     }
-    [self setPanGestureFullArea:!showGesture];
     if (showGesture) {
         CGRect frame;
         frame = gestureZoneView.frame;
@@ -1060,24 +1060,14 @@ NSInteger buttonAction;
 #pragma mark - GestureRecognizer delegate
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer*)gestureRecognizer shouldReceiveTouch:(UITouch*)touch {
-    BOOL isGestureViewActive = (gestureZoneView.alpha > 0);
-    return !isGestureViewActive || self.slidingViewController.underRightShowing;
+    // Do not support any pan gestures, if the Remote's GestureZone was touched
+    if ([touch.view isKindOfClass:[RemoteControllerGestureZoneView class]]) {
+        return NO;
+    }
+    return YES;
 }
 
 # pragma mark - Gestures
-
-- (void)setPanGestureFullArea:(BOOL)allowFullArea {
-    if (allowFullArea) {
-        // Allow panning gesture for full view
-        [self.navigationController.navigationBar removeGestureRecognizer:self.slidingViewController.panGesture];
-        [self.navigationController.view addGestureRecognizer:self.slidingViewController.panGesture];
-    }
-    else {
-        // Only allow panning gesture for navigation bar to not interfere with gesture area
-        [self.navigationController.view removeGestureRecognizer:self.slidingViewController.panGesture];
-        [self.navigationController.navigationBar addGestureRecognizer:self.slidingViewController.panGesture];
-    }
-}
 
 - (IBAction)handleButtonLongPress:(UILongPressGestureRecognizer*)gestureRecognizer {
     if (gestureRecognizer.state == UIGestureRecognizerStateBegan) {
@@ -1189,6 +1179,8 @@ NSInteger buttonAction;
             self.slidingViewController.anchorLeftPeekAmount   = 0;
             self.slidingViewController.anchorLeftRevealAmount = 0;
             self.slidingViewController.panGesture.delegate = self;
+            // Allow panning gesture for full view (but gestureRecognizer will skip if GestureZone is touched)
+            [self.navigationController.view addGestureRecognizer:self.slidingViewController.panGesture];
         }
         RightMenuViewController *rightMenuViewController = [[RightMenuViewController alloc] initWithNibName:@"RightMenuViewController" bundle:nil];
         rightMenuViewController.rightMenuItems = AppDelegate.instance.remoteControlMenuItems;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR simplifies the logic to support or block the pan gestures in the Remote screen, depending on its current mode (active or inactive gesture zone). The former solution was enabling or disabling the pan gesture based on the mode. This needed some special handling for the so-called underRight (aka custom buttons) screen which still was showing some problems. This PR is re-using the iPad's solution for the iPhone as well: Pan gesture is always supported for the full screen, but ignored if the gesture zone is touched. This implicitly takes into account the status of the gesture zone and avoid special handling of other screens.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Pan gesture in remote not working after entering underRight screen for the first time