### PR TITLE
Maintenance: Migrate from NSURLConnection to NSURLSession

### DIFF
--- a/XBMC Remote/HostViewController.h
+++ b/XBMC Remote/HostViewController.h
@@ -11,7 +11,7 @@
 
 #define SERVERPOPUP_BOTTOMPADDING 10
 
-@interface HostViewController : UIViewController <UITextFieldDelegate, NSNetServiceDelegate, NSNetServiceBrowserDelegate, UITableViewDataSource, UITableViewDelegate, NSURLConnectionDataDelegate>{
+@interface HostViewController : UIViewController <UITextFieldDelegate, NSNetServiceDelegate, NSNetServiceBrowserDelegate, UITableViewDataSource, UITableViewDelegate>{
 //    GlobalData *obj;
     IBOutlet UITextField *descriptionUI;
     IBOutlet UITextField *ipUI;

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -468,20 +468,6 @@
     [self resolveIPAddress:services[indexPath.row]];
 }
 
-#pragma mark - NSURLConnection Delegate Methods
-
-- (void)connection:(NSURLConnection*)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge*)challenge {
-    [self fillMacAddressInfo];
-}
-
-- (void)connection:(NSURLConnection*)connection didFailWithError:(NSError*)error {
-    [self fillMacAddressInfo];
-}
-
-- (void)connectionDidFinishLoading:(NSURLConnection*)connection {
-    [self fillMacAddressInfo];
-}
-
 #pragma mark - LifeCycle
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.m
@@ -68,7 +68,6 @@
                     }
                     if (data) {
                         [self didReceiveData:data];
-                        [self connectionDidFinishLoading];
                     }
                     if (error) {
                         [self didFailWithError:error];
@@ -242,6 +241,11 @@
 
             CFRelease(imageSource);
         }
+        
+        if (self.imageData.length >= self.expectedSize) {
+            [self connectionDidFinishLoading];
+        }
+        
         NSUInteger received = self.imageData.length;
         dispatch_async(dispatch_get_main_queue(), ^{
             if (self.progressBlock) {

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -121,8 +121,6 @@
         [plusButton setImage:img forState:UIControlStateNormal];
         [plusButton setImage:img forState:UIControlStateHighlighted];
         
-        [self checkMuteServer];
-        
         [[NSNotificationCenter defaultCenter] addObserver: self
                                                  selector: @selector(handleApplicationOnVolumeChanged:)
                                                      name: @"Application.OnVolumeChanged"

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.h
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.h
@@ -99,7 +99,7 @@ typedef enum {
 typedef void (^DSJSONRPCCompletionHandler)(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *internalError);
 
 
-@interface DSJSONRPC : NSObject <NSURLConnectionDataDelegate> {
+@interface DSJSONRPC : NSObject {
     NSTimer* timer;
 }
 

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -124,6 +124,8 @@
     // Attempt to serialize the call payload to a JSON string
     NSError *error = nil;
     NSData *postData = [NSJSONSerialization dataWithJSONObject:methodCall options:kNilOptions error:&error];
+//    NSString *JSONcommand = [[[NSString alloc] initWithData:postData encoding:NSUTF8StringEncoding] autorelease];
+//    NSLog(@"JSON: %@", JSONcommand);
 //    NSLog(@"PARAMS: %@", methodParams);
     // TODO: Make this a parameter??
     if (error != nil) {
@@ -245,6 +247,8 @@
     // Attempt to deserialize result
     NSError *error = nil;
     NSDictionary *jsonResult = [NSJSONSerialization JSONObjectWithData:connectionData options:kNilOptions error:&error];
+//    NSString *JSONcommand = [[[NSString alloc] initWithData:connectionData encoding:NSUTF8StringEncoding] autorelease];
+//    NSLog(@"JSON REC: %@", JSONcommand);
     
     if (error && completionHandler) {
         NSError *aError = [NSError errorWithDomain:@"it.joethefox.json-rpc" code:DSJSONRPCParseError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[error localizedDescription], NSLocalizedDescriptionKey, nil]];

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -200,41 +200,6 @@
     timer = nil;
 }
 
-#pragma mark - Runtime Method Invocation Handling
-
-- (NSMethodSignature*)methodSignatureForSelector:(SEL)aSelector {
-    // Determine if we handle the method signature
-    // If not, create one so it goes to forwardInvocation
-    NSMethodSignature *aMethodSignature;
-    if (!(aMethodSignature = [super methodSignatureForSelector:aSelector])) {
-        aMethodSignature = [NSMethodSignature signatureWithObjCTypes:"@:@@@"];
-    }
-    
-    return aMethodSignature;
-}
-
-- (void)forwardInvocation:(NSInvocation*)anInvocation {
-    // Get method name from invocation
-    NSString *selectorName = NSStringFromSelector(anInvocation.selector);
-    NSString *methodName = [selectorName componentsSeparatedByString:@":"][0];
-    
-    // Get reference to the first argument passed in
-    id methodParams;
-    [anInvocation getArgument:&methodParams atIndex:2];
-    
-    // If no parameters were given or its not a valid primative type, then pass in nil
-    if (methodParams == nil || !([methodParams isKindOfClass:[NSArray class]] || [methodParams isKindOfClass:[NSDictionary class]] || [methodParams isKindOfClass:[NSString class]] || [methodParams isKindOfClass:[NSNumber class]])) {
-        methodParams = nil;
-    }
-        
-    // Rebuild the invocation request and invoke it
-    [anInvocation setSelector:@selector(callMethod:withParameters:)];
-    [anInvocation setArgument:&methodName atIndex:2];
-    [anInvocation setArgument:&methodParams atIndex:3];
-    [anInvocation invokeWithTarget:self];
-}
-
-
 #pragma mark - Response/Data handlers
 
 - (void)willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge*)challenge {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR resolves some more deprecation warnings and simplifies especially the implementation of `DSJSONRPC`. It also adds `NSLog` messages for sent and received JSON commands for debug purposes. These are disabled by default and can be uncommented on demand.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Migrate from NSURLConnection to NSURLSession