### PR TITLE
Improvements around NowPlaying screen

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -377,7 +377,7 @@ int currentItemID;
         jewelView.image = nil;
     }
     duration.text = @"";
-    albumName.text = LOCALIZED_STR(@"Nothing is playing");
+    albumName.text = @"";
     songName.text = @"";
     artistName.text = @"";
     lastSelected = -1;

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -123,7 +123,7 @@
                             <rect key="frame" x="0.0" y="0.0" width="320" height="372"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <imageView clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.40000000596046448" contentMode="scaleAspectFit" fixedFrame="YES" image="xbmc_overlay" translatesAutoresizingMaskIntoConstraints="NO" id="154" userLabel="Image View - xbmc_overlay_ipad">
+                                <imageView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" fixedFrame="YES" image="xbmc_overlay" translatesAutoresizingMaskIntoConstraints="NO" id="154" userLabel="Image View - xbmc_overlay_ipad">
                                     <rect key="frame" x="20" y="121" width="280" height="72"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                 </imageView>

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -82,14 +82,14 @@
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="No items found." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="134">
-                                            <rect key="frame" x="41" y="10" width="168" height="22"/>
+                                            <rect key="frame" x="40" y="10" width="170" height="22"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" red="0.84919595718383789" green="0.84919595718383789" blue="0.84919595718383789" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" fixedFrame="YES" image="icon_dark" translatesAutoresizingMaskIntoConstraints="NO" id="133">
-                                            <rect key="frame" x="12" y="6" width="30" height="30"/>
+                                            <rect key="frame" x="8" y="6" width="30" height="30"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES"/>
                                         </imageView>
                                     </subviews>

--- a/XBMC Remote/cs.lproj/Localizable.strings
+++ b/XBMC Remote/cs.lproj/Localizable.strings
@@ -79,7 +79,6 @@
 "Details" = "Detaily";
 "Play Trailer" = "Přehrát trailer";
 "Playlist" = "Seznam stop";
-"Nothing is playing" = "Nic pro přehrání";
 "Details not found" = "Detaily nenalezeny";
 "Open in Safari" = "Otevřít v Safari";
 "Error loading page" = "Chyba při načítání stránky";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -84,7 +84,6 @@
 "Details" = "Details";
 "Play Trailer" = "Trailer wiedergeben";
 "Playlist" = "Wiedergabeliste";
-"Nothing is playing" = "Es wird nichts wiedergegeben";
 "Details not found" = "Details nicht gefunden";
 "Open in Safari" = "In Safari öffnen";
 "Error loading page" = "Fehler beim Laden der Seite";

--- a/XBMC Remote/en-US.lproj/Localizable.strings
+++ b/XBMC Remote/en-US.lproj/Localizable.strings
@@ -84,7 +84,6 @@
 "Details" = "Details";
 "Play Trailer" = "Play Trailer";
 "Playlist" = "Playlist";
-"Nothing is playing" = "Nothing is playing";
 "Details not found" = "Details not found";
 "Open in Safari" = "Open in Safari";
 "Error loading page" = "Error loading page";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -93,7 +93,6 @@
 "Play Trailer" = "Play Trailer";
 
 "Playlist" = "Playlist";
-"Nothing is playing" = "Nothing is playing";
 "Details not found" = "Details not found";
 "Open in Safari" = "Open in Safari";
 "Error loading page" = "Error loading page";

--- a/XBMC Remote/es.lproj/Localizable.strings
+++ b/XBMC Remote/es.lproj/Localizable.strings
@@ -79,7 +79,6 @@
 "Details" = "Detalles";
 "Play Trailer" = "Reproducir Trailer";
 "Playlist" = "Lista Reproducción";
-"Nothing is playing" = "Nada en reproducción";
 "Details not found" = "Detalles no encontrados";
 "Open in Safari" = "Abrir en Safari";
 "Error loading page" = "Error cargando página";

--- a/XBMC Remote/fr.lproj/Localizable.strings
+++ b/XBMC Remote/fr.lproj/Localizable.strings
@@ -78,7 +78,6 @@
 "Details" = "Détails";
 "Play Trailer" = "Lire la bande annonce";
 "Playlist" = "Liste de lecture";
-"Nothing is playing" = "Aucune lecture en cours";
 "Details not found" = "Détails non trouvés";
 "Open in Safari" = "Ouvrir dans Safari";
 "Error loading page" = "Erreur lors du chargement de la page";

--- a/XBMC Remote/it.lproj/Localizable.strings
+++ b/XBMC Remote/it.lproj/Localizable.strings
@@ -79,7 +79,6 @@
 "Details" = "Dettagli";
 "Play Trailer" = "Riproduci Trailer";
 "Playlist" = "Playlist";
-"Nothing is playing" = "Niente in riproduzione";
 "Details not found" = "Dettagli non trovati";
 "Open in Safari" = "Apri in Safari";
 "Error loading page" = "Errore nel caricamento della pagina";

--- a/XBMC Remote/nl.lproj/Localizable.strings
+++ b/XBMC Remote/nl.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 "Details" = "Details";
 "Play Trailer" = "Trailer afspelen";
 "Playlist" = "Afspeellijst";
-"Nothing is playing" = "Er wordt niks afgespeeld";
 "Details not found" = "Details niet gevonden";
 "Open in Safari" = "Openen in Safari";
 "Error loading page" = "Fout bij het laden van de pagina";

--- a/XBMC Remote/pl.lproj/Localizable.strings
+++ b/XBMC Remote/pl.lproj/Localizable.strings
@@ -79,7 +79,6 @@
 "Details" = "Szczegóły";
 "Play Trailer" = "Odtwórz zwiastun";
 "Playlist" = "Lista odtwarzania";
-"Nothing is playing" = "Nic nie jest odtwarzane";
 "Details not found" = "Nie odnaleziono szczegółów";
 "Open in Safari" = "Otwórz w Safari";
 "Error loading page" = "Błąd ładowania strony";

--- a/XBMC Remote/pt-PT.lproj/Localizable.strings
+++ b/XBMC Remote/pt-PT.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 "Details" = "Detalhes";
 "Play Trailer" = "Reproduzir trailer";
 "Playlist" = "Lista de reprodução";
-"Nothing is playing" = "Nada em reprodução";
 "Details not found" = "Detalhes não encontrados";
 "Open in Safari" = "Abrir no Safari";
 "Error loading page" = "Erro ao carregar a página";

--- a/XBMC Remote/sv.lproj/Localizable.strings
+++ b/XBMC Remote/sv.lproj/Localizable.strings
@@ -82,7 +82,6 @@
 "Details" = "Information";
 "Play Trailer" = "Spela förhandsvisning";
 "Playlist" = "Spellista";
-"Nothing is playing" = "Ingenting spelas upp";
 "Details not found" = "Information hittades inte";
 "Open in Safari" = "Öppna i Safari";
 "Error loading page" = "Fel vid inläsning av sidan";

--- a/XBMC Remote/tr.lproj/Localizable.strings
+++ b/XBMC Remote/tr.lproj/Localizable.strings
@@ -78,7 +78,6 @@
 "Details" = "Ayrıntılar";
 "Play Trailer" = "Fragmanı izle";
 "Playlist" = "Oynatma Listesi";
-"Nothing is playing" = "Oynatılan bir şey yok";
 "Details not found" = "Ayrıntı bulunamadı";
 "Open in Safari" = "Safari'de aç";
 "Error loading page" = "Sayfa Yükleme Hatası";

--- a/XBMC Remote/zh-Hans.lproj/Localizable.strings
+++ b/XBMC Remote/zh-Hans.lproj/Localizable.strings
@@ -79,7 +79,6 @@
 "Details" = "详情";
 "Play Trailer" = "播放预告片";
 "Playlist" = "播放列表";
-"Nothing is playing" = "未播放任何项目";
 "Details not found" = "详细资料未找到";
 "Open in Safari" = "在Safari中打开";
 "Error loading page" = "载入页面错误";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Adresses suggestions from [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3076638#pid3076638).

1. Remove "Nothing is playing" text and translations
2. No transparency for Kodi icon on iPad's NowPlaying screen for better readability (same as on iPhone)
3. More space between icon and "No items found" for better readability

Screenshots: https://abload.de/img/bildschirmfoto2021-12cnklx.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Better readability of "No items found" in playlist
Improvement: Remove obsolete text "Nothing is playing"