### PR TITLE
Feature: Add en-us as localized language

### DIFF
--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -686,7 +686,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1250;
-				ORGANIZATIONNAME = "joethefox inc.";
+				ORGANIZATIONNAME = "Team Kodi";
 			};
 			buildConfigurationList = 0F5548F0151D1187007E633F /* Build configuration list for PBXProject "Kodi Remote" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -283,6 +283,8 @@
 		B1FF37DF1709D1ED005473FF /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C718444525FFD06300F5A060 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 		C7478BF8257258E700161C1E /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		C7868BB627491FB7001B35B6 /* en-US */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-US"; path = "en-US.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		C7868BB727491FB7001B35B6 /* en-US */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-US"; path = "en-US.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C7F28D4826961FE50004B112 /* ConvenienceMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConvenienceMacros.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -704,6 +706,7 @@
 				tr,
 				sv,
 				Base,
+				"en-US",
 			);
 			mainGroup = 0F5548EB151D1187007E633F;
 			productRefGroup = 0F5548F7151D1187007E633F /* Products */;
@@ -834,6 +837,7 @@
 				0FFB2CF11CF5931D000AECF6 /* nl */,
 				0F4AEB171E0E6A4000709D4F /* tr */,
 				0F55058E1E309C1D0054BB57 /* sv */,
+				C7868BB627491FB7001B35B6 /* en-US */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -853,6 +857,7 @@
 				0FFB2CF21CF5931D000AECF6 /* nl */,
 				0F4AEB181E0E6A4000709D4F /* tr */,
 				0F55058F1E309C1D0054BB57 /* sv */,
+				C7868BB727491FB7001B35B6 /* en-US */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/XBMC Remote/Settings.bundle/en-us.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en-us.lproj/Root.strings
@@ -1,0 +1,40 @@
+/* A single strings file, whose title is specified in your preferences schema. The strings files provide the localized content to display to the user for each of your preferences. */
+
+"General" = "General";
+"Automatic" = "Automatic";
+"Show connection notice" = "Show connection notice";
+"Direct Play mode" = "Direct Play mode";
+"Ken Burns effect" = "Ken Burns effect";
+"Shake to clear playlist" = "Shake to clear playlist";
+"Show jewel cases" = "Show jewel cases";
+"Hide labels in wall view" = "Hide labels in wall view";
+"Use rounded corner images" = "Use rounded corner images";
+"TV logo background" = "TV logo background";
+"Dark" = "Dark";
+"Light" = "Light";
+"Transparent" = "Transparent";
+"Remote Control" = "Remote Control";
+"Gesture remote control" = "Gesture remote control";
+"Vibrate remote control" = "Vibrate remote control";
+"Remote Position" = "Remote Position";
+"Top" = "Top";
+"Bottom" = "Bottom";
+"App Settings" = "App Settings";
+"Clear cache on next start" = "Clear cache on next start";
+"Enable contents cache" = "Enable contents cache";
+"Override Lockscreen" = "Override Lockscreen";
+"Show all files in filemode" = "Show all files in filemode";
+"Filemode changes needs app restart" = "Filemode changes needs app restart";
+"Main Menu" = "Main Menu";
+"Main Menu changes needs app restart" = "Main Menu changes needs app restart";
+"Show MUSIC" = "Show MUSIC";
+"Show MOVIES" = "Show MOVIES";
+"Show VIDEOS" = "Show VIDEOS";
+"Show TV SHOWS" = "Show TV SHOWS";
+"Show PICTURES" = "Show PICTURES";
+"Show LIVE TV" = "Show LIVE TV";
+"Show RADIO" = "Show RADIO";
+"Show FAVOURITES" = "Show FAVORITES";
+"Show NOW PLAYING" = "Show NOW PLAYING";
+"Show REMOTE CONTROL" = "Show REMOTE CONTROL";
+

--- a/XBMC Remote/en-US.lproj/InfoPlist.strings
+++ b/XBMC Remote/en-US.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Localized versions of Info.plist keys */
+
+NSLocalNetworkUsageDescription = "Kodi Remote App uses local network to find and communicate to Kodi instances in the network.";

--- a/XBMC Remote/en-US.lproj/Localizable.strings
+++ b/XBMC Remote/en-US.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+/* 
+  Localisable.strings
+  XBMC Remote
+
+  Created by Andree Buschmann on 21/11/20.
+  Copyright (c) 2021 Team Kodi. All rights reserved.
+ */
+
+"Favourites" = "Favorites";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Based on a discussion on the forums. This PR add US localization for the English translations. Only current difference is _Favourites_ vs. _Favorites_.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Add en-us as localized language