### PR TITLE
Feature: Movieset details

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -264,6 +264,15 @@ NSMutableArray *hostRightMenuItems;
     ];
 }
 
+- (NSArray*)action_queue_to_moviesetdetails {
+    return @[
+        LOCALIZED_STR(@"Queue after current"),
+        LOCALIZED_STR(@"Queue"),
+        LOCALIZED_STR(@"Play"),
+        LOCALIZED_STR(@"Movie Set Details")
+    ];
+}
+
 - (NSArray*)action_queue_to_showcontent {
     return @[
         LOCALIZED_STR(@"Queue after current"),
@@ -2111,6 +2120,8 @@ NSMutableArray *hostRightMenuItems;
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"thumbnail",
+                        @"plot",
+                        @"fanart",
                         @"playcount"]
             }, @"parameters",
             @{
@@ -2268,7 +2279,8 @@ NSMutableArray *hostRightMenuItems;
             @"playlistid": @1,
             @"row8": @"setid",
             @"row9": @"setid",
-            @"row10": @"playcount"
+            @"row10": @"playcount",
+            @"row11": @"plot"
         },
 
         @{
@@ -2344,7 +2356,7 @@ NSMutableArray *hostRightMenuItems;
     menu_Movies.sheetActions = @[
         [self action_queue_to_moviedetails],
         @[],
-        [self action_queue_to_play],
+        [self action_queue_to_moviesetdetails],
         [self action_queue_to_moviedetails],
         @[],
         @[],

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3231,6 +3231,7 @@ NSIndexPath *selected;
     else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Artist Details")] ||
              [actiontitle isEqualToString:LOCALIZED_STR(@"Album Details")] ||
              [actiontitle isEqualToString:LOCALIZED_STR(@"Movie Details")] ||
+             [actiontitle isEqualToString:LOCALIZED_STR(@"Movie Set Details")] ||
              [actiontitle isEqualToString:LOCALIZED_STR(@"Episode Details")] ||
              [actiontitle isEqualToString:LOCALIZED_STR(@"TV Show Details")] ||
              [actiontitle isEqualToString:LOCALIZED_STR(@"Music Video Details")] ||

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 "Artist Details" = "Interpreten-Details";
 "Album Details" = "Albumdetails";
 "Movie Details" = "Filmdetails";
+"Movie Set Details" = "Filmkollektion-Details";
 "Episode Details" = "Episodendetails";
 "TV Show Details" = "Seriendetails";
 "Music Video Details" = "Musikvideo-Details";

--- a/XBMC Remote/en-US.lproj/Localizable.strings
+++ b/XBMC Remote/en-US.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 "Artist Details" = "Artist Details";
 "Album Details" = "Album Details";
 "Movie Details" = "Movie Details";
+"Movie Set Details" = "Movie Set Details";
 "Episode Details" = "Episode Details";
 "TV Show Details" = "TV Show Details";
 "Music Video Details" = "Music Video Details";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "Artist Details" = "Artist Details";
 "Album Details" = "Album Details";
 "Movie Details" = "Movie Details";
+"Movie Set Details" = "Movie Set Details";
 "Episode Details" = "Episode Details";
 "TV Show Details" = "TV Show Details";
 "Music Video Details" = "Music Video Details";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR adds the possibility to show movie set details, incl. plot, art and fanart.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-01lujso.png"><img src="https://abload.de/img/bildschirmfoto2022-01lujso.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Add details for movie sets