### PR TITLE
Maintenance: Use US English as default

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -4871,7 +4871,7 @@ NSMutableArray *hostRightMenuItems;
     ];
     
 #pragma mark - Favourites
-        menu_Favourites.mainLabel = LOCALIZED_STR(@"Favourites");
+        menu_Favourites.mainLabel = LOCALIZED_STR(@"Favorites");
         menu_Favourites.upperLabel = LOCALIZED_STR(@"Choose your");
         menu_Favourites.icon = @"icon_menu_favourites";
         menu_Favourites.family = FamilyDetailView;
@@ -4891,7 +4891,7 @@ NSMutableArray *hostRightMenuItems;
                             @"window",
                             @"windowparameter"]
                 }, @"parameters",
-                LOCALIZED_STR(@"Favourites"), @"label",
+                LOCALIZED_STR(@"Favorites"), @"label",
                 @"nocover_favourites", @"defaultThumb",
                 filemodeRowHeight, @"rowHeight",
                 filemodeThumbWidth, @"thumbWidth",

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -282,7 +282,7 @@
 			<key>Key</key>
 			<string>menu_favourites</string>
 			<key>Title</key>
-			<string>Show FAVOURITES</string>
+			<string>Show FAVORITES</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>

--- a/XBMC Remote/Settings.bundle/cs.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/cs.lproj/Root.strings
@@ -24,7 +24,7 @@
 "Show TV SHOWS" = "Show TV SHOWS";
 "Show PICTURES" = "Show PICTURES";
 "Show LIVE TV" = "Show LIVE TV";
-"Show FAVOURITES" = "Show FAVOURITES";
+"Show FAVORITES" = "Show FAVORITES";
 "Show NOW PLAYING" = "Show NOW PLAYING";
 "Show REMOTE CONTROL" = "Show REMOTE CONTROL";
 "Light" = "Lehký";

--- a/XBMC Remote/Settings.bundle/de.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/de.lproj/Root.strings
@@ -34,6 +34,6 @@
 "Show PICTURES" = "Zeige BILDER";
 "Show LIVE TV" = "Zeige TV";
 "Show RADIO" = "Zeige RADIO";
-"Show FAVOURITES" = "Zeige FAVORITEN";
+"Show FAVORITES" = "Zeige FAVORITEN";
 "Show NOW PLAYING" = "Zeige GERADE LÄUFT";
 "Show REMOTE CONTROL" = "Zeige FERNBEDIENUNG";

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -34,6 +34,6 @@
 "Show PICTURES" = "Show PICTURES";
 "Show LIVE TV" = "Show LIVE TV";
 "Show RADIO" = "Show RADIO";
-"Show FAVOURITES" = "Show FAVOURITES";
+"Show FAVORITES" = "Show FAVORITES";
 "Show NOW PLAYING" = "Show NOW PLAYING";
 "Show REMOTE CONTROL" = "Show REMOTE CONTROL";

--- a/XBMC Remote/Settings.bundle/pl.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/pl.lproj/Root.strings
@@ -23,7 +23,7 @@
 "Remote Position" = "Pozycja sterowania";
 "Show REMOTE CONTROL" = "Pokaż KONTROLA ZDALNA";
 "Show NOW PLAYING" = "Pokaż TERAZ ODTWARZANE";
-"Show FAVOURITES" = "Pokaż ULUBIONE";
+"Show FAVORITES" = "Pokaż ULUBIONE";
 "Show LIVE TV" = "Pokaż TELEWIZJA NA ŻYWO";
 "Show PICTURES" = "Pokaż ZDJĘCIA";
 "Show TV SHOWS" = "Pokaż PROGRAMY TV";

--- a/XBMC Remote/Settings.bundle/zh-Hans.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/zh-Hans.lproj/Root.strings
@@ -22,7 +22,7 @@
 "Light" = "小";
 "Show REMOTE CONTROL" = "显示遥控器控制";
 "Show NOW PLAYING" = "显示正在播放";
-"Show FAVOURITES" = "显示收藏";
+"Show FAVORITES" = "显示收藏";
 "Show LIVE TV" = "显示直播电视";
 "Show PICTURES" = "显示图片";
 "Show TV SHOWS" = "显示剧集";

--- a/XBMC Remote/cs.lproj/Localizable.strings
+++ b/XBMC Remote/cs.lproj/Localizable.strings
@@ -295,7 +295,7 @@
 "Activate window" = "Activate window";
 "Add action button" = "Add action button";
 "Add window activation button" = "Add window activation button";
-"Favourites" = "Oblíbené";
+"Favorites" = "Oblíbené";
 "Video Playlists" = "Seznamy stop videí";
 "Runtime" = "Doba spuštění";
 "Date" = "Datum";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -18,7 +18,7 @@
 "TV Shows" = "Serien";
 "Pictures" = "Bilder";
 "Now Playing" = "Gerade läuft";
-"Favourites" = "Favoriten";
+"Favorites" = "Favoriten";
 "Remote Control" = "Fernbedienung";
 "XBMC Server" = "Kodi-Server";
 "New XBMC Server" = "Neuer Kodi-Server";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -19,7 +19,7 @@
 "TV Shows" = "TV Shows";
 "Pictures" = "Pictures";
 "Now Playing" = "Now playing";
-"Favourites" = "Favourites";
+"Favorites" = "Favorites";
 "Remote Control" = "Remote Control";
 "XBMC Server" = "Kodi Server";
 "New XBMC Server" = "New Kodi Server";

--- a/XBMC Remote/es.lproj/Localizable.strings
+++ b/XBMC Remote/es.lproj/Localizable.strings
@@ -297,7 +297,7 @@
 "Add window activation button" = "Add window activation button";
 "Runtime" = "Duración";
 "Date" = "Fecha";
-"Favourites" = "Favoritos";
+"Favorites" = "Favoritos";
 "Never" = "Nunca";
 "Last Updated: %@" = "Última Actualización: %@";
 "Not Available" = "No disponible";

--- a/XBMC Remote/fr.lproj/Localizable.strings
+++ b/XBMC Remote/fr.lproj/Localizable.strings
@@ -296,7 +296,7 @@
 "Runtime" = "Durée";
 "Pictures Add-ons" = "Extensions Images";
 "Video Playlists" = "Listes de lecture de vidéos";
-"Favourites" = "Favoris";
+"Favorites" = "Favoris";
 "Never" = "Jamais";
 "Last Updated: %@" = "Dernière mise à jour : %@";
 "Not Available" = "Non disponible";

--- a/XBMC Remote/it.lproj/Localizable.strings
+++ b/XBMC Remote/it.lproj/Localizable.strings
@@ -296,7 +296,7 @@
 "Add window activation button" = "Aggiungi pulsante di attivazione finestra";
 "Runtime" = "Durata";
 "Video Playlists" = "Playlist video";
-"Favourites" = "Preferiti";
+"Favorites" = "Preferiti";
 "Date" = "Data";
 "Never" = "Mai";
 "Last Updated: %@" = "Ultimo Aggiornamento: %@";

--- a/XBMC Remote/nl.lproj/Localizable.strings
+++ b/XBMC Remote/nl.lproj/Localizable.strings
@@ -299,7 +299,7 @@
 "Runtime" = "Speelduur";
 "Date" = "Datum";
 "Video Playlists" = "Videoafspeellijsten";
-"Favourites" = "Favorieten";
+"Favorites" = "Favorieten";
 "Never" = "Nooit";
 "Last Updated: %@" = "Laatste update: %@";
 "Not Available" = "Niet beschikbaar";

--- a/XBMC Remote/pl.lproj/Localizable.strings
+++ b/XBMC Remote/pl.lproj/Localizable.strings
@@ -304,7 +304,7 @@
 "Action executed successfully" = "Czynność wykonana pomyślnie";
 "Music Roles" = "Role muzyczne";
 "Video Playlists" = "Listy odtwarzania wideo";
-"Favourites" = "Ulubione";
+"Favorites" = "Ulubione";
 "Choose your" = "Przejdź do";
 "Never" = "Nigdy";
 "Last Updated: %@" = "Ostatnio zaktualizowane: %@";

--- a/XBMC Remote/pt-PT.lproj/Localizable.strings
+++ b/XBMC Remote/pt-PT.lproj/Localizable.strings
@@ -300,7 +300,7 @@
 "Video " = "Vídeo ";
 "Music " = "Música ";
 "Video Playlists" = "Lista Reprodução Vídeo";
-"Favourites" = "Favoritos";
+"Favorites" = "Favoritos";
 "Runtime" = "Duração";
 "Date" = "Data";
 "Music Add-ons" = "Addons de música";

--- a/XBMC Remote/sv.lproj/Localizable.strings
+++ b/XBMC Remote/sv.lproj/Localizable.strings
@@ -301,7 +301,7 @@
 "Date" = "Datum";
 "XBMC \"Gotham\" version 13 or superior is required to access XBMC settings" = "Kodi \"Gotham\" version 13 eller senare krävs för att komma åt Kodi-inställningarna";
 "Video Playlists" = "Videospellistor";
-"Favourites" = "Favoriter";
+"Favorites" = "Favoriter";
 "Choose your" = "Gå till din";
 "Never" = "Aldrig";
 "Last Updated: %@" = "Senast uppdaterad: %@";

--- a/XBMC Remote/tr.lproj/Localizable.strings
+++ b/XBMC Remote/tr.lproj/Localizable.strings
@@ -298,7 +298,7 @@
 "enjoy!" = "İyi eğlenceler!";
 "Pictures Add-ons" = "Resim eklentileri";
 "Video Playlists" = "Video oynatma listeleri";
-"Favourites" = "Sık kullanılanlar";
+"Favorites" = "Sık kullanılanlar";
 "Never" = "Asla";
 "Last Updated: %@" = "Son Güncelleme: %@";
 "Not Available" = "Kullanılamıyor";

--- a/XBMC Remote/zh-Hans.lproj/Localizable.strings
+++ b/XBMC Remote/zh-Hans.lproj/Localizable.strings
@@ -297,7 +297,7 @@
 "Date" = "日期";
 "Slide your finger up to adjust the scrubbing rate." = "向上滑动手指来调整拖动速度。";
 "Video Playlists" = "视频播放列表";
-"Favourites" = "收藏夹";
+"Favorites" = "收藏夹";
 "Channel" = "频道";
 "For search switch to list view" = "搜索切换到列表视图";
 "Unable to activate the window" = "窗口无法激活";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
As dicsussed in the forums we want to use US English as default. This PR changes "Favourites" to "Favorites".

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Use US English as default
