### PR TITLE
Maintenance: Rework playlist

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -246,6 +246,13 @@ NSMutableArray *hostRightMenuItems;
     ];
 }
 
+- (NSArray*)action_simple_queue_to_play {
+    return @[
+        LOCALIZED_STR(@"Queue"),
+        LOCALIZED_STR(@"Play")
+    ];
+}
+
 - (NSArray*)action_queue_to_moviedetails {
     return @[
         LOCALIZED_STR(@"Queue after current"),
@@ -4964,6 +4971,10 @@ NSMutableArray *hostRightMenuItems;
     menu_Pictures.subItem.rowHeight = 76;
     menu_Pictures.subItem.thumbWidth = 53;
     menu_Pictures.subItem.defaultThumb = @"nocover_tvshows_episode";
+    menu_Pictures.subItem.sheetActions = @[
+        [self action_simple_queue_to_play],
+        @[]
+    ];
     
     menu_Pictures.subItem.subItem.mainMethod = [@[
         @[@"Files.GetDirectory", @"method"],

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3939,7 +3939,7 @@ NSIndexPath *selected;
             if (currentPlayerID == 1) { // xbmc bug
                 [[Utilities getJsonRPC] callMethod:@"Player.Stop" withParameters:[NSDictionary dictionaryWithObjectsAndKeys: @(1), @"playerid", nil] onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
                     if (error == nil && methodError == nil) {
-                        [self playerOpen:[NSDictionary dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys: item[@"file"], @"file", nil], @"item", nil] index:indexPath];
+                        [self playerOpen:[NSDictionary dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys: item[@"file"], item[@"filetype"], nil], @"item", nil] index:indexPath];
                     }
                     else {
                         UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
@@ -3948,7 +3948,7 @@ NSIndexPath *selected;
                 }];
             }
             else {
-                [self playerOpen:[NSDictionary dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys: item[@"file"], @"file", nil], @"item", nil] index:indexPath];
+                [self playerOpen:[NSDictionary dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys: item[@"file"], item[@"filetype"], nil], @"item", nil] index:indexPath];
             }
         }];
     }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3930,29 +3930,8 @@ NSIndexPath *selected;
     id cell = [self getCell:indexPath];
     UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
     [queuing startAnimating];
-    if ([mainFields[@"playlistid"] intValue] == 2) {
-        [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:[NSDictionary dictionary] onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
-            int currentPlayerID = 0;
-            if ([methodResult count]) {
-                currentPlayerID = [methodResult[0][@"playerid"] intValue];
-            }
-            if (currentPlayerID == 1) { // xbmc bug
-                [[Utilities getJsonRPC] callMethod:@"Player.Stop" withParameters:[NSDictionary dictionaryWithObjectsAndKeys: @(1), @"playerid", nil] onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
-                    if (error == nil && methodError == nil) {
-                        [self playerOpen:[NSDictionary dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys: item[@"file"], item[@"filetype"], nil], @"item", nil] index:indexPath];
-                    }
-                    else {
-                        UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
-                        [queuing stopAnimating];
-                    }
-                }];
-            }
-            else {
-                [self playerOpen:[NSDictionary dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys: item[@"file"], item[@"filetype"], nil], @"item", nil] index:indexPath];
-            }
-        }];
-    }
-    else if ([mainFields[@"row8"] isEqualToString:@"channelid"] || [mainFields[@"row8"] isEqualToString:@"broadcastid"]) {
+    if ([mainFields[@"row8"] isEqualToString:@"channelid"] ||
+        [mainFields[@"row8"] isEqualToString:@"broadcastid"]) {
         NSNumber *channelid = item[mainFields[@"row8"]];
         NSString *param = @"channelid";
         if ([mainFields[@"row8"] isEqualToString:@"broadcastid"]) {

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -50,8 +50,6 @@
     int playerPlaying;
     BOOL PlayerPaused;
     int musicPartyMode;
-    IBOutlet UIButton *seg_music;
-    IBOutlet UIButton *seg_video;
     IBOutlet UIButton *editTableButton;
     IBOutlet UIButton *PartyModeButton;
     IBOutlet UIImageView *backgroundImageView;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -396,9 +396,7 @@ int currentItemID;
         coverView.alpha = 1.0;
         UIView *timePlaying = (UIView*)[cell viewWithTag:5];
         storeSelection = nil;
-        if (!timePlaying.hidden) {
-            [self fadeView:timePlaying hidden:YES];
-        }
+        [self fadeView:timePlaying hidden:YES];
     }
     [self showPlaylistTable];
     [self toggleSongDetails];
@@ -894,9 +892,7 @@ int currentItemID;
                                      CGFloat newx = MAX(MAX_CELLBAR_WIDTH * [(NSNumber*)methodResult[@"percentage"] doubleValue] / 100, 1.0);
                                      [self resizeCellBar:newx image:playlistActualBar];
                                      UIView *timePlaying = (UIView*)[cell viewWithTag:5];
-                                     if (timePlaying.hidden) {
-                                         [self fadeView:timePlaying hidden:NO];
-                                     }
+                                     [self fadeView:timePlaying hidden:NO];
                                  }
                                  int playlistPosition = [methodResult[@"position"] intValue];
                                  if (playlistPosition > -1) {
@@ -929,9 +925,7 @@ int currentItemID;
                                                  if (selection) {
                                                      UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:selection];
                                                      UIView *timePlaying = (UIView*)[cell viewWithTag:5];
-                                                     if (!timePlaying.hidden) {
-                                                         [self fadeView:timePlaying hidden:YES];
-                                                     }
+                                                     [self fadeView:timePlaying hidden:YES];
                                                      UIImageView *coverView = (UIImageView*)[cell viewWithTag:4];
                                                      coverView.alpha = 1.0;
                                                  }
@@ -943,9 +937,7 @@ int currentItemID;
                                                  [playlistTableView selectRowAtIndexPath:newSelection animated:YES scrollPosition:position];
                                                  UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:newSelection];
                                                  UIView *timePlaying = (UIView*)[cell viewWithTag:5];
-                                                 if (timePlaying.hidden) {
-                                                     [self fadeView:timePlaying hidden:NO];
-                                                 }
+                                                 [self fadeView:timePlaying hidden:NO];
                                                  storeSelection = newSelection;
                                                  lastSelected = playlistPosition;
                                              }
@@ -956,9 +948,7 @@ int currentItemID;
                                                  [playlistTableView deselectRowAtIndexPath:selection animated:YES];
                                                  UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:selection];
                                                  UIView *timePlaying = (UIView*)[cell viewWithTag:5];
-                                                 if (!timePlaying.hidden) {
-                                                     [self fadeView:timePlaying hidden:YES];
-                                                 }
+                                                 [self fadeView:timePlaying hidden:YES];
                                                  UIImageView *coverView = (UIImageView*)[cell viewWithTag:4];
                                                  coverView.alpha = 1.0;
                                              }
@@ -2131,9 +2121,7 @@ int currentItemID;
     // andResize:CGSizeMake(thumb.frame.size.width, thumb.frame.size.height)
     thumb = [Utilities applyRoundedEdgesView:thumb drawBorder:YES];
     UIView *timePlaying = (UIView*)[cell viewWithTag:5];
-    if (!timePlaying.hidden) {
-        [self fadeView:timePlaying hidden:YES];
-    }
+    [self fadeView:timePlaying hidden:YES];
     
     return cell;
 }
@@ -2143,9 +2131,7 @@ int currentItemID;
     coverView.alpha = 1.0;
     UIView *timePlaying = (UIView*)[cell viewWithTag:5];
     storeSelection = nil;
-    if (!timePlaying.hidden) {
-        [self fadeView:timePlaying hidden:YES];
-    }
+    [self fadeView:timePlaying hidden:YES];
 }
 
 - (void)checkPartyMode {
@@ -2172,9 +2158,7 @@ int currentItemID;
              UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
              [queuing stopAnimating];
              UIView *timePlaying = (UIView*)[cell viewWithTag:5];
-             if (timePlaying.hidden) {
-                 [self fadeView:timePlaying hidden:NO];
-             }
+             [self fadeView:timePlaying hidden:NO];
 //             [self SimpleAction:@"GUI.SetFullscreen" params:[NSDictionary dictionaryWithObjectsAndKeys:@(YES), @"fullscreen", nil] reloadPlaylist:NO startProgressBar:NO];
          }
          else {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -990,18 +990,17 @@ int currentItemID;
          if (error == nil && methodError == nil && [methodResult isKindOfClass: [NSDictionary class]]) {
              hiresImage.hidden = YES;
              if (playerID == 0 && currentPlayerID == playerID) {
-                 NSString *codec = [methodResult[@"MusicPlayer.Codec"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@", methodResult[@"MusicPlayer.Codec"]];
-                 songSampleRateImage.image = nil;
-                 songNumChanImage.image = nil;
-                 
+                 NSString *codec = [Utilities getStringFromItem:methodResult[@"MusicPlayer.Codec"]];
                  [self setSongDetails:songCodec image:songCodecImage item:[self processSongCodecName:codec]];
                  [self setSongDetails:songBitRate image:songBitRateImage item:methodResult[@"MusicPlayer.Channels"]];
                  
                  BOOL isLossless = [self isLosslessFormat:codec];
                  
-                 NSString *bps = [methodResult[@"MusicPlayer.BitsPerSample"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@ Bit", methodResult[@"MusicPlayer.BitsPerSample"]];
+                 NSString *bps = [Utilities getStringFromItem:methodResult[@"MusicPlayer.BitsPerSample"]];
+                 bps = bps.length ? [NSString stringWithFormat:@"%@ Bit", bps] : @"";
                  
-                 NSString *kHz = [methodResult[@"MusicPlayer.SampleRate"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@ kHz", methodResult[@"MusicPlayer.SampleRate"]];
+                 NSString *kHz = [Utilities getStringFromItem:methodResult[@"MusicPlayer.SampleRate"]];
+                 kHz = kHz.length ? [NSString stringWithFormat:@"%@ kHz", kHz] : @"";
                  
                  // Check for High Resolution Audio
                  // Must be using a lossless codec and have either at least 24 Bit or at least 88.2 kHz.
@@ -1014,10 +1013,13 @@ int currentItemID;
                  NSString *samplerate = [NSString stringWithFormat:@"%@%@%@", bps, newLine, kHz];
                  songNumChannels.text = samplerate;
                  songNumChannels.hidden = NO;
+                 songNumChanImage.image = nil;
                  
-                 NSString *bitrate = [methodResult[@"MusicPlayer.BitRate"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@\nkbit/s", methodResult[@"MusicPlayer.BitRate"]];
+                 NSString *bitrate = [Utilities getStringFromItem:methodResult[@"MusicPlayer.BitRate"]];
+                 bitrate = bitrate.length ? [NSString stringWithFormat:@"%@\nkbit/s", bitrate] : @"";
                  songSampleRate.text = bitrate;
                  songSampleRate.hidden = NO;
+                 songSampleRateImage.image = nil;
              }
              else if (playerID == 1 && currentPlayerID == playerID) {
                  [self setSongDetails:songCodec image:songCodecImage item:methodResult[@"VideoPlayer.VideoResolution"]];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -881,9 +881,6 @@ int currentItemID;
                                      duration.hidden = YES;
                                  }
                                  NSIndexPath* selection = [playlistTableView indexPathForSelectedRow];
-                                 if (storeSelection) {
-                                     selection = storeSelection;
-                                 }
                                  if (selection) {
                                      UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:selection];
                                      UILabel *playlistActualTime = (UILabel*)[cell viewWithTag:6];
@@ -919,9 +916,6 @@ int currentItemID;
                                          if (playlistPosition > 0) {
                                              if (lastSelected != playlistPosition) {
                                                  NSIndexPath* selection = [playlistTableView indexPathForSelectedRow];
-                                                 if (storeSelection) {
-                                                     selection = storeSelection;
-                                                 }
                                                  if (selection) {
                                                      UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:selection];
                                                      UIView *timePlaying = (UIView*)[cell viewWithTag:5];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -110,6 +110,12 @@
 
 #pragma mark - utility
 
+- (void)setSongDetails:(UILabel*)label image:(UIImageView*)imageView item:(id)item {
+    label.text = [Utilities getStringFromItem:item];
+    imageView.image = [self loadImageFromName:label.text];
+    label.hidden = imageView.image != nil;
+}
+
 - (NSString*)processSongCodecName:(NSString*)codec {
     if ([codec rangeOfString:@"musepack"].location != NSNotFound) {
         codec = [codec stringByReplacingOccurrencesOfString:@"musepack" withString:@"mpc"];
@@ -982,35 +988,14 @@ int currentItemID;
                                    @"VideoPlayer.VideoCodec"]}
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
          if (error == nil && methodError == nil && [methodResult isKindOfClass: [NSDictionary class]]) {
-             NSString *codec = @"";
-             NSString *bitrate = @"";
-             NSString *samplerate = @"";
-             NSString *numchan = @"";
              hiresImage.hidden = YES;
              if (playerID == 0 && currentPlayerID == playerID) {
-                 codec = [methodResult[@"MusicPlayer.Codec"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@", methodResult[@"MusicPlayer.Codec"]];
-                 songCodec.text = codec;
-                 songCodec.hidden = NO;
-                 songCodecImage.image = nil;
+                 NSString *codec = [methodResult[@"MusicPlayer.Codec"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@", methodResult[@"MusicPlayer.Codec"]];
                  songSampleRateImage.image = nil;
                  songNumChanImage.image = nil;
                  
-                 codec = [self processSongCodecName:codec];
-                 UIImage *songImage = [self loadImageFromName:codec];
-                 songCodecImage.image = songImage;
-                 if (songImage != nil) {
-                     songCodec.hidden = YES;
-                 }
-                 
-                 numchan = [methodResult[@"MusicPlayer.Channels"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@", methodResult[@"MusicPlayer.Channels"]];
-                 songBitRate.text = numchan;
-                 songBitRate.hidden = NO;
-                 songBitRateImage.image = nil;
-                 UIImage *numChanImage = [self loadImageFromName:numchan];
-                 songBitRateImage.image = numChanImage;
-                 if (numChanImage != nil) {
-                     songBitRate.hidden = YES;
-                 }
+                 [self setSongDetails:songCodec image:songCodecImage item:[self processSongCodecName:codec]];
+                 [self setSongDetails:songBitRate image:songBitRateImage item:methodResult[@"MusicPlayer.Channels"]];
                  
                  BOOL isLossless = [self isLosslessFormat:codec];
                  
@@ -1026,55 +1011,19 @@ int currentItemID;
                  }
                 
                  NSString *newLine = ![bps isEqualToString:@""] && ![kHz isEqualToString:@""] ? @"\n" : @"";
-                 samplerate = [NSString stringWithFormat:@"%@%@%@", bps, newLine, kHz];
+                 NSString *samplerate = [NSString stringWithFormat:@"%@%@%@", bps, newLine, kHz];
                  songNumChannels.text = samplerate;
                  songNumChannels.hidden = NO;
                  
-                 bitrate = [methodResult[@"MusicPlayer.BitRate"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@\nkbit/s", methodResult[@"MusicPlayer.BitRate"]];
+                 NSString *bitrate = [methodResult[@"MusicPlayer.BitRate"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@\nkbit/s", methodResult[@"MusicPlayer.BitRate"]];
                  songSampleRate.text = bitrate;
                  songSampleRate.hidden = NO;
              }
              else if (playerID == 1 && currentPlayerID == playerID) {
-                 codec = [methodResult[@"VideoPlayer.VideoResolution"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@", methodResult[@"VideoPlayer.VideoResolution"]];
-                 songCodec.text = codec;
-                 songCodec.hidden = NO;
-                 songCodecImage.image = nil;
-                 UIImage *resolutionImage = [self loadImageFromName:codec];
-                 songCodecImage.image = resolutionImage;
-                 if (resolutionImage != nil) {
-                     songCodec.hidden = YES;
-                 }
-                 
-                 bitrate = [methodResult[@"VideoPlayer.VideoAspect"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@", methodResult[@"VideoPlayer.VideoAspect"]];
-                 songBitRate.text = bitrate;
-                 songBitRate.hidden = NO;
-                 songBitRateImage.image = nil;
-                 UIImage *aspectImage = [self loadImageFromName:bitrate];
-                 songBitRateImage.image = aspectImage;
-                 if (aspectImage != nil) {
-                     songBitRate.hidden = YES;
-                 }
-                 
-                 samplerate = [methodResult[@"VideoPlayer.VideoCodec"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@", methodResult[@"VideoPlayer.VideoCodec"]];
-                 songSampleRate.text = samplerate;
-                 songSampleRate.hidden = NO;
-                 songSampleRateImage.image = nil;
-                 UIImage *videoCodecImage = [self loadImageFromName:samplerate];
-                 songSampleRateImage.image = videoCodecImage;
-                 if (videoCodecImage != nil) {
-                     songSampleRate.hidden = YES;
-                 }
-                 
-                 numchan = [methodResult[@"VideoPlayer.AudioCodec"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"%@", methodResult[@"VideoPlayer.AudioCodec"]];
-                 numchan = [self processSongCodecName:numchan];
-                 songNumChannels.text = numchan;
-                 songNumChannels.hidden = NO;
-                 songNumChanImage.image = nil;
-                 UIImage *audioCodecImage = [self loadImageFromName:numchan];
-                 songNumChanImage.image = audioCodecImage;
-                 if (audioCodecImage != nil) {
-                     songNumChannels.hidden = YES;
-                 }
+                 [self setSongDetails:songCodec image:songCodecImage item:methodResult[@"VideoPlayer.VideoResolution"]];
+                 [self setSongDetails:songBitRate image:songBitRateImage item:methodResult[@"VideoPlayer.VideoAspect"]];
+                 [self setSongDetails:songSampleRate image:songSampleRateImage item:methodResult[@"VideoPlayer.VideoCodec"]];
+                 [self setSongDetails:songNumChannels image:songNumChanImage item:methodResult[@"VideoPlayer.AudioCodec"]];
              }
              else {
                  songCodec.hidden = YES;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -388,16 +388,7 @@ int currentItemID;
     hiresImage.hidden = YES;
     musicPartyMode = 0;
     [self setIOS7backgroundEffect:UIColor.clearColor barTintColor:TINT_COLOR];
-    NSIndexPath *selection = [playlistTableView indexPathForSelectedRow];
-    if (selection) {
-        [playlistTableView deselectRowAtIndexPath:selection animated:YES];
-        UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:selection];
-        UIImageView *coverView = (UIImageView*)[cell viewWithTag:4];
-        coverView.alpha = 1.0;
-        UIView *timePlaying = (UIView*)[cell viewWithTag:5];
-        storeSelection = nil;
-        [self fadeView:timePlaying hidden:YES];
-    }
+    [self hidePlaylistProgressbarWithDeselect:YES];
     [self showPlaylistTable];
     [self toggleSongDetails];
 }
@@ -915,14 +906,7 @@ int currentItemID;
                                      if ((playlistData.count >= playlistPosition) && currentPlayerID == playerID) {
                                          if (playlistPosition > 0) {
                                              if (lastSelected != playlistPosition) {
-                                                 NSIndexPath* selection = [playlistTableView indexPathForSelectedRow];
-                                                 if (selection) {
-                                                     UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:selection];
-                                                     UIView *timePlaying = (UIView*)[cell viewWithTag:5];
-                                                     [self fadeView:timePlaying hidden:YES];
-                                                     UIImageView *coverView = (UIImageView*)[cell viewWithTag:4];
-                                                     coverView.alpha = 1.0;
-                                                 }
+                                                 [self hidePlaylistProgressbarWithDeselect:NO];
                                                  NSIndexPath *newSelection = [NSIndexPath indexPathForRow:playlistPosition - 1 inSection:0];
                                                  UITableViewScrollPosition position = UITableViewScrollPositionMiddle;
                                                  if (musicPartyMode) {
@@ -937,15 +921,7 @@ int currentItemID;
                                              }
                                          }
                                          else {
-                                             NSIndexPath* selection = [playlistTableView indexPathForSelectedRow];
-                                             if (selection) {
-                                                 [playlistTableView deselectRowAtIndexPath:selection animated:YES];
-                                                 UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:selection];
-                                                 UIView *timePlaying = (UIView*)[cell viewWithTag:5];
-                                                 [self fadeView:timePlaying hidden:YES];
-                                                 UIImageView *coverView = (UIImageView*)[cell viewWithTag:4];
-                                                 coverView.alpha = 1.0;
-                                             }
+                                             [self hidePlaylistProgressbarWithDeselect:YES];
                                          }
                                      }
                                  }
@@ -1267,6 +1243,21 @@ int currentItemID;
                    [self showPlaylistTable];
                }
            }];
+}
+
+- (void)hidePlaylistProgressbarWithDeselect:(BOOL)deselect {
+    NSIndexPath* selection = [playlistTableView indexPathForSelectedRow];
+    if (!selection) {
+        return;
+    }
+    if (deselect) {
+        [playlistTableView deselectRowAtIndexPath:selection animated:YES];
+    }
+    UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:selection];
+    UIView *timePlaying = (UIView*)[cell viewWithTag:5];
+    [self fadeView:timePlaying hidden:YES];
+    UIImageView *coverView = (UIImageView*)[cell viewWithTag:4];
+    coverView.alpha = 1.0;
 }
 
 - (void)showPlaylistTable {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -286,6 +286,7 @@
 
 #pragma mark - JSON management
 
+int lastPlayerID = -1;
 int lastSelected = -1;
 int currentPlayerID = -1;
 float storePercentage;
@@ -581,13 +582,21 @@ int currentItemID;
                     response = methodResult[0][@"playerid"];
                 }
                 currentPlayerID = [response intValue];
-                if (playerID != [response intValue] || (selectedPlayerID > -1 && playerID != selectedPlayerID)) {  // DA SISTEMARE SE AGGIUNGONO ITEM DALL'ESTERNO: FUTURA SEGNALAZIONE CON SOCKET!
-                    if (selectedPlayerID > -1 && playerID != selectedPlayerID) {
-                        playerID = selectedPlayerID;
+                if (playerID != [response intValue] ||
+                    lastPlayerID != currentPlayerID ||
+                    (selectedPlayerID != -1 && playerID != selectedPlayerID)) {  // DA SISTEMARE SE AGGIUNGONO ITEM DALL'ESTERNO: FUTURA SEGNALAZIONE CON SOCKET!
+                    if (selectedPlayerID != -1 && playerID != selectedPlayerID) {
+                        lastPlayerID = playerID = selectedPlayerID;
                     }
                     else if (selectedPlayerID == -1) {
-                        playerID = [response intValue];
+                        lastPlayerID = playerID = [response intValue];
                         [self createPlaylist:NO animTableView:YES];
+                    }
+                    else if (lastPlayerID != currentPlayerID) {
+                        lastPlayerID = selectedPlayerID = currentPlayerID;
+                        if (playerID != currentPlayerID) {
+                            [self createPlaylist:NO animTableView:YES];
+                        }
                     }
                 }
                 NSMutableArray *properties = [@[@"album", @"artist", @"title", @"thumbnail", @"track", @"studio", @"showtitle", @"episode", @"season", @"fanart", @"description", @"plot"] mutableCopy];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -44,7 +44,7 @@
 #define PROGRESSBAR_PADDING_LEFT 20
 #define PROGRESSBAR_PADDING_BOTTOM 80
 #define SEGMENTCONTROL_WIDTH 122
-#define SEGMENTCONTROL_HEIGHT 29
+#define SEGMENTCONTROL_HEIGHT 32
 #define TOOLBAR_HEIGHT 44
 #define TAG_ID_PREVIOUS 1
 #define TAG_ID_PLAYPAUSE 2
@@ -1159,6 +1159,11 @@ int currentItemID;
         playlistSegmentedControl.selectedSegmentIndex = 1;
         [self AnimButton:PartyModeButton AnimDuration:0.3 hidden:YES XPos:-PartyModeButton.frame.size.width];
     }
+    else if (playlistID == 2) {
+        playerID = 2;
+        playlistSegmentedControl.selectedSegmentIndex = 2;
+        [self AnimButton:PartyModeButton AnimDuration:0.3 hidden:YES XPos:-PartyModeButton.frame.size.width];
+    }
     [self alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
     [[Utilities getJsonRPC] callMethod:@"Playlist.GetItems"
                         withParameters:@{@"properties": @[@"thumbnail",
@@ -1798,6 +1803,9 @@ int currentItemID;
         else if (playerID == 1) {
             playlistName = LOCALIZED_STR(@"Video ");
         }
+        else if (playerID == 2) {
+            playlistName = LOCALIZED_STR(@"Pictures ");
+        }
         NSString *message = [NSString stringWithFormat:LOCALIZED_STR(@"Are you sure you want to clear the %@playlist?"), playlistName];
         UIAlertController *alertView = [UIAlertController alertControllerWithTitle:message message:nil preferredStyle:UIAlertControllerStyleAlert];
         UIAlertAction* cancelButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {}];
@@ -2092,6 +2100,9 @@ int currentItemID;
             break;
         case 1:
             cornerLabel.text = item[@"runtime"];
+            break;
+        case 2:
+            cornerLabel.text = @"";
             break;
         default:
             break;
@@ -2431,12 +2442,18 @@ int currentItemID;
 }
 
 - (void)addSegmentControl {
-    playlistSegmentedControl = [[UISegmentedControl alloc] initWithItems:@[LOCALIZED_STR(@"Music"), [[LOCALIZED_STR(@"Video") capitalizedString] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]]];
+    NSArray *segmentItems = @[[UIImage imageNamed:@"icon_song"],
+                              [UIImage imageNamed:@"icon_video"],
+                              [UIImage imageNamed:@"icon_picture"]];
+    playlistSegmentedControl = [[UISegmentedControl alloc] initWithItems:segmentItems];
     CGFloat left_margin = (PAD_MENU_TABLE_WIDTH - SEGMENTCONTROL_WIDTH)/2;
     if (IS_IPHONE) {
         left_margin = floor(([self currentScreenBoundsDependOnOrientation].size.width - SEGMENTCONTROL_WIDTH)/2);
     }
-    playlistSegmentedControl.frame = CGRectMake(left_margin, (playlistActionView.frame.size.height - SEGMENTCONTROL_HEIGHT)/2, SEGMENTCONTROL_WIDTH, SEGMENTCONTROL_HEIGHT);
+    playlistSegmentedControl.frame = CGRectMake(left_margin,
+                                                (playlistActionView.frame.size.height - SEGMENTCONTROL_HEIGHT)/2,
+                                                SEGMENTCONTROL_WIDTH,
+                                                SEGMENTCONTROL_HEIGHT);
     playlistSegmentedControl.tintColor = UIColor.whiteColor;
     [playlistSegmentedControl addTarget:self action:@selector(segmentValueChanged:) forControlEvents: UIControlEventValueChanged];
     [playlistActionView addSubview:playlistSegmentedControl];
@@ -2455,6 +2472,10 @@ int currentItemID;
             
         case 1:
             selectedPlayerID = 1;
+            break;
+            
+        case 2:
+            selectedPlayerID = 2;
             break;
             
         default:

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -980,7 +980,6 @@ int currentItemID;
             else {
                 [self nothingIsPlaying];
                 if (playerID == PLAYERID_UNKNOWN && selectedPlayerID == PLAYERID_UNKNOWN) {
-                    playerID = -2;
                     [self createPlaylist:YES animTableView:YES];
                 }
             }
@@ -2160,9 +2159,6 @@ int currentItemID;
     UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
     storeSelection = nil;
     [queuing startAnimating];
-    if (playerID == -2) {
-        playerID = PLAYERID_MUSIC;
-    }
     [[Utilities getJsonRPC]
      callMethod:@"Player.Open" 
      withParameters:[NSDictionary dictionaryWithObjectsAndKeys:

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -53,8 +53,6 @@
 #define TAG_SEEK_BACKWARD 6
 #define TAG_SEEK_FORWARD 7
 #define TAG_ID_EDIT 88
-#define TAG_ID_SEGMENT_MUSIC 101
-#define TAG_ID_SEGMENT_VIDEO 102
 
 - (void)setDetailItem:(id)newDetailItem {
     if (_detailItem != newDetailItem) {
@@ -107,36 +105,6 @@
 
 - (UIImage*)resizeToolbarThumb:(UIImage*)img {
     return [self resizeImage:img width:34 height:34 padding:0];
-}
-
-- (IBAction)changePlaylist:(id)sender {
-    if ([sender tag] == TAG_ID_SEGMENT_MUSIC && seg_music.selected) {
-        return;
-    }
-    if ([sender tag] == TAG_ID_SEGMENT_VIDEO && seg_video.selected) {
-        return;
-    }
-    [self editTable:nil forceClose:YES];
-    if (playlistData.count && (playlistTableView.dragging || playlistTableView.decelerating)) {
-        NSArray *visiblePaths = [playlistTableView indexPathsForVisibleRows];
-        [playlistTableView scrollToRowAtIndexPath:visiblePaths[0] atScrollPosition:UITableViewScrollPositionTop animated:NO];
-    }
-    if (seg_music.selected) {
-        lastSelected = -1;
-        seg_music.selected = NO;
-        seg_video.selected = YES;
-        selectedPlayerID = 1;
-        musicPartyMode = 0;
-        [self createPlaylist:NO animTableView:YES];
-    }
-    else {
-        lastSelected = -1;
-        seg_music.selected = YES;
-        seg_video.selected = NO;
-        selectedPlayerID = 0;
-        musicPartyMode = 0;
-        [self createPlaylist:NO animTableView:YES];
-    }
 }
 
 #pragma mark - utility
@@ -1232,15 +1200,11 @@ int currentItemID;
     if (playlistID == 0) {
         playerID = 0;
         playlistSegmentedControl.selectedSegmentIndex = 0;
-        seg_music.selected = YES;
-        seg_video.selected = NO;
         [self AnimButton:PartyModeButton AnimDuration:0.3 hidden:NO XPos:8];
     }
     else if (playlistID == 1) {
         playerID = 1;
         playlistSegmentedControl.selectedSegmentIndex = 1;
-        seg_music.selected = NO;
-        seg_video.selected = YES;
         [self AnimButton:PartyModeButton AnimDuration:0.3 hidden:YES XPos:-72];
     }
     [self alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
@@ -2515,8 +2479,6 @@ int currentItemID;
 }
 
 - (void)addSegmentControl {
-    seg_music.hidden = YES;
-    seg_video.hidden = YES;
     playlistSegmentedControl = [[UISegmentedControl alloc] initWithItems:@[LOCALIZED_STR(@"Music"), [[LOCALIZED_STR(@"Video") capitalizedString] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]]];
     CGFloat left_margin = (PAD_MENU_TABLE_WIDTH - SEGMENTCONTROL_WIDTH)/2;
     if (IS_IPHONE) {
@@ -2536,8 +2498,6 @@ int currentItemID;
     }
     if (segment.selectedSegmentIndex == 0) {
         lastSelected = -1;
-        seg_music.selected = YES;
-        seg_video.selected = NO;
         selectedPlayerID = 0;
         musicPartyMode = 0;
         [self createPlaylist:NO animTableView:YES];
@@ -2545,8 +2505,6 @@ int currentItemID;
     }
     else if (segment.selectedSegmentIndex == 1) {
         lastSelected = -1;
-        seg_music.selected = NO;
-        seg_video.selected = YES;
         selectedPlayerID = 1;
         musicPartyMode = 0;
         [self createPlaylist:NO animTableView:YES];
@@ -2750,8 +2708,6 @@ int currentItemID;
     tempFanartImageView = [UIImageView new];
     tempFanartImageView.hidden = YES;
     [self.view addSubview:tempFanartImageView];
-    [seg_music setTitle:LOCALIZED_STR(@"Music") forState:UIControlStateNormal];
-    [seg_video setTitle:LOCALIZED_STR(@"Video") forState:UIControlStateNormal];
     [PartyModeButton setTitle:LOCALIZED_STR(@"Party") forState:UIControlStateNormal];
     [PartyModeButton setTitle:LOCALIZED_STR(@"Party") forState:UIControlStateHighlighted];
     [PartyModeButton setTitle:LOCALIZED_STR(@"Party") forState:UIControlStateSelected];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -859,6 +859,7 @@ int currentItemID;
                                  int hours = [time[@"hours"] intValue];
                                  int minutes = [time[@"minutes"] intValue];
                                  int seconds = [time[@"seconds"] intValue];
+                                 float percentage = [(NSNumber*)methodResult[@"percentage"] floatValue];
                                  NSString *actualTime = [NSString stringWithFormat:@"%@%02i:%02i", (hoursGlobal == 0) ? @"" : [NSString stringWithFormat:@"%02i:", hours], minutes, seconds];
                                  if (updateProgressBar) {
                                      currentTime.text = actualTime;
@@ -871,22 +872,12 @@ int currentItemID;
                                      currentTime.hidden = YES;
                                      duration.hidden = YES;
                                  }
-                                 NSIndexPath* selection = [playlistTableView indexPathForSelectedRow];
-                                 if (selection) {
-                                     UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:selection];
-                                     UILabel *playlistActualTime = (UILabel*)[cell viewWithTag:6];
-                                     playlistActualTime.text = actualTime;
-                                     UIImageView *playlistActualBar = (UIImageView*)[cell viewWithTag:7];
-                                     CGFloat newx = MAX(MAX_CELLBAR_WIDTH * [(NSNumber*)methodResult[@"percentage"] doubleValue] / 100, 1.0);
-                                     [self resizeCellBar:newx image:playlistActualBar];
-                                     UIView *timePlaying = (UIView*)[cell viewWithTag:5];
-                                     [self fadeView:timePlaying hidden:NO];
-                                 }
+                                 [self updatePlaylistProgressbar:percentage actual:actualTime];
                                  int playlistPosition = [methodResult[@"position"] intValue];
                                  if (playlistPosition > -1) {
                                      playlistPosition += 1;
                                  }
-                                 if (musicPartyMode && [(NSNumber*)methodResult[@"percentage"] floatValue] < storePercentage) { // BLEAH!!!
+                                 if (musicPartyMode && percentage < storePercentage) { // BLEAH!!!
                                      [self checkPartyMode];
                                  }
                                  //                                 if (selection) {
@@ -901,7 +892,7 @@ int currentItemID;
                                  //                                 }
                                  
                                  //                                 NSLog(@"CURRENT ITEMID %d PLAYLIST ID %@", currentItemID, playlistData[selection.row][@"idItem"]);
-                                 storePercentage = [(NSNumber*)methodResult[@"percentage"] floatValue];
+                                 storePercentage = percentage;
                                  if (playlistPosition != lastSelected && playlistPosition > 0) {
                                      if ((playlistData.count >= playlistPosition) && currentPlayerID == playerID) {
                                          if (playlistPosition > 0) {
@@ -1243,6 +1234,21 @@ int currentItemID;
                    [self showPlaylistTable];
                }
            }];
+}
+
+- (void)updatePlaylistProgressbar:(float)percentage actual:(NSString*)actualTime {
+    NSIndexPath* selection = [playlistTableView indexPathForSelectedRow];
+    if (!selection) {
+        return;
+    }
+    UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:selection];
+    UILabel *playlistActualTime = (UILabel*)[cell viewWithTag:6];
+    playlistActualTime.text = actualTime;
+    UIImageView *playlistActualBar = (UIImageView*)[cell viewWithTag:7];
+    CGFloat newx = MAX(MAX_CELLBAR_WIDTH * percentage / 100.0, 1.0);
+    [self resizeCellBar:newx image:playlistActualBar];
+    UIView *timePlaying = (UIView*)[cell viewWithTag:5];
+    [self fadeView:timePlaying hidden:NO];
 }
 
 - (void)hidePlaylistProgressbarWithDeselect:(BOOL)deselect {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2517,7 +2517,7 @@ int currentItemID;
 - (void)addSegmentControl {
     seg_music.hidden = YES;
     seg_video.hidden = YES;
-    playlistSegmentedControl = [[UISegmentedControl alloc] initWithItems:@[LOCALIZED_STR(@"Music"), [[LOCALIZED_STR(@"Video ") capitalizedString] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]]];
+    playlistSegmentedControl = [[UISegmentedControl alloc] initWithItems:@[LOCALIZED_STR(@"Music"), [[LOCALIZED_STR(@"Video") capitalizedString] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]]];
     CGFloat left_margin = (PAD_MENU_TABLE_WIDTH - SEGMENTCONTROL_WIDTH)/2;
     if (IS_IPHONE) {
         left_margin = floor(([self currentScreenBoundsDependOnOrientation].size.width - SEGMENTCONTROL_WIDTH)/2);

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -40,6 +40,7 @@
 @synthesize itemDescription;
 
 #define MAX_CELLBAR_WIDTH 45
+#define PARTYBUTTON_PADDING_LEFT 8
 #define PROGRESSBAR_PADDING_LEFT 20
 #define PROGRESSBAR_PADDING_BOTTOM 80
 #define SEGMENTCONTROL_WIDTH 122
@@ -1200,12 +1201,12 @@ int currentItemID;
     if (playlistID == 0) {
         playerID = 0;
         playlistSegmentedControl.selectedSegmentIndex = 0;
-        [self AnimButton:PartyModeButton AnimDuration:0.3 hidden:NO XPos:8];
+        [self AnimButton:PartyModeButton AnimDuration:0.3 hidden:NO XPos:PARTYBUTTON_PADDING_LEFT];
     }
     else if (playlistID == 1) {
         playerID = 1;
         playlistSegmentedControl.selectedSegmentIndex = 1;
-        [self AnimButton:PartyModeButton AnimDuration:0.3 hidden:YES XPos:-72];
+        [self AnimButton:PartyModeButton AnimDuration:0.3 hidden:YES XPos:-PartyModeButton.frame.size.width];
     }
     [self alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
     [[Utilities getJsonRPC] callMethod:@"Playlist.GetItems"

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2778,14 +2778,17 @@ int currentItemID;
 }
 
 - (void)handleXBMCPlaylistHasChanged:(NSNotification*)sender {
+    if (sender.userInfo) {
+        selectedPlayerID = [sender.userInfo[@"params"][@"data"][@"playlistid"] intValue];
+    }
     playerID = PLAYERID_UNKNOWN;
-    selectedPlayerID = PLAYERID_UNKNOWN;
     lastSelected = SELECTED_NONE;
     storedItemID = SELECTED_NONE;
     storeSelection = nil;
     lastThumbnail = @"";
     [playlistData performSelectorOnMainThread:@selector(removeAllObjects) withObject:nil waitUntilDone:YES];
     [playlistTableView performSelectorOnMainThread:@selector(reloadData) withObject:nil waitUntilDone:YES];
+    [self createPlaylist:NO animTableView:YES];
 }
 
 - (void)dealloc {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -874,8 +874,10 @@ int currentItemID;
                                  if (updateProgressBar) {
                                      currentTime.text = actualTime;
                                      ProgressSlider.hidden = NO;
+                                     currentTime.hidden = NO;
+                                     duration.hidden = NO;
                                  }
-                                 if (playerID == PLAYERID_PICTURES) {
+                                 if (currentPlayerID == PLAYERID_PICTURES) {
                                      ProgressSlider.hidden = YES;
                                      currentTime.hidden = YES;
                                      duration.hidden = YES;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2496,19 +2496,22 @@ int currentItemID;
         NSArray *visiblePaths = [playlistTableView indexPathsForVisibleRows];
         [playlistTableView scrollToRowAtIndexPath:visiblePaths[0] atScrollPosition:UITableViewScrollPositionTop animated:NO];
     }
-    if (segment.selectedSegmentIndex == 0) {
-        lastSelected = -1;
-        selectedPlayerID = 0;
-        musicPartyMode = 0;
-        [self createPlaylist:NO animTableView:YES];
-        
+    switch (segment.selectedSegmentIndex) {
+        case 0:
+            selectedPlayerID = 0;
+            break;
+            
+        case 1:
+            selectedPlayerID = 1;
+            break;
+            
+        default:
+            NSAssert(NO, @"Unexpected segment selected.");
+            break;
     }
-    else if (segment.selectedSegmentIndex == 1) {
-        lastSelected = -1;
-        selectedPlayerID = 1;
-        musicPartyMode = 0;
-        [self createPlaylist:NO animTableView:YES];
-    }
+    lastSelected = -1;
+    musicPartyMode = 0;
+    [self createPlaylist:NO animTableView:YES];
 }
 
 #pragma mark - Life Cycle

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2296,6 +2296,9 @@ int currentItemID;
     if (playlistData.count == 0 && !playlistTableView.editing) {
         return;
     }
+    if (playerID == PLAYERID_PICTURES) {
+        return;
+    }
     if (playlistTableView.editing || forceClose) {
         [playlistTableView setEditing:NO animated:YES];
         editTableButton.selected = NO;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -209,6 +209,10 @@ typedef enum {
 }
 
 - (void)fadeView:(UIView*)view hidden:(BOOL)value {
+    // Do not unhide the playlist progress bar while in pictures playlist
+    if (!value && currentPlayerID == PLAYERID_PICTURES) {
+        return;
+    }
     if (value == view.hidden) {
         return;
     }

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -385,7 +385,7 @@
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </imageView>
-                        <button opaque="NO" tag="88" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="117">
+                        <button opaque="NO" tag="88" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="117">
                             <rect key="frame" x="239" y="8" width="73" height="28"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                             <gestureRecognizers/>

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -37,8 +37,6 @@
                 <outlet property="scrabbingMessage" destination="221" id="225"/>
                 <outlet property="scrabbingRate" destination="222" id="226"/>
                 <outlet property="scrabbingView" destination="220" id="224"/>
-                <outlet property="seg_music" destination="123" id="124"/>
-                <outlet property="seg_video" destination="122" id="125"/>
                 <outlet property="shuffleButton" destination="176" id="177"/>
                 <outlet property="songBitRate" destination="111" id="114"/>
                 <outlet property="songBitRateImage" destination="kOE-C4-EVV" id="yNf-7i-XWq"/>
@@ -157,11 +155,11 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gWQ-ZF-P81" userLabel="Item Logo Image">
-                                            <rect key="frame" x="27" y="4" width="183" height="34"/>
+                                            <rect key="frame" x="26" y="4" width="183" height="34"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                         </imageView>
                                         <button opaque="NO" alpha="0.80000000000000004" contentMode="scaleAspectFit" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lna-Os-O4e" userLabel="Button Close">
-                                            <rect key="frame" x="210" y="0.0" width="31" height="30"/>
+                                            <rect key="frame" x="210" y="0.0" width="30" height="30"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                             <state key="normal" image="button_close"/>
                                             <connections>
@@ -204,7 +202,7 @@
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                         </imageView>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.80000000000000004" contentMode="left" fixedFrame="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="112">
-                                            <rect key="frame" x="125" y="162" width="46" height="33"/>
+                                            <rect key="frame" x="124" y="162" width="46" height="33"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -213,11 +211,11 @@
                                             <size key="shadowOffset" width="0.0" height="0.0"/>
                                         </label>
                                         <imageView userInteractionEnabled="NO" alpha="0.80000000000000004" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="b3u-Km-zml" userLabel="Song Sample Rate Image">
-                                            <rect key="frame" x="125" y="162" width="46" height="33"/>
+                                            <rect key="frame" x="124" y="162" width="46" height="33"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" alpha="0.80000000000000004" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="lj7-SC-PJA" userLabel="Song Num Channels">
-                                            <rect key="frame" x="181" y="162" width="46" height="33"/>
+                                            <rect key="frame" x="180" y="162" width="46" height="33"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -226,7 +224,7 @@
                                             <size key="shadowOffset" width="0.0" height="0.0"/>
                                         </label>
                                         <imageView userInteractionEnabled="NO" alpha="0.80000000000000004" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="s2g-nT-iuw" userLabel="Song Num Channels Image">
-                                            <rect key="frame" x="181" y="162" width="46" height="33"/>
+                                            <rect key="frame" x="180" y="162" width="46" height="33"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                         </imageView>
                                         <button hidden="YES" opaque="NO" alpha="0.80000000000000004" contentMode="center" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="179" userLabel="Button Repeat">
@@ -245,7 +243,7 @@
                                             </connections>
                                         </button>
                                         <button hidden="YES" opaque="NO" alpha="0.80000000000000004" contentMode="center" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="176" userLabel="Button Shuffle">
-                                            <rect key="frame" x="127" y="191" width="41" height="41"/>
+                                            <rect key="frame" x="126" y="191" width="41" height="41"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                             <state key="normal" backgroundImage="button_shuffle">
@@ -260,7 +258,7 @@
                                             </connections>
                                         </button>
                                         <imageView userInteractionEnabled="NO" alpha="0.80000000000000004" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="hires" translatesAutoresizingMaskIntoConstraints="NO" id="wNZ-yG-OdQ" userLabel="HiRes Image">
-                                            <rect key="frame" x="183" y="191" width="41" height="41"/>
+                                            <rect key="frame" x="182" y="191" width="41" height="41"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         </imageView>
                                     </subviews>
@@ -323,7 +321,7 @@
                                                     <size key="shadowOffset" width="1" height="1"/>
                                                 </label>
                                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="31" userLabel="Label Total Time">
-                                                    <rect key="frame" x="225" y="40" width="90" height="10"/>
+                                                    <rect key="frame" x="224" y="40" width="91" height="10"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -387,55 +385,8 @@
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </imageView>
-                        <button opaque="NO" tag="101" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="123">
-                            <rect key="frame" x="103" y="8" width="42" height="28"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
-                            <size key="titleShadowOffset" width="1" height="1"/>
-                            <state key="normal" title=" Music">
-                                <color key="titleColor" red="1" green="1" blue="1" alpha="0.90000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="disabled">
-                                <color key="titleColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="selected">
-                                <color key="titleColor" red="1" green="1" blue="1" alpha="0.90000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="highlighted">
-                                <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <connections>
-                                <action selector="changePlaylist:" destination="-1" eventType="touchUpInside" id="126"/>
-                            </connections>
-                        </button>
-                        <button opaque="NO" tag="102" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="122">
-                            <rect key="frame" x="172" y="8" width="41" height="28"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
-                            <size key="titleShadowOffset" width="1" height="1"/>
-                            <state key="normal" title="Video ">
-                                <color key="titleColor" red="1" green="1" blue="1" alpha="0.90000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="disabled">
-                                <color key="titleColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="selected">
-                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="highlighted">
-                                <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <connections>
-                                <action selector="changePlaylist:" destination="-1" eventType="touchUpInside" id="127"/>
-                            </connections>
-                        </button>
                         <button opaque="NO" tag="88" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="117">
-                            <rect key="frame" x="240" y="8" width="72" height="28"/>
+                            <rect key="frame" x="239" y="8" width="73" height="28"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                             <gestureRecognizers/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -95,9 +95,9 @@
 "Episodes: %@" = "Episoden: %@";
 "1 result" = "1 Ergebnis";
 "%d results" = "%d Ergebnisse";
-"Music " = "Musik ";
-"Video " = "Video ";
-"Pictures " = "Bilder ";
+"Music " = "Musik-";
+"Video " = "Video-";
+"Pictures " = "Bilder-";
 "Songs" = "Titel";
 "Song" = "Titel";
 "Mins." = "Min.";
@@ -110,7 +110,7 @@
 "Cannot do that" = "Dies ist nicht möglich";
 "Wake On Lan" = "Wake-On-LAN";
 "No saved hosts found" = "Keine gespeicherten Server gefunden";
-"Are you sure you want to clear the %@playlist?" = "Soll die Wiedergabeliste %@ gelöscht werden?";
+"Are you sure you want to clear the %@playlist?" = "Soll die %@Wiedergabeliste gelöscht werden?";
 "Are you sure you want to power off your XBMC system now?" = "Soll das Kodi-System jetzt ausgeschaltet werden?";
 "Are you sure you want to hibernate your XBMC system now?" = "Soll das Kodi-System jetzt in den Ruhezustand gehen?";
 "Are you sure you want to suspend your XBMC system now?" = "Soll das Kodi-System jetzt in den Standby gehen?";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -97,6 +97,7 @@
 "%d results" = "%d Ergebnisse";
 "Music " = "Musik ";
 "Video " = "Video ";
+"Pictures " = "Bilder ";
 "Songs" = "Titel";
 "Song" = "Titel";
 "Mins." = "Min.";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -106,6 +106,7 @@
 "%d results" = "%d results";
 "Music " = "Music ";
 "Video " = "Video ";
+"Pictures " = "Pictures ";
 "Songs" = "Songs";
 "Song" = "Song";
 "Mins." = "Mins.";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/477.

This PR has several changes around `NowPlaying`, with a focus to the playlists and especially picture playlist.
- Support "Pictures" playlists (deleting, but no editing supported)
- Support queueing pictures into playlist ("Queue", but no "Queue after current" supported)
- Use icons instead of text items for playlist's `UISegmentedControl`
- Right-align `"Edit"` button in playlist's segment control
- Remove unneeded code, magic numbers and avoid code duplication

Screenshots: https://abload.de/img/bildschirmfoto2021-1215jis.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show playback time and duration after running a pictures playlist
Bugfix: Fix German translation for playlist deletion popup
Improvement: Support "Pictures" playlist incl. layout update of segment control
Improvement: Keep playlist's mode while editing
Maintenance: Remove unneeded code, magic numbers and avoid code duplication in NowPlaying