### PR TITLE
Feature: Server info

### DIFF
--- a/XBMC Remote/HostManagementViewController.h
+++ b/XBMC Remote/HostManagementViewController.h
@@ -32,7 +32,7 @@
     MessagesView *messagesView;
     __weak IBOutlet UIToolbar *bottomToolbar;
     __weak IBOutlet UIImageView *bottomToolbarShadowImageView;
-    UIScrollView *serverInfoView;
+    UITextView *serverInfoView;
     __weak IBOutlet UIButton *serverInfoButton;
     NSTimer *serverInfoTimer;
 }

--- a/XBMC Remote/HostManagementViewController.h
+++ b/XBMC Remote/HostManagementViewController.h
@@ -32,6 +32,8 @@
     MessagesView *messagesView;
     __weak IBOutlet UIToolbar *bottomToolbar;
     __weak IBOutlet UIImageView *bottomToolbarShadowImageView;
+    UIScrollView *serverInfoView;
+    __weak IBOutlet UIButton *serverInfoButton;
 }
 
 - (id)initWithNibName:(NSString*)nibNameOrNil bundle:(NSBundle*)nibBundleOrNil;

--- a/XBMC Remote/HostManagementViewController.h
+++ b/XBMC Remote/HostManagementViewController.h
@@ -34,6 +34,7 @@
     __weak IBOutlet UIImageView *bottomToolbarShadowImageView;
     UIScrollView *serverInfoView;
     __weak IBOutlet UIButton *serverInfoButton;
+    NSTimer *serverInfoTimer;
 }
 
 - (id)initWithNibName:(NSString*)nibNameOrNil bundle:(NSBundle*)nibBundleOrNil;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -418,9 +418,22 @@ static inline BOOL IsEmpty(id obj) {
                                                                offset,
                                                                serverInfoView.frame.size.width - 2 * MARGIN,
                                                                0)];
-    label.text = [NSString stringWithFormat:@"%@: %@", name, text];
-    label.textColor = UIColor.whiteColor;
-    label.font = [UIFont systemFontOfSize:fontSize];
+    
+    // Bold & gray for label, normal and white for the text itself.
+    name = [NSString stringWithFormat:@"%@: ", name];
+    NSDictionary *boldFontAttrib = @{
+        NSFontAttributeName: [UIFont boldSystemFontOfSize:fontSize],
+        NSForegroundColorAttributeName: UIColor.lightGrayColor
+    };
+    NSMutableAttributedString *string1 = [[NSMutableAttributedString alloc] initWithString:name attributes:boldFontAttrib];
+    NSDictionary *normalFontAttrib = @{
+        NSFontAttributeName: [UIFont systemFontOfSize:fontSize],
+        NSForegroundColorAttributeName: UIColor.whiteColor
+    };
+    NSMutableAttributedString *string2 = [[NSMutableAttributedString alloc] initWithString:text attributes:normalFontAttrib];
+    [string1 appendAttributedString:string2];
+    
+    label.attributedText = string1;
     label.numberOfLines = 2;
     label.lineBreakMode = NSLineBreakByWordWrapping;
     label.hidden = NO;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -288,8 +288,9 @@ static inline BOOL IsEmpty(id obj) {
     if (serverListTableView.editing || forceClose) {
         [serverListTableView setEditing:NO animated:YES];
         editTableButton.selected = NO;
-        if (AppDelegate.instance.arrayServerList.count == 0)
+        if (AppDelegate.instance.arrayServerList.count == 0) {
             [serverListTableView reloadData];
+        }
         if (storeServerSelection) {
             [serverListTableView selectRowAtIndexPath:storeServerSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
             UITableViewCell *cell = [serverListTableView cellForRowAtIndexPath:storeServerSelection];

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -31,7 +31,7 @@
     return self;
 }
 
-#pragma mark - Button Mamagement
+#pragma mark - Button Management
 
 - (IBAction)addHost:(id)sender {
     serverInfoView.hidden = YES;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -551,17 +551,11 @@ static inline BOOL IsEmpty(id obj) {
     supportedVersionLabel.text = LOCALIZED_STR(@"Supported XBMC version is Eden (11) or higher");
     self.navigationController.navigationBar.barTintColor = BAR_TINT_COLOR;
     
-    [editTableButton setBackgroundImage:[UIImage new] forState:UIControlStateNormal];
-    [editTableButton setBackgroundImage:[UIImage new] forState:UIControlStateHighlighted];
-    [editTableButton setBackgroundImage:[UIImage new] forState:UIControlStateSelected];
     editTableButton.titleLabel.font = [UIFont systemFontOfSize:15];
     [editTableButton setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];
     [editTableButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
     editTableButton.titleLabel.shadowOffset = CGSizeZero;
     
-    [addHostButton setBackgroundImage:[UIImage new] forState:UIControlStateNormal];
-    [addHostButton setBackgroundImage:[UIImage new] forState:UIControlStateHighlighted];
-    [addHostButton setBackgroundImage:[UIImage new] forState:UIControlStateSelected];
     addHostButton.titleLabel.font = [UIFont systemFontOfSize:15];
     [addHostButton setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];
     [addHostButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -379,34 +379,35 @@ static inline BOOL IsEmpty(id obj) {
                                    @"System.OSVersionInfo"]}
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
         if (error == nil && methodError == nil) {
-            
-            for (UIView *subview in serverInfoView.subviews) {
-                [subview removeFromSuperview];
-            }
-            CGFloat offset = MARGIN;
-            offset = [self addLabel:@"Name" text:methodResult[@"System.FriendlyName"] offset:offset];
-            offset = [self addLabel:@"Build" text:methodResult[@"System.BuildVersion"] offset:offset];
-            offset = [self addLabel:@"Build Date" text:methodResult[@"System.BuildDate"] offset:offset];
-            offset = [self addLabel:@"Server Date" text:methodResult[@"System.Date"] offset:offset];
-            offset = [self addLabel:@"Server Time" text:methodResult[@"System.Time"] offset:offset] + BLOCK_MARGIN;
-            offset = [self addLabel:@"OS" text:methodResult[@"System.OSVersionInfo"] offset:offset] + BLOCK_MARGIN;
-            offset = [self addLabel:@"Screen" text:methodResult[@"System.ScreenResolution"] offset:offset];
-            offset = [self addLabel:@"FPS" text:methodResult[@"System.FPS"] offset:offset] + BLOCK_MARGIN;
-            offset = [self addLabel:@"CPU Clock" text:methodResult[@"System.CpuFrequency"] offset:offset];
-            offset = [self addLabel:@"CPU Load" text:methodResult[@"System.CpuUsage"] offset:offset];
-            offset = [self addLabel:@"CPU Temp" text:methodResult[@"System.CPUTemperature"] offset:offset];
-            offset = [self addLabel:@"GPU Temp" text:methodResult[@"System.GPUTemperature"] offset:offset];
-            offset = [self addLabel:@"HDD Temp" text:methodResult[@"System.HddTemperature"] offset:offset] + BLOCK_MARGIN;
+            NSMutableAttributedString *infoString = [NSMutableAttributedString new];
+            NSAttributedString *newLine = [[NSAttributedString alloc] initWithString:@"\n"];
+            [infoString appendAttributedString:[self formatInfo:@"Name" text:methodResult[@"System.FriendlyName"]]];
+            [infoString appendAttributedString:[self formatInfo:@"Build" text:methodResult[@"System.BuildVersion"]]];
+            [infoString appendAttributedString:[self formatInfo:@"Build Date" text:methodResult[@"System.BuildDate"]]];
+            [infoString appendAttributedString:[self formatInfo:@"Server Date" text:methodResult[@"System.Date"]]];
+            [infoString appendAttributedString:[self formatInfo:@"Server Time" text:methodResult[@"System.Time"]]];
+            [infoString appendAttributedString:newLine];
+            [infoString appendAttributedString:[self formatInfo:@"OS" text:methodResult[@"System.OSVersionInfo"]]];
+            [infoString appendAttributedString:newLine];
+            [infoString appendAttributedString:[self formatInfo:@"Screen" text:methodResult[@"System.ScreenResolution"]]];
+            [infoString appendAttributedString:[self formatInfo:@"FPS" text:methodResult[@"System.FPS"]]];
+            [infoString appendAttributedString:newLine];
+            [infoString appendAttributedString:[self formatInfo:@"CPU Clock" text:methodResult[@"System.CpuFrequency"]]];
+            [infoString appendAttributedString:[self formatInfo:@"CPU Load" text:methodResult[@"System.CpuUsage"]]];
+            [infoString appendAttributedString:[self formatInfo:@"CPU Temp" text:methodResult[@"System.CPUTemperature"]]];
+            [infoString appendAttributedString:[self formatInfo:@"GPU Temp" text:methodResult[@"System.GPUTemperature"]]];
+            [infoString appendAttributedString:[self formatInfo:@"HDD Temp" text:methodResult[@"System.HddTemperature"]]];
+            [infoString appendAttributedString:newLine];
             NSString *memory = [NSString stringWithFormat:@"%@ Used / %@ Total",
                                 methodResult[@"System.Memory(used.percent)"],
                                 methodResult[@"System.Memory(total)"]];
-            offset = [self addLabel:@"Memory" text:memory offset:offset];
+            [infoString appendAttributedString:[self formatInfo:@"Memory" text:memory]];
             NSString *storage = [NSString stringWithFormat:@"%@ / %@",
                                 methodResult[@"System.UsedSpacePercent"],
                                 methodResult[@"System.TotalSpace"]];
-            offset = [self addLabel:@"Storage" text:storage offset:offset];
+            [infoString appendAttributedString:[self formatInfo:@"Storage" text:storage]];
             
-            serverInfoView.contentSize = CGSizeMake(serverInfoView.frame.size.width, offset);
+            serverInfoView.attributedText = infoString;
         }
     }];
 }
@@ -422,37 +423,25 @@ static inline BOOL IsEmpty(id obj) {
     }
 }
 
-- (CGFloat)addLabel:(NSString*)name text:(NSString*)text offset:(CGFloat)offset {
+- (NSAttributedString*)formatInfo:(NSString*)name text:(NSString*)text {
     int fontSize = 15;
-    UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(MARGIN,
-                                                               offset,
-                                                               serverInfoView.frame.size.width - 2 * MARGIN,
-                                                               0)];
-    
-    // Bold & gray for label, normal and white for the text itself.
+    // Bold and gray for label
     name = [NSString stringWithFormat:@"%@: ", name];
     NSDictionary *boldFontAttrib = @{
         NSFontAttributeName: [UIFont boldSystemFontOfSize:fontSize],
         NSForegroundColorAttributeName: UIColor.lightGrayColor
     };
+    // Normal and white for the text
     NSMutableAttributedString *string1 = [[NSMutableAttributedString alloc] initWithString:name attributes:boldFontAttrib];
+    text = [NSString stringWithFormat:@"%@\n", text];
     NSDictionary *normalFontAttrib = @{
         NSFontAttributeName: [UIFont systemFontOfSize:fontSize],
         NSForegroundColorAttributeName: UIColor.whiteColor
     };
     NSMutableAttributedString *string2 = [[NSMutableAttributedString alloc] initWithString:text attributes:normalFontAttrib];
+    // Build the complete string
     [string1 appendAttributedString:string2];
-    
-    label.attributedText = string1;
-    label.numberOfLines = 2;
-    label.lineBreakMode = NSLineBreakByWordWrapping;
-    label.hidden = NO;
-    CGRect frame = label.frame;
-    frame.size.height = [Utilities getHeightOfLabel:label];
-    label.frame = frame;
-    [serverInfoView addSubview:label];
-    
-    return offset + frame.size.height;
+    return string1;
 }
 
 #pragma mark - LifeCycle
@@ -523,7 +512,7 @@ static inline BOOL IsEmpty(id obj) {
     messagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     [self.view addSubview:messagesView];
     
-    serverInfoView = [[UIScrollView alloc] initWithFrame:CGRectMake(MARGIN, deltaY + MARGIN, self.view.frame.size.width - 2 * MARGIN, self.view.frame.size.height - bottomPadding - deltaY - 44 - 2 * MARGIN)];
+    serverInfoView = [[UITextView alloc] initWithFrame:CGRectMake(MARGIN, deltaY + MARGIN, self.view.frame.size.width - 2 * MARGIN, self.view.frame.size.height - bottomPadding - deltaY - 44 - 2 * MARGIN)];
     serverInfoView.autoresizingMask = UIViewAutoresizingFlexibleWidth |
                                       UIViewAutoresizingFlexibleHeight |
                                       UIViewAutoresizingFlexibleLeftMargin |

--- a/XBMC Remote/HostManagementViewController.xib
+++ b/XBMC Remote/HostManagementViewController.xib
@@ -16,6 +16,7 @@
                 <outlet property="connectingActivityIndicator" destination="26" id="27"/>
                 <outlet property="editTableButton" destination="5" id="18"/>
                 <outlet property="lpgr" destination="20" id="22"/>
+                <outlet property="serverInfoButton" destination="WtD-wt-do5" id="6jU-nT-b83"/>
                 <outlet property="serverListTableView" destination="8" id="15"/>
                 <outlet property="supportedVersionLabel" destination="12" id="fyu-35-aWq"/>
                 <outlet property="supportedVersionView" destination="TtA-IV-ddn" id="fr3-iF-Lcf"/>
@@ -39,7 +40,7 @@
                 </toolbar>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="10">
                     <rect key="frame" x="10" y="211" width="125" height="28"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                     <size key="titleShadowOffset" width="1" height="1"/>
                     <state key="normal" title="Add Host">
@@ -56,6 +57,23 @@
                     <connections>
                         <action selector="addHost:" destination="-1" eventType="touchUpInside" id="14"/>
                     </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WtD-wt-do5" userLabel="Info Button">
+                    <rect key="frame" x="146" y="211" width="28" height="28"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
+                    <size key="titleShadowOffset" width="1" height="1"/>
+                    <state key="normal" image="button_info">
+                        <color key="titleColor" red="1" green="1" blue="1" alpha="0.90000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
+                    <state key="selected">
+                        <color key="titleColor" red="1" green="1" blue="1" alpha="0.90000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
+                    <state key="highlighted">
+                        <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5">
                     <rect key="frame" x="185" y="211" width="125" height="28"/>
@@ -118,7 +136,7 @@
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-19" y="40"/>
+            <point key="canvasLocation" x="-20.289855072463769" y="39.508928571428569"/>
         </view>
         <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.5" id="20">
             <connections>
@@ -127,6 +145,7 @@
         </pongPressGestureRecognizer>
     </objects>
     <resources>
+        <image name="button_info" width="25" height="25"/>
         <image name="shiny_black_back" width="240" height="408"/>
         <image name="tableDown" width="480" height="8"/>
         <image name="tableUp" width="480" height="8"/>

--- a/XBMC Remote/playlistCellView.xib
+++ b/XBMC Remote/playlistCellView.xib
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,7 +21,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     </imageView>
                     <label clipsSubviews="YES" userInteractionEnabled="NO" tag="1" contentMode="left" fixedFrame="YES" text="La grande bouffe" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="7">
-                        <rect key="frame" x="60" y="3" width="254" height="35"/>
+                        <rect key="frame" x="60" y="3" width="253" height="35"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
@@ -27,7 +29,7 @@
                         <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </label>
                     <label clipsSubviews="YES" userInteractionEnabled="NO" tag="2" contentMode="left" fixedFrame="YES" text="Action / Drama / Crime / Thriller" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="8">
-                        <rect key="frame" x="60" y="35" width="207" height="16"/>
+                        <rect key="frame" x="60" y="35" width="206" height="16"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -82,12 +84,13 @@
                 </subviews>
             </tableViewCellContentView>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <point key="canvasLocation" x="139" y="54"/>
         </tableViewCell>
     </objects>
     <resources>
-        <image name="pgbar_act" width="128" height="128"/>
-        <image name="pgbar_inact_fake" width="128" height="128"/>
-        <image name="timeBackground" width="128" height="128"/>
+        <image name="pgbar_act" width="44" height="17"/>
+        <image name="pgbar_inact_fake" width="50" height="17"/>
+        <image name="timeBackground" width="53" height="17"/>
         <systemColor name="darkTextColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/389.

This PR implements a detailed server info, comparable to Kodi's System Info. The current state is shown in the screenshot below. More details can be shown, if this should be required. I am avoiding to add eye-candy like bars for memory consumption or the CPU load as I would need to parse Kodi's responses, and I am already seeing different string formats between my main test systems 17.6 and 19.3.

Screenshots (Kodi 19.3 on a VM):
<a href="https://abload.de/image.php?img=bildschirmfoto2021-121tk7s.png"><img src="https://abload.de/img/bildschirmfoto2021-121tk7s.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Server info