### PR TITLE
Rework: Sort / section behaviour

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -960,6 +960,7 @@ NSMutableArray *hostRightMenuItems;
             @"row16": @"born",
             @"row17": @"formed",
             @"row18": @"died",
+            @"row19": @"artist",
             @"row20": @"roles",
             @"itemid_extra_info": @"artistdetails"
         },

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1636,7 +1636,7 @@ NSMutableArray *hostRightMenuItems;
         }
     ];
     
-    menu_Music.subItem.enableSection = NO;
+    menu_Music.subItem.enableSection = YES;
     menu_Music.subItem.rowHeight = 53;
     menu_Music.subItem.thumbWidth = 53;
     menu_Music.subItem.defaultThumb = @"nocover_music";
@@ -2666,7 +2666,7 @@ NSMutableArray *hostRightMenuItems;
         }
     ];
     
-    menu_Movies.subItem.enableSection = NO;
+    menu_Movies.subItem.enableSection = YES;
     menu_Movies.subItem.rowHeight = 76;
     menu_Movies.subItem.thumbWidth = 53;
     menu_Movies.subItem.defaultThumb = @"nocover_movies";
@@ -3130,7 +3130,7 @@ NSMutableArray *hostRightMenuItems;
         }
     ];
     
-    menu_Videos.subItem.enableSection = NO;
+    menu_Videos.subItem.enableSection = YES;
     menu_Videos.subItem.rowHeight = 76;
     menu_Videos.subItem.thumbWidth = 53;
     menu_Videos.subItem.defaultThumb = @"nocover_movies";
@@ -3682,7 +3682,7 @@ NSMutableArray *hostRightMenuItems;
         }
     ];
     
-    menu_TVShows.subItem.enableSection = NO;
+    menu_TVShows.subItem.enableSection = YES;
     menu_TVShows.subItem.rowHeight = 53;
     menu_TVShows.subItem.thumbWidth = 95;
     menu_TVShows.subItem.defaultThumb = @"nocover_tvshows_episode";
@@ -5038,7 +5038,6 @@ NSMutableArray *hostRightMenuItems;
             },
         ];
         
-        menu_Favourites.enableSection = NO;
         menu_Favourites.rowHeight = 53;
         menu_Favourites.thumbWidth = 53;
         menu_Favourites.defaultThumb = @"nocover_filemode";

--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -116,7 +116,7 @@
     BOOL hiddenLabel;
     UIPinchGestureRecognizer *twoFingerPinch;
     NSTimer* channelListUpdateTimer;
-    NSUInteger sortMethodIndex;
+    NSInteger sortMethodIndex;
     NSString *sortMethodName;
     NSString *sortAscDesc;
     int numberOfStars;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -857,7 +857,7 @@
 - (void)setUpSort:(NSDictionary*)methods parameters:(NSDictionary*)parameters {
     NSDictionary *sortDictionary = parameters[@"available_sort_methods"];
     sortMethodName = [self getCurrentSortMethod:methods withParameters:parameters];
-    NSUInteger foundIndex = [sortDictionary[@"method"] indexOfObject:sortMethodName];
+    NSUInteger foundIndex = sortDictionary ? [sortDictionary[@"method"] indexOfObject:sortMethodName] : NSNotFound;
     if (foundIndex != NSNotFound) {
         sortMethodIndex = foundIndex;
     }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4698,6 +4698,10 @@ NSIndexPath *selected;
     [self AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
 }
 
+- (BOOL)isEligibleForSections:(NSArray*)array {
+    return [self.detailItem enableSection] && array.count > SECTIONS_START_AT;
+}
+
 - (NSString*)ignoreSorttoken:(NSString*)text {
     if (AppDelegate.instance.KodiSorttokens.count == 0) {
         return text;
@@ -4807,33 +4811,7 @@ NSIndexPath *selected;
         }
     }
     
-    if ([self.detailItem enableSection] && copyRichResults.count > SECTIONS_START_AT && (sortMethodIndex == -1 || [sortMethodName isEqualToString:@"label"])) {
-        addUITableViewIndexSearch = YES;
-        BOOL found;
-        NSCharacterSet * set = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLKMNOPQRSTUVWXYZ"] invertedSet];
-        NSCharacterSet * numberset = [[NSCharacterSet characterSetWithCharactersInString:@"0123456789"] invertedSet];
-        for (NSDictionary *item in copyRichResults) {
-            NSString *c = @"/";
-            if ([item[sortbymethod] length] > 0) {
-                c = [[item[sortbymethod] substringToIndex:1] uppercaseString];
-            }
-            if ([c rangeOfCharacterFromSet:numberset].location == NSNotFound) {
-                c = @"#";
-            }
-            else if ([c rangeOfCharacterFromSet:set].location != NSNotFound) {
-                c = @"/";
-            }
-            found = NO;
-            if ([[self.sections allKeys] containsObject:c]) {
-                found = YES;
-            }
-            if (!found) {
-                [self.sections setValue:[NSMutableArray new] forKey:c];
-            }
-            [self.sections[c] addObject:item];
-        }
-    }
-    else if (episodesView) {
+    if (episodesView) {
         for (NSDictionary *item in self.richResults) {
             BOOL found;
             NSString *c = [NSString stringWithFormat:@"%@", item[@"season"]];
@@ -4911,7 +4889,7 @@ NSIndexPath *selected;
         [NSThread detachNewThreadSelector:@selector(backgroundSaveEPGToDisk:) toTarget:self withObject:epgparams];
     }
     else {
-        if ([self isSortDifferentToDefault]) {
+        if (sortbymethod && ([self isSortDifferentToDefault] || [self isEligibleForSections:copyRichResults])) {
             BOOL found;
             addUITableViewIndexSearch = YES;
             for (NSDictionary *item in copyRichResults) {
@@ -4982,7 +4960,7 @@ NSIndexPath *selected;
         NSDateComponents *components = [[NSCalendar currentCalendar] components: NSCalendarUnitYear fromDate:[xbmcDateFormatter dateFromString:currentValue]];
         currentValue = [NSString stringWithFormat:@"%ld", (long)[components year]];
     }
-    else if (([sortMethod isEqualToString:@"label"] || [sortMethod isEqualToString:@"genre"] || [sortMethod isEqualToString:@"album"] || [sortMethod isEqualToString:@"channel"] || [sortMethod isEqualToString:@"artist"]) && currentValue.length) {
+    else if (currentValue.length) {
         NSCharacterSet * set = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLKMNOPQRSTUVWXYZ"] invertedSet];
         NSCharacterSet * numberset = [[NSCharacterSet characterSetWithCharactersInString:@"0123456789"] invertedSet];
         NSString *c = @"/";

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -875,6 +875,7 @@
     NSDictionary *parameters = nil;
     NSMutableDictionary *mutableParameters = nil;
     NSMutableArray *mutableProperties = nil;
+    BOOL refresh = NO;
     
     // Read new tab index
     numTabs = (int)[[self.detailItem mainMethod] count];
@@ -906,10 +907,12 @@
                 switch (filterModeType) {
                     case ViewModeAlbumArtists:
                         mutableParameters[@"albumartistsonly"] = @YES;
+                        refresh = YES;
                         break;
                         
                     case ViewModeSongArtists:
                         mutableParameters[@"albumartistsonly"] = @NO;
+                        refresh = YES;
                         break;
                         
                     case ViewModeDefaultArtists:
@@ -1019,7 +1022,7 @@
         dataList.separatorInset = UIEdgeInsetsMake(0, [parameters[@"itemSizes"][@"separatorInset"] intValue], 0, 0);
     }
     if (methods[@"method"] != nil) {
-        [self retrieveData:methods[@"method"] parameters:mutableParameters sectionMethod:methods[@"extra_section_method"] sectionParameters:parameters[@"extra_section_parameters"] resultStore:self.richResults extraSectionCall:NO refresh:NO];
+        [self retrieveData:methods[@"method"] parameters:mutableParameters sectionMethod:methods[@"extra_section_method"] sectionParameters:parameters[@"extra_section_parameters"] resultStore:self.richResults extraSectionCall:NO refresh:refresh];
     }
     else {
         [activityIndicatorView stopAnimating];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4961,8 +4961,8 @@ NSIndexPath *selected;
         currentValue = [NSString stringWithFormat:@"%ld", (long)[components year]];
     }
     else if (currentValue.length) {
-        NSCharacterSet * set = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLKMNOPQRSTUVWXYZ"] invertedSet];
-        NSCharacterSet * numberset = [[NSCharacterSet characterSetWithCharactersInString:@"0123456789"] invertedSet];
+        NSCharacterSet *set = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLKMNOPQRSTUVWXYZ"] invertedSet];
+        NSCharacterSet *numberset = [[NSCharacterSet characterSetWithCharactersInString:@"0123456789"] invertedSet];
         NSString *c = @"/";
         if (currentValue.length > 0) {
             c = [[currentValue substringToIndex:1] uppercaseString];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR applies some rework to the visibility of sections/index in combination with sort mode. In general it is desired to only show sections/index if: 
a) The list has more than 100 entries
b) The user applied a different sort (method or order) than default

The code changes fix rule b) for Music Artists which was broken due to a missing configuration. In addition, this PR refactors building of sections to avoid code duplication and allows section/index for few more submenus which tend to have >100 list items.

Screenshots:
https://abload.de/img/bildschirmfoto2022-01ozkcn.png (remove unwanted sections)
https://abload.de/img/bildschirmfoto2022-018djcz.png (section/index for submenus if >100 list items)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Align visibility of sections in artists list with other lists
Bugfix: Do not show dummy "/" section (e.g. >100 recently added songs)
Improvement: Allow section/index for Music/Movies/Videos/TVShow submenus