### PR TITLE
Maintenance: Remove openWithVLC

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -2326,10 +2326,10 @@ NSMutableArray *hostRightMenuItems;
     menu_Movies.thumbWidth = 53;
     menu_Movies.defaultThumb = @"nocover_movies";
     menu_Movies.sheetActions = @[
-        [self action_queue_to_moviedetails], //, LOCALIZED_STR(@"Open with VLC")
+        [self action_queue_to_moviedetails],
         @[],
         [self action_queue_to_play],
-        [self action_queue_to_moviedetails], //, LOCALIZED_STR(@"Open with VLC"),
+        [self action_queue_to_moviedetails],
         @[],
         @[],
         [self action_queue_to_showcontent]
@@ -2665,10 +2665,10 @@ NSMutableArray *hostRightMenuItems;
     menu_Movies.subItem.defaultThumb = @"nocover_movies";
     menu_Movies.subItem.sheetActions = @[
         @[],
-        [self action_queue_to_moviedetails], //, LOCALIZED_STR(@"Open with VLC")
-        [self action_queue_to_moviedetails], //, LOCALIZED_STR(@"Open with VLC")
+        [self action_queue_to_moviedetails],
+        [self action_queue_to_moviedetails],
         @[],
-        [self action_queue_to_play], //, LOCALIZED_STR(@"Open with VLC")
+        [self action_queue_to_play],
         [self action_queue_to_play],
         [self action_queue_to_moviedetails]
     ];
@@ -2967,8 +2967,8 @@ NSMutableArray *hostRightMenuItems;
     menu_Videos.thumbWidth = 53;
     menu_Videos.defaultThumb = @"nocover_movies";
     menu_Videos.sheetActions = @[
-        [self action_queue_to_musicvideodetails], //, LOCALIZED_STR(@"Open with VLC")
-        [self action_queue_to_musicvideodetails], //, LOCALIZED_STR(@"Open with VLC")
+        [self action_queue_to_musicvideodetails],
+        [self action_queue_to_musicvideodetails],
         @[],
         @[],
         [self action_queue_to_showcontent]
@@ -3131,7 +3131,7 @@ NSMutableArray *hostRightMenuItems;
     menu_Videos.subItem.sheetActions = @[
         @[],
         @[],
-        [self action_queue_to_play], //, LOCALIZED_STR(@"Open with VLC")
+        [self action_queue_to_play],
         [self action_queue_to_play],
         [self action_queue_to_moviedetails]
     ];
@@ -3682,9 +3682,9 @@ NSMutableArray *hostRightMenuItems;
     menu_TVShows.subItem.thumbWidth = 95;
     menu_TVShows.subItem.defaultThumb = @"nocover_tvshows_episode";
     menu_TVShows.subItem.sheetActions = @[
-        [self action_queue_to_episodedetails], //, LOCALIZED_STR(@"Open with VLC")
+        [self action_queue_to_episodedetails],
         @[],
-        [self action_queue_to_play], //, LOCALIZED_STR(@"Open with VLC")
+        [self action_queue_to_play],
         [self action_queue_to_play], //, @"Stream to iPhone"
         [self action_queue_to_moviedetails]
     ];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3242,9 +3242,6 @@ NSIndexPath *selected;
     else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Play Trailer")]) {
         [self playerOpen:[NSDictionary dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys: item[@"trailer"], @"file", nil], @"item", nil] index:selected];
     }
-    else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Open with VLC")]) {
-        [self openWithVLC:item indexPath:selected];
-    }
     else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Search Wikipedia")]) {
         [self searchWeb:(NSMutableDictionary*)item indexPath:selected serviceURL:[NSString stringWithFormat:@"http://%@.m.wikipedia.org/wiki?search=%%@", LOCALIZED_STR(@"WIKI_LANG")]];
     }
@@ -3710,34 +3707,6 @@ NSIndexPath *selected;
             DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:MenuItem.subItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
             [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:NO];
         }
-    }
-}
-
-- (void)openWithVLC:(NSDictionary*)item indexPath:(NSIndexPath*)indexPath {
-    id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
-    [queuing startAnimating];
-    if (![UIApplication.sharedApplication canOpenURL:[NSURL URLWithString:@"vlc://"]]) {
-        [queuing stopAnimating];
-        UIAlertController *alertView = [Utilities createAlertOK:LOCALIZED_STR(@"Cannot do that") message:nil];
-        [self presentViewController:alertView animated:YES completion:nil];
-    }
-    else {
-        [[Utilities getJsonRPC] callMethod:@"Files.PrepareDownload" withParameters:[NSDictionary dictionaryWithObjectsAndKeys:item[@"file"], @"path", nil] onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
-            if (error == nil && methodError == nil) {
-                if ([methodResult count] > 0) {
-                    GlobalData *obj = [GlobalData getInstance];
-                    NSString *userPassword = [AppDelegate.instance.obj.serverPass isEqualToString:@""] ? @"" : [NSString stringWithFormat:@":%@", AppDelegate.instance.obj.serverPass];
-                    NSString *serverURL = [NSString stringWithFormat:@"%@%@@%@:%@", obj.serverUser, userPassword, obj.serverIP, obj.serverPort];
-                    NSString *stringURL = [NSString stringWithFormat:@"vlc://%@://%@/%@", (NSArray*)methodResult[@"protocol"], serverURL, (NSDictionary*)methodResult[@"details"][@"path"]];
-                    [Utilities SFloadURL:stringURL fromctrl:self];
-                    [queuing stopAnimating];
-                }
-            }
-            else {
-                [queuing stopAnimating];
-            }
-        }];
     }
 }
 

--- a/XBMC Remote/Kodi Remote-Info.plist
+++ b/XBMC Remote/Kodi Remote-Info.plist
@@ -36,9 +36,7 @@
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>vlc</string>
-	</array>
+	<array/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -104,9 +104,6 @@ double round(double d) {
             NSString *pvrAction = [item[@"hastimer"] boolValue] ? LOCALIZED_STR(@"Stop Recording") : LOCALIZED_STR(@"Record");
             sheetActions = [@[LOCALIZED_STR(@"Play"), pvrAction] mutableCopy];
         }
-//        else if ([item[@"family"] isEqualToString:@"episodeid"] || [item[@"family"] isEqualToString:@"movieid"] || [item[@"family"] isEqualToString:@"musicvideoid"]) {
-//            [sheetActions addObject:LOCALIZED_STR(@"Open with VLC")];
-//        }
         if ([item[@"trailer"] isKindOfClass:[NSString class]]) {
             if ([item[@"trailer"] length] > 0) {
                 [sheetActions addObject:LOCALIZED_STR(@"Play Trailer")];
@@ -389,9 +386,6 @@ double round(double d) {
     else if (([actiontitle isEqualToString:LOCALIZED_STR(@"Record")] ||
               [actiontitle isEqualToString:LOCALIZED_STR(@"Stop Recording")])) {
         [self recordChannel];
-    }
-    else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Open with VLC")]) {
-        [self openWithVLC:self.detailItem];
     }
     else if ([actiontitle rangeOfString:LOCALIZED_STR(@"Resume from")].location != NSNotFound) {
         [self addPlayback:resumePointPercentage];
@@ -1527,36 +1521,6 @@ double round(double d) {
 }
 
 # pragma mark - JSON Data
-
-- (void)openWithVLC:(NSDictionary*)item {
-    self.navigationItem.rightBarButtonItem.enabled = NO;
-    [activityIndicatorView startAnimating];
-    if (![UIApplication.sharedApplication canOpenURL:[NSURL URLWithString:@"vlc://"]]) {
-        [activityIndicatorView stopAnimating];
-        self.navigationItem.rightBarButtonItem.enabled = YES;
-        UIAlertController *alertView = [Utilities createAlertOK:LOCALIZED_STR(@"VLC non installed") message:nil];
-        [self presentViewController:alertView animated:YES completion:nil];
-    }
-    else {
-        [[Utilities getJsonRPC] callMethod:@"Files.PrepareDownload" withParameters:[NSDictionary dictionaryWithObjectsAndKeys:item[@"file"], @"path", nil] onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
-            if (error == nil && methodError == nil) {
-                if ([methodResult count] > 0) {
-                    GlobalData *obj = [GlobalData getInstance];
-                    NSString *userPassword = [AppDelegate.instance.obj.serverPass isEqualToString:@""] ? @"" : [NSString stringWithFormat:@":%@", AppDelegate.instance.obj.serverPass];
-                    NSString *serverURL = [NSString stringWithFormat:@"%@%@@%@:%@", obj.serverUser, userPassword, obj.serverIP, obj.serverPort];
-                    NSString *stringURL = [NSString stringWithFormat:@"vlc://%@://%@/%@", (NSArray*)methodResult[@"protocol"], serverURL, (NSDictionary*)methodResult[@"details"][@"path"]];
-                    [Utilities SFloadURL:stringURL fromctrl:self];
-                    [activityIndicatorView stopAnimating];
-                    self.navigationItem.rightBarButtonItem.enabled = YES;
-                }
-            }
-            else {
-                [activityIndicatorView stopAnimating];
-                self.navigationItem.rightBarButtonItem.enabled = YES;
-            }
-        }];
-    }
-}
 
 - (void)addQueueAfterCurrent:(BOOL)afterCurrent {
     self.navigationItem.rightBarButtonItem.enabled = NO;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/299.

The action "Open with VLC" was not working and not enabled. This PR removes the obsolete code.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Remove openWithVLC