### PR TITLE
Hide index when entering "more" tab

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -950,6 +950,7 @@
 //        return;
 //    }
     mainMenu *menuItem = self.detailItem;
+    self.indexView.hidden = YES;
     button6.hidden = YES;
     button7.hidden = YES;
     [self alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This fixes a visible index which is not related to the "more" menu content when entering "more" menu from a grid view with index. The issue was reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3086045#pid3086045).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Hide index when entering "more" tab