### PR TITLE
Bugfix: Volume bar must be visible on embedded screen

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -5574,7 +5574,7 @@ NSMutableArray *hostRightMenuItems;
 #pragma mark - Now Playing Right Menu
     nowPlayingMenuItems = [NSMutableArray arrayWithCapacity:1];
     __auto_type nowPlayingItem1 = [mainMenu new];
-    nowPlayingItem1.mainLabel = @"VolumeControl";
+    nowPlayingItem1.mainLabel = @"EmbeddedRemote";
     nowPlayingItem1.family = FamilyNowPlaying;
     nowPlayingItem1.mainMethod = @[
         @{

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -733,6 +733,11 @@
             [Utilities hasRemoteToolBar];
 }
 
+- (BOOL)showEmbeddedVolumeBar:(NSDictionary*)item mainLabel:(NSString*)mainLabel {
+    return [item[@"label"] isEqualToString:LOCALIZED_STR(@"VolumeControl")] &&
+           [mainLabel isEqualToString:@"EmbeddedRemote"] && [Utilities hasRemoteToolBar];
+}
+
 - (void)setRightMenuOption:(NSString*)key reloadTableData:(BOOL)reload {
     mainMenu *menuItems = self.rightMenuItems[0];
     tableData = [[NSMutableArray alloc] initWithCapacity:0];
@@ -785,6 +790,10 @@
          
         // Do not show the remoteToolBar items in the menu while in "online" state
         if (!([self itemShownInRemoteToolBar:item] && [key isEqualToString:@"online"])) {
+            [tableData addObject:itemDict];
+        }
+        // "embedded remote" (reachable from NowPlaying screen) always has the volume bar
+        if ([self showEmbeddedVolumeBar:item mainLabel:[menuItems mainLabel]] && [key isEqualToString:@"online"]) {
             [tableData addObject:itemDict];
         }
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
On iPhone there are two screens which have a volume bar: "remote" and "embedded remote" (reachable only from NowPlaying). For the "remote" the visibility is handled by `itemShownInRemoteToolBar`. For the "embedded remote" the volume bar always needs to be shown, this is now checked by `showEmbeddedVolumeBar`. This also works for iPhone which have a small screens (volume bar shown on "embedded remote" and the right panel of the "remote").

Screenshots:
https://abload.de/img/bildschirmfoto2022-01wlj8p.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Volume bar must be visible on embedded screen