### PR TITLE
Bugfix: Fix crashes

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6082,7 +6082,6 @@ NSIndexPath *selected;
 }
 
 - (void)handleEnterForeground:(NSNotification*)sender {
-    [self checkDiskCache];
 }
 
 - (void)handleChangeLibraryView {

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1282,6 +1282,10 @@ NSInteger buttonAction;
     [Utilities turnTorchOn:sender on:torchIsOn];
 }
 
+- (void)dismissModal {
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
 - (void)toggleRemotePosition {
     positionMode = positionMode == remoteBottom ? remoteTop : remoteBottom;
     CGRect frame = remoteControlView.frame;
@@ -1300,9 +1304,9 @@ NSInteger buttonAction;
     torchIsOn = [Utilities isTorchOn];
     // Non-embedded layout has 5 buttons (Settings > Gesture > Keyboard > Info > Torch with Flex around the buttons)
     // Embedded layout has 4 buttons (Gesture > Keyboard > Info > Torch with Flex around the buttons)
-    int numButtons = isEmbedded ? 4 : 5;
-    // On iPhone an addtional button to toggle the remote's position is available
-    numButtons = IS_IPHONE ? numButtons + 1 : numButtons;
+    // iPhone has an addtional button to toggle the remote's position is available
+    // iPad has an additional button to close the modal view
+    int numButtons = isEmbedded ? 5 : 6;
     CGFloat ToolbarFlexSpace = ((width - numButtons * TOOLBAR_ICON_SIZE) / (numButtons + 1));
     CGFloat ToolbarPadding = (TOOLBAR_ICON_SIZE + ToolbarFlexSpace);
     
@@ -1376,6 +1380,16 @@ NSInteger buttonAction;
         [positionButton addTarget:self action:@selector(toggleRemotePosition) forControlEvents:UIControlEventTouchUpInside];
         positionButton.alpha = 0.6;
         [remoteToolbar addSubview:positionButton];
+    }
+    else {
+        UIButton *closeButton = [UIButton buttonWithType:UIButtonTypeCustom];
+        frame.origin.x += ToolbarPadding;
+        closeButton.frame = frame;
+        closeButton.showsTouchWhenHighlighted = YES;
+        [closeButton setImage:[UIImage imageNamed:@"button_close"] forState:UIControlStateNormal];
+        [closeButton addTarget:self action:@selector(dismissModal) forControlEvents:UIControlEventTouchUpInside];
+        closeButton.alpha = 0.6;
+        [remoteToolbar addSubview:closeButton];
     }
     
     // Add toolbar to RemoteController's view

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1422,6 +1422,7 @@ NSInteger buttonAction;
         [self presentViewController:alertView animated:YES completion:nil];
     }
     else {
+        [self dismissViewControllerAnimated:YES completion:nil];
         RightMenuViewController *rightMenuViewController = [[RightMenuViewController alloc] initWithNibName:@"RightMenuViewController" bundle:nil];
         rightMenuViewController.rightMenuItems = AppDelegate.instance.remoteControlMenuItems;
         if (rightMenuViewController.rightMenuItems.count) {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1186,13 +1186,15 @@ double round(double d) {
     embedVideoURL = nil;
     if (trailerString.length > 0) {
         if ([trailerString hasPrefix:@"plugin://plugin.video.youtube"]) {
-            NSURL* url = [NSURL URLWithString:trailerString];
-            NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:YES];
-            NSArray *queryItems = urlComponents.queryItems;
-            for (NSURLQueryItem *item in queryItems) {
-                if ([item.name isEqualToString:@"videoid"]) {
-                    embedVideoURL = [NSString stringWithFormat:@"https://www.youtube.com/watch?v=%@", item.value];
-                    break; // We can leave the loop as we found what we were looking for.
+            NSURL *url = [NSURL URLWithString:trailerString];
+            if (url) {
+                NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:YES];
+                NSArray *queryItems = urlComponents.queryItems;
+                for (NSURLQueryItem *item in queryItems) {
+                    if ([item.name isEqualToString:@"videoid"]) {
+                        embedVideoURL = [NSString stringWithFormat:@"https://www.youtube.com/watch?v=%@", item.value];
+                        break; // We can leave the loop as we found what we were looking for.
+                    }
                 }
             }
         }

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -897,24 +897,21 @@
 	
 	if (viewControllersStack.count > 1) {
 //        NSLog(@"DUE");
-		NSInteger indexOfViewController = [viewControllersStack
-										   indexOfObject:invokeByController]+1;
-		
-		if ([invokeByController parentViewController]) {
-			indexOfViewController = [viewControllersStack
-									 indexOfObject:[invokeByController parentViewController]]+1;
-		}
-		
-		NSInteger viewControllerCount = viewControllersStack.count;
-		for (NSInteger i = indexOfViewController; i < viewControllerCount; i++) {
+        UIViewController *invokedBy = invokeByController.parentViewController ?: invokeByController;
+        NSInteger indexOfViewController = [viewControllersStack indexOfObject:invokedBy];
+        if (indexOfViewController == NSNotFound) {
+            indexOfViewController = viewControllersStack.count;
+        }
+        else {
+            indexOfViewController += 1;
+        }
+
+        NSInteger viewControllerCount = viewControllersStack.count;
+        for (NSInteger i = indexOfViewController; i < viewControllerCount; i++) {
             [[slideViews viewWithTag:i + VIEW_TAG] removeFromSuperview];
-//FIXME: 
-            if (!TARGET_IPHONE_SIMULATOR) {
-                [viewControllersStack removeObjectAtIndex:indexOfViewController];
-            }
-// END FIXME
-			viewXPosition = self.view.frame.size.width - controller.view.frame.size.width;
-		}
+            [viewControllersStack removeObjectAtIndex:indexOfViewController];
+            viewXPosition = self.view.frame.size.width - controller.view.frame.size.width;
+        }
 	}
     else if (viewControllersStack.count == 0) {
 //        NSLog(@"TRE"); //FIRST


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/604.
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/606.

1. Out-of-bounds crash in iPad's `StackViewController`. In 1.10 test builds this could be triggered by pressing remote's settings twice.
2. Crash of `componentsWithURL:resolvingAgainstBaseURL:` when handing `url == nil`.
3. Crash of `checkDiskCache` after wakeup.
3. Adding a "close" button to the iPad's remote toolbar to allow closing the modal view.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix crash when loading movie details (processing trailer URL)
Bugfix: Fix crash when pressing remote setting twice on iPad (1.10 test builds only)
Bugfix: Fix possible UI lock up when entering remote on iPad and iOS 13 and earlier (1.10 test builds only)