### PR TITLE
Bugfix: Fix two more runtime warning caused by imageNamed: with empty string

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -314,7 +314,7 @@ NSMutableArray *hostRightMenuItems;
                 @(ViewModeUnwatched),
                 @(ViewModeWatched)],
         @"icons": @[
-                @"",
+                @"blank",
                 @"st_unchecked",
                 @"st_checked"]
     };
@@ -327,7 +327,7 @@ NSMutableArray *hostRightMenuItems;
                 @(ViewModeNotListened),
                 @(ViewModeListened)],
         @"icons": @[
-                @"",
+                @"blank",
                 @"st_unchecked",
                 @"st_checked"]
     };


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
In https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/445 I had overseen two obvious issues of exactly the same type. Again, this fixes runtime warnings when trying to load images with name `@"".`

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix two more runtime warnings caused by imageNamed: with empty string