### PR TITLE
[german] fix typo: 'Aufnehemen'

### DIFF
--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -182,7 +182,7 @@
 "All channels" = "Alle Kanäle";
 "Channel Groups" = "Kanalgruppen";
 "Channel Guide" = "Kanal-Programm-Guide";
-"Record" = "Aufnehemen";
+"Record" = "Aufnehmen";
 "Stop Recording" = "Aufnehmen beenden";
 "Recordings" = "Aufnahmen";
 "Timers" = "Timer";


### PR DESCRIPTION
## Description
German translation for `Record` is `Aufnehmen`

@wutschel

EDIT: or should things like this be handled in Weblate? idk