### PR TITLE
Improvement: No upper labels in main menu

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -19,6 +19,7 @@
     GlobalData *obj;
 }
 
+#define PHONE_MENU_HEIGHT 50
 #define PAD_MENU_HEIGHT 50
 #define PAD_MENU_INFO_HEIGHT 18
 #define PAD_MENU_TABLE_WIDTH 300

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -509,7 +509,6 @@ NSMutableArray *hostRightMenuItems;
     
 #pragma mark - Music
     menu_Music.mainLabel = LOCALIZED_STR(@"Music");
-    menu_Music.upperLabel = LOCALIZED_STR(@"Listen to");
     menu_Music.icon = @"icon_menu_music";
     menu_Music.family = FamilyDetailView;
     menu_Music.enableSection = YES;
@@ -1993,7 +1992,6 @@ NSMutableArray *hostRightMenuItems;
 
 #pragma mark - Movies
     menu_Movies.mainLabel = LOCALIZED_STR(@"Movies");
-    menu_Movies.upperLabel = LOCALIZED_STR(@"Watch your");
     menu_Movies.icon = @"icon_menu_movies";
     menu_Movies.family = FamilyDetailView;
     menu_Movies.enableSection = YES;
@@ -2744,7 +2742,6 @@ NSMutableArray *hostRightMenuItems;
     
 #pragma mark - Videos
     menu_Videos.mainLabel = LOCALIZED_STR(@"Videos");
-    menu_Videos.upperLabel = LOCALIZED_STR(@"Watch your");
     menu_Videos.icon = @"icon_menu_videos";
     menu_Videos.family = FamilyDetailView;
     menu_Videos.enableSection = YES;
@@ -3195,7 +3192,6 @@ NSMutableArray *hostRightMenuItems;
     
 #pragma mark - TV Shows
     menu_TVShows.mainLabel = LOCALIZED_STR(@"TV Shows");
-    menu_TVShows.upperLabel = LOCALIZED_STR(@"Watch your");
     menu_TVShows.icon = @"icon_menu_tvshows";
     menu_TVShows.family = FamilyDetailView;
     menu_TVShows.enableSection = YES;
@@ -3762,7 +3758,6 @@ NSMutableArray *hostRightMenuItems;
 
 #pragma mark - Live TV
     menu_LiveTV.mainLabel = LOCALIZED_STR(@"Live TV");
-    menu_LiveTV.upperLabel = LOCALIZED_STR(@"Watch");
     menu_LiveTV.icon = @"icon_menu_livetv";
     menu_LiveTV.family = FamilyDetailView;
     menu_LiveTV.enableSection = YES;
@@ -4292,7 +4287,6 @@ NSMutableArray *hostRightMenuItems;
 
 #pragma mark - Radio
     menu_Radio.mainLabel = LOCALIZED_STR(@"Radio");
-    menu_Radio.upperLabel = LOCALIZED_STR(@"Listen to");
     menu_Radio.icon = @"icon_menu_radio";
     menu_Radio.family = FamilyDetailView;
     menu_Radio.enableSection = YES;
@@ -4822,7 +4816,6 @@ NSMutableArray *hostRightMenuItems;
 
 #pragma mark - Pictures
     menu_Pictures.mainLabel = LOCALIZED_STR(@"Pictures");
-    menu_Pictures.upperLabel = LOCALIZED_STR(@"Browse your");
     menu_Pictures.icon = @"icon_menu_pictures";
     menu_Pictures.family = FamilyDetailView;
     menu_Pictures.enableSection = YES;
@@ -4984,7 +4977,6 @@ NSMutableArray *hostRightMenuItems;
     
 #pragma mark - Favourites
         menu_Favourites.mainLabel = LOCALIZED_STR(@"Favourites");
-        menu_Favourites.upperLabel = LOCALIZED_STR(@"Choose your");
         menu_Favourites.icon = @"icon_menu_favourites";
         menu_Favourites.family = FamilyDetailView;
         menu_Favourites.enableSection = YES;
@@ -5036,19 +5028,16 @@ NSMutableArray *hostRightMenuItems;
     
 #pragma mark - Now Playing
     menu_NowPlaying.mainLabel = LOCALIZED_STR(@"Now Playing");
-    menu_NowPlaying.upperLabel = LOCALIZED_STR(@"See what's");
     menu_NowPlaying.icon = @"icon_menu_playing";
     menu_NowPlaying.family = FamilyNowPlaying;
     
 #pragma mark - Remote Control
     menu_Remote.mainLabel = LOCALIZED_STR(@"Remote Control");
-    menu_Remote.upperLabel = LOCALIZED_STR(@"Use as");
     menu_Remote.icon = @"icon_menu_remote";
     menu_Remote.family = FamilyRemote;
     
 #pragma mark - XBMC Server Management
     menu_Server.mainLabel = LOCALIZED_STR(@"XBMC Server");
-    menu_Server.upperLabel = @"";
     menu_Server.icon = @"";
     menu_Server.family = FamilyServer;
     

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -147,10 +147,7 @@
         }
     }
     UIImageView *icon = (UIImageView*)[cell viewWithTag:1];
-    UILabel *upperTitle = (UILabel*)[cell viewWithTag:2];
     UILabel *title = (UILabel*)[cell viewWithTag:3];
-    upperTitle.font = [UIFont fontWithName:@"Roboto-Regular" size:11];
-    upperTitle.text = item.upperLabel;
     if (indexPath.row == 0) {
         iconName = @"connection_off";
         if (AppDelegate.instance.serverOnLine) {
@@ -164,12 +161,10 @@
     }
     if (AppDelegate.instance.serverOnLine || indexPath.row == 0) {
         icon.alpha = 1.0;
-        upperTitle.alpha = 1.0;
         title.alpha = 1.0;
     }
     else {
         icon.alpha = 0.3;
-        upperTitle.alpha = 0.3;
         title.alpha = 0.3;
     }
     icon.image = [UIImage imageNamed:iconName];
@@ -277,7 +272,7 @@
     if (indexPath.row == 0) {
         return 44;
     }
-    return 56;
+    return PHONE_MENU_HEIGHT;
 }
 
 #pragma mark - App clear disk cache methods

--- a/XBMC Remote/cellView.xib
+++ b/XBMC Remote/cellView.xib
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,27 +13,19 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="gray" indentationWidth="10" reuseIdentifier="mainMenuCell" rowHeight="56" id="3">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="gray" indentationWidth="10" reuseIdentifier="mainMenuCell" rowHeight="46" id="3">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3" id="gro-gV-D4K">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" tag="1" contentMode="scaleAspectFit" fixedFrame="YES" image="icon_menu_music" translatesAutoresizingMaskIntoConstraints="NO" id="4">
-                        <rect key="frame" x="18" y="13" width="30" height="30"/>
+                        <rect key="frame" x="18" y="10" width="30" height="30"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </imageView>
-                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="2" contentMode="left" fixedFrame="YES" text="upperLabel" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="65" y="6" width="222" height="20"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
-                        <color key="textColor" systemColor="systemGrayColor"/>
-                        <color key="highlightedColor" systemColor="systemGrayColor"/>
-                        <size key="shadowOffset" width="1" height="1"/>
-                    </label>
                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="3" contentMode="left" fixedFrame="YES" text="Main Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="6">
-                        <rect key="frame" x="65" y="16" width="192" height="34"/>
+                        <rect key="frame" x="58" y="8" width="192" height="34"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="20"/>
                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -47,11 +38,11 @@
                         <color key="backgroundColor" red="0.15686274510000001" green="0.15686274510000001" blue="0.15686274510000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </imageView>
                     <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.80000001192092896" tag="5" contentMode="center" fixedFrame="YES" image="table_arrow_right" highlightedImage="table_arrow_right_selected" translatesAutoresizingMaskIntoConstraints="NO" id="12">
-                        <rect key="frame" x="259" y="22" width="10" height="14"/>
+                        <rect key="frame" x="259" y="18" width="10" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES"/>
                     </imageView>
                     <imageView userInteractionEnabled="NO" alpha="0.80000001192092896" contentMode="scaleToFill" fixedFrame="YES" highlightedImage="selected" translatesAutoresizingMaskIntoConstraints="NO" id="13" userLabel="Image View - selected line">
-                        <rect key="frame" x="0.0" y="0.0" width="4" height="57"/>
+                        <rect key="frame" x="0.0" y="0.0" width="4" height="51"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     </imageView>
                 </subviews>
@@ -65,8 +56,5 @@
         <image name="selected" width="6" height="56"/>
         <image name="table_arrow_right" width="10" height="14"/>
         <image name="table_arrow_right_selected" width="10" height="14"/>
-        <systemColor name="systemGrayColor">
-            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
     </resources>
 </document>

--- a/XBMC Remote/cellViewIPad.xib
+++ b/XBMC Remote/cellViewIPad.xib
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,24 +26,15 @@
                         <color key="backgroundColor" red="0.27628877758979797" green="0.27628877758979797" blue="0.27628877758979797" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </imageView>
                     <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" tag="1" contentMode="scaleAspectFill" fixedFrame="YES" image="icon_menu_music" translatesAutoresizingMaskIntoConstraints="NO" id="4">
-                        <rect key="frame" x="13" y="11" width="30" height="30"/>
+                        <rect key="frame" x="12" y="10" width="30" height="30"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </imageView>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" fixedFrame="YES" highlightedImage="selected" translatesAutoresizingMaskIntoConstraints="NO" id="12" userLabel="Image View - selected line">
                         <rect key="frame" x="0.0" y="0.0" width="4" height="51"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                     </imageView>
-                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="2" contentMode="left" fixedFrame="YES" text="upperLabel" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="54" y="4" width="222" height="18"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
-                        <color key="textColor" systemColor="systemGrayColor"/>
-                        <color key="highlightedColor" systemColor="systemGrayColor"/>
-                        <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                        <size key="shadowOffset" width="0.0" height="0.0"/>
-                    </label>
                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="3" contentMode="left" fixedFrame="YES" text="Main Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="6">
-                        <rect key="frame" x="54" y="16" width="243" height="29"/>
+                        <rect key="frame" x="52" y="8" width="243" height="34"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -61,8 +51,5 @@
     <resources>
         <image name="icon_menu_music" width="30" height="30"/>
         <image name="selected" width="6" height="56"/>
-        <systemColor name="systemGrayColor">
-            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
     </resources>
 </document>

--- a/XBMC Remote/cs.lproj/Localizable.strings
+++ b/XBMC Remote/cs.lproj/Localizable.strings
@@ -6,12 +6,6 @@
  Copyright (c) 2012 joethefox inc. All rights reserved.
  */
 
-"Listen to" = "Poslouchat";
-"Watch your" = "Sledovat";
-"Browse your" = "Procházet";
-"See what's" = "Podívat se, co";
-"Use as" = "Použít jako";
-"Watch" = "Sledovat";
 "Music" = "Hudba";
 "Movies" = "Filmy";
 "TV Shows" = "Seriály";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -6,13 +6,6 @@
   Copyright (c) 2012 joethefox inc. All rights reserved.
  */
 
-"Listen to" = "Höre deine";
-"Watch your" = "Schaue deine";
-"Browse your" = "Durchsuche deine";
-"See what's" = "Schaue was";
-"Use as" = "Benutze die";
-"Watch" = "Schaue";
-"Choose your" = "Wähle deine";
 "Music" = "Musik";
 "Movies" = "Filme";
 "TV Shows" = "Serien";

--- a/XBMC Remote/en-US.lproj/Localizable.strings
+++ b/XBMC Remote/en-US.lproj/Localizable.strings
@@ -6,13 +6,6 @@
   Copyright (c) 2021 Team Kodi. All rights reserved.
  */
 
-"Listen to" = "Listen to";
-"Watch your" = "Watch your";
-"Browse your" = "Browse your";
-"See what's" = "See what's";
-"Use as" = "Use as";
-"Watch" = "Watch";
-"Choose your" = "Go to your";
 "Music" = "Music";
 "Movies" = "Movies";
 "TV Shows" = "TV Shows";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -6,14 +6,6 @@
   Copyright (c) 2012 joethefox inc. All rights reserved.
  */
 
-"Listen to" = "Listen to";
-"Watch your" = "Watch your";
-"Browse your" = "Browse your";
-"See what's" = "See what's";
-"Use as" = "Use as";
-"Watch" = "Watch";
-"Choose your" = "Go to your";
-
 "Music" = "Music";
 "Movies" = "Movies";
 "TV Shows" = "TV Shows";

--- a/XBMC Remote/es.lproj/Localizable.strings
+++ b/XBMC Remote/es.lproj/Localizable.strings
@@ -6,12 +6,6 @@
  Copyright (c) 2012 joethefox inc. All rights reserved.
  */
 
-"Listen to" = "Escuchar";
-"Watch your" = "Ver tu";
-"Browse your" = "Explorar tu";
-"See what's" = "Ver qué es esto";
-"Use as" = "Usar como";
-"Watch" = "Ver";
 "Music" = "Musica";
 "Movies" = "Películas";
 "TV Shows" = "Programas TV";

--- a/XBMC Remote/fr.lproj/Localizable.strings
+++ b/XBMC Remote/fr.lproj/Localizable.strings
@@ -6,12 +6,6 @@
   Copyright (c) 2012 joethefox inc. All rights reserved.
  */
 
-"Listen to" = "Ecoutez votre";
-"Watch your" = "Regardez vos";
-"Browse your" = "Explorez vos";
-"See what's" = "Regardez la";
-"Use as" = "Utiliser comme";
-"Watch" = "Regardez";
 "Music" = "Musique";
 "Movies" = "Films";
 "TV Shows" = "Séries TV";

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -245,12 +245,9 @@
     }
     mainMenu *item = mainMenuItems[indexPath.row];
     UIImageView *icon = (UIImageView*)[cell viewWithTag:1];
-    UILabel *upperTitle = (UILabel*)[cell viewWithTag:2];
     UILabel *title = (UILabel*)[cell viewWithTag:3];
     UIImageView *line = (UIImageView*)[cell viewWithTag:4];
     NSString *iconName = item.icon;
-    upperTitle.font = [UIFont fontWithName:@"Roboto-Regular" size:12];
-    upperTitle.text = item.upperLabel;
     if (indexPath.row == 0) {
         iconName = @"connection_off";
         if (AppDelegate.instance.serverOnLine) {
@@ -274,12 +271,10 @@
     icon.image = [UIImage imageNamed:iconName];
     if (AppDelegate.instance.serverOnLine) {
         icon.alpha = 1.0;
-        upperTitle.alpha = 1.0;
         title.alpha = 1.0;
     }
     else if (indexPath.row != 0) {
         icon.alpha = 0.3;
-        upperTitle.alpha = 0.3;
         title.alpha = 0.3;
     }
     return cell;

--- a/XBMC Remote/it.lproj/Localizable.strings
+++ b/XBMC Remote/it.lproj/Localizable.strings
@@ -6,12 +6,6 @@
   Copyright (c) 2012 joethefox inc. All rights reserved.
  */
 
-"Listen to" = "Ascolta la";
-"Watch your" = "Guarda";
-"Browse your" = "Sfoglia le tue";
-"See what's" = "Vedi cosa c'è";
-"Use as" = "Usa come";
-"Watch" = "Guarda";
 "Music" = "Musica";
 "Movies" = "Film";
 "TV Shows" = "Serie TV";

--- a/XBMC Remote/mainMenu.h
+++ b/XBMC Remote/mainMenu.h
@@ -29,7 +29,6 @@ typedef enum {
 @interface mainMenu : NSObject
 
 @property (nonatomic, copy) NSString *mainLabel;
-@property (nonatomic, copy) NSString *upperLabel;
 @property MenuItemFamilyType family;
 @property BOOL enableSection;
 @property (nonatomic, copy) NSString *icon;

--- a/XBMC Remote/mainMenu.m
+++ b/XBMC Remote/mainMenu.m
@@ -10,12 +10,11 @@
 
 @implementation mainMenu
 
-@synthesize mainLabel, upperLabel, icon, family, mainButtons, mainMethod, mainFields, mainParameters, rowHeight, thumbWidth, defaultThumb, subItem, enableSection, sheetActions, showInfo, originYearDuration, widthLabel, showRuntime, originLabel, noConvertTime, chooseTab, disableNowPlaying, filterModes, currentFilterMode;
+@synthesize mainLabel, icon, family, mainButtons, mainMethod, mainFields, mainParameters, rowHeight, thumbWidth, defaultThumb, subItem, enableSection, sheetActions, showInfo, originYearDuration, widthLabel, showRuntime, originLabel, noConvertTime, chooseTab, disableNowPlaying, filterModes, currentFilterMode;
 
 - (id)copyWithZone:(NSZone*)zone {
     mainMenu *menuCopy = [[mainMenu allocWithZone: zone] init];
     menuCopy.mainLabel = [self.mainLabel copy];
-    menuCopy.upperLabel = [self.upperLabel copy];
     menuCopy.family = self.family;
     menuCopy.enableSection = self.enableSection;
     menuCopy.icon = [self.icon copy];

--- a/XBMC Remote/nl.lproj/Localizable.strings
+++ b/XBMC Remote/nl.lproj/Localizable.strings
@@ -8,12 +8,6 @@
  Copyright (c) 2012 joethefox inc. All rights reserved.
  */
 
-"Listen to" = "Luisteren naar";
-"Watch your" = "Bekijk je";
-"Browse your" = "Bekijk je";
-"See what's" = "Zien wat er nu";
-"Use as" = "Gebruiken als";
-"Watch" = "Bekijk";
 "Music" = "Muziek";
 "Movies" = "Films";
 "TV Shows" = "TV Series";

--- a/XBMC Remote/pl.lproj/Localizable.strings
+++ b/XBMC Remote/pl.lproj/Localizable.strings
@@ -6,12 +6,6 @@
   Copyright (c) 2012 joethefox inc. All rights reserved.
  */
 
-"Listen to" = "Słuchaj";
-"Watch your" = "Oglądaj";
-"Browse your" = "Przeglądaj";
-"See what's" = "Zobacz, co";
-"Use as" = "Użyj jako";
-"Watch" = "Oglądaj";
 "Music" = "Muzyka";
 "Movies" = "Filmy";
 "TV Shows" = "Programy TV";
@@ -302,7 +296,6 @@
 "Music Roles" = "Role muzyczne";
 "Video Playlists" = "Listy odtwarzania wideo";
 "Favourites" = "Ulubione";
-"Choose your" = "Przejdź do";
 "Never" = "Nigdy";
 "Last Updated: %@" = "Ostatnio zaktualizowane: %@";
 "Not Available" = "Niedostępne";

--- a/XBMC Remote/pt-PT.lproj/Localizable.strings
+++ b/XBMC Remote/pt-PT.lproj/Localizable.strings
@@ -6,12 +6,6 @@
   Copyright (c) 2016 joethefox inc. All rights reserved.
  */
 
-"Listen to" = "Ouvir";
-"Watch your" = "Ver";
-"Browse your" = "Ver";
-"See what's" = "Ver o que está";
-"Use as" = "Utilizar como";
-"Watch" = "Ver";
 "Music" = "Música";
 "Movies" = "Filmes";
 "TV Shows" = "Séries de TV";
@@ -313,7 +307,6 @@
 "Search last.fm charts" = "Pesquisar classificações do last.fm";
 "Pictures Add-ons" = "Extensões de fotos";
 "Music Roles" = "Funções musicais";
-"Choose your" = "Vá ao seu";
 "Never" = "Nunca";
 "Last Updated: %@" = "Última Actualização: %@";
 "Not Available" = "Indisponível";

--- a/XBMC Remote/sv.lproj/Localizable.strings
+++ b/XBMC Remote/sv.lproj/Localizable.strings
@@ -9,12 +9,6 @@
  
  */
 
-"Listen to" = "Lyssna på";
-"Watch your" = "Se på dina";
-"Browse your" = "Sök efter dina";
-"See what's" = "Se vad som är";
-"Use as" = "Använd som";
-"Watch" = "Se";
 "Music" = "Musik";
 "Movies" = "Filmer";
 "TV Shows" = "TV-serier";
@@ -299,7 +293,6 @@
 "XBMC \"Gotham\" version 13 or superior is required to access XBMC settings" = "Kodi \"Gotham\" version 13 eller senare krävs för att komma åt Kodi-inställningarna";
 "Video Playlists" = "Videospellistor";
 "Favourites" = "Favoriter";
-"Choose your" = "Gå till din";
 "Never" = "Aldrig";
 "Last Updated: %@" = "Senast uppdaterad: %@";
 "Not Available" = "Inte tillgänglig";

--- a/XBMC Remote/tr.lproj/Localizable.strings
+++ b/XBMC Remote/tr.lproj/Localizable.strings
@@ -6,12 +6,6 @@
   Copyright (c) 2016 joethefox inc. All rights reserved.
  */
 
-"Listen to" = "Dinle";
-"Watch your" = "İzle";
-"Browse your" = "Gözat";
-"See what's" = "Görüntüle";
-"Use as" = "Kullan";
-"Watch" = "İzle";
 "Music" = "Müzik";
 "Movies" = "Filmler";
 "TV Shows" = "Diziler";

--- a/XBMC Remote/zh-Hans.lproj/Localizable.strings
+++ b/XBMC Remote/zh-Hans.lproj/Localizable.strings
@@ -6,12 +6,6 @@
   Copyright (c) 2012 joethefox inc. All rights reserved.
  */
 
-"Listen to" = "收听";
-"Watch your" = "观看";
-"Browse your" = "浏览";
-"See what's" = "查看";
-"Use as" = "使用";
-"Watch" = "看";
 "Music" = "音乐";
 "Movies" = "电影";
 "TV Shows" = "剧集";
@@ -302,7 +296,6 @@
 "Unable to execute the action" = "动作无法执行";
 "Action executed successfully" = "动作执行成功";
 "Music Roles" = "音乐角色";
-"Choose your" = "选择";
 "Never" = "从不";
 "Not Available" = "不可用";
 "Username" = "用户名";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/505.

This PR implements a suggestion coming from a Team Kodi member. The so-called "upper labels" (e.g. "Listen to") above the main menu label (e.g. "MUSIC") are hardly readable and do not add a real value. In addition, these strings are not translating well into German where the common rule is to not directly address the user, but use a passive form (e.g. "Höre deine Musik" would become "Deine Musik hören"). Kodi server also simply shows the icon and label in the main menu.

Changes in this PR:
- Remove upper labels from xib and code
- Alignment of icon and label in the cell
- Same cell height for iPhone and iPad

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2021-11f4j0l.png"><img src="https://abload.de/img/bildschirmfoto2021-11f4j0l.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: No upper labels in main menu