### PR TITLE
Improvement: Hide the keyboard when swiping back

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3436,6 +3436,10 @@ NSIndexPath *selected;
     [self.navigationController popViewControllerAnimated:YES];
 }
 
+- (void)hideKeyboard:(id)sender {
+    [self.searchController.searchBar resignFirstResponder];
+}
+
 #pragma mark - View Configuration
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
@@ -5623,6 +5627,11 @@ NSIndexPath *selected;
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(revealMenu:)
                                                  name: @"RevealMenu"
+                                               object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(hideKeyboard:)
+                                                 name: @"ECSlidingViewUnderLeftWillAppear"
                                                object: nil];
     
     [[NSNotificationCenter defaultCenter] addObserver: self


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR implements a fix/improvement for a issue described in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3079674#pid3079674). The keyboard which is shown during search should be hidden when swiping back.

Screenshots (after swiping back from a search for music albums):
<a href="https://abload.de/image.php?img=bildschirmfoto2022-01ccj6z.png"><img src="https://abload.de/img/bildschirmfoto2022-01ccj6z.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Hide the keyboard when swiping back