### PR TITLE
Feature: Add an app setting to allow fanart-fallback to art

### DIFF
--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -91,6 +91,16 @@
 			<true/>
 		</dict>
 		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Use thumbnail when fanart is missing</string>
+			<key>Key</key>
+			<string>fanart_fallback_preference</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
+		<dict>
 			<key>DefaultValue</key>
 			<string>auto</string>
 			<key>Key</key>

--- a/XBMC Remote/Settings.bundle/de.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/de.lproj/Root.strings
@@ -10,6 +10,7 @@
 "Hide labels in wall view" = "Keine Texte in der Kachelansicht";
 "Prefer posters for TV shows" = "Poster für Serien bevorzugen";
 "Use rounded corner images" = "Abgerundete Ecken für Vorschaubilder verwenden";
+"Use thumbnail when fanart is missing" = "Vorschaubild nutzen falls Fan Art fehlt";
 "TV logo background" = "TV-Logo-Hintergrund";
 "Dark" = "Dunkel";
 "Light" = "Hell";

--- a/XBMC Remote/Settings.bundle/en-us.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en-us.lproj/Root.strings
@@ -10,6 +10,7 @@
 "Hide labels in wall view" = "Hide labels in wall view";
 "Prefer posters for TV shows" = "Prefer posters for TV shows";
 "Use rounded corner images" = "Use rounded corner images";
+"Use thumbnail when fanart is missing" = "Use thumbnail when fanart is missing";
 "TV logo background" = "TV logo background";
 "Dark" = "Dark";
 "Light" = "Light";

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -10,6 +10,7 @@
 "Hide labels in wall view" = "Hide labels in wall view";
 "Prefer posters for TV shows" = "Prefer posters for TV shows";
 "Use rounded corner images" = "Use rounded corner images";
+"Use thumbnail when fanart is missing" = "Use thumbnail when fanart is missing";
 "TV logo background" = "TV logo background";
 "Dark" = "Dark";
 "Light" = "Light";

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -871,7 +871,12 @@ double round(double d) {
     
     [self loadThumbnail:item[@"thumbnail"] placeHolder:placeHolderImage jewelType:jeweltype jewelEnabled:enableJewel];
     
-    [self loadFanart:item[@"fanart"]];
+    NSString *fanart = item[@"fanart"];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    if (fanart.length == 0 && [userDefaults boolForKey:@"fanart_fallback_preference"]) {
+        fanart = item[@"thumbnail"];
+    }
+    [self loadFanart:fanart];
     
     voteLabel.text = [Utilities getStringFromItem:item[@"rating"]];
     starsView.image = [UIImage imageNamed:[NSString stringWithFormat:@"stars_%.0f", roundf([item[@"rating"] floatValue])]];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
If "fanart" is missing, the user can now allow a fallback to "art" (typically the thumbnail). Making this an option as users might not have "fanart" intentionally.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-01utjp0.png"><img src="https://abload.de/img/bildschirmfoto2022-01utjp0.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Add an app setting to allow fanart to fall back to art