### PR TITLE
Maintenance: Remove unused string "Stream to iPhone"

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1645,7 +1645,7 @@ NSMutableArray *hostRightMenuItems;
         [self action_queue_to_play],
         [self action_queue_to_play],
         [self action_queue_to_play],
-        [self action_queue_to_fmcharts] //, @"Stream to iPhone"
+        [self action_queue_to_fmcharts]
     ];
     
     menu_Music.subItem.originYearDuration = 248;
@@ -1838,7 +1838,7 @@ NSMutableArray *hostRightMenuItems;
     menu_Music.subItem.subItem.defaultThumb = @"nocover_music";
     menu_Music.subItem.subItem.sheetActions = @[
         [self action_queue_to_play],
-        [self action_queue_to_play],//@"Stream to iPhone",
+        [self action_queue_to_play],
         [self action_queue_to_play],
         @[],
         [self action_queue_to_play],
@@ -3681,7 +3681,7 @@ NSMutableArray *hostRightMenuItems;
         [self action_queue_to_episodedetails],
         @[],
         [self action_queue_to_play],
-        [self action_queue_to_play], //, @"Stream to iPhone"
+        [self action_queue_to_play],
         [self action_queue_to_moviedetails]
     ];
     

--- a/XBMC Remote/cs.lproj/Localizable.strings
+++ b/XBMC Remote/cs.lproj/Localizable.strings
@@ -66,7 +66,6 @@
 "Queue after current" = "Fronta po stávající";
 "Queue" = "Fronta";
 "Play" = "Přehrát";
-"Stream to iPhone" = "Streamovat do iPhone";
 "Search Wikipedia" = "Hledat na Wikipedia";
 "Search last.fm charts" = "Hledat last.fm charts";
 "Album Tracks" = "Skladby alba";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -71,7 +71,6 @@
 "Queue after current" = "Nach Aktuellem hinzufügen";
 "Queue" = "Hinzufügen";
 "Play" = "Wiedergeben";
-"Stream to iPhone" = "Zum iPhone streamen";
 "Search Wikipedia" = "Wikipedia durchsuchen";
 "Search last.fm charts" = "last.fm-Charts durchsuchen";
 "Album Tracks" = "Albumtitel";

--- a/XBMC Remote/en-US.lproj/Localizable.strings
+++ b/XBMC Remote/en-US.lproj/Localizable.strings
@@ -71,7 +71,6 @@
 "Queue after current" = "Queue after current";
 "Queue" = "Queue";
 "Play" = "Play";
-"Stream to iPhone" = "Stream to iPhone";
 "Search Wikipedia" = "Search Wikipedia";
 "Search last.fm charts" = "Search last.fm charts";
 "Album Tracks" = "Album Tracks";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -79,7 +79,6 @@
 "Queue after current" = "Queue after current";
 "Queue" = "Queue";
 "Play" = "Play";
-"Stream to iPhone" = "Stream to iPhone";
 "Search Wikipedia" = "Search Wikipedia";
 "Search last.fm charts" = "Search last.fm charts";
 "Album Tracks" = "Album Tracks";

--- a/XBMC Remote/es.lproj/Localizable.strings
+++ b/XBMC Remote/es.lproj/Localizable.strings
@@ -66,7 +66,6 @@
 "Queue after current" = "Cola después de actual";
 "Queue" = "Cola";
 "Play" = "Reproducir";
-"Stream to iPhone" = "Enviar a iPhone";
 "Search Wikipedia" = "Buscar en Wikipedia";
 "Search last.fm charts" = "Buscar en last.fm";
 "Album Tracks" = "Pistas de Álbum";

--- a/XBMC Remote/fr.lproj/Localizable.strings
+++ b/XBMC Remote/fr.lproj/Localizable.strings
@@ -65,7 +65,6 @@
 "Queue after current" = "Ajouter comme suivant";
 "Queue" = "Ajouter à la queue";
 "Play" = "Lire";
-"Stream to iPhone" = "Envoyer sur l'iPhone";
 "Search Wikipedia" = "Rechercher sur Wikipedia";
 "Search last.fm charts" = "Rechercher sur last.fm";
 "Album Tracks" = "Titres de l'album";

--- a/XBMC Remote/it.lproj/Localizable.strings
+++ b/XBMC Remote/it.lproj/Localizable.strings
@@ -66,7 +66,6 @@
 "Queue after current" = "Accoda dopo il corrente";
 "Queue" = "Accoda";
 "Play" = "Riproduci";
-"Stream to iPhone" = "Stream to iPhone";
 "Search Wikipedia" = "Ricerca Wikipedia";
 "Search last.fm charts" = "Ricerca classifiche last.fm";
 "Album Tracks" = "Tracce Album";

--- a/XBMC Remote/nl.lproj/Localizable.strings
+++ b/XBMC Remote/nl.lproj/Localizable.strings
@@ -68,7 +68,6 @@
 "Queue after current" = "Na huidige toevoegen";
 "Queue" = "Toevoegen";
 "Play" = "Afspelen";
-"Stream to iPhone" = "Naar iPhone streamen";
 "Search Wikipedia" = "Op Wikipedia zoeken";
 "Search last.fm charts" = "In 'last.fm'-lijsten zoeken";
 "Album Tracks" = "Albumnummers";

--- a/XBMC Remote/pl.lproj/Localizable.strings
+++ b/XBMC Remote/pl.lproj/Localizable.strings
@@ -66,7 +66,6 @@
 "Queue after current" = "Kolejkuj po bieżącym";
 "Queue" = "Kolejkuj";
 "Play" = "Odtwarzaj";
-"Stream to iPhone" = "Streamuj do iPhone'a";
 "Search Wikipedia" = "Wyszukaj w Wikipedii";
 "Search last.fm charts" = "Przeszukaj notowania last.fm";
 "Album Tracks" = "Utwory albumu";

--- a/XBMC Remote/pt-PT.lproj/Localizable.strings
+++ b/XBMC Remote/pt-PT.lproj/Localizable.strings
@@ -68,7 +68,6 @@
 "Queue after current" = "Colocar na fila depois de actual";
 "Queue" = "Fila";
 "Play" = "Reproduzir";
-"Stream to iPhone" = "Transmitir para iPhone";
 "Search Wikipedia" = "Procurar na Wikipédia";
 "Search last.fm charts" = "Procurar tabelas do last.fm";/*------ To verify ------*/
 "Album Tracks" = "Faixas do álbum";

--- a/XBMC Remote/sv.lproj/Localizable.strings
+++ b/XBMC Remote/sv.lproj/Localizable.strings
@@ -69,7 +69,6 @@
 "Queue after current" = "Kölägg efter aktuell";
 "Queue" = "Kölägg";
 "Play" = "Spela";
-"Stream to iPhone" = "Strömma till iPhone";
 "Search Wikipedia" = "Sök på Wikipedia";
 "Search last.fm charts" = "Sök på last.fm-topplistor";
 "Album Tracks" = "Albumspår";

--- a/XBMC Remote/tr.lproj/Localizable.strings
+++ b/XBMC Remote/tr.lproj/Localizable.strings
@@ -65,7 +65,6 @@
 "Queue after current" = "Bundan Sonra Oynat";
 "Queue" = "Kuyruğa Ekle";
 "Play" = "Oynat";
-"Stream to iPhone" = "iPhone'da oynat";
 "Search Wikipedia" = "Vikipedi'de ara";
 "Search last.fm charts" = "last.fm listelerinde ara";
 "Album Tracks" = "Albüm Başlıkları";

--- a/XBMC Remote/zh-Hans.lproj/Localizable.strings
+++ b/XBMC Remote/zh-Hans.lproj/Localizable.strings
@@ -66,7 +66,6 @@
 "Queue after current" = "队列当前位置后";
 "Queue" = "队列";
 "Play" = "播放";
-"Stream to iPhone" = "流化到iPhone";
 "Search Wikipedia" = "搜索Wikipedia";
 "Search last.fm charts" = "搜索last.fm歌单";
 "Album Tracks" = "专辑曲目";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR removes the unused string "Stream to iPhone" from localized strings.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Remove unused string "Stream to iPhone"