### PR TITLE
Bugfix: Show "No results found" for movie sets

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4840,8 +4840,8 @@ NSIndexPath *selected;
                          
                          // Postprocessing of movie sets lists to ignore 1-movie-sets
                          if (ignoreSingleMovieSets) {
-                             BOOL isLastItem = i == total-1;
-                             if (i==0) {
+                             BOOL isLastItem = (i == total - 1);
+                             if (i == 0) {
                                  [storeRichResults removeAllObjects];
                              }
                              NSString *newMethodToCall = @"VideoLibrary.GetMovieSetDetails";
@@ -4850,8 +4850,8 @@ NSIndexPath *selected;
                               callMethod:newMethodToCall
                               withParameters:newParameter
                               onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
-                                 if (error==nil && methodError==nil) {
-                                     if ([methodResult[@"setdetails"][@"movies"] count]>1) {
+                                 if (error == nil && methodError == nil) {
+                                     if ([methodResult[@"setdetails"][@"movies"] count] > 1) {
                                          [storeRichResults addObject:newDict];
                                      }
                                  }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4903,6 +4903,9 @@ NSIndexPath *selected;
 //                 NSLog(@"RICH RESULTS %@", resultStoreArray);
                  // Leave as all necessary steps are handled in callbacks of the postprocessing for 1-movie-sets
                  if (ignoreSingleMovieSets) {
+                     if (!storeRichResults.count) {
+                         [self showNoResultsFound:resultStoreArray refresh:forceRefresh];
+                     }
                      return;
                  }
                  if (!extraSectionCallBool) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
When there are no results for movie sets we need to call `showNoResultsFound` to end the animation and show "No results found". In addition change a few spaces and brackets for better readability.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show "No results found" for movie sets