### PR TITLE
Bugfix: Hide ProgressSlider in viewDidLoad

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2747,6 +2747,7 @@ int currentItemID;
     ProgressSlider.userInteractionEnabled = NO;
     [ProgressSlider setThumbImage:[UIImage new] forState:UIControlStateNormal];
     [ProgressSlider setThumbImage:[UIImage new] forState:UIControlStateHighlighted];
+    ProgressSlider.hidden = YES;
     scrabbingMessage.text = LOCALIZED_STR(@"Slide your finger up to adjust the scrubbing rate.");
     scrabbingRate.text = LOCALIZED_STR(@"Scrubbing 1");
     sheetActions = [NSMutableArray new];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3084204#pid3084204). The NowPlaying view shall start with hidden ProgressSlider (initialized in `viewDidLoad`). It will be unhidden when playback is detected. This avoids to have a visible ProgressSlider for a fraction of a second before "Nothing is playing" is detected.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Start NowPlaying with hidden ProgressSlider