### PR TITLE
Improvement: Better readability of section header when sorting for playcount

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1916,7 +1916,7 @@ int originYear = 0;
         }
         else {
             NSNumberFormatter *formatter = [NSNumberFormatter new];
-            formatter.numberStyle = NSNumberFormatterSpellOutStyle;
+            formatter.numberStyle = NSNumberFormatterDecimalStyle;
             NSString *formatString = LOCALIZED_STR(@"Watched %@ times");
             if (watchedListenedStrings[@"watchedTimes"] != nil) {
                 formatString = watchedListenedStrings[@"watchedTimes"];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR improves the readability of the section header when sorting for `playcount`. Use `NSNumberFormatterDecimalStyle` to show a decimal number instead of spelling out the number (e.g. "37" instead of "thirty-seven"). This is especially helpful for music files which have been played a lot.

Screenshot:
<a href="https://abload.de/image.php?img=bildschirmfoto2021-12tpknb.png"><img src="https://abload.de/img/bildschirmfoto2021-12tpknb.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Better readability of section header when sorting for playcount