### PR TITLE
Bugfix: Hide Partybutton swiping non-Music playlist

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -232,6 +232,7 @@ typedef enum {
 	frame = button.frame;
 	frame.origin.x = X;
 	button.frame = frame;
+    button.hidden = hiddenValue;
     [UIView commitAnimations];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fix a minor glitch reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3081481#pid3081481). The "Party" button is sliding in and out with an animation. It needs to be hidden as well to avoid unveiling when swiping a video or picture playlist to the right.

Screenshot: https://abload.de/img/bildschirmfoto2022-01r4j43.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Hide Partybutton while swiping non-Music playlist