### PR TITLE
Improvement: Slide behaviour for anchor

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5148,7 +5148,6 @@ NSIndexPath *selected;
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputFinished" object:nil userInfo:nil];
-    [[NSNotificationCenter defaultCenter] removeObserver: self name:@"ECSLidingSwipeLeft" object:nil];
     self.navigationController.navigationBar.tintColor = UIColor.lightGrayColor;
     [channelListUpdateTimer invalidate];
     channelListUpdateTimer = nil;
@@ -5196,10 +5195,6 @@ NSIndexPath *selected;
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(handleSwipeFromLeft:)
-                                                 name: @"ECSLidingSwipeLeft"
-                                               object: nil];
     if (self.slidingViewController.view != nil) {
         [self disableScrollsToTopPropertyOnAllSubviewsOf:self.slidingViewController.view];
     }

--- a/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
+++ b/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
@@ -244,15 +244,12 @@ NSString *const ECSlidingViewTopDidReset             = @"ECSlidingViewTopDidRese
     }
 }
 
-BOOL moved;
-
 - (void)updateTopViewHorizontalCenterWithRecognizer:(UIPanGestureRecognizer*)recognizer {
     CGPoint currentTouchPoint     = [recognizer locationInView:self.view];
     CGFloat currentTouchPositionX = currentTouchPoint.x;
     if (recognizer.state == UIGestureRecognizerStateBegan) {
         self.initialTouchPositionX = currentTouchPositionX;
         self.initialHoizontalCenter = self.topView.center.x;
-        moved = NO;
     }
     else if (recognizer.state == UIGestureRecognizerStateChanged) {
         CGPoint translation = [recognizer translationInView:self.view];
@@ -263,9 +260,6 @@ BOOL moved;
 
             if ((newCenterPosition < self.resettedCenter && self.anchorLeftTopViewCenter == NSNotFound) || (newCenterPosition > self.resettedCenter && self.anchorRightTopViewCenter == NSNotFound)) {
                 newCenterPosition = self.resettedCenter;
-            }
-            else {
-                moved = YES;
             }
 
             [self topViewHorizontalCenterWillChange:newCenterPosition];
@@ -278,9 +272,6 @@ BOOL moved;
         CGFloat currentVelocityX     = currentVelocityPoint.x;
         CGPoint translation = [recognizer translationInView:self.view];
 
-        if (currentVelocityX < SWIPE_LEFT_THRESHOLD && !moved) { // Detected a swipe to the left
-            [[NSNotificationCenter defaultCenter] postNotificationName:@"ECSLidingSwipeLeft" object:nil userInfo:nil];
-        }
         if ([self underLeftShowing] && [self slideToAnchorPosition:YES velocity:currentVelocityX translation:translation.x]) {
             [self anchorTopViewTo:ECRight];
         }

--- a/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
+++ b/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
@@ -281,16 +281,34 @@ BOOL moved;
         if (currentVelocityX < SWIPE_LEFT_THRESHOLD && !moved) { // Detected a swipe to the left
             [[NSNotificationCenter defaultCenter] postNotificationName:@"ECSLidingSwipeLeft" object:nil userInfo:nil];
         }
-        if ([self underLeftShowing] && (currentVelocityX > 1000 || translation.x > self.view.bounds.size.width / 2)) {
+        if ([self underLeftShowing] && [self slideToAnchorPosition:YES velocity:currentVelocityX translation:translation.x]) {
             [self anchorTopViewTo:ECRight];
         }
-        else if ([self underRightShowing] && (currentVelocityX < -1000 || translation.x < -self.view.bounds.size.width / 2)) {
+        else if ([self underRightShowing] && [self slideToAnchorPosition:NO velocity:currentVelocityX translation:translation.x]) {
             [self anchorTopViewTo:ECLeft];
         }
         else {
             [self resetTopView];
         }
     }
+}
+
+- (BOOL)slideToAnchorPosition:(BOOL)isAnchorRight velocity:(CGFloat)velocity translation:(CGFloat)xTranslation {
+    // Invert when we check for the anchor on the left
+    if (!isAnchorRight) {
+        velocity = -velocity;
+        xTranslation = -xTranslation;
+    }
+    // Flick to expand the anchor (right anchor flicked to the left)
+    if (velocity < -1000) {
+        return NO;
+    }
+    // 1. Flick to anchor view (full screen flicked to right)
+    // 2. Move full screen more than 50% (full screen moved >50% to the right)
+    // 3. Move anchor more than 50% (right anchor moved >50% to the left)
+    return (velocity > 1000 ||
+            (xTranslation > 0 && xTranslation > GET_MAINSCREEN_WIDTH / 2) ||
+            (xTranslation < 0 && xTranslation >= -GET_MAINSCREEN_WIDTH / 2 + ANCHOR_RIGHT_PEEK));
 }
 
 - (UIPanGestureRecognizer*)panGesture {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1755,10 +1755,6 @@ double round(double d) {
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(handleSwipeFromLeft:)
-                                                 name: @"ECSLidingSwipeLeft"
-                                               object: nil];
     if (foundTintColor != nil) {
         [self setIOS7barTintColor:foundTintColor];
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
When the anchor is visible (partially displayed screen on the left or right), the anchor always opened to full view once touched. The user would expect that the anchor is snapping back to its position when the anchor is moved less than 50% of the screen width.

This PR does a bit of rework and refinement of the sliding conditions. Now the anchor's behaviour is same as for the fullscreen:
1. Flicking a fully visible screen moves it into an anchor
2. Moving a fully visible screen >50% moves it into an anchor
3. Moving a fully visible screen <50% lets it snap back to full screen
4. Flicking an anchor will switch to full screen
5. Moving an anchor >50% opens it to a full screen
6. Moving an anchor  <50% lets it snap back to the anchor

In addition, the PR removes the obsolete notification `"ECSLidingSwipeLeft"`. The condition to send this notification was only met in very rare cases, and the controllers handling it have an alternative `UISwipeGestureRecognizer` defined to handle the swipe gesture.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Slide behaviour for anchor