### PR TITLE
Bugfixes: Settings view controller

### DIFF
--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -94,7 +94,7 @@
         else if ([itemControls[@"type"] isEqualToString:@"spinner"] && settingOptions == nil) {
             xbmcSetting = cSlider;
             storeSliderValue = [self.detailItem[@"value"] intValue];
-            cellHeight = 184.0;
+            cellHeight = 242.0;
         }
         else if ([itemControls[@"type"] isEqualToString:@"edit"]) {
             xbmcSetting = cInput;
@@ -518,10 +518,11 @@
             cellLabel.textAlignment = NSTextAlignmentCenter;
             cellText = [NSString stringWithFormat:@"%@", self.detailItem[@"label"]];
             
-            descriptionLabel.frame = CGRectMake(descriptionLabel.frame.origin.x, descriptionLabel.frame.origin.y + 2, self.view.bounds.size.width - (cellLabelOffset * 2), 58);
+            descriptionLabel.frame = CGRectMake(descriptionLabel.frame.origin.x, descriptionLabel.frame.origin.y + 2, self.view.bounds.size.width - (cellLabelOffset * 2), 116);
             descriptionLabel.textAlignment = NSTextAlignmentCenter;
-            descriptionLabel.numberOfLines = 4;
+            descriptionLabel.numberOfLines = 8;
             descriptionLabel.text = [NSString stringWithFormat:@"%@", self.detailItem[@"genre"]];
+            [self adjustFontSize:descriptionLabel];
             slider.minimumValue = [self.detailItem[@"minimum"] intValue];
             slider.maximumValue = [self.detailItem[@"maximum"] intValue];
             slider.value = [self.detailItem[@"value"] intValue];

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -232,9 +232,7 @@
             subTitle = [NSString stringWithFormat:@": %@", settingOptions[longPressRow.row][@"label"]];
             break;
         case cSlider:
-            if (itemControls[@"formatlabel"] != nil) {
-                stringFormat = [NSString stringWithFormat:@": %@", itemControls[@"formatlabel"]];
-            }
+            stringFormat = [self getStringFormatFromItem:itemControls defaultFormat:stringFormat];
             subTitle = [NSString stringWithFormat:stringFormat, (int)storeSliderValue];
             break;
         case cUnsupported:
@@ -344,7 +342,18 @@
     return;
 }
 
-#pragma mark -
+#pragma mark Helper
+
+- (NSString*)getStringFormatFromItem:(id)item defaultFormat:(NSString*)defaultFormat {
+    // Workaround!! Before Kodi 18.x an older format ("%i ms") was used. The new format ("{0:d} ms") needs
+    // an updated parser. Until this is implemented just display the value itself, without the unit.
+    NSString *format = item[@"formatlabel"];
+    if (format.length > 0 && AppDelegate.instance.serverVersion < 18) {
+        return format;
+    }
+    return defaultFormat;
+}
+
 #pragma mark Table view data source
 
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
@@ -526,9 +535,7 @@
             slider.minimumValue = [self.detailItem[@"minimum"] intValue];
             slider.maximumValue = [self.detailItem[@"maximum"] intValue];
             slider.value = [self.detailItem[@"value"] intValue];
-            if (itemControls[@"formatlabel"] != nil) {
-                stringFormat = [NSString stringWithFormat:@"%@", itemControls[@"formatlabel"]];
-            }
+            stringFormat = [self getStringFormatFromItem:itemControls defaultFormat:stringFormat];
             sliderLabel.text = [NSString stringWithFormat:stringFormat, [self.detailItem[@"value"] intValue]];
             break;
             
@@ -789,9 +796,7 @@
         if ([[[slider superview] viewWithTag:102] isKindOfClass:[UILabel class]]) {
             UILabel *sliderLabel = (UILabel*)[[slider superview] viewWithTag:102];
             NSString *stringFormat = @"%i";
-            if (itemControls[@"formatlabel"] != nil) {
-                stringFormat = [NSString stringWithFormat:@"%@", itemControls[@"formatlabel"]];
-            }
+            stringFormat = [self getStringFormatFromItem:itemControls defaultFormat:stringFormat];
             sliderLabel.text = [NSString stringWithFormat:stringFormat, (int)storeSliderValue];
         }
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/485.
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/486.

This PR is just fixing two observed topics which are easily recognized by users: Non-usable displayed values in sliders (e.g. "{0:d}") and truncated strings.

The first issue is caused by Kodi server providing different format strings in different versions. Examples (old -> new -> display):
`"%i %%"` -> `"{0:d} %"` -> "3 %" (UI Zoom)
`"%i.0 dB"` -> `"{0:d}.0 dB"` -> "96.0 dB" (Music Replaygain)
`"%i ms"` -> `"{0:d} ms"` -> "750 ms" (Delays)
`"%i"` -> `"{0:d}"` -> "5" (Stereoscopic 3D effect)
This PR handles above cases -- tested with Kodi 17.6 and Kodi 19.3.

The second issue is caused by the App just hardcoding the label height for different types of settings. This PR does not rework this behaviour, but adjusts label's `height`, `numberOfLines` and font size to show the full text of the longest string found during testing ("Interface -> Skin -> Stereoscopic 3D effect strength").

The SettingsValueViewController in general needs more rework. The label's height and other UI element's positions (e.g. headers, footers, sliders, toggle switches) should be positioned dynamically based on the text field space requirements.

Screenshots (using Kodi 19.3):
<a href="https://abload.de/image.php?img=bildschirmfoto2021-11jqjgc.png"><img src="https://abload.de/img/bildschirmfoto2021-11jqjgc.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show correct units and complete tex in sliders in the Kodi settings menu