### PR TITLE
Bugfix: Hide toolbar while active search

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5445,12 +5445,12 @@ NSIndexPath *selected;
 
 - (void)searchBarSearchButtonClicked:(UISearchBar*)searchbar {
     showkeyboard = NO;
-    // Hide the toolbar while search is active
-    [self hideButtonList:YES];
 }
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar*)searchbar {
     showkeyboard = YES;
+    // Hide the toolbar while search is active
+    [self hideButtonList:YES];
 }
 
 #pragma mark UISearchController Delegate Methods


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/523.

Hide button list when editing the searchbar text field. Avoids issues when attempting to change the mode while a search is active and you do not press keyboard's "Enter". Typically this happens when using an external keyboard or hiding the popup keyboard.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Hide toolbar while active search