### PR TITLE
Bugfix: Playlist possibly not highlighting played item

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -894,26 +894,19 @@ int currentItemID;
                                  //                                 NSLog(@"CURRENT ITEMID %d PLAYLIST ID %@", currentItemID, playlistData[selection.row][@"idItem"]);
                                  storePercentage = percentage;
                                  if (playlistPosition != lastSelected && playlistPosition > 0) {
-                                     if ((playlistData.count >= playlistPosition) && currentPlayerID == playerID) {
-                                         if (playlistPosition > 0) {
-                                             if (lastSelected != playlistPosition) {
-                                                 [self hidePlaylistProgressbarWithDeselect:NO];
-                                                 NSIndexPath *newSelection = [NSIndexPath indexPathForRow:playlistPosition - 1 inSection:0];
-                                                 UITableViewScrollPosition position = UITableViewScrollPositionMiddle;
-                                                 if (musicPartyMode) {
-                                                     position = UITableViewScrollPositionNone;
-                                                 }
-                                                 [playlistTableView selectRowAtIndexPath:newSelection animated:YES scrollPosition:position];
-                                                 UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:newSelection];
-                                                 UIView *timePlaying = (UIView*)[cell viewWithTag:5];
-                                                 [self fadeView:timePlaying hidden:NO];
-                                                 storeSelection = newSelection;
-                                                 lastSelected = playlistPosition;
-                                             }
+                                     if (playlistData.count >= playlistPosition && currentPlayerID == playerID) {
+                                         [self hidePlaylistProgressbarWithDeselect:NO];
+                                         NSIndexPath *newSelection = [NSIndexPath indexPathForRow:playlistPosition - 1 inSection:0];
+                                         UITableViewScrollPosition position = UITableViewScrollPositionMiddle;
+                                         if (musicPartyMode) {
+                                             position = UITableViewScrollPositionNone;
                                          }
-                                         else {
-                                             [self hidePlaylistProgressbarWithDeselect:YES];
-                                         }
+                                         [playlistTableView selectRowAtIndexPath:newSelection animated:YES scrollPosition:position];
+                                         UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:newSelection];
+                                         UIView *timePlaying = (UIView*)[cell viewWithTag:5];
+                                         [self fadeView:timePlaying hidden:NO];
+                                         storeSelection = newSelection;
+                                         lastSelected = playlistPosition;
                                      }
                                  }
                              }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1280,6 +1280,7 @@ int currentItemID;
     }
     [playlistTableView performSelectorOnMainThread:@selector(reloadData) withObject:nil waitUntilDone:YES];
     [activityIndicatorView stopAnimating];
+    lastSelected = SELECTED_NONE;
 }
 
 - (void)SimpleAction:(NSString*)action params:(NSDictionary*)parameters reloadPlaylist:(BOOL)reload startProgressBar:(BOOL)progressBar {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -579,14 +579,14 @@ int currentItemID;
                     response = methodResult[0][@"playerid"];
                 }
                 currentPlayerID = [response intValue];
-                if (playerID != [response intValue] ||
+                if (playerID != currentPlayerID ||
                     lastPlayerID != currentPlayerID ||
                     (selectedPlayerID != PLAYERID_UNKNOWN && playerID != selectedPlayerID)) {
                     if (selectedPlayerID != PLAYERID_UNKNOWN && playerID != selectedPlayerID) {
                         lastPlayerID = playerID = selectedPlayerID;
                     }
                     else if (selectedPlayerID == PLAYERID_UNKNOWN) {
-                        lastPlayerID = playerID = [response intValue];
+                        lastPlayerID = playerID = currentPlayerID;
                         [self createPlaylist:NO animTableView:YES];
                     }
                     else if (lastPlayerID != currentPlayerID) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a race condition which caused the in-playlist progress bar not to be shown under certain conditions. Setting `lastSelected = SELECTED_NONE` will now force any running playback to select the related row and show the progress bar. Use case: Show the Music Playlist in the App, and then trigger playback of a movie via Kodi.
In addition, this PR removes the inner checks for `(playlistPosition > 0)` and `(lastSelected != playlistPosition)`. Both conditions were already checked in the outer condition.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Playlist possibly not highlighting played item