### PR TITLE
Bugfix: Keep default thumb if key "isreminder" is not present

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -654,8 +654,11 @@
     }
 }
 
-- (NSString*)getTimerDefaultThumb:(BOOL)isReminder {
-    return isReminder ? @"nocover_reminder" : @"nocover_recording";
+- (NSString*)getTimerDefaultThumb:(id)item {
+    if (item[@"isreminder"]) {
+        return [item[@"isreminder"] boolValue] ? @"nocover_reminder" : @"nocover_recording";
+    }
+    return defaultThumb;
 }
 
 #pragma mark - Tabbar management
@@ -1462,7 +1465,7 @@
             cell.posterLabelFullscreen.hidden = YES;
         }
         
-        defaultThumb = displayThumb = [self getTimerDefaultThumb:[item[@"isreminder"] boolValue]];
+        defaultThumb = displayThumb = [self getTimerDefaultThumb:item];
         
         if ([item[@"filetype"] length] != 0 || [item[@"family"] isEqualToString:@"file"] || [item[@"family"] isEqualToString:@"genreid"]) {
             if (![stringURL isEqualToString:@""]) {
@@ -2265,7 +2268,7 @@ int originYear = 0;
                 NSDate *timerStartTime = [xbmcDateFormatter dateFromString:item[@"starttime"]];
                 NSDate *endTime = [xbmcDateFormatter dateFromString:item[@"endtime"]];
                 
-                defaultThumb = displayThumb = [self getTimerDefaultThumb:[item[@"isreminder"] boolValue]];
+                defaultThumb = displayThumb = [self getTimerDefaultThumb:item];
 
                 NSString *timerPlan;
                 if ([item[@"istimerrule"] boolValue] && ![item[@"genre"] isEqualToString:@""]) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression of https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/476 which caused the default thumbs of non-timer item's wall views to fall back to recording thumbs. The fix is to check if the key `"isreminder"` is present or not. If not, keep the default thumb. If it is present, the item is a timer and we can read the value to decide whether to show a recording or a reminder thumb.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2021-11bdkdi.png"><img src="https://abload.de/img/bildschirmfoto2021-11bdkdi.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Keep default thumbs in wall view of non-timer items
