### PR TITLE
Feature: Add view options for TV Shows

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3302,7 +3302,9 @@
             @"YES", @"blackTableSeparator",
             @"YES", @"FrodoExtraArt",
             @"YES", @"enableLibraryCache",
-            [self itemSizes_insets:@"0"], @"itemSizes"
+            @"YES", @"enableCollectionView",
+            @"YES", @"enableLibraryFullScreen",
+            [self itemSizes_Moviefullscreen], @"itemSizes"
         ],
                             
         @[

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -530,8 +530,10 @@
     NSString *year = [Utilities getYearFromItem:item[mainFields[@"row3"]]];
     NSString *runtime = [Utilities getTimeFromItem:item[mainFields[@"row4"]] sec2min:sec2min];
     NSString *rating = [Utilities getRatingFromItem:item[mainFields[@"row5"]]];
-    NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:item useBanner:tvshowsView useIcon:recordingListView];
+    NSString *thumbnailPath = [Utilities getThumbnailFromDictionary:item useBanner:NO useIcon:recordingListView];
+    NSString *bannerPath = [Utilities getThumbnailFromDictionary:item useBanner:YES useIcon:recordingListView];
     NSString *stringURL = [Utilities formatStringURL:thumbnailPath serverURL:serverURL];
+    NSString *bannerURL = [Utilities formatStringURL:bannerPath serverURL:serverURL];
     NSString *fanartURL = [Utilities formatStringURL:item[@"fanart"] serverURL:serverURL];
     if ([stringURL isEqualToString:@""]) {
         stringURL = [Utilities getItemIconFromDictionary:item mainFields:mainFields];
@@ -564,6 +566,7 @@
                                  genre, @"genre",
                                  stringURL, @"thumbnail",
                                  fanartURL, @"fanart",
+                                 bannerURL, @"banner",
                                  runtime, @"runtime",
                                  seasonNumber, @"season",
                                  row19obj, row19key,
@@ -2543,7 +2546,7 @@
                                     nil];
             [NSThread detachNewThreadSelector:@selector(getChannelEpgInfo:) toTarget:self withObject:params];
         }
-        NSString *stringURL = item[@"thumbnail"];
+        NSString *stringURL = tvshowsView ? item[@"banner"] : item[@"thumbnail"];
         NSString *displayThumb = globalSearchView ? [self getGlobalSearchThumb:item] : defaultThumb;
         if ([item[@"filetype"] length] != 0 ||
             [item[@"family"] isEqualToString:@"file"] ||


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/544.

This PR adds view options for TV Shows like for other views.
- Support grid view and fullscreen (iPad only)
- Add specific `"banner"` key instead of overwriting `"thumbnail"` to allow loading both in parallel
- Needs re-sync of data to show correct thumbs when toggling the views

Screenshots:
https://abload.de/img/bildschirmfoto2022-01xhkbm.png (iPhone)
https://abload.de/img/bildschirmfoto2022-01e1jic.png (iPad fullscreen)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Add view options for TV Shows