### PR TITLE
Bugfix: Show correct albumview content 

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1246,6 +1246,7 @@ NSMutableArray *hostRightMenuItems;
                         @"rating",
                         @"playcount",
                         @"artist",
+                        @"albumartist",
                         @"albumid",
                         @"file",
                         @"fanart"]
@@ -1343,6 +1344,7 @@ NSMutableArray *hostRightMenuItems;
                         @"rating",
                         @"playcount",
                         @"artist",
+                        @"albumartist",
                         @"albumid",
                         @"file",
                         @"fanart"]
@@ -1364,6 +1366,7 @@ NSMutableArray *hostRightMenuItems;
                         @"rating",
                         @"playcount",
                         @"artist",
+                        @"albumartist",
                         @"albumid",
                         @"file",
                         @"fanart"]
@@ -1385,6 +1388,7 @@ NSMutableArray *hostRightMenuItems;
                         @"rating",
                         @"playcount",
                         @"artist",
+                        @"albumartist",
                         @"albumid",
                         @"file",
                         @"fanart"]
@@ -1472,7 +1476,7 @@ NSMutableArray *hostRightMenuItems;
             @"playlistid": @0,
             @"row9": @"songid",
             @"row10": @"file",
-            @"row11": @"artist"
+            @"row11": @"albumartist"
         },
                               
         @{
@@ -1539,7 +1543,7 @@ NSMutableArray *hostRightMenuItems;
             @"playlistid": @0,
             @"row9": @"songid",
             @"row10": @"file",
-            @"row11": @"artist"
+            @"row11": @"albumartist"
         },
                               
         @{},
@@ -1557,7 +1561,7 @@ NSMutableArray *hostRightMenuItems;
             @"playlistid": @0,
             @"row9": @"songid",
             @"row10": @"file",
-            @"row11": @"artist"
+            @"row11": @"albumartist"
         },
                               
         @{},
@@ -1575,7 +1579,7 @@ NSMutableArray *hostRightMenuItems;
             @"playlistid": @0,
             @"row9": @"songid",
             @"row10": @"file",
-            @"row11": @"artist"
+            @"row11": @"albumartist"
         },
                               
         @{},
@@ -1711,6 +1715,7 @@ NSMutableArray *hostRightMenuItems;
                         @"rating",
                         @"playcount",
                         @"artist",
+                        @"albumartist",
                         @"albumid",
                         @"file",
                         @"fanart"]
@@ -1730,6 +1735,7 @@ NSMutableArray *hostRightMenuItems;
                         @"rating",
                         @"playcount",
                         @"artist",
+                        @"albumartist",
                         @"albumid",
                         @"file",
                         @"fanart"],
@@ -1793,7 +1799,7 @@ NSMutableArray *hostRightMenuItems;
             @"playlistid": @0,
             @"row9": @"songid",
             @"row10": @"file",
-            @"row11": @"artist"
+            @"row11": @"albumartist"
         },
                                       
         @{
@@ -1809,7 +1815,7 @@ NSMutableArray *hostRightMenuItems;
             @"playlistid": @0,
             @"row9": @"songid",
             @"row10": @"file",
-            @"row11": @"artist"
+            @"row11": @"albumartist"
         },
           
         @{},
@@ -1922,6 +1928,7 @@ NSMutableArray *hostRightMenuItems;
                         @"rating",
                         @"playcount",
                         @"artist",
+                        @"albumartist",
                         @"albumid",
                         @"file",
                         @"fanart"]
@@ -1957,7 +1964,7 @@ NSMutableArray *hostRightMenuItems;
             @"playlistid": @0,
             @"row9": @"songid",
             @"row10": @"file",
-            @"row11": @"artist"
+            @"row11": @"albumartist"
         }
     ];
     

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1142,7 +1142,7 @@
                                         nil], @"parameters",
                                        parameters[@"disableFilterParameter"], @"disableFilterParameter",
                                        libraryRowHeight, @"rowHeight", libraryThumbWidth, @"thumbWidth",
-                                       item[@"label"], @"label",
+                                       parameters[@"label"], @"label",
                                        [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
                                        [NSString stringWithFormat:@"%d", [parameters[@"FrodoExtraArt"] boolValue]], @"FrodoExtraArt",
                                        [NSString stringWithFormat:@"%d", [parameters[@"enableLibraryCache"] boolValue]], @"enableLibraryCache",
@@ -1166,6 +1166,7 @@
         if (parameters[@"parameters"][@"albumartistsonly"]) {
             newParameters[0][@"albumartistsonly"] = parameters[@"parameters"][@"albumartistsonly"];
         }
+        MenuItem.subItem.mainLabel = item[@"label"];
         mainMenu *newMenuItem = [MenuItem.subItem copy];
         [[newMenuItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
         newMenuItem.chooseTab = choosedTab;
@@ -1214,11 +1215,12 @@
                                                 parameters[@"parameters"][@"media"], @"media",
                                                 parameters[@"parameters"][@"sort"], @"sort",
                                                 parameters[@"parameters"][@"file_properties"], @"file_properties",
-                                                nil], @"parameters", item[@"label"], @"label", @"nocover_filemode", @"defaultThumb", filemodeRowHeight, @"rowHeight", filemodeThumbWidth, @"thumbWidth", @"icon_song", @"fileThumb",
+                                                nil], @"parameters", parameters[@"label"], @"label", @"nocover_filemode", @"defaultThumb", filemodeRowHeight, @"rowHeight", filemodeThumbWidth, @"thumbWidth", @"icon_song", @"fileThumb",
                                                [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
                                                [NSString stringWithFormat:@"%d", [parameters[@"enableCollectionView"] boolValue]], @"enableCollectionView",
                                                parameters[@"disableFilterParameter"], @"disableFilterParameter",
                                                nil];
+                MenuItem.mainLabel = item[@"label"];
                 mainMenu *newMenuItem = [MenuItem copy];
                 [[newMenuItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
                 newMenuItem.chooseTab = choosedTab;
@@ -1274,7 +1276,7 @@
                                             parameters[@"parameters"][@"media"], @"media",
                                             parameters[@"parameters"][@"sort"], @"sort",
                                             parameters[@"parameters"][@"file_properties"], @"file_properties",
-                                            nil], @"parameters", item[@"label"], @"label", @"nocover_filemode", @"defaultThumb", filemodeRowHeight, @"rowHeight", filemodeThumbWidth, @"thumbWidth",
+                                            nil], @"parameters", parameters[@"label"], @"label", @"nocover_filemode", @"defaultThumb", filemodeRowHeight, @"rowHeight", filemodeThumbWidth, @"thumbWidth",
                                            [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
                                            [NSString stringWithFormat:@"%d", [parameters[@"enableCollectionView"] boolValue]], @"enableCollectionView",
                                            parameters[@"disableFilterParameter"], @"disableFilterParameter",
@@ -1282,6 +1284,7 @@
             if ([item[@"family"] isEqualToString:@"sectionid"] || [item[@"family"] isEqualToString:@"categoryid"]) {
                 newParameters[0][@"level"] = @"expert";
             }
+            MenuItem.subItem.mainLabel = item[@"label"];
             mainMenu *newMenuItem = [MenuItem.subItem copy];
             [[newMenuItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
             newMenuItem.chooseTab = choosedTab;
@@ -3679,12 +3682,13 @@ NSIndexPath *selected;
                                     mutableProperties, @"file_properties",
                                     nil], @"parameters",
                                    libraryRowHeight, @"rowHeight", libraryThumbWidth, @"thumbWidth",
-                                   item[@"label"], @"label", @"nocover_filemode", @"defaultThumb", filemodeRowHeight, @"rowHeight", filemodeThumbWidth, @"thumbWidth",
+                                   parameters[@"label"], @"label", @"nocover_filemode", @"defaultThumb", filemodeRowHeight, @"rowHeight", filemodeThumbWidth, @"thumbWidth",
                                    [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
                                    [NSString stringWithFormat:@"%d", [parameters[@"enableCollectionView"] boolValue]], @"enableCollectionView",
                                    @"Files.GetDirectory", @"exploreCommand",
                                    parameters[@"disableFilterParameter"], @"disableFilterParameter",
                                    nil];
+    MenuItem.subItem.mainLabel = item[@"label"];
     mainMenu *newMenuItem = [MenuItem.subItem copy];
     [[newMenuItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
     newMenuItem.chooseTab = choosedTab;
@@ -4987,7 +4991,7 @@ NSIndexPath *selected;
     numResults = (int)self.richResults.count;
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:[self.detailItem mainParameters][choosedTab]];
     
-    NSString *labelText = parameters[@"label"];
+    NSString *labelText = [self.detailItem mainLabel];
     if (@available(iOS 11.0, *)) {
         self.navigationItem.backButtonTitle = labelText;
         if (!albumView) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2603,7 +2603,7 @@ int originYear = 0;
         artist.font = [UIFont systemFontOfSize:artistFontSize];
         artist.adjustsFontSizeToFitWidth = YES;
         artist.minimumScaleFactor = 9.0 / artistFontSize;
-        artist.text = item[@"genre"];
+        artist.text = [Utilities getStringFromItem:item[@"albumartist"]];
         [albumDetailView addSubview:artist];
         
         albumLabel.backgroundColor = UIColor.clearColor;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR provides two bugfixes:
1. Show correct title in fullscreen album view. This was caused by not correctly handling the album view in modal view mode.
2. Show correct albumartist in album view. This was simply never implemented. Now the App requests "albumartist" from Kodi and displays this in the album view.

Screenshots:
https://abload.de/img/bildschirmfoto2022-01fekr6.png (before)
https://abload.de/img/bildschirmfoto2022-01iij51.png (after)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show correct title in fullscreen album view
Bugfix: Show correct albumartist in album view 