### PR TITLE
Improvement: Better usability of playlist toggle button

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2584,19 +2584,6 @@ int currentItemID;
         }
         if (IS_IPHONE) {
             startFlipDemo = YES;
-            UIImage *buttonImage;
-            if ([self enableJewelCases]) {
-                buttonImage = [self resizeToolbarThumb:thumbnailView.image];
-            }
-            else {
-                buttonImage = [self resizeToolbarThumb:jewelView.image];
-            }
-            if (buttonImage.size.width == 0) {
-                buttonImage = [UIImage imageNamed:@"st_kodi_window"];
-            }
-            [playlistButton setImage:buttonImage forState:UIControlStateNormal];
-            [playlistButton setImage:buttonImage forState:UIControlStateHighlighted];
-            [playlistButton setImage:buttonImage forState:UIControlStateSelected];
         }
     }
     [[NSNotificationCenter defaultCenter] addObserver: self

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -355,7 +355,7 @@ int currentItemID;
 
 - (void)nothingIsPlaying {
     if (startFlipDemo) {
-        UIImage *image = [UIImage imageNamed:@"xbmc_overlay_small"];
+        UIImage *image = [UIImage imageNamed:@"st_kodi_window"];
         [playlistButton setImage:image forState:UIControlStateNormal];
         [playlistButton setImage:image forState:UIControlStateHighlighted];
         [playlistButton setImage:image forState:UIControlStateSelected];
@@ -1577,7 +1577,7 @@ int currentItemID;
                                  buttonImage = [self resizeToolbarThumb:jewelView.image];
                              }
                              if (!buttonImage.size.width) {
-                                 buttonImage = [self resizeToolbarThumb:[UIImage imageNamed:@"xbmc_overlay_small"]];
+                                 buttonImage = [self resizeToolbarThumb:[UIImage imageNamed:@"st_kodi_window"]];
                              }
                              [button setImage:buttonImage forState:UIControlStateNormal];
                              [button setImage:buttonImage forState:UIControlStateHighlighted];
@@ -2592,7 +2592,7 @@ int currentItemID;
                 buttonImage = [self resizeToolbarThumb:jewelView.image];
             }
             if (buttonImage.size.width == 0) {
-                buttonImage = [UIImage imageNamed:@"xbmc_overlay_small"];
+                buttonImage = [UIImage imageNamed:@"st_kodi_window"];
             }
             [playlistButton setImage:buttonImage forState:UIControlStateNormal];
             [playlistButton setImage:buttonImage forState:UIControlStateHighlighted];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/515.

This PR improves the usability of the the playlist view toolbar. The button to toggle between the playlist and the NowPlaying view was showing an unreadable icon if nothing is playing.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2021-12qkj5g.png"><img src="https://abload.de/img/bildschirmfoto2021-12qkj5g.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Better usability of playlist toggle button