### PR TITLE
Improvement: Trigger Local Network Privacy Alert on manual sever selection

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -44,6 +44,7 @@
 
 - (void)saveServerList;
 - (void)clearAppDiskCache;
+- (void)triggerLocalNetworkPrivacyAlert;
 - (void)sendWOL:(NSString*)MAC withPort:(NSInteger)WOLport;
 - (NSURL*)getServerJSONEndPoint;
 - (NSDictionary*)getServerHTTPHeaders;

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -5753,6 +5753,82 @@ NSMutableArray *hostRightMenuItems;
     }
 }
 
+// Returns the addresses of the discard service (port 9) on every
+/// broadcast-capable interface.
+///
+/// Each array entry contains either a `sockaddr_in` or `sockaddr_in6`.
+- (NSArray<NSData*>*) addressesOfDiscardServiceOnBroadcastCapableInterfaces {
+    struct ifaddrs *addrList = NULL;
+    int err = getifaddrs(&addrList);
+    if (err != 0) {
+        return @[];
+    }
+    NSMutableArray<NSData*> *result = [NSMutableArray array];
+    for (struct ifaddrs *cursor = addrList; cursor != NULL; cursor = cursor->ifa_next) {
+        if ( (cursor->ifa_flags & IFF_BROADCAST) &&
+             (cursor->ifa_addr != NULL)
+           ) {
+            switch (cursor->ifa_addr->sa_family) {
+            case AF_INET: {
+                struct sockaddr_in sin = *(struct sockaddr_in*) cursor->ifa_addr;
+                sin.sin_port = htons(9);
+                NSData *addr = [NSData dataWithBytes:&sin length:sizeof(sin)];
+                [result addObject:addr];
+            } break;
+            case AF_INET6: {
+                struct sockaddr_in6 sin6 = *(struct sockaddr_in6*) cursor->ifa_addr;
+                sin6.sin6_port = htons(9);
+                NSData *addr = [NSData dataWithBytes:&sin6 length:sizeof(sin6)];
+                [result addObject:addr];
+            } break;
+            default: {
+                // do nothing
+            } break;
+            }
+        }
+    }
+    freeifaddrs(addrList);
+    return result;
+}
+
+/// Does a best effort attempt to trigger the local network privacy alert.
+///
+/// It works by sending a UDP datagram to the discard service (port 9) of every
+/// IP address associated with a broadcast-capable interface interface. This
+/// should trigger the local network privacy alert, assuming the alert hasn’t
+/// already been displayed for this app.
+///
+/// This code takes a ‘best effort’. It handles errors by ignoring them. As
+/// such, there’s guarantee that it’ll actually trigger the alert.
+///
+/// - note: iOS devices don’t actually run the discard service. I’m using it
+/// here because I need a port to send the UDP datagram to and port 9 is
+/// always going to be safe (either the discard service is running, in which
+/// case it will discard the datagram, or it’s not, in which case the TCP/IP
+/// stack will discard it).
+///
+/// There should be a proper API for this (r. 69157424).
+///
+/// For more background on this, see [Triggering the Local Network Privacy Alert](https://developer.apple.com/forums/thread/663768).
+- (void)triggerLocalNetworkPrivacyAlert {
+    int sock4 = socket(AF_INET, SOCK_DGRAM, 0);
+    int sock6 = socket(AF_INET6, SOCK_DGRAM, 0);
+    
+    if ((sock4 >= 0) && (sock6 >= 0)) {
+        char message = '!';
+        NSArray<NSData*> *addresses = [self addressesOfDiscardServiceOnBroadcastCapableInterfaces];
+        for (NSData *address in addresses) {
+            int sock = ((const struct sockaddr*) address.bytes)->sa_family == AF_INET ? sock4 : sock6;
+            (void) sendto(sock, &message, sizeof(message), MSG_DONTWAIT, address.bytes, (socklen_t) address.length);
+        }
+    }
+    
+    // If we failed to open a socket, the descriptor will be -1 and it’s safe to
+    // close that (it’s guaranteed to fail with `EBADF`).
+    close(sock4);
+    close(sock6);
+}
+
 - (void)sendWOL:(NSString*)MAC withPort:(NSInteger)WOLport {
     CFSocketRef     WOLsocket;
     WOLsocket = CFSocketCreate(kCFAllocatorDefault, PF_INET, SOCK_DGRAM, IPPROTO_UDP, 0, NULL, NULL);

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -189,6 +189,8 @@ static inline BOOL IsEmpty(id obj) {
             if (standardUserDefaults) {
                 [standardUserDefaults setObject: @(indexPath.row) forKey:@"lastServer"];
             }
+            // Trigger Local Network Privacy Alert (if not already done for the App)
+            [AppDelegate.instance triggerLocalNetworkPrivacyAlert];
         }
     }
     [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCServerHasChanged" object: nil]; 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/488.

This PR will trigger the Local Network Privacy Alert when a user manually selects a server. It is expected to resolve a problem where users could not connect to Kodi server after iOS upgrade from iOS before 14 to iOS 14 or later. Without this PR users need to run "Find Kodi" at least once after an update or clean install of the Remote App.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Trigger Local Network Privacy Alert on manual sever selection