### PR TITLE
Bugfix: Show plot in recording list

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2296,7 +2296,7 @@ int originYear = 0;
                 genre.text = [NSString stringWithFormat:@"%@ (%@)", timerPlan, runtime];
             }
             else {
-                genre.text = [NSString stringWithFormat:@"%@ - %@", item[@"channel"], item[@"year"]];
+                genre.text = [NSString stringWithFormat:@"%@ - %@", item[@"channel"], item[@"plot"]];
                 genre.numberOfLines = 3;
             }
             genre.autoresizingMask = title.autoresizingMask;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes an interesting regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/461/commits/f5c2606b08c38531ab5b79793526db4b91e3badf.

Since long ago the recording list was by fault showing the content of the key `"year"`. This key was obviously by fault filled with the content of `"plot" `before. Since https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/461/commits/f5c2606b08c38531ab5b79793526db4b91e3badf the processing of year strings is corrected and will not show any non-number strings anymore. In consequence the recording list was not showing the plot anymore. 

The fix is simply to use the correct key `"plot"`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show plot in recording list