### PR TITLE
Improvement: Show TV/Radio channel numbers

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3791,6 +3791,7 @@ NSMutableArray *hostRightMenuItems;
                 @"channelgroupid": @"alltv",
                 @"properties": @[
                         @"thumbnail",
+                        @"channelnumber",
                         @"channel"]
             }, @"parameters",
             @{
@@ -3975,7 +3976,7 @@ NSMutableArray *hostRightMenuItems;
             @"row3": @"endtime",
             @"row4": @"filetype",
             @"row5": @"filetype",
-            @"row6": @"channelid",
+            @"row6": @"channelnumber",
             @"playlistid": @1,
             @"row8": @"channelid",
             @"row9": @"isrecording",
@@ -4117,6 +4118,7 @@ NSMutableArray *hostRightMenuItems;
             @{
                 @"properties": @[
                         @"thumbnail",
+                        @"channelnumber",
                         @"channel"]
             }, @"parameters",
             @{
@@ -4163,7 +4165,7 @@ NSMutableArray *hostRightMenuItems;
             @"row3": @"endtime",
             @"row4": @"filetype",
             @"row5": @"filetype",
-            @"row6": @"channelid",
+            @"row6": @"channelnumber",
             @"playlistid": @1,
             @"row8": @"channelid",
             @"row9": @"channelid",
@@ -4321,6 +4323,7 @@ NSMutableArray *hostRightMenuItems;
                 @"channelgroupid": @"allradio",
                 @"properties": @[
                         @"thumbnail",
+                        @"channelnumber",
                         @"channel"]
             }, @"parameters",
             @{
@@ -4505,7 +4508,7 @@ NSMutableArray *hostRightMenuItems;
             @"row3": @"endtime",
             @"row4": @"filetype",
             @"row5": @"filetype",
-            @"row6": @"channelid",
+            @"row6": @"channelnumber",
             @"playlistid": @1,
             @"row8": @"channelid",
             @"row9": @"isrecording",
@@ -4647,6 +4650,7 @@ NSMutableArray *hostRightMenuItems;
             @{
                 @"properties": @[
                         @"thumbnail",
+                        @"channelnumber",
                         @"channel"]
             }, @"parameters",
             @{
@@ -4693,7 +4697,7 @@ NSMutableArray *hostRightMenuItems;
             @"row3": @"endtime",
             @"row4": @"filetype",
             @"row5": @"filetype",
-            @"row6": @"channelid",
+            @"row6": @"channelnumber",
             @"playlistid": @1,
             @"row8": @"channelid",
             @"row9": @"channelid",

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2164,7 +2164,12 @@ int originYear = 0;
     frame.origin.x = labelPosition;
     frame.size.width = Menuitem.widthLabel;
     title.frame = frame;
-    title.text = item[@"label"];
+    if (channelListView && item[@"channelnumber"]) {
+        title.text = [NSString stringWithFormat:@"%@. %@", item[@"channelnumber"], item[@"label"]];
+    }
+    else {
+        title.text = item[@"label"];
+    }
 
     frame = genre.frame;
     frame.size.width = frame.size.width - (labelPosition - frame.origin.x);


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/517.

This PR implements a suggestion by a user to show TV/Radio channel numbers. The code change is pretty simple and straight forward. I keep this as draft as I need to check, if the parameter `"channelnumber"` is available in older APIs as well, and how this looks like when IPTV channels are added.

Screenshots (only shown for TV - All channels, works as well for the lists under channel groups and for Radio):
<a href="https://abload.de/image.php?img=bildschirmfoto2021-12pnkhj.png"><img src="https://abload.de/img/bildschirmfoto2021-12pnkhj.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Show TV/Radio channel numbers