### PR TITLE
Bugfix: Fix sort issues caused by latest features/reworks

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3869,7 +3869,7 @@ NSMutableArray *hostRightMenuItems;
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Channel"),
                         LOCALIZED_STR(@"Date"),
-                        LOCALIZED_STR(@"Playcount"),
+                        LOCALIZED_STR(@"Play count"),
                         LOCALIZED_STR(@"Runtime")],
                 @"method": @[
                         @"label",

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4955,6 +4955,10 @@ NSIndexPath *selected;
         NSDateComponents *components = [[NSCalendar currentCalendar] components: NSCalendarUnitYear fromDate:[xbmcDateFormatter dateFromString:currentValue]];
         currentValue = [NSString stringWithFormat:@"%ld", (long)[components year]];
     }
+    else if ([sortMethod isEqualToString:@"playcount"] ||
+             [sortMethod isEqualToString:@"track"]) {
+        currentValue = [NSString stringWithFormat:@"%@", value];
+    }
     else if (currentValue.length) {
         NSCharacterSet *set = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLKMNOPQRSTUVWXYZ"] invertedSet];
         NSCharacterSet *numberset = [[NSCharacterSet characterSetWithCharactersInString:@"0123456789"] invertedSet];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
- Fix sort by `"track"` and by `"playcount"`. Both sort methods shall result in a section per count. Regression of [#541](https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/541).
- Use `"Play count"` instead  of `"Playcount"` for the action sheet. This will correctly pick the localized translations.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix sort by playcount & track (regression of PR#541)
Bugfix: Fix localized string "Play count" for recordings (issue of PR#543)