### PR TITLE
Bugfix: Fix processing button presses in song details overlay on iPad

### DIFF
--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -478,6 +478,8 @@
     
     menuViewController.tableView.separatorInset = UIEdgeInsetsZero;
     
+    [self.view insertSubview:self.nowPlayingController.songDetailsView aboveSubview:rootView];
+    
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     BOOL clearCache = [[userDefaults objectForKey:@"clearcache_preference"] boolValue];
     if (clearCache) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/506.

Button presses (repeat and shuffle) in the song details overlay were not recognized on iPad. The overlay window was simply closed.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix repeat/shuffle in song details overlay on iPad