### PR TITLE
Improvement: More information for music videos and recordings in playlist

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1146,6 +1146,7 @@ int currentItemID;
                                                           @"albumid",
                                                           @"genre",
                                                           @"tvshowid",
+                                                          @"channel",
                                                           @"file",
                                                           @"title",
                                                           @"art"],
@@ -1190,6 +1191,7 @@ int currentItemID;
                            NSString *artistid = [NSString stringWithFormat:@"%@", playlistItems[i][@"artistid"]];
                            NSString *albumid = [NSString stringWithFormat:@"%@", playlistItems[i][@"albumid"]];
                            NSString *movieid = [NSString stringWithFormat:@"%@", playlistItems[i][@"id"]];
+                           NSString *channel = [NSString stringWithFormat:@"%@", playlistItems[i][@"channel"]];
                            NSString *genre = [Utilities getStringFromItem:playlistItems[i][@"genre"]];
                            NSString *durationTime = @"";
                            if ([playlistItems[i][@"duration"] isKindOfClass:[NSNumber class]]) {
@@ -1213,6 +1215,7 @@ int currentItemID;
                                                     genre, @"genre",
                                                     movieid, @"movieid",
                                                     movieid, @"episodeid",
+                                                    channel, @"channel",
                                                     stringURL, @"thumbnail",
                                                     runtime, @"runtime",
                                                     showtitle, @"showtitle",
@@ -2089,6 +2092,9 @@ int currentItemID;
     }
     else if ([item[@"type"] isEqualToString:@"movie"]) {
         subLabel.text = [NSString stringWithFormat:@"%@", item[@"genre"]];
+    }
+    else if ([item[@"type"] isEqualToString:@"recording"]) {
+        subLabel.text = [NSString stringWithFormat:@"%@", item[@"channel"]];
     }
     UIImage *defaultThumb;
     switch (playerID) {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2082,7 +2082,8 @@ int currentItemID;
         }
         subLabel.text = [NSString stringWithFormat:@"%@", item[@"showtitle"]];
     }
-    else if ([item[@"type"] isEqualToString:@"song"]) {
+    else if ([item[@"type"] isEqualToString:@"song"] ||
+             [item[@"type"] isEqualToString:@"musicvideo"]) {
         NSString *artist = [item[@"artist"] length] == 0 ? @"" : [NSString stringWithFormat:@" - %@", item[@"artist"]];
         subLabel.text = [NSString stringWithFormat:@"%@%@", item[@"album"], artist];
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR adds more information for music videos and recordings in the playlist view. 

Remark: The additional channel name for recordings is only supported from Kodi 20.0 on.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-01b0k73.png"><img src="https://abload.de/img/bildschirmfoto2022-01b0k73.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: More information for music videos and recordings in playlist