### PR TITLE
Bugfix: Show the keyboard after hiding it when moving to main menu (iPhone)

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3445,6 +3445,13 @@ NSIndexPath *selected;
     [self.searchController.searchBar resignFirstResponder];
 }
 
+- (void)showKeyboard:(id)sender {
+    // Show the keyboard if it was active when the view was shown last time. Remark: Only works with dalay!
+    if (showkeyboard) {
+        [[self getSearchTextField] performSelector:@selector(becomeFirstResponder) withObject:nil afterDelay:0.1];
+    }
+}
+
 #pragma mark - View Configuration
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
@@ -5625,6 +5632,10 @@ NSIndexPath *selected;
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(hideKeyboard:)
                                                  name: @"ECSlidingViewUnderLeftWillAppear"
+                                               object: nil];
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(showKeyboard:)
+                                                 name: @"ECSlidingViewTopDidReset"
                                                object: nil];
     
     [[NSNotificationCenter defaultCenter] addObserver: self


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3084017#pid3084017). An active keyboard was hidden when swiping left towards the main menu. When bringing the view back the keyboard shall be brought up again.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show the keyboard after hiding it when moving to main menu (iPhone)