### PR TITLE
Bugfix: Channel guide not showing up

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3971,11 +3971,11 @@ NSMutableArray *hostRightMenuItems;
             @"row3": @"endtime",
             @"row4": @"filetype",
             @"row5": @"filetype",
-            @"row6": @"channelnumber",
+            @"row6": @"channelid",
             @"playlistid": @1,
             @"row8": @"channelid",
             @"row9": @"isrecording",
-            @"row10": @"filetype",
+            @"row10": @"channelnumber",
             @"row11": @"type"
         },
                       
@@ -4160,11 +4160,11 @@ NSMutableArray *hostRightMenuItems;
             @"row3": @"endtime",
             @"row4": @"filetype",
             @"row5": @"filetype",
-            @"row6": @"channelnumber",
+            @"row6": @"channelid",
             @"playlistid": @1,
             @"row8": @"channelid",
             @"row9": @"channelid",
-            @"row10": @"filetype",
+            @"row10": @"channelnumber",
             @"row11": @"type"
         },
                               
@@ -4502,11 +4502,11 @@ NSMutableArray *hostRightMenuItems;
             @"row3": @"endtime",
             @"row4": @"filetype",
             @"row5": @"filetype",
-            @"row6": @"channelnumber",
+            @"row6": @"channelid",
             @"playlistid": @1,
             @"row8": @"channelid",
             @"row9": @"isrecording",
-            @"row10": @"filetype",
+            @"row10": @"channelnumber",
             @"row11": @"type"
         },
                       
@@ -4691,11 +4691,11 @@ NSMutableArray *hostRightMenuItems;
             @"row3": @"endtime",
             @"row4": @"filetype",
             @"row5": @"filetype",
-            @"row6": @"channelnumber",
+            @"row6": @"channelid",
             @"playlistid": @1,
             @"row8": @"channelid",
             @"row9": @"channelid",
-            @"row10": @"filetype",
+            @"row10": @"channelnumber",
             @"row11": @"type"
         },
                               


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/537.

This PR fixes a regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/518. The channel guide was not showing anymore as the configuration for JSON commands uses the key `"row6"` to load channel details which require they object `"channelid"`.  As a fix this PR moves the object `"channelnumber"` to the otherwise unused key "`row10"`. As a result the details can be loaded again, and also the channel numbers are still available.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Channel guide not showing up