### PR TITLE
Bugfix: Fix crash after using "Search Wikipedia" during active search

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5547,6 +5547,7 @@ NSIndexPath *selected;
     dataList.tableFooterView = [UIView new];
 
     self.searchController = [[UISearchController alloc]initWithSearchResultsController:nil];
+    [self.searchController.searchBar setShowsCancelButton:YES animated:NO];
     self.searchController.searchResultsUpdater = self;
     self.searchController.dimsBackgroundDuringPresentation = NO;
     self.searchController.searchBar.delegate = self;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/520.

The animation can interfere with restoring the active keyboard after e.g. leaving for "Search Wikipedia" and re-entering the search. This results in a crash. Removing the animation resolves this problem.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix crash after using "Search Wikipedia" during active search