### PR TITLE
Improvement: Similar behaviour for App's and iOS pan gesture

### DIFF
--- a/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
+++ b/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
@@ -276,14 +276,15 @@ BOOL moved;
     else if (recognizer.state == UIGestureRecognizerStateEnded || recognizer.state == UIGestureRecognizerStateCancelled) {
         CGPoint currentVelocityPoint = [recognizer velocityInView:self.view];
         CGFloat currentVelocityX     = currentVelocityPoint.x;
+        CGPoint translation = [recognizer translationInView:self.view];
 
         if (currentVelocityX < SWIPE_LEFT_THRESHOLD && !moved) { // Detected a swipe to the left
             [[NSNotificationCenter defaultCenter] postNotificationName:@"ECSLidingSwipeLeft" object:nil userInfo:nil];
         }
-        if ([self underLeftShowing] && currentVelocityX > 100) {
+        if ([self underLeftShowing] && (currentVelocityX > 1000 || translation.x > self.view.bounds.size.width / 2)) {
             [self anchorTopViewTo:ECRight];
         }
-        else if ([self underRightShowing] && currentVelocityX < -100) {
+        else if ([self underRightShowing] && (currentVelocityX < -1000 || translation.x < -self.view.bounds.size.width / 2)) {
             [self anchorTopViewTo:ECLeft];
         }
         else {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR is taking up a discussion from [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3072368#pid3072368). Main idea is to align the slide/pan behaviour of the App-internal and the iOS implementation. The change is quite simple and now does check _both_ the _velocity_ of a sliding gesture (flicking) and the _amount_ of the slide (snap back when moved <=50% of the screen width, slide when >50%).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Similar behaviour for App's and iOS pan gesture