### PR TITLE
Improvements around recordings (needs Kodi Nexus)

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3869,11 +3869,13 @@ NSMutableArray *hostRightMenuItems;
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Channel"),
                         LOCALIZED_STR(@"Date"),
+                        LOCALIZED_STR(@"Playcount"),
                         LOCALIZED_STR(@"Runtime")],
                 @"method": @[
                         @"label",
                         @"channel",
                         @"starttime",
+                        @"playcount",
                         @"runtime"]
             }, @"available_sort_methods",
             LOCALIZED_STR(@"Recordings"), @"label",

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3847,7 +3847,9 @@ NSIndexPath *selected;
     if ([item[@"filetype"] isEqualToString:@"directory"]) {
         key = @"directory";
     }
-    else if ([mainFields[@"row9"] isEqualToString:@"recordingid"]) {
+    // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
+    // Before, the JSON parameters must use the file path.
+    else if (!(AppDelegate.instance.APImajorVersion >= 12 && AppDelegate.instance.APIminorVersion >= 7) && [mainFields[@"row9"] isEqualToString:@"recordingid"]) {
         key = @"file";
         value = item[@"file"];
     }
@@ -3959,7 +3961,9 @@ NSIndexPath *selected;
                 if ([item[@"filetype"] isEqualToString:@"directory"]) {
                     key = @"directory";
                 }
-                else if ([mainFields[@"row8"] isEqualToString:@"recordingid"]) {
+                // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
+                // Before, the JSON parameters must use the file path.
+                else if (!(AppDelegate.instance.APImajorVersion >= 12 && AppDelegate.instance.APIminorVersion >= 7) && [mainFields[@"row8"] isEqualToString:@"recordingid"]) {
                     key = @"file";
                     value = item[@"file"];
                 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -107,6 +107,12 @@ typedef enum {
 
 #pragma mark - utility
 
+- (NSString*)getNowPlayingThumbnailPath:(NSDictionary*)item {
+    // If a recording is played, we can use the iocn (typically the station logo)
+    BOOL useIcon = [item[@"type"] isEqualToString:@"recording"];
+    return [Utilities getThumbnailFromDictionary:item useBanner:NO useIcon:useIcon];
+}
+
 - (void)setSongDetails:(UILabel*)label image:(UIImageView*)imageView item:(id)item {
     label.text = [Utilities getStringFromItem:item];
     imageView.image = [self loadImageFromName:label.text];
@@ -645,7 +651,7 @@ int currentItemID;
                                  if (AppDelegate.instance.serverVersion > 11) {
                                      serverURL = [NSString stringWithFormat:@"%@:%@/image/", obj.serverIP, obj.serverPort];
                                  }
-                                 NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:nowPlayingInfo useBanner:NO useIcon:NO];
+                                 NSString *thumbnailPath = [self getNowPlayingThumbnailPath:nowPlayingInfo];
                                  NSString *stringURL = [Utilities formatStringURL:thumbnailPath serverURL:serverURL];
                                  if (![lastThumbnail isEqualToString:stringURL] || [lastThumbnail isEqualToString:@""]) {
                                      if (IS_IPAD) {
@@ -1189,8 +1195,7 @@ int currentItemID;
                            if ([playlistItems[i][@"duration"] isKindOfClass:[NSNumber class]]) {
                                durationTime = [Utilities convertTimeFromSeconds:playlistItems[i][@"duration"]];
                            }
-
-                           NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:playlistItems[i] useBanner:NO useIcon:NO];
+                           NSString *thumbnailPath = [self getNowPlayingThumbnailPath:playlistItems[i]];
                            NSString *stringURL = [Utilities formatStringURL:thumbnailPath serverURL:serverURL];
                            NSNumber *tvshowid = @([[NSString stringWithFormat:@"%@", playlistItems[i][@"tvshowid"]] intValue]);
                            NSString *file = [NSString stringWithFormat:@"%@", playlistItems[i][@"file"]];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1527,7 +1527,9 @@ double round(double d) {
     NSDictionary *item = self.detailItem;
     NSString *param = item[@"family"];
     id value = item[item[@"family"]];
-    if ([self.detailItem[@"family"] isEqualToString:@"recordingid"]) {
+    // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
+    // Before, the JSON parameters must use the file path.
+    if (!(AppDelegate.instance.APImajorVersion >= 12 && AppDelegate.instance.APIminorVersion >= 7) && [self.detailItem[@"family"] isEqualToString:@"recordingid"]) {
         param = @"file";
         value = item[@"file"];
     }
@@ -1596,7 +1598,9 @@ double round(double d) {
             if (error == nil && methodError == nil) {
                 NSString *param = item[@"family"];
                 id value = item[item[@"family"]];
-                if ([self.detailItem[@"family"] isEqualToString:@"recordingid"]) {
+                // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
+                // Before, the JSON parameters must use the file path.
+                if (!(AppDelegate.instance.APImajorVersion >= 12 && AppDelegate.instance.APIminorVersion >= 7) && [self.detailItem[@"family"] isEqualToString:@"recordingid"]) {
                     param = @"file";
                     value = item[@"file"];
                 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/430.

With Kodi Nexus (API 12.7.0) the handling of recordings was improved. This allows to add `recordingid` to `Playlist.Insert` and `Playlist.Add`. This fixes multiple problems:
- Now `playcount` increases when recording playback is triggered from the App
- The correct recording name is shown in the UI (before the file name was shown)
- Icon art and plot is provided when asking for "Playlist.GetItems"

With this the App now again supports sorting by playcount. In addition, the NowPlaying screen and the Playlist will use icon art (typically the broadcast station logo).

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-01owj9x.png"><img src="https://abload.de/img/bildschirmfoto2022-01owj9x.png" /></a>
<a href="https://abload.de/image.php?img=bildschirmfoto2022-01vaj3a.png"><img src="https://abload.de/img/bildschirmfoto2022-01vaj3a.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvements around recordings (needs Kodi Nexus)