### PR TITLE
Improvement: Also check for review when starting playback from ShowInfoVC

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1644,6 +1644,7 @@ double round(double d) {
                                 [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCPlaylistHasChanged" object: nil];
                                 [activityIndicatorView stopAnimating];
                                 [self showNowPlaying];
+                                [Utilities checkForReviewRequest];
                                 if (resumePointLocal) {
                                     [NSThread sleepForTimeInterval:1.0];
                                     [self SimpleAction:@"Player.Seek" params:[Utilities buildPlayerSeekPercentageParams:[item[@"playlistid"] intValue] percentage:resumePointLocal]];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The review checker was not called when starting the playback from the info view controller ("Play" or "Resume from"). This PR also triggers the check in this case.

Screenshot:
<a href="https://abload.de/image.php?img=bildschirmfoto2021-12u9j5w.png"><img src="https://abload.de/img/bildschirmfoto2021-12u9j5w.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Also check for review when starting playback from ShowInfoVC