### PR TITLE
Bugfix: Avoid lockup of an active search after "Pull-To-Sync"

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1439,7 +1439,9 @@
         collectionView.autoresizingMask = dataList.autoresizingMask;
         __weak DetailViewController *weakSelf = self;
         [collectionView addPullToRefreshWithActionHandler:^{
+            [weakSelf.searchController setActive:NO];
             [weakSelf startRetrieveDataWithRefresh:YES];
+            [weakSelf hideButtonListWhenEmpty];
         }];
         [collectionView setShowsPullToRefresh:enableDiskCache];
         collectionView.alwaysBounceVertical = YES;
@@ -5499,7 +5501,9 @@ NSIndexPath *selected;
     
     __weak DetailViewController *weakSelf = self;
     [dataList addPullToRefreshWithActionHandler:^{
+        [weakSelf.searchController setActive:NO];
         [weakSelf startRetrieveDataWithRefresh:YES];
+        [weakSelf hideButtonListWhenEmpty];
     }];
     [self disableScrollsToTopPropertyOnAllSubviewsOf:self.slidingViewController.view];
     for (UIView *subView in self.searchController.searchBar.subviews) {


### PR DESCRIPTION
The search needs to be deactivated before updating the data after a "Pull-To-Sync" was triggered. Without this the search bar will be locked up and only re-entering the main menu (e.g. MOVIES) will resolve this.

## Description
<!--- Detailed info for reviewers and developers -->
This PR resolves an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3081376#pid3081376). When having an active search and then triggering "pull-to-sync", the search bar is locking up and shown always on top. You cannot end the search or start any new search until you re-enter from the main menu again. To fix this the active search is explicitly stopped when "pull-to-sync" was performed by the user.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid lockup of an active search after "Pull-To-Sync"