### PR TITLE
Bugfix: Fix potentially wrong background color for default thumbs

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -638,7 +638,9 @@
                       withBorder:showBorder
                         progress:nil
                        completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-            if (channelListView || channelGuideView || recordingListView || isOnPVR) {
+            // Only set the logo background, if the attempt to load it was successful (image != nil).
+            // This avoids a possibly wrong background for a default thumb.
+            if (image && (channelListView || channelGuideView || recordingListView || isOnPVR)) {
                 [Utilities setLogoBackgroundColor:weakImageView mode:logoBackgroundMode];
             }
         }];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/500.

The automatic background color for TV station logos shall not be set, if the attempt to load the station logo fails. In this case the default thumb shall be shown without any adaption of the background color (defaults to clear color). Screenshots can be seen in the issue linked above.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix potentially wrong background color for default thumbs
