### PR TITLE
Improvement: Remove doubled volume control from remote screen's right panel

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -728,6 +728,7 @@
     return ([item[@"label"] isEqualToString:LOCALIZED_STR(@"Keyboard")] ||
             [item[@"label"] isEqualToString:LOCALIZED_STR(@"Button Pad/Gesture Zone")] ||
             [item[@"label"] isEqualToString:LOCALIZED_STR(@"Help Screen")] ||
+            [item[@"label"] isEqualToString:LOCALIZED_STR(@"VolumeControl")] ||
             [item[@"label"] isEqualToString:LOCALIZED_STR(@"LED Torch")]) &&
             [Utilities hasRemoteToolBar];
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
For iPhones with enough screen height to show the volume control on the remote screen itself, the volume control can be removed from right panel. All items which do not need to be shown on the right pane are configured in `itemShownInRemoteToolBar`.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-01cfklr.png"><img src="https://abload.de/img/bildschirmfoto2022-01cfklr.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Remove doubled volume control from iPhone