### PR TITLE
Maintenance: Replace constructed message with complete strings

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1793,17 +1793,21 @@ int currentItemID;
 
 - (void)showClearPlaylistAlert {
     if (!playlistView.hidden && self.view.superview != nil) {
-        NSString *playlistName = @"";
-        if (playerID == PLAYERID_MUSIC) {
-            playlistName = LOCALIZED_STR(@"Music ");
+        NSString *message;
+        switch (playerID) {
+            case PLAYERID_MUSIC:
+                message = LOCALIZED_STR(@"Are you sure you want to clear the music playlist?");
+                break;
+            case PLAYERID_VIDEO:
+                message = LOCALIZED_STR(@"Are you sure you want to clear the video playlist?");
+                break;
+            case PLAYERID_PICTURES:
+                message = LOCALIZED_STR(@"Are you sure you want to clear the picture playlist?");
+                break;
+            default:
+                message = LOCALIZED_STR(@"Are you sure you want to clear the playlist?");
+                break;
         }
-        else if (playerID == PLAYERID_VIDEO) {
-            playlistName = LOCALIZED_STR(@"Video ");
-        }
-        else if (playerID == PLAYERID_PICTURES) {
-            playlistName = LOCALIZED_STR(@"Pictures ");
-        }
-        NSString *message = [NSString stringWithFormat:LOCALIZED_STR(@"Are you sure you want to clear the %@playlist?"), playlistName];
         UIAlertController *alertView = [UIAlertController alertControllerWithTitle:message message:nil preferredStyle:UIAlertControllerStyleAlert];
         UIAlertAction* cancelButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {}];
         UIAlertAction* clearButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Clear Playlist") style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {

--- a/XBMC Remote/cs.lproj/Localizable.strings
+++ b/XBMC Remote/cs.lproj/Localizable.strings
@@ -90,8 +90,6 @@
 "Episodes: %@" = "Epizod: %@";
 "1 result" = "1 výsledek";
 "%d results" = "%d výsledků";
-"Music " = "Hudba ";
-"Video " = "Video ";
 "Songs" = "Skladeb";
 "Song" = "Skladba";
 "Mins." = "Mins.";
@@ -104,7 +102,10 @@
 "Cannot do that" = "Nelze udělat";
 "Wake On Lan" = "Wake On Lan";
 "No saved hosts found" = "Nebyly nalezeni žádní uložení hostitelé";
-"Are you sure you want to clear the %@playlist?" = "Opravdu chcete zrušit %@playlist?";
+"Are you sure you want to clear the playlist?" = "Opravdu chcete zrušit playlist?";
+"Are you sure you want to clear the music playlist?" = "Opravdu chcete zrušit hudba playlist?";
+"Are you sure you want to clear the video playlist?" = "Opravdu chcete zrušit video playlist?";
+"Are you sure you want to clear the picture playlist?" = "Opravdu chcete zrušit obrázky playlist?";
 "Are you sure you want to power off your XBMC system now?" = "Opravdu chcete nyní vypnout systém Kodi?";
 "Are you sure you want to hibernate your XBMC system now?" = "Opravdu chcete nyní hibernovat systém Kodi?";
 "Are you sure you want to suspend your XBMC system now?" = "Opravdu chcete nyní uspat systém Kodi?";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -95,9 +95,6 @@
 "Episodes: %@" = "Episoden: %@";
 "1 result" = "1 Ergebnis";
 "%d results" = "%d Ergebnisse";
-"Music " = "Musik-";
-"Video " = "Video-";
-"Pictures " = "Bilder- ";
 "Songs" = "Titel";
 "Song" = "Titel";
 "Mins." = "Min.";
@@ -110,7 +107,10 @@
 "Cannot do that" = "Dies ist nicht möglich";
 "Wake On Lan" = "Wake-On-LAN";
 "No saved hosts found" = "Keine gespeicherten Server gefunden";
-"Are you sure you want to clear the %@playlist?" = "Soll die %@Wiedergabeliste gelöscht werden?";
+"Are you sure you want to clear the playlist?" = "Soll die Wiedergabeliste gelöscht werden?";
+"Are you sure you want to clear the music playlist?" = "Soll die Musik-Wiedergabeliste gelöscht werden?";
+"Are you sure you want to clear the video playlist?" = "Soll die Video-Wiedergabeliste gelöscht werden?";
+"Are you sure you want to clear the picture playlist?" = "Soll die Bild-Wiedergabeliste gelöscht werden?";
 "Are you sure you want to power off your XBMC system now?" = "Soll das Kodi-System jetzt ausgeschaltet werden?";
 "Are you sure you want to hibernate your XBMC system now?" = "Soll das Kodi-System jetzt in den Ruhezustand gehen?";
 "Are you sure you want to suspend your XBMC system now?" = "Soll das Kodi-System jetzt in den Standby gehen?";

--- a/XBMC Remote/en-US.lproj/Localizable.strings
+++ b/XBMC Remote/en-US.lproj/Localizable.strings
@@ -95,8 +95,6 @@
 "Episodes: %@" = "Episodes: %@";
 "1 result" = "1 result";
 "%d results" = "%d results";
-"Music " = "Music ";
-"Video " = "Video ";
 "Songs" = "Songs";
 "Song" = "Song";
 "Mins." = "Mins.";
@@ -109,7 +107,10 @@
 "Cannot do that" = "Cannot do that";
 "Wake On Lan" = "Wake On Lan";
 "No saved hosts found" = "No saved hosts found";
-"Are you sure you want to clear the %@playlist?" = "Are you sure you want to clear the %@playlist?";
+"Are you sure you want to clear the playlist?" = "Are you sure you want to clear the playlist?";
+"Are you sure you want to clear the music playlist?" = "Are you sure you want to clear the music playlist?";
+"Are you sure you want to clear the video playlist?" = "Are you sure you want to clear the video playlist?";
+"Are you sure you want to clear the picture playlist?" = "Are you sure you want to clear the picture playlist?";
 "Are you sure you want to power off your XBMC system now?" = "Are you sure you want to power off your Kodi system now?";
 "Are you sure you want to hibernate your XBMC system now?" = "Are you sure you want to hibernate your Kodi system now?";
 "Are you sure you want to suspend your XBMC system now?" = "Are you sure you want to suspend your Kodi system now?";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -104,9 +104,6 @@
 "Episodes: %@" = "Episodes: %@";
 "1 result" = "1 result";
 "%d results" = "%d results";
-"Music " = "Music ";
-"Video " = "Video ";
-"Pictures " = "Pictures ";
 "Songs" = "Songs";
 "Song" = "Song";
 "Mins." = "Mins.";
@@ -121,7 +118,10 @@
 "Wake On Lan" = "Wake On Lan";
 "No saved hosts found" = "No saved hosts found";
 
-"Are you sure you want to clear the %@playlist?" = "Are you sure you want to clear the %@playlist?";
+"Are you sure you want to clear the playlist?" = "Are you sure you want to clear the playlist?";
+"Are you sure you want to clear the music playlist?" = "Are you sure you want to clear the music playlist?";
+"Are you sure you want to clear the video playlist?" = "Are you sure you want to clear the video playlist?";
+"Are you sure you want to clear the picture playlist?" = "Are you sure you want to clear the picture playlist?";
 "Are you sure you want to power off your XBMC system now?" = "Are you sure you want to power off your Kodi system now?";
 "Are you sure you want to hibernate your XBMC system now?" = "Are you sure you want to hibernate your Kodi system now?";
 "Are you sure you want to suspend your XBMC system now?" = "Are you sure you want to suspend your Kodi system now?";

--- a/XBMC Remote/es.lproj/Localizable.strings
+++ b/XBMC Remote/es.lproj/Localizable.strings
@@ -90,8 +90,6 @@
 "Episodes: %@" = "Episodios: %@";
 "1 result" = "1 resultado";
 "%d results" = "%d resultados";
-"Music " = "Música ";
-"Video " = "Vídeo ";
 "Songs" = "Canciones";
 "Song" = "Canción";
 "Mins." = "Mins.";
@@ -104,7 +102,10 @@
 "Cannot do that" = "No puedes hacer eso";
 "Wake On Lan" = "Activación de LAN";
 "No saved hosts found" = "No se encontraron hosts guardados";
-"Are you sure you want to clear the %@playlist?" = "¿Estás seguro que quieres borrar %@playlist?";
+"Are you sure you want to clear the playlist?" = "¿Estás seguro que quieres borrar playlist?";
+"Are you sure you want to clear the music playlist?" = "¿Estás seguro que quieres borrar playlist de música?";
+"Are you sure you want to clear the video playlist?" = "¿Estás seguro que quieres borrar playlist de video?";
+"Are you sure you want to clear the picture playlist?" = "¿Estás seguro que quieres borrar playlist de imágenes?";
 "Are you sure you want to power off your XBMC system now?" = "¿Estás seguro que quieres apagar tu sistema Kodi ahora?";
 "Are you sure you want to hibernate your XBMC system now?" = "¿Estás seguro que quieres hibernar tu sistema Kodi ahora?";
 "Are you sure you want to suspend your XBMC system now?" = "¿Estás seguro que quieres suspender tu sistema Kodi ahora?";

--- a/XBMC Remote/fr.lproj/Localizable.strings
+++ b/XBMC Remote/fr.lproj/Localizable.strings
@@ -89,8 +89,6 @@
 "Episodes: %@" = "Episodes: %@";
 "1 result" = "1 resultat";
 "%d results" = "%d resultats";
-"Music " = "Musique ";
-"Video " = "Video ";
 "Songs" = "Chansons";
 "Song" = "Chanson";
 "Mins." = "Mins.";
@@ -103,7 +101,10 @@
 "Cannot do that" = "Impossible de faire ceci";
 "Wake On Lan" = "Wake On Lan";
 "No saved hosts found" = "Aucun serveur enregistré";
-"Are you sure you want to clear the %@playlist?" = "Etes-vous sur de vouloir nettoyer %@playlist ?";
+"Are you sure you want to clear the playlist?" = "Etes-vous sur de vouloir nettoyer playlist ?";
+"Are you sure you want to clear the music playlist?" = "Etes-vous sur de vouloir nettoyer playlist musique ?";
+"Are you sure you want to clear the video playlist?" = "Etes-vous sur de vouloir nettoyer playlist vidéo ?";
+"Are you sure you want to clear the picture playlist?" = "Etes-vous sur de vouloir nettoyer playlist image ?";
 "Are you sure you want to power off your XBMC system now?" = "Etes-vous sur de vouloir éteindre votre système Kodi maintenant ?";
 "Are you sure you want to hibernate your XBMC system now?" = "Etes-vous sur de vouloir mettre votre système Kodi en veille prolongée ?";
 "Are you sure you want to suspend your XBMC system now?" = "Etes-vous sur de vouloir mettre votre système Kodi en veille ?";

--- a/XBMC Remote/it.lproj/Localizable.strings
+++ b/XBMC Remote/it.lproj/Localizable.strings
@@ -90,8 +90,6 @@
 "Episodes: %@" = "Episodi: %@";
 "1 result" = "1 risultato";
 "%d results" = "%d risultati";
-"Music " = "Musica ";
-"Video " = "Video ";
 "Songs" = "Brani";
 "Song" = "Brano";
 "Mins." = "Minuti";
@@ -104,7 +102,10 @@
 "Cannot do that" = "Non lo posso fare";
 "Wake On Lan" = "Wake On Lan";
 "No saved hosts found" = "Nessun server trovato";
-"Are you sure you want to clear the %@playlist?" = "Sei sicuro di voler cancellare la playlist%@?";
+"Are you sure you want to clear the playlist?" = "Sei sicuro di voler cancellare la playlist?";
+"Are you sure you want to clear the music playlist?" = "Sei sicuro di voler cancellare la playlist musica?";
+"Are you sure you want to clear the video playlist?" = "Sei sicuro di voler cancellare la playlist video?";
+"Are you sure you want to clear the picture playlist?" = "Sei sicuro di voler cancellare la playlist immagini?";
 "Are you sure you want to power off your XBMC system now?" = "Sei sicuro di voler spegnere il tuo sistema Kodi adesso?";
 "Are you sure you want to hibernate your XBMC system now?" = "Sei sicuro di voler ibernare il tuo sistema Kodi adesso?";
 "Are you sure you want to suspend your XBMC system now?" = "Sei sicuro di voler sospendere il tuo sistema Kodi adesso?";

--- a/XBMC Remote/nl.lproj/Localizable.strings
+++ b/XBMC Remote/nl.lproj/Localizable.strings
@@ -92,8 +92,6 @@
 "Episodes: %@" = "Afleveringen: %@";
 "1 result" = "1 resultaat";
 "%d results" = "%d resultaten";
-"Music " = "Muziek ";
-"Video " = "Video ";
 "Songs" = "Nummers";
 "Song" = "Nummer";
 "Mins." = "Min.";
@@ -106,7 +104,10 @@
 "Cannot do that" = "Dat is niet mogelijk";
 "Wake On Lan" = "Wake On Lan";
 "No saved hosts found" = "Geen opgeslagen hosts gevonden";
-"Are you sure you want to clear the %@playlist?" = "Weet je zeker dat je %@playlist wil leegmaken?";
+"Are you sure you want to clear the playlist?" = "Weet je zeker dat je playlist wil leegmaken?";
+"Are you sure you want to clear the music playlist?" = "Weet je zeker dat je muziek playlist wil leegmaken?";
+"Are you sure you want to clear the video playlist?" = "Weet je zeker dat je video playlist wil leegmaken?";
+"Are you sure you want to clear the picture playlist?" = "Weet je zeker dat je foto playlist wil leegmaken?";
 "Are you sure you want to power off your XBMC system now?" = "Weet je zeker dat je het systeem wil uitschakelen?";
 "Are you sure you want to hibernate your XBMC system now?" = "Weet je zeker dat je het systeem in slaapstand wil zetten?";
 "Are you sure you want to suspend your XBMC system now?" = "Weet je zeker dat je het systeem op standby wil zetten?";

--- a/XBMC Remote/pl.lproj/Localizable.strings
+++ b/XBMC Remote/pl.lproj/Localizable.strings
@@ -90,8 +90,6 @@
 "Episodes: %@" = "Odcinki: %@";
 "1 result" = "1 wynik";
 "%d results" = "%d wyników";
-"Music " = "Muzyka ";
-"Video " = "Wideo ";
 "Songs" = "Piosenki";
 "Song" = "Piosenka";
 "Mins." = "Minut";
@@ -104,7 +102,10 @@
 "Cannot do that" = "Nie można wykonać";
 "Wake On Lan" = "Wake-on-LAN (WoL)";
 "No saved hosts found" = "Nie znaleziono zapisanych hostów";
-"Are you sure you want to clear the %@playlist?" = "Na pewno chcesz wyczyścić %@listę odtwarzania?";
+"Are you sure you want to clear the playlist?" = "Na pewno chcesz wyczyścić listę odtwarzania?";
+"Are you sure you want to clear the music playlist?" = "Na pewno chcesz wyczyścić muzyka listę odtwarzania?";
+"Are you sure you want to clear the video playlist?" = "Na pewno chcesz wyczyścić wideo listę odtwarzania?";
+"Are you sure you want to clear the picture playlist?" = "Na pewno chcesz wyczyścić zdjęcio listę odtwarzania?";
 "Are you sure you want to power off your XBMC system now?" = "Na pewno chcesz wyłączyć system Kodi teraz?";
 "Are you sure you want to hibernate your XBMC system now?" = "Na pewno chcesz zahibernować system Kodi teraz?";
 "Are you sure you want to suspend your XBMC system now?" = "Na pewno chcesz wstrzymać system Kodi teraz?";

--- a/XBMC Remote/pt-PT.lproj/Localizable.strings
+++ b/XBMC Remote/pt-PT.lproj/Localizable.strings
@@ -106,7 +106,10 @@
 "Wake On Lan" = "Ligar via rede local (WoL)";
 "No saved hosts found" = "Nenhum servidor guardado encontrado";
 
-"Are you sure you want to clear the %@?" = "Tem a certeza que pretende limpar a %@?";/*------ To verify ------*/
+"Are you sure you want to clear the playlist?" = "Tem a certeza de que quer apagar a playlist?";
+"Are you sure you want to clear the music playlist?" = "Tem a certeza de que quer apagar a playlist de música?";
+"Are you sure you want to clear the video playlist?" = "Tem a certeza de que quer apagar a playlist de vídeo?";
+"Are you sure you want to clear the picture playlist?" = "Tem a certeza de que quer apagar a playlist de imagens?";
 "Are you sure you want to power off your XBMC system now?" = "Tem a certeza que pretende desligar o seu sistema Kodi agora?";
 "Are you sure you want to hibernate your XBMC system now?" = "Tem a certeza que pretende hibernar o seu sistema Kodi agora?";
 "Are you sure you want to suspend your XBMC system now?" = "Tem a certeza que pretende suspender o seu sistema Kodi agora?";
@@ -286,8 +289,6 @@
 "Activate window" = "Activar janela";
 "Add action button" = "Adicionar botão de acção";
 "Add window activation button" = "Adicionar botão de activação de janela";
-"Video " = "Vídeo ";
-"Music " = "Música ";
 "Video Playlists" = "Lista Reprodução Vídeo";
 "Favourites" = "Favoritos";
 "Runtime" = "Duração";
@@ -300,7 +301,6 @@
 "Window activated successfully" = "Ativação da janela com sucesso";
 "Action executed successfully" = "Execução bem sucedida da ação";
 "Unable to execute the action" = "Não foi possível executar a ação";
-"Are you sure you want to clear the %@playlist?" = "Tem a certeza de que quer apagar a %@playlist?";
 "Released %d" = "Lançado %d";
 "Search last.fm charts" = "Pesquisar classificações do last.fm";
 "Pictures Add-ons" = "Extensões de fotos";

--- a/XBMC Remote/sv.lproj/Localizable.strings
+++ b/XBMC Remote/sv.lproj/Localizable.strings
@@ -93,8 +93,6 @@
 "Episodes: %@" = "Avsnitt: %@";
 "1 result" = "1 resultat";
 "%d results" = "%d resultat";
-"Music " = "Musik ";
-"Video " = "Film ";
 "Songs" = "Låtar";
 "Song" = "Låt";
 "Mins." = "Min.";
@@ -107,7 +105,10 @@
 "Cannot do that" = "Kan inte göra detta";
 "Wake On Lan" = "Wake On Lan";
 "No saved hosts found" = "Inga sparade värddatorer hittades";
-"Are you sure you want to clear the %@playlist?" = "Är du säker på att du vill tömma %@playlist?";
+"Are you sure you want to clear the playlist?" = "Är du säker på att du vill tömma playlist?";
+"Are you sure you want to clear the music playlist?" = "Är du säker på att du vill tömma musik playlist?";
+"Are you sure you want to clear the video playlist?" = "Är du säker på att du vill tömma film playlist?";
+"Are you sure you want to clear the picture playlist?" = "Är du säker på att du vill tömma bild playlist?";
 "Are you sure you want to power off your XBMC system now?" = "Är du säker på att du vill stänga av ditt Kodi-system nu?";
 "Are you sure you want to hibernate your XBMC system now?" = "Är du säker på att du vill försätta ditt Kodi-system i vänteläge nu?";
 "Are you sure you want to suspend your XBMC system now?" = "Är du säker på att du vill försätta ditt Kodi-system i viloläge nu?";

--- a/XBMC Remote/tr.lproj/Localizable.strings
+++ b/XBMC Remote/tr.lproj/Localizable.strings
@@ -89,8 +89,6 @@
 "Episodes: %@" = "Bölüm Sayısı: %@";
 "1 result" = "1 sonuç";
 "%d results" = "%d sonuç";
-"Music " = "Müzik ";
-"Video " = "Video ";
 "Songs" = "Şarkılar";
 "Song" = "Şarkı";
 "Mins." = "Dakika";
@@ -103,7 +101,10 @@
 "Cannot do that" = "Yapılamıyor";
 "Wake On Lan" = "Ağ bağlantısında uyan";
 "No saved hosts found" = "Kayıtlı sunucu bulunamadı";
-"Are you sure you want to clear the %@playlist?" = "Temizlensin mi: %@playlist ?";
+"Are you sure you want to clear the playlist?" = "Temizlensin mi: playlist ?";
+"Are you sure you want to clear the music playlist?" = "Temizlensin mi: müzik playlist ?";
+"Are you sure you want to clear the video playlist?" = "Temizlensin mi: video playlist ?";
+"Are you sure you want to clear the picture playlist?" = "Temizlensin mi: resimler playlist ?";
 "Are you sure you want to power off your XBMC system now?" = "Kodi kapatılsın mı?";
 "Are you sure you want to hibernate your XBMC system now?" = "Kodi uyku moduna alınsın mı?";
 "Are you sure you want to suspend your XBMC system now?" = "Kodi askıya alınsın mı?";

--- a/XBMC Remote/zh-Hans.lproj/Localizable.strings
+++ b/XBMC Remote/zh-Hans.lproj/Localizable.strings
@@ -90,8 +90,6 @@
 "Episodes: %@" = "集：%@";
 "1 result" = "1个结果";
 "%d results" = "%d个结果";
-"Music " = "音乐 ";
-"Video " = "视频 ";
 "Songs" = "音乐";
 "Song" = "音乐";
 "Mins." = "分。";
@@ -104,7 +102,10 @@
 "Cannot do that" = "无法做到";
 "Wake On Lan" = "网络唤醒";
 "No saved hosts found" = "未找到保存的主机";
-"Are you sure you want to clear the %@playlist?" = "确定要清除%@playlist?";
+"Are you sure you want to clear the playlist?" = "确定要清除playlist?";
+"Are you sure you want to clear the music playlist?" = "确定要清除音乐playlist?";
+"Are you sure you want to clear the video playlist?" = "确定要清除视频playlist?";
+"Are you sure you want to clear the picture playlist?" = "确定要清除图片playlist?";
 "Are you sure you want to power off your XBMC system now?" = "确定现在要让Kodi系统关机？";
 "Are you sure you want to hibernate your XBMC system now?" = "确定现在要让Kodi系统休眠？";
 "Are you sure you want to suspend your XBMC system now?" = "确定现在要让Kodi系统待机？";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Based on a discussion in https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/559 this PR replaces a constructed message with the complete string. This resolves issues with the localization for several languages. The translations were checked and adapted with help of Google Translator.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Replace constructed message with complete strings