### PR TITLE
Improvement: "Prefer poster for TV shows" setting moved to app settings

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1270,7 +1270,7 @@
     if (mutableProperties != nil) {
         mutableParameters[@"properties"] = mutableProperties;
     }
-    if ([parameters[@"blackTableSeparator"] boolValue] && !AppDelegate.instance.obj.preferTVPosters) {
+    if ([parameters[@"blackTableSeparator"] boolValue] && ![Utilities getPreferTvPosterMode]) {
         blackTableSeparator = YES;
         dataList.separatorColor = [Utilities getGrayColor:38 alpha:1];
     }
@@ -5829,7 +5829,7 @@ NSIndexPath *selected;
         dataList.separatorInset = UIEdgeInsetsMake(0, 18, 0, 0);
     }
     else if ([methods[@"tvshowsView"] boolValue]) {
-        tvshowsView = AppDelegate.instance.serverVersion > 11 && !AppDelegate.instance.obj.preferTVPosters;
+        tvshowsView = AppDelegate.instance.serverVersion > 11 && ![Utilities getPreferTvPosterMode];
         [self setTVshowThumbSize];
     }
     else if ([methods[@"channelGuideView"] boolValue]) {
@@ -5842,7 +5842,7 @@ NSIndexPath *selected;
         globalSearchView = YES;
     }
     
-    if ([parameters[@"blackTableSeparator"] boolValue] && !AppDelegate.instance.obj.preferTVPosters) {
+    if ([parameters[@"blackTableSeparator"] boolValue] && ![Utilities getPreferTvPosterMode]) {
         blackTableSeparator = YES;
         dataList.separatorInset = UIEdgeInsetsZero;
         dataList.separatorColor = [Utilities getGrayColor:38 alpha:1];

--- a/XBMC Remote/GlobalData.h
+++ b/XBMC Remote/GlobalData.h
@@ -15,8 +15,7 @@
     NSString *serverIP; 
     NSString *serverPort;
     int tcpPort;
-    NSString *serverHWAddr; 
-    BOOL preferTVPosters;
+    NSString *serverHWAddr;
 
     
 }
@@ -27,7 +26,6 @@
 @property int tcpPort;
 @property (nonatomic, strong)NSString *serverPort;
 @property (nonatomic, strong)NSString *serverHWAddr; 
-@property BOOL preferTVPosters;
 
 + (GlobalData*)getInstance;
 @end

--- a/XBMC Remote/GlobalData.m
+++ b/XBMC Remote/GlobalData.m
@@ -17,7 +17,6 @@
 @synthesize serverPort;
 @synthesize tcpPort;
 @synthesize serverHWAddr;
-@synthesize preferTVPosters;
 
 static GlobalData *instance = nil;
 + (GlobalData*)getInstance {

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -142,7 +142,6 @@ static inline BOOL IsEmpty(id obj) {
     AppDelegate.instance.obj.serverIP = IsEmpty(item[@"serverIP"]) ? @"" : item[@"serverIP"];
     AppDelegate.instance.obj.serverPort = IsEmpty(item[@"serverPort"]) ? @"" : item[@"serverPort"];
     AppDelegate.instance.obj.serverHWAddr = IsEmpty(item[@"serverMacAddress"]) ? @"" : item[@"serverMacAddress"];
-    AppDelegate.instance.obj.preferTVPosters = [item[@"preferTVPosters"] boolValue];
     AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue];
 }
 

--- a/XBMC Remote/HostViewController.h
+++ b/XBMC Remote/HostViewController.h
@@ -24,7 +24,6 @@
     IBOutlet UITextField *mac_3_UI;
     IBOutlet UITextField *mac_4_UI;
     IBOutlet UITextField *mac_5_UI;
-    IBOutlet UISwitch *preferTVPostersUI;
     IBOutlet UITextField *tcpPortUI;
     NSMutableArray *services;
     BOOL searching;
@@ -39,7 +38,6 @@
     IBOutlet UILabel *hostLabel;
     IBOutlet UILabel *macLabel;
     IBOutlet UILabel *userLabel;
-    IBOutlet UILabel *preferLabel;
     IBOutlet UILabel *noInstancesLabel;
     IBOutlet UILabel *findLabel;
     IBOutlet UIView *tipView;

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -103,7 +103,6 @@
         if (num_octects > 5) {
             mac_5_UI.text = mac_octect[5];
         }
-        preferTVPostersUI.on = [AppDelegate.instance.arrayServerList[idx.row][@"preferTVPosters"] boolValue];
         tcpPortUI.text = AppDelegate.instance.arrayServerList[idx.row][@"tcpPort"];
     }
 }
@@ -164,7 +163,6 @@
                                                            ipUI.text, @"serverIP",
                                                            portUI.text, @"serverPort",
                                                            macAddress, @"serverMacAddress",
-                                                           @(preferTVPostersUI.on), @"preferTVPosters",
                                                            tcpPortUI.text, @"tcpPort",
                                                            nil
                                                            ]];
@@ -179,7 +177,6 @@
                                                               ipUI.text, @"serverIP",
                                                               portUI.text, @"serverPort",
                                                               macAddress, @"serverMacAddress",
-                                                              @(preferTVPostersUI.on), @"preferTVPosters",
                                                               tcpPortUI.text, @"tcpPort",
                                                               nil
                                                               ] atIndex:idx.row];
@@ -515,7 +512,6 @@
     mac_3_UI.text = @"";
     mac_4_UI.text = @"";
     mac_5_UI.text = @"";
-    preferTVPostersUI.on = NO;
     descriptionUI.textColor = [Utilities get1stLabelColor];
     ipUI.textColor = [Utilities get1stLabelColor];
     portUI.textColor = [Utilities get1stLabelColor];
@@ -534,7 +530,6 @@
     hostLabel.text = LOCALIZED_STR(@"Host : port /\nTCP port");
     macLabel.text = LOCALIZED_STR(@"MAC Address");
     userLabel.text = LOCALIZED_STR(@"Username and Password");
-    preferLabel.text = LOCALIZED_STR(@"Prefer posters for TV shows");
     noInstancesLabel.text = LOCALIZED_STR(@"No XBMC instances were found :(");
     findLabel.text = LOCALIZED_STR(@"\"Find XBMC\" requires XBMC server option\n\"Announce these services to other systems via Zeroconf\" enabled");
     howtoLabel.text = LOCALIZED_STR(@"How-to activate the remote app in Kodi");

--- a/XBMC Remote/HostViewController.xib
+++ b/XBMC Remote/HostViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -30,8 +30,6 @@
                 <outlet property="noInstancesLabel" destination="43" id="hQf-mn-wP2"/>
                 <outlet property="passwordUI" destination="11" id="24"/>
                 <outlet property="portUI" destination="14" id="22"/>
-                <outlet property="preferLabel" destination="17" id="fjs-rC-uyf"/>
-                <outlet property="preferTVPostersUI" destination="56" id="57"/>
                 <outlet property="saveButton" destination="37" id="Ttx-kq-fCl"/>
                 <outlet property="startDiscover" destination="39" id="45"/>
                 <outlet property="tcpPortUI" destination="93" id="96"/>
@@ -71,7 +69,7 @@
                             <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                         </imageView>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="18">
-                            <rect key="frame" x="7" y="31" width="76" height="31"/>
+                            <rect key="frame" x="6" y="31" width="76" height="31"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <string key="text">Host : port /
 TCP port</string>
@@ -82,7 +80,7 @@ TCP port</string>
                             <size key="shadowOffset" width="1" height="1"/>
                         </label>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text=":" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="55">
-                            <rect key="frame" x="188" y="37" width="10" height="20"/>
+                            <rect key="frame" x="187" y="37" width="10" height="20"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -109,7 +107,7 @@ TCP port</string>
                             <size key="shadowOffset" width="1" height="1"/>
                         </label>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text=":" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="78">
-                            <rect key="frame" x="154" y="67" width="6" height="20"/>
+                            <rect key="frame" x="153" y="67" width="6" height="20"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -136,7 +134,7 @@ TCP port</string>
                             <size key="shadowOffset" width="1" height="1"/>
                         </label>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text=":" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="81">
-                            <rect key="frame" x="263" y="67" width="6" height="20"/>
+                            <rect key="frame" x="262" y="67" width="6" height="20"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -144,17 +142,8 @@ TCP port</string>
                             <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <size key="shadowOffset" width="1" height="1"/>
                         </label>
-                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Prefer posters for TV shows" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="17">
-                            <rect key="frame" x="12" y="127" width="201" height="22"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                            <fontDescription key="fontDescription" type="italicSystem" pointSize="13"/>
-                            <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <nil key="highlightedColor"/>
-                            <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <size key="shadowOffset" width="1" height="1"/>
-                        </label>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Username and Password" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="16">
-                            <rect key="frame" x="14" y="91" width="69" height="31"/>
+                            <rect key="frame" x="13" y="91" width="70" height="31"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="10"/>
                             <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -172,7 +161,7 @@ TCP port</string>
                             <size key="shadowOffset" width="1" height="1"/>
                         </label>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Description" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="10">
-                            <rect key="frame" x="14" y="7" width="69" height="20"/>
+                            <rect key="frame" x="13" y="7" width="70" height="20"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -181,7 +170,7 @@ TCP port</string>
                             <size key="shadowOffset" width="1" height="1"/>
                         </label>
                         <textField clipsSubviews="YES" tag="2" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="e.g. 192.168.0.8" textAlignment="center" minimumFontSize="10" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                            <rect key="frame" x="87" y="34" width="104" height="26"/>
+                            <rect key="frame" x="86" y="34" width="104" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -192,7 +181,7 @@ TCP port</string>
                             </connections>
                         </textField>
                         <textField clipsSubviews="YES" tag="1" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="e.g. My XBMC" textAlignment="center" minimumFontSize="10" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="8">
-                            <rect key="frame" x="87" y="4" width="213" height="26"/>
+                            <rect key="frame" x="86" y="4" width="213" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -203,7 +192,7 @@ TCP port</string>
                             </connections>
                         </textField>
                         <textField clipsSubviews="YES" tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="00" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="58">
-                            <rect key="frame" x="87" y="64" width="32" height="26"/>
+                            <rect key="frame" x="86" y="64" width="32" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -225,7 +214,7 @@ TCP port</string>
                             </connections>
                         </textField>
                         <textField clipsSubviews="YES" tag="7" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="00" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="64">
-                            <rect key="frame" x="159" y="64" width="32" height="26"/>
+                            <rect key="frame" x="158" y="64" width="32" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -258,7 +247,7 @@ TCP port</string>
                             </connections>
                         </textField>
                         <textField clipsSubviews="YES" tag="10" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="00" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="73">
-                            <rect key="frame" x="268" y="64" width="32" height="26"/>
+                            <rect key="frame" x="267" y="64" width="32" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -291,7 +280,7 @@ TCP port</string>
                             </connections>
                         </textField>
                         <textField clipsSubviews="YES" tag="11" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="Username" textAlignment="center" minimumFontSize="10" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="13">
-                            <rect key="frame" x="87" y="94" width="104" height="26"/>
+                            <rect key="frame" x="86" y="94" width="104" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -317,7 +306,7 @@ TCP port</string>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         </activityIndicatorView>
                         <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="37">
-                            <rect key="frame" x="195" y="166" width="104" height="28"/>
+                            <rect key="frame" x="195" y="141" width="103" height="28"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                             <size key="titleShadowOffset" width="1" height="1"/>
@@ -336,7 +325,7 @@ TCP port</string>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="39">
-                            <rect key="frame" x="86" y="166" width="104" height="28"/>
+                            <rect key="frame" x="86" y="141" width="104" height="28"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                             <inset key="titleEdgeInsets" minX="4" minY="0.0" maxX="4" maxY="0.0"/>
@@ -433,11 +422,6 @@ TCP port</string>
                             </subviews>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
-                        <switch opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="56">
-                            <rect key="frame" x="232" y="125" width="51" height="31"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                            <inset key="insetFor6xAndEarlier" minX="10" minY="0.0" maxX="-10" maxY="0.0"/>
-                        </switch>
                     </subviews>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1423,7 +1423,7 @@ int currentItemID;
                  NSDictionary *art = itemExtraDict[@"art"];
                  NSString *clearlogo = [Utilities getClearArtFromDictionary:art type:@"clearlogo"];
                  NSString *clearart = [Utilities getClearArtFromDictionary:art type:@"clearart"];
-//                 if (art.count && [art[@"banner"] length] != 0 && AppDelegate.instance.serverVersion > 11 && !AppDelegate.instance.obj.preferTVPosters) {
+//                 if (art.count && [art[@"banner"] length] != 0 && AppDelegate.instance.serverVersion > 11 && ![Utilities getPreferTvPosterMode]) {
 //                     thumbnailPath = art[@"banner"];
 //                 }
                  NSString *stringURL = [Utilities formatStringURL:thumbnailPath serverURL:serverURL];

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -74,6 +74,16 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
+			<string>Prefer posters for TV shows</string>
+			<key>Key</key>
+			<string>prefer_TVposter_preference</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
 			<string>Use rounded corner images</string>
 			<key>Key</key>
 			<string>rounded_corner_preference</string>

--- a/XBMC Remote/Settings.bundle/cs.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/cs.lproj/Root.strings
@@ -8,6 +8,7 @@
 "Shake to clear playlist" = "Shake to clear playlist";
 "Show jewel cases" = "Show jewel cases";
 "Hide labels in wall view" = "Hide labels in wall view";
+"Prefer posters for TV shows" = "Preferuji postery pro seriály";
 "Remote Control" = "Dálkové ovládání";
 "Gesture remote control" = "Gesture remote control";
 "Vibrate remote control" = "Vibrate remote control";

--- a/XBMC Remote/Settings.bundle/de.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/de.lproj/Root.strings
@@ -8,6 +8,7 @@
 "Shake to clear playlist" = "Wiedergabeliste durch Schütteln löschen";
 "Show jewel cases" = "CD/DVD-Hüllen anzeigen";
 "Hide labels in wall view" = "Keine Texte in der Kachelansicht";
+"Prefer posters for TV shows" = "Poster für Serien bevorzugen";
 "Use rounded corner images" = "Abgerundete Ecken für Vorschaubilder verwenden";
 "TV logo background" = "TV-Logo-Hintergrund";
 "Dark" = "Dunkel";

--- a/XBMC Remote/Settings.bundle/en-us.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en-us.lproj/Root.strings
@@ -8,6 +8,7 @@
 "Shake to clear playlist" = "Shake to clear playlist";
 "Show jewel cases" = "Show jewel cases";
 "Hide labels in wall view" = "Hide labels in wall view";
+"Prefer posters for TV shows" = "Prefer posters for TV shows";
 "Use rounded corner images" = "Use rounded corner images";
 "TV logo background" = "TV logo background";
 "Dark" = "Dark";

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -8,6 +8,7 @@
 "Shake to clear playlist" = "Shake to clear playlist";
 "Show jewel cases" = "Show jewel cases";
 "Hide labels in wall view" = "Hide labels in wall view";
+"Prefer posters for TV shows" = "Prefer posters for TV shows";
 "Use rounded corner images" = "Use rounded corner images";
 "TV logo background" = "TV logo background";
 "Dark" = "Dark";

--- a/XBMC Remote/Settings.bundle/es.lprj/Root.strings
+++ b/XBMC Remote/Settings.bundle/es.lprj/Root.strings
@@ -8,6 +8,7 @@
 "Shake to clear playlist" = "Agitar para borrar lista de reproducción";
 "Show jewel cases" = "Mostrar estuches";
 "Hide labels in wall view" = "Hide labels in wall view";
+"Prefer posters for TV shows" = "Preferir posters para Programas TV";
 "Remote Control" = "Control Remoto";
 "Gesture remote control" = "Gestos control remoto";
 "Vibrate remote control" = "Vibración control remoto";

--- a/XBMC Remote/Settings.bundle/fr.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/fr.lproj/Root.strings
@@ -8,6 +8,7 @@
 "Shake to clear playlist" = "Shake to clear playlist";
 "Show jewel cases" = "Show jewel cases";
 "Hide labels in wall view" = "Hide labels in wall view";
+"Prefer posters for TV shows" = "Posters pour les séries TV";
 "Remote Control" = "Télécommande";
 "Gesture remote control" = "Gesture remote control";
 "Vibrate remote control" = "Vibrate remote control";

--- a/XBMC Remote/Settings.bundle/it.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/it.lproj/Root.strings
@@ -8,6 +8,7 @@
 "Shake to clear playlist" = "Agita pulisce playlist";
 "Show jewel cases" = "Visualizza custodie";
 "Hide labels in wall view" = "Nascondi etichette vista muro";
+"Prefer posters for TV shows" = "Preferisci i poster per le serie TV";
 "Remote Control" = "Telecomando";
 "Gesture remote control" = "Zona gesti";
 "Vibrate remote control" = "Vibrazione Telecomando";

--- a/XBMC Remote/Settings.bundle/nl.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/nl.lproj/Root.strings
@@ -8,6 +8,7 @@
 "Shake to clear playlist" = "Schud om afspeellijst te legen";
 "Show jewel cases" = "Toon cd-doosjes";
 "Hide labels in wall view" = "Verberg labels in muurvertoning";
+"Prefer posters for TV shows" = "Gebruik liefst posters voor TV-series";
 "Remote Control" = "Afstandsbediening";
 "Gesture remote control" = "Afstandsbediening met gebaren";
 "Vibrate remote control" = "Afstandsbediening met trilling";

--- a/XBMC Remote/Settings.bundle/pl.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/pl.lproj/Root.strings
@@ -8,6 +8,7 @@
 "Shake to clear playlist" = "Potrząśnięcie czyści listę odtw.";
 "Show jewel cases" = "Pokazuj pudełka CD";
 "Hide labels in wall view" = "Ukryj etykiety w widoku ściany";
+"Prefer posters for TV shows" = "Preferuj plakaty z programów TV";
 "Remote Control" = "Kontrola zdalna";
 "Gesture remote control" = "Domyślnie: kontrola gestami";
 "Vibrate remote control" = "Włącz wibrację przycisków";

--- a/XBMC Remote/Settings.bundle/pt-PT.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/pt-PT.lproj/Root.strings
@@ -4,3 +4,4 @@
 "Automatic" = "Automático";
 "General" = "Geral";
 "Remote Control" = "Controlo remoto";
+"Prefer posters for TV shows" = "Preferir posters para séries de TV";

--- a/XBMC Remote/Settings.bundle/sv.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/sv.lproj/Root.strings
@@ -9,6 +9,7 @@
 "Shake to clear playlist" = "Skaka för att tömma spellista";
 "Show jewel cases" = "Visa omslagsbilder";
 "Hide labels in wall view" = "Dölj etiketter i väggvy";
+"Prefer posters for TV shows" = "Föredra affischer för tv-serier";
 "Remote Control" = "Fjärrkontroll";
 "Gesture remote control" = "Fjärrkontroll med gester";
 "Vibrate remote control" = "Vibrera fjärrkontrollen";

--- a/XBMC Remote/Settings.bundle/tr.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/tr.lproj/Root.strings
@@ -8,6 +8,7 @@
 "Shake to clear playlist" = "Listeyi temizlemek için sallayın";
 "Show jewel cases" = "Mücevher kutularını göster";
 "Hide labels in wall view" = "Duvar görünümünde etiketleri gizle";
+"Prefer posters for TV shows" = "Dizilerde posterleri tercih et";
 "Remote Control" = "Uzaktan Kumanda";
 "Gesture remote control" = "Uzaktan kumandayı işaret et";
 "Vibrate remote control" = "Uzaktan kumandayı titret";

--- a/XBMC Remote/Settings.bundle/zh-Hans.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/zh-Hans.lproj/Root.strings
@@ -8,6 +8,7 @@
 "Shake to clear playlist" = "晃动清除播放列表";
 "Show jewel cases" = "显示碟片盒";
 "Hide labels in wall view" = "隐藏壁上观标签";
+"Prefer posters for TV shows" = "剧集倾向使用海报";
 "Remote Control" = "遥控器";
 "Gesture remote control" = "手势遥控器";
 "Vibrate remote control" = "震动遥控器";

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -266,7 +266,7 @@ double round(double d) {
             choosedMenuItem.mainLabel = actorName;
             menuItem.enableSection = NO;
             menuItem.mainButtons = nil;
-            if (AppDelegate.instance.obj.preferTVPosters) {
+            if ([Utilities getPreferTvPosterMode]) {
                 thumbWidth = PHONE_TV_SHOWS_POSTER_WIDTH;
                 tvshowHeight = PHONE_TV_SHOWS_POSTER_HEIGHT;
             }
@@ -641,8 +641,7 @@ double round(double d) {
         
         [self setTvShowsToolbar];
         
-        GlobalData *obj = [GlobalData getInstance];
-        if (!obj.preferTVPosters && AppDelegate.instance.serverVersion < 12) {
+        if (![Utilities getPreferTvPosterMode] && AppDelegate.instance.serverVersion < 12) {
             placeHolderImage = @"blank";
             jewelView.hidden = YES;
         }

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -40,6 +40,7 @@ typedef enum {
 + (UIColor*)updateColor:(UIColor*)newColor lightColor:(UIColor*)lighter darkColor:(UIColor*)darker trigger:(CGFloat)trigger;
 + (UIImage*)colorizeImage:(UIImage*)image withColor:(UIColor*)color;
 + (void)setLogoBackgroundColor:(UIImageView*)imageview mode:(LogoBackgroundType)mode;
++ (BOOL)getPreferTvPosterMode;
 + (LogoBackgroundType)getLogoBackgroundMode;
 + (RemotePositionType)getRemotePositionMode;
 + (NSDictionary*)buildPlayerSeekPercentageParams:(int)playerID percentage:(float)percentage;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -265,6 +265,12 @@
     imageview.backgroundColor = bgcolor;
 }
 
++ (BOOL)getPreferTvPosterMode {
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    BOOL result = [[userDefaults objectForKey:@"prefer_TVposter_preference"] boolValue];
+    return result;
+}
+
 + (LogoBackgroundType)getLogoBackgroundMode {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     LogoBackgroundType setting = bgAuto;

--- a/XBMC Remote/cs.lproj/Localizable.strings
+++ b/XBMC Remote/cs.lproj/Localizable.strings
@@ -221,7 +221,6 @@
 "Host : port /\nTCP port" = "Hostitel : port /\nTCP port";
 "MAC Address" = "MAC adresa";
 "Username and Password" = "Uživatelské jméno a heslo";
-"Prefer posters for TV shows" = "Preferuji postery pro seriály";
 "Find XBMC" = "Najít Kodi";
 "Save" = "Uložit";
 "No XBMC instances were found :(" = "Žádné zařízení Kodi nebylo nalezeno :(";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -234,7 +234,6 @@
 "Host : port /\nTCP port" = "Server : port /\nTCP port";
 "MAC Address" = "MAC-Adresse";
 "Username and Password" = "Benutzername und Passwort";
-"Prefer posters for TV shows" = "Poster für Serien bevorzugen";
 "Find XBMC" = "Kodi finden";
 "Save" = "Speichern";
 "No XBMC instances were found :(" = "Es wurden keine Kodi-Installationen gefunden :(";

--- a/XBMC Remote/en-US.lproj/Localizable.strings
+++ b/XBMC Remote/en-US.lproj/Localizable.strings
@@ -233,7 +233,6 @@
 "Host : port /\nTCP port" = "Host : port /\nTCP port";
 "MAC Address" = "MAC Address";
 "Username and Password" = "Username and Password";
-"Prefer posters for TV shows" = "Prefer posters for TV shows";
 "Find XBMC" = "Find Kodi";
 "Save" = "Save";
 "No XBMC instances were found :(" = "No Kodi instances were found :(";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -265,7 +265,6 @@
 "Host : port /\nTCP port" = "Host : port /\nTCP port";
 "MAC Address" = "MAC Address";
 "Username and Password" = "Username and Password";
-"Prefer posters for TV shows" = "Prefer posters for TV shows";
 "Find XBMC" = "Find Kodi";
 "Save" = "Save";
 "No XBMC instances were found :(" = "No Kodi instances were found :(";

--- a/XBMC Remote/es.lproj/Localizable.strings
+++ b/XBMC Remote/es.lproj/Localizable.strings
@@ -221,7 +221,6 @@
 "Host : port /\nTCP port" = "Host : puerto /\npuerto TCP";
 "MAC Address" = "Dirección MAC";
 "Username and Password" = "Usuario y Contraseña";
-"Prefer posters for TV shows" = "Preferir posters para Programas TV";
 "Find XBMC" = "Encontrar Kodi";
 "Save" = "Guardar";
 "No XBMC instances were found :(" = "No se encontraron instancias de Kodi :(";

--- a/XBMC Remote/fr.lproj/Localizable.strings
+++ b/XBMC Remote/fr.lproj/Localizable.strings
@@ -220,7 +220,6 @@
 "Host : port /\nTCP port" = "Host : port /\nTCP port";
 "MAC Address" = "Adresse MAC";
 "Username and Password" = "Utilisateur et Mot de passe";
-"Prefer posters for TV shows" = "Posters pour les séries TV";
 "Find XBMC" = "Recherche Kodi";
 "Save" = "Enregistrer";
 "No XBMC instances were found :(" = "Aucune instance Kodi n'a été trouvée :(";

--- a/XBMC Remote/it.lproj/Localizable.strings
+++ b/XBMC Remote/it.lproj/Localizable.strings
@@ -221,7 +221,6 @@
 "Host : port /\nTCP port" = "Host : porta /\nporta TCP";
 "MAC Address" = "Indirizzo MAC";
 "Username and Password" = "Username e Password";
-"Prefer posters for TV shows" = "Preferisci i poster per le serie TV";
 "Find XBMC" = "Trova Kodi";
 "Save" = "Salva";
 "No XBMC instances were found :(" = "Nessun server Kodi è stato trovato :(";

--- a/XBMC Remote/nl.lproj/Localizable.strings
+++ b/XBMC Remote/nl.lproj/Localizable.strings
@@ -223,7 +223,6 @@
 "Host : port /\nTCP port" = "Host : poort /\nTCP poort";
 "MAC Address" = "MAC-adres";
 "Username and Password" = "Gebruikersnaam en wachtwoord";
-"Prefer posters for TV shows" = "Gebruik liefst posters voor TV-series";
 "Find XBMC" = "Kodi zoeken";
 "Save" = "Opslaan";
 "No XBMC instances were found :(" = "Er is geen Kodi-systeem gevonden :(";

--- a/XBMC Remote/pl.lproj/Localizable.strings
+++ b/XBMC Remote/pl.lproj/Localizable.strings
@@ -221,7 +221,6 @@
 "Host : port /\nTCP port" = "Host : port /\nPort TCP";
 "MAC Address" = "Adres MAC";
 "Username and Password" = "Użytkownik i hasło";
-"Prefer posters for TV shows" = "Preferuj plakaty z programów TV";
 "Find XBMC" = "Znajdź Kodi";
 "Save" = "Zachowaj";
 "No XBMC instances were found :(" = "Nie znaleziono serwerów Kodi :(";

--- a/XBMC Remote/pt-PT.lproj/Localizable.strings
+++ b/XBMC Remote/pt-PT.lproj/Localizable.strings
@@ -224,7 +224,6 @@
 "Host : port /\nTCP port" = "Servidor : porta /\nPorta TCP";
 "MAC Address" = "Endereço MAC";
 "Username and Password" = "Utilizador e palavra-passe";
-"Prefer posters for TV shows" = "Preferir posters para séries de TV";
 "Find XBMC" = "Encontrar Kodi";
 "Save" = "Guardar";
 "No XBMC instances were found :(" = "Nenhum Kodi encontrado :(";

--- a/XBMC Remote/sv.lproj/Localizable.strings
+++ b/XBMC Remote/sv.lproj/Localizable.strings
@@ -223,7 +223,6 @@
 "Host : port /\nTCP port" = "Värd : port /\nTCP-port";
 "MAC Address" = "Hårdvaruadress";
 "Username and Password" = "Användarnamn och lösenord";
-"Prefer posters for TV shows" = "Föredra affischer för tv-serier";
 "Find XBMC" = "Sök efter Kodi";
 "Save" = "Spara";
 "No XBMC instances were found :(" = "Inga Kodi-instanser hittades :(";

--- a/XBMC Remote/tr.lproj/Localizable.strings
+++ b/XBMC Remote/tr.lproj/Localizable.strings
@@ -220,7 +220,6 @@
 "Host : port /\nTCP port" = "Sunucu : port /\nTCP port";
 "MAC Address" = "MAC Adresi";
 "Username and Password" = "Kullanıcı adı ve şifre";
-"Prefer posters for TV shows" = "Dizilerde posterleri tercih et";
 "Find XBMC" = "Kodi Bul";
 "Save" = "Kaydet";
 "No XBMC instances were found :(" = "Kodi bulunamadı :(";

--- a/XBMC Remote/zh-Hans.lproj/Localizable.strings
+++ b/XBMC Remote/zh-Hans.lproj/Localizable.strings
@@ -220,7 +220,6 @@
 "Host : port /\nTCP port" = "站点 : 端口 /\nTCP 端口";
 "MAC Address" = "MAC 地址";
 "Username and Password" = "用户名和密码";
-"Prefer posters for TV shows" = "剧集倾向使用海报";
 "Find XBMC" = "查找Kodi";
 "Save" = "保存";
 "No XBMC instances were found :(" = "未找到 Kodi 实例 :(";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/580.

The setting to prefer posters for TV shows was not easy to find for many users. It was part of the server connection configuration to be able to use different settings for different Kodi instances. Out of consistency with all other settings this now moved to the app settings (see screenshots). The setting is now valid for all instances. The default is NO as before. Users who enabled this setting, need to enable the setting again.

Changes in code:
- Add app setting and helper method `getPreferTvPosterMode` to read configuration
- Remove unneeded code, variables and UI elements
- Move the localized string from app to root

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-014bj85.png"><img src="https://abload.de/img/bildschirmfoto2022-014bj85.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: "Prefer poster for TV shows" setting moved to app settings