### PR TITLE
Bugfix: Use correct aspect ratio for Music Playlist thumbs

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1421,7 +1421,7 @@ NSMutableArray *hostRightMenuItems;
             LOCALIZED_STR(@"Files"), @"label",
             @"nocover_filemode", @"defaultThumb",
             filemodeRowHeight, @"rowHeight",
-            @"53", @"thumbWidth"
+            filemodeThumbWidth, @"thumbWidth"
         ],
                                   
         @[


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/554.

Use the correct width for the thumbs fixes the aspect ratio.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-01cvjqm.png"><img src="https://abload.de/img/bildschirmfoto2022-01cvjqm.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use correct aspect ratio for Music Playlist thumbs