### PR TITLE
Bugfix: Properly handle arrays in getYearFromItem

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -639,6 +639,9 @@
             year = @"";
         }
     }
+    else if ([item isKindOfClass:[NSArray class]]) {
+        year = [item componentsJoinedByString:@" / "];
+    }
     else if ([item integerValue] > 0) {
         year = item;
     }

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -617,7 +617,7 @@
         runtime = @"";
     }
     else if ([item isKindOfClass:[NSArray class]]) {
-        runtime = [NSString stringWithFormat:@"%@", [item componentsJoinedByString:@" / "]];
+        runtime = [item componentsJoinedByString:@" / "];
     }
     else {
         int minutes = [item intValue] / secondsToMinute;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The key `"activeyears"` provides an array of length 1 with a string inside. This results in a crash when calling `[item integerValue].`

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix crash when handling an array inside getYearFromItem