### PR TITLE
Let MD5 hash for cache also consider App version

### DIFF
--- a/XBMC Remote/AppInfoViewController.m
+++ b/XBMC Remote/AppInfoViewController.m
@@ -8,6 +8,7 @@
 
 #import "AppInfoViewController.h"
 #import "AppDelegate.h"
+#import "Utilities.h"
 
 @interface AppInfoViewController ()
 
@@ -91,8 +92,7 @@
     [super viewDidLoad];
     self.edgesForExtendedLayout = 0;
     appName.text = LOCALIZED_STR(@"Official XBMC Remote\nfor iOS");
-    __auto_type infoDictionary = NSBundle.mainBundle.infoDictionary;
-    appVersion.text = [NSString stringWithFormat:@"v%@ (%@)", infoDictionary[@"CFBundleShortVersionString"], infoDictionary[(NSString*)kCFBundleVersionKey]];
+    appVersion.text = [Utilities getAppVersionString];
     appDescription.text = LOCALIZED_STR(@"Official XBMC Remote app uses art coming from http://fanart.tv, download and execute the \"artwork downloader\" XBMC add-on to unlock the beauty of additional artwork!\n\nXBMC logo, Zappy mascot and Official XBMC Remote icons are property of XBMC\nhttp://www.xbmc.org/contribute");
     appGreeting.text = LOCALIZED_STR(@"enjoy!");
 }

--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -121,7 +121,7 @@
     NSString *sortAscDesc;
     int numberOfStars;
     NSDictionary *watchedListenedStrings;
-    int serverVersion;
+    int serverMajorVersion;
     int serverMinorVersion;
     NSString *libraryCachePath;
     CGFloat bottomPadding;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -326,8 +326,9 @@
     // Which JSON request's results do we cache??
     NSString *jsonRequest = [NSString stringWithFormat:@"%@ %@", fieldA, fieldB];
     
-    // Get MD5 hash for the combination given above
-    return [[NSString stringWithFormat:@"%@%@%@%@", serverInfo, serverVersion, appVersion, jsonRequest] MD5String];
+    // Get SHA256 hash for the combination given above
+    NSString *text = [NSString stringWithFormat:@"%@%@%@%@", serverInfo, serverVersion, appVersion, jsonRequest];
+    return [text SHA256String];
 }
 
 - (void)saveData:(NSMutableDictionary*)mutableParameters {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -321,8 +321,7 @@
     NSString *serverVersion = [NSString stringWithFormat:@"%d.%d", serverMajorVersion, serverMinorVersion];
     
     // Which App version are we running?
-    __auto_type infoDictionary = NSBundle.mainBundle.infoDictionary;
-    NSString *appVersion = [NSString stringWithFormat:@"v%@ (%@)", infoDictionary[@"CFBundleShortVersionString"], infoDictionary[(NSString*)kCFBundleVersionKey]];
+    NSString *appVersion = [Utilities getAppVersionString];
     
     // Which JSON request's results do we cache??
     NSString *jsonRequest = [NSString stringWithFormat:@"%@ %@", fieldA, fieldB];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -313,8 +313,22 @@
 #pragma mark - library disk cache management
 
 - (NSString*)getCacheKey:(NSString*)fieldA parameters:(NSMutableDictionary*)fieldB {
+    // Which server are we connected to?
     GlobalData *obj = [GlobalData getInstance];
-    return [[NSString stringWithFormat:@"%@%@%@%d%d%@%@", obj.serverIP, obj.serverPort, obj.serverDescription, serverVersion, serverMinorVersion, fieldA, fieldB] MD5String];
+    NSString *serverInfo = [NSString stringWithFormat:@"%@ %@ %@", obj.serverIP, obj.serverPort, obj.serverDescription];
+    
+    // Which version does the serer have?
+    NSString *serverVersion = [NSString stringWithFormat:@"%d.%d", serverMajorVersion, serverMinorVersion];
+    
+    // Which App version are we running?
+    __auto_type infoDictionary = NSBundle.mainBundle.infoDictionary;
+    NSString *appVersion = [NSString stringWithFormat:@"v%@ (%@)", infoDictionary[@"CFBundleShortVersionString"], infoDictionary[(NSString*)kCFBundleVersionKey]];
+    
+    // Which JSON request's results do we cache??
+    NSString *jsonRequest = [NSString stringWithFormat:@"%@ %@", fieldA, fieldB];
+    
+    // Get MD5 hash for the combination given above
+    return [[NSString stringWithFormat:@"%@%@%@%@", serverInfo, serverVersion, appVersion, jsonRequest] MD5String];
 }
 
 - (void)saveData:(NSMutableDictionary*)mutableParameters {
@@ -5744,7 +5758,7 @@ NSIndexPath *selected;
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    serverVersion = AppDelegate.instance.serverVersion;
+    serverMajorVersion = AppDelegate.instance.serverVersion;
     serverMinorVersion = AppDelegate.instance.serverMinorVersion;
     libraryCachePath = AppDelegate.instance.libraryCachePath;
     epgCachePath = AppDelegate.instance.epgCachePath;

--- a/XBMC Remote/NSString+MD5/NSString+MD5.h
+++ b/XBMC Remote/NSString+MD5/NSString+MD5.h
@@ -11,5 +11,6 @@
 @interface NSString (MD5)
 
 - (NSString*)MD5String;
+- (NSString*)SHA256String;
 
 @end

--- a/XBMC Remote/NSString+MD5/NSString+MD5.m
+++ b/XBMC Remote/NSString+MD5/NSString+MD5.m
@@ -25,4 +25,16 @@
             ];
 }
 
+- (NSString*)SHA256String {
+    const char *utf8chars = [self UTF8String];
+    unsigned char result[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(utf8chars, (CC_LONG)strlen(utf8chars), result);
+    
+    NSMutableString *ret = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH*2];
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
+        [ret appendFormat:@"%02x", result[i]];
+    }
+    return ret;
+}
+
 @end

--- a/XBMC Remote/NSString+MD5/NSString+MD5.m
+++ b/XBMC Remote/NSString+MD5/NSString+MD5.m
@@ -12,17 +12,15 @@
 @implementation NSString (MD5)
 
 - (NSString*)MD5String {
-    const char *cstr = [self UTF8String];
-    unsigned char result[16];
-    CC_MD5(cstr, (int)strlen(cstr), result);
+    const char *utf8chars = [self UTF8String];
+    unsigned char result[CC_MD5_DIGEST_LENGTH];
+    CC_MD5(utf8chars, (CC_LONG)strlen(utf8chars), result);
     
-    return [NSString stringWithFormat:
-            @"%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
-            result[0], result[1], result[2], result[3],
-            result[4], result[5], result[6], result[7],
-            result[8], result[9], result[10], result[11],
-            result[12], result[13], result[14], result[15]
-            ];
+    NSMutableString *ret = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
+    for (int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
+        [ret appendFormat:@"%02x", result[i]];
+    }
+    return ret;
 }
 
 - (NSString*)SHA256String {

--- a/XBMC Remote/SDWebImage/SDImageCache.m
+++ b/XBMC Remote/SDWebImage/SDImageCache.m
@@ -8,6 +8,7 @@
 
 #import "SDImageCache.h"
 #import "SDWebImageDecoder.h"
+#import "NSString+MD5.h"
 #import <CommonCrypto/CommonDigest.h>
 #import <mach/mach.h>
 #import <mach/mach_host.h>
@@ -79,13 +80,7 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 31; // 1 month
 #pragma mark SDImageCache (private)
 
 - (NSString*)cachePathForKey:(NSString*)key {
-    const char *str = [key UTF8String];
-    unsigned char r[CC_MD5_DIGEST_LENGTH];
-    CC_MD5(str, (CC_LONG)strlen(str), r);
-    NSString *filename = [NSString stringWithFormat:@"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
-                          r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10], r[11], r[12], r[13], r[14], r[15]];
-
-    return [self.diskCachePath stringByAppendingPathComponent:filename];
+    return [self.diskCachePath stringByAppendingPathComponent:[key SHA256String]];
 }
 
 #pragma mark ImageCache

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -83,6 +83,7 @@ typedef enum {
 + (BOOL)hasRemoteToolBar;
 + (CGFloat)getBottomPadding;
 + (void)sendXbmcHttp:(NSString*)command;
++ (NSString*)getAppVersionString;
 + (void)checkForReviewRequest;
 + (NSString*)getConnectionStatusIconName;
 + (void)addShadowsToView:(UIView*)view viewFrame:(CGRect)frame;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -846,6 +846,12 @@
     [[NSURLSession.sharedSession dataTaskWithURL:[NSURL URLWithString:serverHTTP]] resume];
 }
 
++ (NSString*)getAppVersionString {
+    NSDictionary *infoDict = NSBundle.mainBundle.infoDictionary;
+    NSString *appVersion = [NSString stringWithFormat:@"v%@ (%@)", infoDict[@"CFBundleShortVersionString"], infoDict[(NSString*)kCFBundleVersionKey]];
+    return appVersion;
+}
+
 + (void)showReviewController {
     if (@available(iOS 10.3, *)) {
         [SKStoreReviewController requestReview];
@@ -853,9 +859,7 @@
 }
 
 + (void)checkForReviewRequest {
-    NSDictionary *infoDict = NSBundle.mainBundle.infoDictionary;
-    NSString *currentVersion = [NSString stringWithFormat:@"v%@ (%@)", infoDict[@"CFBundleShortVersionString"],
-                                                                       infoDict[(NSString*)kCFBundleVersionKey]];
+    NSString *currentVersion = [Utilities getAppVersionString];
     NSString *savedVersion = [[NSUserDefaults standardUserDefaults] stringForKey:PERSISTENCE_KEY_VERSION];
     // Compare current version with version under review
     if (![savedVersion isEqualToString:currentVersion]) {

--- a/XBMC Remote/customButton.m
+++ b/XBMC Remote/customButton.m
@@ -24,7 +24,7 @@
 
 - (NSString*)getServerKey {
     GlobalData *obj = [GlobalData getInstance];
-    return [[NSString stringWithFormat:@"%@%@%@", obj.serverIP, obj.serverPort, obj.serverDescription] MD5String];
+    return [[NSString stringWithFormat:@"%@%@%@", obj.serverIP, obj.serverPort, obj.serverDescription] SHA256String];
 }
 
 - (void)loadData {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This change ensures the cache is refreshed when a new app version is installed. It does this by adding the App version to the calculation of the MD5 hash for each cache file.

**Pro:**
The benefit is that there is no inconsistency between the cached data format and the expected one. This avoids glitches when presenting the results. In the past users which observed such glitches were asked to re-synchronize the data manually via the pull-down menu.

**Con:**
The downside is a re-sync is done for the first time entering a certain menu or view. This is a performance impact for the very first time.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Force cache updates for new App versions to ensure data consistency
Improvement: Use SHA256 instead of MD5 for the hash calculation