### PR TITLE
Improvement: Show error message in server info view while disconnected

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -403,6 +403,11 @@ static inline BOOL IsEmpty(id obj) {
             
             serverInfoView.attributedText = infoString;
         }
+        else if (error != nil){
+            NSMutableAttributedString *infoString = [NSMutableAttributedString new];
+            [infoString appendAttributedString:[self formatInfo:LOCALIZED_STR(@"No connection") text:error.localizedDescription]];
+            serverInfoView.attributedText = infoString;
+        }
     }];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/574.

Add an error message to the server info screen while the App is not connected to a Kodi server. The error message is taken from the JSON response.

Screenshot:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-01fmjs2.png"><img src="https://abload.de/img/bildschirmfoto2022-01fmjs2.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Show error message in server info view while disconnected