### PR TITLE
Bugfix: Empty list of albums for most music roles

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1418,6 +1418,7 @@ NSMutableArray *hostRightMenuItems;
                                   
         @[
             @{
+                @"albumartistsonly": @NO,
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"thumbnail",

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1116,6 +1116,9 @@
         if (parameters[@"combinedFilter"]) {
             [newParameters addObjectsFromArray:@[parameters[@"combinedFilter"], @"combinedFilter"]];
         }
+        if (parameters[@"parameters"][@"albumartistsonly"]) {
+            newParameters[0][@"albumartistsonly"] = parameters[@"parameters"][@"albumartistsonly"];
+        }
         [[MenuItem.subItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
         MenuItem.subItem.chooseTab = choosedTab;
         MenuItem.subItem.currentFilterMode = filterModeType;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1113,6 +1113,9 @@
         if (parameters[@"available_sort_methods"] != nil) {
             [newParameters addObjectsFromArray:@[parameters[@"available_sort_methods"], @"available_sort_methods"]];
         }
+        if (parameters[@"combinedFilter"]) {
+            [newParameters addObjectsFromArray:@[parameters[@"combinedFilter"], @"combinedFilter"]];
+        }
         [[MenuItem.subItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
         MenuItem.subItem.chooseTab = choosedTab;
         MenuItem.subItem.currentFilterMode = filterModeType;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a issues when searching for albums of an artist for a certain music role. Before this change only "artist" music roles where working properly. All other music roles where resulting in an empty album list in most cases. In addition, the artist's for roles are now _always_ taken from the pool of _all_ artists and not only album artists (if this should be configured in Kodi). This way you can always see Composers, even if they are not an album artist.

The code changes itself ensure to add the parameter `"albumartistsonly": "NO"` and to retain `"albumartistsonly"` and `"combinedFilter"` in the parameter set. This lets the JSON request for the artists and albums use the correct filter for the music roles and artists.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Empty list of albums for most music roles
Improvement: Music role filter always applied for all artists (not following the Kodi setting "album artists only")