### PR TITLE
Bugfix: Correct the frame dimension for the main menu

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -262,6 +262,14 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    // The menu list starts at the bottom of the status bar to not overlap with it
+    CGFloat statuBarHeight = CGRectGetHeight(UIApplication.sharedApplication.statusBarFrame);
+    CGRect frame = menuList.frame;
+    frame.origin.y = statuBarHeight;
+    frame.size.height = frame.size.height - statuBarHeight;
+    menuList.frame = frame;
+    
     menuList.separatorInset = UIEdgeInsetsMake(0, 0, 0, 0);
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     BOOL clearCache = [[userDefaults objectForKey:@"clearcache_preference"] boolValue];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue where the main menu was overlapping with the status bar on older iPhones with iOS 10. The problem is a regression of https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/535, in which a hardcoded layout calculation was removed. This had no effect on iOS 11 or newer but broke older setups (in this case iPhone 5 with iOS 10). The fix does now correct the calculation to take into account the proper height of the status bar to set the frame dimension of the main menu view.

Screenshot:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-01eekej.png"><img src="https://abload.de/img/bildschirmfoto2022-01eekej.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct the frame dimension for the main menu