### PR TITLE
Bugfix: Applied unwanted rounded corners

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2511,7 +2511,7 @@ int originYear = 0;
                                   andResize:CGSizeMake(albumThumbHeight, albumThumbHeight)
                                   completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
                                       if (image != nil) {
-                                          weakThumbView.image = [Utilities roundedCornerImage:image drawBorder:YES];
+                                          weakThumbView.image = [Utilities applyRoundedEdgesImage:image drawBorder:YES];
                                           [self setViewColor:albumDetailView
                                                        image:image
                                                    isTopMost:YES
@@ -2699,7 +2699,7 @@ int originYear = 0;
                                       andResize:CGSizeMake(seasonThumbWidth, albumViewHeight - (albumViewPadding * 2))
                                       completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
                     if (image != nil) {
-                        weakThumbView.image = [Utilities roundedCornerImage:image drawBorder:YES];
+                        weakThumbView.image = [Utilities applyRoundedEdgesImage:image drawBorder:YES];
                         [self setViewColor:albumDetailView
                                      image:image
                                  isTopMost:isFirstListedSeason

--- a/XBMC Remote/SDWebImage/UIImageView+WebCache.m
+++ b/XBMC Remote/SDWebImage/UIImageView+WebCache.m
@@ -79,7 +79,7 @@ static char operationKey;
         objc_setAssociatedObject(self, &operationKey, operation, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
     else {
-        self.image = [Utilities roundedCornerImage:placeholder drawBorder:withBorder];
+        self.image = [Utilities applyRoundedEdgesImage:placeholder drawBorder:withBorder];
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3076909#pid3076909)

Instead of calling the method `applyRoundedEdgesImage` which checks the App settings, the method `roundedCornerImage` which directly applies the rounded corner was called. In effect default thumbs and thumbs in the info screen were always shown with rounded corners.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2021-12dzjyn.png"><img src="https://abload.de/img/bildschirmfoto2021-12dzjyn.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Applied unwanted rounded corners