### PR TITLE
Feature: Playlist longpress details for music videos and recordings

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -66,6 +66,7 @@
 @property (nonatomic, retain) mainMenu *playlistMovies;
 @property (nonatomic, retain) mainMenu *playlistMusicVideos;
 @property (nonatomic, retain) mainMenu *playlistTvShows;
+@property (nonatomic, retain) mainMenu *playlistPVR;
 @property (nonatomic, retain) mainMenu *xbmcSettings;
 @property (nonatomic, retain) NSMutableArray *rightMenuItems;
 @property (nonatomic, retain) NSMutableArray *nowPlayingMenuItems;

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -64,6 +64,7 @@
 
 @property (nonatomic, retain) mainMenu *playlistArtistAlbums;
 @property (nonatomic, retain) mainMenu *playlistMovies;
+@property (nonatomic, retain) mainMenu *playlistMusicVideos;
 @property (nonatomic, retain) mainMenu *playlistTvShows;
 @property (nonatomic, retain) mainMenu *xbmcSettings;
 @property (nonatomic, retain) NSMutableArray *rightMenuItems;

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -54,35 +54,35 @@
 
 @property (strong, nonatomic) CustomNavigationController *navigationController;
 
-@property (nonatomic, retain) ViewControllerIPad *windowController;
+@property (nonatomic, strong) ViewControllerIPad *windowController;
 
-@property (retain, nonatomic) NSString *dataFilePath;
-@property (retain, nonatomic) NSString *libraryCachePath;
-@property (retain, nonatomic) NSString *epgCachePath;
+@property (strong, nonatomic) NSString *dataFilePath;
+@property (strong, nonatomic) NSString *libraryCachePath;
+@property (strong, nonatomic) NSString *epgCachePath;
 
-@property (nonatomic, retain) NSMutableArray *arrayServerList;
+@property (nonatomic, strong) NSMutableArray *arrayServerList;
 
-@property (nonatomic, retain) mainMenu *playlistArtistAlbums;
-@property (nonatomic, retain) mainMenu *playlistMovies;
-@property (nonatomic, retain) mainMenu *playlistMusicVideos;
-@property (nonatomic, retain) mainMenu *playlistTvShows;
-@property (nonatomic, retain) mainMenu *playlistPVR;
-@property (nonatomic, retain) mainMenu *xbmcSettings;
-@property (nonatomic, retain) NSMutableArray *rightMenuItems;
-@property (nonatomic, retain) NSMutableArray *nowPlayingMenuItems;
-@property (nonatomic, retain) NSMutableArray *remoteControlMenuItems;
+@property (nonatomic, strong) mainMenu *playlistArtistAlbums;
+@property (nonatomic, strong) mainMenu *playlistMovies;
+@property (nonatomic, strong) mainMenu *playlistMusicVideos;
+@property (nonatomic, strong) mainMenu *playlistTvShows;
+@property (nonatomic, strong) mainMenu *playlistPVR;
+@property (nonatomic, strong) mainMenu *xbmcSettings;
+@property (nonatomic, strong) NSMutableArray *rightMenuItems;
+@property (nonatomic, strong) NSMutableArray *nowPlayingMenuItems;
+@property (nonatomic, strong) NSMutableArray *remoteControlMenuItems;
 @property (nonatomic, assign) BOOL serverOnLine;
 @property (nonatomic, assign) BOOL serverTCPConnectionOpen;
 @property (nonatomic, assign) int serverVersion;
 @property (nonatomic, assign) int serverMinorVersion;
 @property (nonatomic, assign) int serverVolume;
-@property (retain, nonatomic) NSString *serverName;
+@property (strong, nonatomic) NSString *serverName;
 @property (nonatomic, assign) int APImajorVersion;
 @property (nonatomic, assign) int APIminorVersion;
 @property (nonatomic, assign) int APIpatchVersion;
 @property (nonatomic, assign) BOOL isIgnoreArticlesEnabled;
 @property (nonatomic, assign) BOOL isGroupSingleItemSetsEnabled;
 @property (nonatomic, copy) NSArray *KodiSorttokens;
-@property (nonatomic, retain) GlobalData *obj;
+@property (nonatomic, strong) GlobalData *obj;
 
 @end

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -35,6 +35,7 @@ NSMutableArray *hostRightMenuItems;
 @synthesize obj;
 @synthesize playlistArtistAlbums;
 @synthesize playlistMovies;
+@synthesize playlistMusicVideos;
 @synthesize playlistTvShows;
 @synthesize rightMenuItems;
 @synthesize serverName;
@@ -5092,6 +5093,11 @@ NSMutableArray *hostRightMenuItems;
     playlistMovies = [menu_Movies copy];
     playlistMovies.subItem.disableNowPlaying = YES;
     playlistMovies.subItem.subItem.disableNowPlaying = YES;
+    
+#pragma mark - Plalist Movies
+    playlistMusicVideos = [menu_Videos copy];
+    playlistMusicVideos.subItem.disableNowPlaying = YES;
+    playlistMusicVideos.subItem.subItem.disableNowPlaying = YES;
     
 #pragma mark - Playlist TV Shows
     playlistTvShows = [menu_TVShows copy];

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -2770,7 +2770,8 @@ NSMutableArray *hostRightMenuItems;
         @"st_playlists"];
     
     menu_Videos.mainMethod = @[
-            @[@"VideoLibrary.GetMusicVideos", @"method"],
+            @[@"VideoLibrary.GetMusicVideos", @"method",
+              @"VideoLibrary.GetMusicVideoDetails", @"extra_info_method"],
             @[@"VideoLibrary.GetRecentlyAddedMusicVideos", @"method"],
             @[@"Files.GetSources", @"method"],
             @[@"Files.GetDirectory", @"method"],
@@ -2795,6 +2796,21 @@ NSMutableArray *hostRightMenuItems;
                         @"fanart",
                         @"resume"]
             }, @"parameters",
+            @{
+                @"properties": @[
+                        @"artist",
+                        @"year",
+                        @"playcount",
+                        @"thumbnail",
+                        @"genre",
+                        @"runtime",
+                        @"studio",
+                        @"director",
+                        @"plot",
+                        @"file",
+                        @"fanart",
+                        @"resume"]
+            }, @"extra_info_parameters",
             @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
@@ -2909,7 +2925,8 @@ NSMutableArray *hostRightMenuItems;
             @"row14": @"resume",
             @"row15": @"votes",
             @"row16": @"artist",
-            @"row7": @"file"
+            @"row7": @"file",
+            @"itemid_extra_info": @"musicvideodetails"
         },
         
         @{

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -37,6 +37,7 @@ NSMutableArray *hostRightMenuItems;
 @synthesize playlistMovies;
 @synthesize playlistMusicVideos;
 @synthesize playlistTvShows;
+@synthesize playlistPVR;
 @synthesize rightMenuItems;
 @synthesize serverName;
 @synthesize nowPlayingMenuItems;
@@ -5104,6 +5105,11 @@ NSMutableArray *hostRightMenuItems;
     playlistTvShows.subItem.disableNowPlaying = YES;
     playlistTvShows.subItem.subItem.disableNowPlaying = YES;
 
+#pragma mark - Playlist PVR
+    playlistPVR = [menu_LiveTV copy];
+    playlistPVR.subItem.disableNowPlaying = YES;
+    playlistPVR.subItem.subItem.disableNowPlaying = YES;
+    
 #pragma mark - XBMC Settings 
     xbmcSettings = [mainMenu new];
     xbmcSettings.subItem = [mainMenu new];

--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -134,15 +134,15 @@
 - (id)initWithFrame:(CGRect)frame;
 - (id)initWithNibName:(NSString*)nibNameOrNil withItem:(mainMenu*)item withFrame:(CGRect)frame bundle:(NSBundle*)nibBundleOrNil;
 
-@property (nonatomic, retain) NSMutableArray *filteredListContent;
+@property (nonatomic, strong) NSMutableArray *filteredListContent;
 @property (strong, nonatomic) id detailItem;
 @property (nonatomic, readonly) UIActivityIndicatorView *activityIndicatorView;
 @property (strong, nonatomic) BDKCollectionIndexView *indexView;
-@property (nonatomic, retain) NSMutableDictionary *sections;
-@property (nonatomic, retain) NSMutableArray *richResults;
-@property (nonatomic, retain) NSArray *sectionArray;
-@property (nonatomic, retain) NSMutableArray *sectionArrayOpen;
-@property (nonatomic, retain) NSMutableArray *extraSectionRichResults;
+@property (nonatomic, strong) NSMutableDictionary *sections;
+@property (nonatomic, strong) NSMutableArray *richResults;
+@property (nonatomic, strong) NSArray *sectionArray;
+@property (nonatomic, strong) NSMutableArray *sectionArrayOpen;
+@property (nonatomic, strong) NSMutableArray *extraSectionRichResults;
 @property (strong, nonatomic) UISearchController *searchController;
 
 @end

--- a/XBMC Remote/GlobalData.h
+++ b/XBMC Remote/GlobalData.h
@@ -20,13 +20,13 @@
 
     
 }
-@property (nonatomic, retain)NSString *serverDescription;
-@property (nonatomic, retain)NSString *serverUser;
-@property (nonatomic, retain)NSString *serverPass;
-@property (nonatomic, retain)NSString *serverIP;
+@property (nonatomic, strong)NSString *serverDescription;
+@property (nonatomic, strong)NSString *serverUser;
+@property (nonatomic, strong)NSString *serverPass;
+@property (nonatomic, strong)NSString *serverIP;
 @property int tcpPort;
-@property (nonatomic, retain)NSString *serverPort;
-@property (nonatomic, retain)NSString *serverHWAddr; 
+@property (nonatomic, strong)NSString *serverPort;
+@property (nonatomic, strong)NSString *serverHWAddr; 
 @property BOOL preferTVPosters;
 
 + (GlobalData*)getInstance;

--- a/XBMC Remote/KenBurns/JBKenBurnsView.h
+++ b/XBMC Remote/KenBurns/JBKenBurnsView.h
@@ -46,7 +46,7 @@
 }
 
 @property (nonatomic, assign) NSTimeInterval timeTransition;
-@property (nonatomic, retain) NSMutableArray *imagesArray;
+@property (nonatomic, strong) NSMutableArray *imagesArray;
 @property (nonatomic) BOOL isLoop;
 @property (nonatomic) BOOL isLandscape;
 @property (weak) id<KenBurnsViewDelegate> delegate;

--- a/XBMC Remote/MessagesView.h
+++ b/XBMC Remote/MessagesView.h
@@ -18,6 +18,6 @@
 - (id)initWithFrame:(CGRect)frame deltaY:(CGFloat)deltaY deltaX:(CGFloat)deltaX;
 - (void)showMessage:(NSString*)message timeout:(NSTimeInterval)timeout color:(UIColor*)color;
 
-@property (nonatomic, retain) UILabel *viewMessage;
+@property (nonatomic, strong) UILabel *viewMessage;
 
 @end

--- a/XBMC Remote/MoreItemsViewController.h
+++ b/XBMC Remote/MoreItemsViewController.h
@@ -16,6 +16,6 @@
 
 - (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu;
 
-@property (nonatomic, retain) UITableView* tableView;
+@property (nonatomic, strong) UITableView* tableView;
 
 @end

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1216,6 +1216,7 @@ int currentItemID;
                                                     genre, @"genre",
                                                     movieid, @"movieid",
                                                     movieid, @"episodeid",
+                                                    movieid, @"musicvideoid",
                                                     channel, @"channel",
                                                     stringURL, @"thumbnail",
                                                     runtime, @"runtime",
@@ -1845,6 +1846,9 @@ int currentItemID;
                 else if ([item[@"type"] isEqualToString:@"episode"]) {
                     [sheetActions addObjectsFromArray:@[LOCALIZED_STR(@"TV Show Details"), LOCALIZED_STR(@"Episode Details")]];
                 }
+                else if ([item[@"type"] isEqualToString:@"musicvideo"]) {
+                    [sheetActions addObjectsFromArray:@[LOCALIZED_STR(@"Music Video Details")]];
+                }
             }
             NSInteger numActions = sheetActions.count;
             if (numActions) {
@@ -1995,6 +1999,12 @@ int currentItemID;
             choosedTab = 0;
             MenuItem.subItem.mainLabel = item[@"label"];
         }
+    }
+    else if ([item[@"type"] isEqualToString:@"musicvideo"]) {
+        MenuItem = AppDelegate.instance.playlistMusicVideos;
+        choosedTab = 0;
+        MenuItem.subItem.mainLabel = item[@"label"];
+        notificationName = @"MainMenuDeselectSection";
     }
     else {
         return;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -109,7 +109,7 @@ typedef enum {
 
 - (NSString*)getNowPlayingThumbnailPath:(NSDictionary*)item {
     // If a recording is played, we can use the iocn (typically the station logo)
-    BOOL useIcon = [item[@"type"] isEqualToString:@"recording"];
+    BOOL useIcon = [item[@"type"] isEqualToString:@"recording"] || [item[@"recordingid"] intValue] > 0;
     return [Utilities getThumbnailFromDictionary:item useBanner:NO useIcon:useIcon];
 }
 
@@ -1217,6 +1217,7 @@ int currentItemID;
                                                     movieid, @"movieid",
                                                     movieid, @"episodeid",
                                                     movieid, @"musicvideoid",
+                                                    movieid, @"recordingid",
                                                     channel, @"channel",
                                                     stringURL, @"thumbnail",
                                                     runtime, @"runtime",
@@ -1418,7 +1419,7 @@ int currentItemID;
                  
                  NSString *rating = [Utilities getRatingFromItem:itemExtraDict[mainFields[@"row5"]]];
                  
-                 NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:itemExtraDict useBanner:NO useIcon:NO];
+                 NSString *thumbnailPath = [self getNowPlayingThumbnailPath:itemExtraDict];
                  NSDictionary *art = itemExtraDict[@"art"];
                  NSString *clearlogo = [Utilities getClearArtFromDictionary:art type:@"clearlogo"];
                  NSString *clearart = [Utilities getClearArtFromDictionary:art type:@"clearart"];
@@ -1849,6 +1850,9 @@ int currentItemID;
                 else if ([item[@"type"] isEqualToString:@"musicvideo"]) {
                     [sheetActions addObjectsFromArray:@[LOCALIZED_STR(@"Music Video Details")]];
                 }
+                else if ([item[@"type"] isEqualToString:@"recording"]) {
+                    [sheetActions addObjectsFromArray:@[LOCALIZED_STR(@"Recording Details")]];
+                }
             }
             NSInteger numActions = sheetActions.count;
             if (numActions) {
@@ -2003,6 +2007,12 @@ int currentItemID;
     else if ([item[@"type"] isEqualToString:@"musicvideo"]) {
         MenuItem = AppDelegate.instance.playlistMusicVideos;
         choosedTab = 0;
+        MenuItem.subItem.mainLabel = item[@"label"];
+        notificationName = @"MainMenuDeselectSection";
+    }
+    else if ([item[@"type"] isEqualToString:@"recording"]) {
+        MenuItem = AppDelegate.instance.playlistPVR;
+        choosedTab = 2;
         MenuItem.subItem.mainLabel = item[@"label"];
         notificationName = @"MainMenuDeselectSection";
     }

--- a/XBMC Remote/RemoteController.h
+++ b/XBMC Remote/RemoteController.h
@@ -35,7 +35,7 @@
 - (void)resetRemote;
 - (id)initWithNibName:(NSString*)nibNameOrNil withEmbedded:(BOOL)withEmbedded bundle:(NSBundle*)nibBundleOrNil;
 @property (strong, nonatomic) id detailItem;
-@property (nonatomic, retain) NSTimer* holdVolumeTimer;
+@property (nonatomic, strong) NSTimer* holdVolumeTimer;
 @property (strong, nonatomic) UIImageView *panFallbackImageView;
 
 @end

--- a/XBMC Remote/SettingsValuesViewController.h
+++ b/XBMC Remote/SettingsValuesViewController.h
@@ -39,7 +39,7 @@ typedef enum {
 
 - (id)initWithFrame:(CGRect)frame withItem:(id)item;
 
-@property (nonatomic, retain) UITableView* tableView;
+@property (nonatomic, strong) UITableView* tableView;
 @property (strong, nonatomic) id detailItem;
 
 @end

--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -89,6 +89,6 @@
 - (id)initWithNibName:(NSString*)nibNameOrNil withItem:(NSDictionary*)item withFrame:(CGRect)frame bundle:(NSBundle*)nibBundleOrNil;
 
 @property (strong, nonatomic) id detailItem;
-@property (nonatomic, retain) KenBurnsView *kenView;
+@property (nonatomic, strong) KenBurnsView *kenView;
 
 @end

--- a/XBMC Remote/ViewControllerIPad.h
+++ b/XBMC Remote/ViewControllerIPad.h
@@ -44,11 +44,11 @@
 }
 
 @property (nonatomic, strong) NSMutableArray *mainMenu;
-@property (nonatomic, retain) MenuViewController* menuViewController;
-@property (nonatomic, retain) NowPlaying* nowPlayingController;
+@property (nonatomic, strong) MenuViewController* menuViewController;
+@property (nonatomic, strong) NowPlaying* nowPlayingController;
 @property (nonatomic, strong) StackScrollViewController* stackScrollViewController;
 @property (strong, nonatomic) tcpJSONRPC *tcpJSONRPCconnection;
-@property (nonatomic, retain) HostManagementViewController *hostPickerViewController;
-@property (nonatomic, retain) AppInfoViewController *appInfoView;
+@property (nonatomic, strong) HostManagementViewController *hostPickerViewController;
+@property (nonatomic, strong) AppInfoViewController *appInfoView;
 
 @end

--- a/XBMC Remote/VolumeSliderView.h
+++ b/XBMC Remote/VolumeSliderView.h
@@ -28,9 +28,9 @@
 
 - (void)stopTimer;
 
-@property (nonatomic, retain) NSTimer* timer;
+@property (nonatomic, strong) NSTimer* timer;
 
-@property (nonatomic, retain) NSTimer* holdVolumeTimer;
+@property (nonatomic, strong) NSTimer* holdVolumeTimer;
 
 
 @end

--- a/XBMC Remote/customButton.h
+++ b/XBMC Remote/customButton.h
@@ -10,7 +10,7 @@
 
 @interface customButton : NSObject
 
-@property (nonatomic, retain) NSMutableArray *buttons;
+@property (nonatomic, strong) NSMutableArray *buttons;
 
 - (void)loadData;
 - (void)saveData;

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSARCHelpers.h
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSARCHelpers.h
@@ -48,7 +48,7 @@
 #endif
 
 #ifndef DS_ARC_ENABLED
-#define DS_STRONG           retain
+#define DS_STRONG           strong
 #define DS_WEAK             assign
 #define DS_RELEASE(X)       [X release], X = nil;
 #define DS_RETAIN(X)        [X retain];

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -81,6 +81,7 @@
 "Episode Details" = "Episodendetails";
 "TV Show Details" = "Seriendetails";
 "Music Video Details" = "Musikvideo-Details";
+"Recording Details" = "Aufnahmedetails";
 "Details" = "Details";
 "Play Trailer" = "Trailer wiedergeben";
 "Playlist" = "Wiedergabeliste";

--- a/XBMC Remote/en-US.lproj/Localizable.strings
+++ b/XBMC Remote/en-US.lproj/Localizable.strings
@@ -81,6 +81,7 @@
 "Episode Details" = "Episode Details";
 "TV Show Details" = "TV Show Details";
 "Music Video Details" = "Music Video Details";
+"Recording Details" = "Recording Details";
 "Details" = "Details";
 "Play Trailer" = "Play Trailer";
 "Playlist" = "Playlist";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -89,6 +89,7 @@
 "Episode Details" = "Episode Details";
 "TV Show Details" = "TV Show Details";
 "Music Video Details" = "Music Video Details";
+"Recording Details" = "Recording Details";
 "Details" = "Details";
 "Play Trailer" = "Play Trailer";
 

--- a/XBMC Remote/iPad/MenuViewController.h
+++ b/XBMC Remote/iPad/MenuViewController.h
@@ -49,7 +49,7 @@
 - (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu;
 - (void)setLastSelected:(int)selection;
 
-@property (nonatomic, retain) UITableView* tableView;
+@property (nonatomic, strong) UITableView* tableView;
 
 
 @end

--- a/XBMC Remote/iPad/StackScrollViewController.h
+++ b/XBMC Remote/iPad/StackScrollViewController.h
@@ -77,8 +77,8 @@
 - (void)addViewInSlider:(UIViewController*)controller invokeByController:(UIViewController*)invokeByController isStackStartView:(BOOL)isStackStartView;
 - (void)bounceBack:(NSString*)animationID finished:(NSNumber*)finished context:(void*)context;
 
-@property (nonatomic, retain) UIView *slideViews;
-@property (nonatomic, retain) UIView *borderViews;
+@property (nonatomic, strong) UIView *slideViews;
+@property (nonatomic, strong) UIView *borderViews;
 @property (nonatomic, assign) CGFloat slideStartPosition;
 @property (nonatomic, strong) NSMutableArray *viewControllersStack;
 

--- a/XBMC Remote/mainMenu.h
+++ b/XBMC Remote/mainMenu.h
@@ -36,8 +36,8 @@ typedef enum {
 @property (nonatomic, copy) NSString *defaultThumb;
 @property (nonatomic, copy) NSArray *mainButtons;
 @property (nonatomic, copy) NSArray *mainFields;
-@property (nonatomic, retain) NSMutableArray *mainParameters;
-@property (nonatomic, retain) mainMenu *subItem;
+@property (nonatomic, strong) NSMutableArray *mainParameters;
+@property (nonatomic, strong) mainMenu *subItem;
 @property (nonatomic, copy) NSArray *sheetActions;
 @property int rowHeight;
 @property int thumbWidth;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR implements the longpress functionality for music videos and recordings in the playlist. This is consistent with the longpress functionality for music, movies and TV shows.

Remark: The new functionality for recordings will only work with Kodi 20.0 and later.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-01fzjpk.png"><img src="https://abload.de/img/bildschirmfoto2022-01fzjpk.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Playlist longpress details for music videos and recordings