### PR TITLE
Improvement: Deselect main menu on iPad when entering details via playlist

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1944,7 +1944,7 @@ int currentItemID;
     mainMenu *MenuItem = nil;
     notificationName = @"";
     if ([item[@"type"] isEqualToString:@"song"]) {
-        notificationName = @"UIApplicationEnableMusicSection";
+        notificationName = @"MainMenuDeselectSection";
         MenuItem = [AppDelegate.instance.playlistArtistAlbums copy];
         if ([actiontitle isEqualToString:LOCALIZED_STR(@"Album Details")]) {
             choosedTab = 0;
@@ -1972,10 +1972,10 @@ int currentItemID;
         MenuItem = AppDelegate.instance.playlistMovies;
         choosedTab = 0;
         MenuItem.subItem.mainLabel = item[@"label"];
-        notificationName = @"UIApplicationEnableMovieSection";
+        notificationName = @"MainMenuDeselectSection";
     }
     else if ([item[@"type"] isEqualToString:@"episode"]) {
-        notificationName = @"UIApplicationEnableTvShowSection";
+        notificationName = @"MainMenuDeselectSection";
         if ([actiontitle isEqualToString:LOCALIZED_STR(@"Episode Details")]) {
             MenuItem = AppDelegate.instance.playlistTvShows.subItem;
             choosedTab = 0;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -215,19 +215,19 @@ double round(double d) {
     id movieObjKey = nil;
     NSString *blackTableSeparator = @"NO";
     if ([item[@"family"] isEqualToString:@"albumid"]) {
-        notificationName = @"UIApplicationEnableMusicSection";
+        notificationName = @"MainMenuDeselectSection";
         MenuItem = [AppDelegate.instance.playlistArtistAlbums copy];
         choosedMenuItem = MenuItem.subItem;
         choosedMenuItem.mainLabel = [NSString stringWithFormat:@"%@", item[@"label"]];
     }
     else if ([item[@"family"] isEqualToString:@"tvshowid"] && ![sender isKindOfClass:[NSString class]]) {
-        notificationName = @"UIApplicationEnableTvShowSection";
+        notificationName = @"MainMenuDeselectSection";
         MenuItem = [AppDelegate.instance.playlistTvShows copy];
         choosedMenuItem = MenuItem.subItem;
         choosedMenuItem.mainLabel = [NSString stringWithFormat:@"%@", item[@"label"]];
     }
     else if ([item[@"family"] isEqualToString:@"artistid"]) {
-        notificationName = @"UIApplicationEnableMusicSection";
+        notificationName = @"MainMenuDeselectSection";
         choosedTab = 1;
         MenuItem = [AppDelegate.instance.playlistArtistAlbums copy];
         choosedMenuItem = MenuItem.subItem;

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -84,46 +84,16 @@
     [super viewDidLoad];
     lastSelected = -1;
     [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(handleEnableMusicSection)
-                                                 name: @"UIApplicationEnableMusicSection"
-                                               object: nil];
-    [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(handleEnableMovieSection)
-                                                 name: @"UIApplicationEnableMovieSection"
-                                               object: nil];
-    [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(handleEnableTvShowSection)
-                                                 name: @"UIApplicationEnableTvShowSection"
+                                             selector: @selector(handleDeselectSection)
+                                                 name: @"MainMenuDeselectSection"
                                                object: nil];
 }
 
-- (void)handleEnableMusicSection {
-    NSIndexPath* selection = [self.tableView indexPathForSelectedRow];
-    if (selection.row != 1 || selection == nil) {
+- (void)handleDeselectSection {
+    NSIndexPath *selection = [self.tableView indexPathForSelectedRow];
+    if (selection != nil) {
         [self.tableView deselectRowAtIndexPath:selection animated:YES];
-        [self.tableView selectRowAtIndexPath:[NSIndexPath indexPathForRow:1 inSection:0] animated:YES scrollPosition:UITableViewScrollPositionNone];
-        lastSelected = 1;
-        [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollOnScreen" object: nil]; 
-    }		
-}
-
-- (void)handleEnableMovieSection {
-    NSIndexPath* selection = [self.tableView indexPathForSelectedRow];
-    if (selection.row != 2 || selection == nil) {
-        [self.tableView deselectRowAtIndexPath:selection animated:YES];
-        [self.tableView selectRowAtIndexPath:[NSIndexPath indexPathForRow:2 inSection:0] animated:YES scrollPosition:UITableViewScrollPositionNone];
-        lastSelected = 2;
-        [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollOnScreen" object: nil];
-    }
-}
-
-- (void)handleEnableTvShowSection {
-    NSIndexPath* selection = [self.tableView indexPathForSelectedRow];
-    if (selection.row != 3 || selection == nil) {
-        [self.tableView deselectRowAtIndexPath:selection animated:YES];
-        [self.tableView selectRowAtIndexPath:[NSIndexPath indexPathForRow:3 inSection:0] animated:YES scrollPosition:UITableViewScrollPositionNone];
-        lastSelected = 3;
-        [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollOnScreen" object: nil];
+        lastSelected = -1;
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
When entering item details from outside the menu structure on iPad (e.g. long press on an item in a playlist) any active submenu is overwritten with this detail screen. The App had an implementation to select the related main menu (e.g. "MUSIC" when showing the album details). Since the support for user configurable main menu the wrong main menu was highlighted.

Instead of this automatic selection it is recommended to just _deselect_ the current main menu as users can now enable any desired submenu again with a single click. Before this PR users always needed to first deselect and then select again (two clicks).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Deselect main menu on iPad when entering details via playlist