### PR TITLE
Add Global Search as option for "Start in view"

### DIFF
--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -200,6 +200,7 @@
 				<string>Favourites</string>
 				<string>Now Playing</string>
 				<string>Remote Control</string>
+				<string>Global Search</string>
 			</array>
 			<key>Values</key>
 			<array>
@@ -214,6 +215,7 @@
 				<string>Favourites</string>
 				<string>Now Playing</string>
 				<string>Remote Control</string>
+				<string>Global Search</string>
 			</array>
 		</dict>
 		<dict>

--- a/XBMC Remote/Settings.bundle/de.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/de.lproj/Root.strings
@@ -33,6 +33,7 @@
 "Radio" = "Radio";
 "Favourites" = "Favoriten";
 "Now Playing" = "Gerade läuft";
+"Global Search" = "Globale Suche";
 "Main Menu changes needs app restart" = "Hauptmenü-Änderungen erfordern einen App-Neustart";
 "Show MUSIC" = "MUSIK anzeigen";
 "Show MOVIES" = "FILME anzeigen";

--- a/XBMC Remote/Settings.bundle/en-us.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en-us.lproj/Root.strings
@@ -33,6 +33,7 @@
 "Radio" = "Radio";
 "Favourites" = "Favorites";
 "Now Playing" = "Now Playing";
+"Global Search" = "Global Search";
 "Main Menu changes needs app restart" = "Main Menu changes needs app restart";
 "Show MUSIC" = "Show MUSIC";
 "Show MOVIES" = "Show MOVIES";

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -33,6 +33,7 @@
 "Radio" = "Radio";
 "Favourites" = "Favourites";
 "Now Playing" = "Now Playing";
+"Global Search" = "Global Search";
 "Main Menu changes needs app restart" = "Main Menu changes needs app restart";
 "Show MUSIC" = "Show MUSIC";
 "Show MOVIES" = "Show MOVIES";

--- a/XBMC Remote/Settings.bundle/pl.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/pl.lproj/Root.strings
@@ -45,3 +45,4 @@
 "Radio" = "Radio";
 "Favourites" = "Ulubione";
 "Now Playing" = "Teraz odtwarzane";
+"Global Search" = "Wyszukiwanie globalne";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This change was missed during rebasing. The PR simply adds the option to also select the recently "Global Search" to the new app setting "Start in view".

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Add Global Search as option for "Start in view"