### PR TITLE
Bugfix: Fix runtime when showing movie details from playlist item

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1398,8 +1398,10 @@ int currentItemID;
                  }
                  NSString *serverURL = @"";
                  serverURL = [NSString stringWithFormat:@"%@:%@/vfs/", obj.serverIP, obj.serverPort];
+                 int runtimeInMinute = 1;
                  if (AppDelegate.instance.serverVersion > 11) {
                      serverURL = [NSString stringWithFormat:@"%@:%@/image/", obj.serverIP, obj.serverPort];
+                     runtimeInMinute = 60;
                  }
 
                  NSString *label = [NSString stringWithFormat:@"%@", itemExtraDict[mainFields[@"row1"]]];
@@ -1407,7 +1409,7 @@ int currentItemID;
                  
                  NSString *year = [Utilities getYearFromItem:itemExtraDict[mainFields[@"row3"]]];
 
-                 NSString *runtime = [Utilities getStringFromItem:itemExtraDict[mainFields[@"row4"]]];
+                 NSString *runtime = [Utilities getTimeFromItem:itemExtraDict[mainFields[@"row4"]] sec2min:runtimeInMinute];
                  
                  NSString *rating = [Utilities getRatingFromItem:itemExtraDict[mainFields[@"row5"]]];
                  


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes the runtime in the movie detail screen when opening it via long pressing a movie item in the playlist. Before this change the runtime was shown as a number representing the seconds (e.g. "8100"). Now it will properly show the minutes (e.g. "135 min").

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-013zjbn.png"><img src="https://abload.de/img/bildschirmfoto2022-013zjbn.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix runtime when showing movie details from playlist item