### PR TITLE
Improvement: Highlight selected main menu icon

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -141,10 +141,6 @@
             title.numberOfLines = 2;
             arrowRight.frame = CGRectMake(arrowRight.frame.origin.x, (int)((cellHeight/2) - (arrowRight.frame.size.height/2)), arrowRight.frame.size.width, arrowRight.frame.size.height);
         }
-        else {
-            title.font = [UIFont fontWithName:@"Roboto-Regular" size:20];
-            title.text = [item.mainLabel uppercaseString];
-        }
     }
     UIImageView *icon = (UIImageView*)[cell viewWithTag:1];
     UILabel *title = (UILabel*)[cell viewWithTag:3];
@@ -158,6 +154,13 @@
                 iconName = @"connection_on_notcp";
             }
         }
+        icon.image = [UIImage imageNamed:iconName];
+    }
+    else {
+        title.font = [UIFont fontWithName:@"Roboto-Regular" size:20];
+        title.text = [item.mainLabel uppercaseString];
+        icon.highlightedImage = [UIImage imageNamed:iconName];
+        icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:UIColor.grayColor];
     }
     if (AppDelegate.instance.serverOnLine || indexPath.row == 0) {
         icon.alpha = 1.0;
@@ -167,7 +170,6 @@
         icon.alpha = 0.3;
         title.alpha = 0.3;
     }
-    icon.image = [UIImage imageNamed:iconName];
     return cell;
 }
 

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -258,6 +258,7 @@
                 iconName = @"connection_on_notcp";
             }
         }
+        icon.image = [UIImage imageNamed:iconName];
         line.hidden = YES;
         int cellHeight = PAD_MENU_INFO_HEIGHT;
         int cellHeightPad = cellHeight - 4;
@@ -267,13 +268,14 @@
     else {
         title.font = [UIFont fontWithName:@"Roboto-Regular" size:20];
         title.text = [item.mainLabel uppercaseString];
+        icon.highlightedImage = [UIImage imageNamed:iconName];
+        icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:UIColor.grayColor];
     }
-    icon.image = [UIImage imageNamed:iconName];
-    if (AppDelegate.instance.serverOnLine) {
+    if (AppDelegate.instance.serverOnLine || indexPath.row == 0) {
         icon.alpha = 1.0;
         title.alpha = 1.0;
     }
-    else if (indexPath.row != 0) {
+    else {
         icon.alpha = 0.3;
         title.alpha = 0.3;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR improves the visualization of the selected main menu item. Dark icons are shown when not highlighted. The icon turns bright when highlighted. This is aligned with the visualization of the Kodi 19.x main menu.

Screenshot (left = before, middle = after, right = Kodi 19.x):
<a href="https://abload.de/image.php?img=bildschirmfoto2021-12p6koy.png"><img src="https://abload.de/img/bildschirmfoto2021-12p6koy.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Highlight selected main menu icon