### PR TITLE
Bugfix: Do not fade iPhone connection status in main menu

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -940,7 +940,12 @@
 
 + (void)setStyleOfMenuItems:(UITableView*)tableView active:(BOOL)active {
     CGFloat alpha = active ? 1.0 : 0.3;
-    for (UITableViewCell *cell in tableView.visibleCells) {
+    for (NSIndexPath *indexPath in tableView.indexPathsForVisibleRows) {
+        // The iPhone uses the top most cell as connection status. This should not be faded/unfaded.
+        if (IS_IPHONE && indexPath.row == 0 && indexPath.section == 0) {
+            continue;
+        }
+        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
         [UIView animateWithDuration:0.3
                          animations:^{
                             ((UIImageView*)[cell viewWithTag:1]).alpha = alpha;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/535. The iPhone uses the top most cell of the main menu as connection status. This should not be faded/unfaded.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-0111kv6.png"><img src="https://abload.de/img/bildschirmfoto2022-0111kv6.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not fade iPhone connection status in main menu (regression of PR#535)