### PR TITLE
Maintenance: Prepare migration of NSKeyedArchiver methods and move to block-based animation

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -383,29 +383,28 @@
 
 - (id)init {
 	if ((self = [super init])) {
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-        NSString *documentsDirectory = paths[0];
-        self.dataFilePath = [documentsDirectory stringByAppendingPathComponent:@"serverList_saved.dat"];
-        NSFileManager *fileManager1 = [NSFileManager defaultManager];
-        if ([fileManager1 fileExistsAtPath:self.dataFilePath]) {
-            NSMutableArray *tempArray;
-            tempArray = [NSKeyedUnarchiver unarchiveObjectWithFile:self.dataFilePath];
+        NSArray *docPaths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+        self.dataFilePath = docPaths[0];
+        NSMutableArray *tempArray = [Utilities unarchivePath:self.dataFilePath file:@"serverList_saved.dat"];
+        if (tempArray) {
             [self setArrayServerList:tempArray];
         }
         else {
             arrayServerList = [NSMutableArray new];
         }
-        NSString *fullNamespace = @"LibraryCache";
-        paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-        self.libraryCachePath = [paths[0] stringByAppendingPathComponent:fullNamespace];
-        if (![fileManager1 fileExistsAtPath:self.libraryCachePath]) {
-            [fileManager1 createDirectoryAtPath:self.libraryCachePath withIntermediateDirectories:YES attributes:nil error:NULL];
-        }
-        self.epgCachePath = [paths[0] stringByAppendingPathComponent:@"EPGDataCache"];
-//        [[NSFileManager defaultManager] removeItemAtPath:self.epgCachePath error:nil];
-        if (![fileManager1 fileExistsAtPath:self.epgCachePath]) {
-            [fileManager1 createDirectoryAtPath:self.epgCachePath withIntermediateDirectories:YES attributes:nil error:NULL];
-        }
+        
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        NSArray *cachePaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+        self.libraryCachePath = [cachePaths[0] stringByAppendingPathComponent:@"LibraryCache"];
+        [fileManager createDirectoryAtPath:self.libraryCachePath
+               withIntermediateDirectories:YES
+                                attributes:nil
+                                     error:NULL];
+        self.epgCachePath = [cachePaths[0] stringByAppendingPathComponent:@"EPGDataCache"];
+        [fileManager createDirectoryAtPath:self.epgCachePath
+               withIntermediateDirectories:YES
+                                attributes:nil
+                                     error:NULL];
     }
 	return self;
 	
@@ -6037,10 +6036,7 @@
 }
 
 - (void)saveServerList {
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-    if (paths.count > 0) { 
-        [NSKeyedArchiver archiveRootObject:arrayServerList toFile:self.dataFilePath];
-    }
+    [Utilities archivePath:self.dataFilePath file:@"serverList_saved.dat" data:arrayServerList];
 }
 
 - (void)clearAppDiskCache {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -941,7 +941,7 @@
     }
     choosedTab = MAX_NORMAL_BUTTONS;
     [buttonsIB[choosedTab] setSelected:YES];
-    [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
+    [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
     int i;
     NSInteger count = [menuItem mainParameters].count;
     NSMutableArray *moreMenu = [NSMutableArray new];
@@ -1223,7 +1223,7 @@
     if (newEnableCollectionView != enableCollectionView) {
         animDuration = 0.0;
     }
-    [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:animDuration Alpha:1.0 XPos:viewWidth];
+    [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:animDuration Alpha:1.0 XPos:viewWidth];
     enableCollectionView = newEnableCollectionView;
     recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
     [activeLayoutView setContentOffset:[(UITableView*)activeLayoutView contentOffset] animated:NO];
@@ -1262,7 +1262,7 @@
     }
     else {
         [activityIndicatorView stopAnimating];
-        [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
+        [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
     }
 }
 
@@ -3733,10 +3733,10 @@ NSIndexPath *selected;
                              [self choseParams];
                              if (forceCollection) {
                                  forceCollection = NO;
-                                 [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:viewWidth];
+                                 [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:viewWidth];
                                  enableCollectionView = NO;
                                  [self configureLibraryView];
-                                 [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:0];
+                                 [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:0];
                              }
                              [self setFlowLayoutParams];
                              [collectionView.collectionViewLayout invalidateLayout];
@@ -3780,10 +3780,10 @@ NSIndexPath *selected;
                              moreItemsViewController.view.hidden = YES;
                              if (!enableCollectionView) {
                                  forceCollection = YES;
-                                 [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:viewWidth];
+                                 [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:viewWidth];
                                  enableCollectionView = YES;
                                  [self configureLibraryView];
-                                 [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:0];
+                                 [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:0];
                              }
                              else {
                                  forceCollection = NO;
@@ -3936,7 +3936,7 @@ NSIndexPath *selected;
                [self deselectAtIndexPath:indexPath];
                if (error == nil && methodError == nil) {
                    [self.searchController setActive:NO];
-                   [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
+                   [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
                    [self startRetrieveDataWithRefresh:YES];
                }
                else {
@@ -4475,7 +4475,7 @@ NSIndexPath *selected;
     }
     else {
         [activityIndicatorView stopAnimating];
-        [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
+        [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
     }
 }
 
@@ -4885,7 +4885,7 @@ NSIndexPath *selected;
     self.sections[@""] = @[];
     [self animateNoResultsFound];
     [activeLayoutView reloadData];
-    [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
+    [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
 }
 
 - (BOOL)isEligibleForSections:(NSArray*)array {
@@ -5225,7 +5225,7 @@ NSIndexPath *selected;
     [self setFlowLayoutParams];
     [activityIndicatorView stopAnimating];
     [activeLayoutView reloadData];
-    [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
+    [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
     [dataList setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
     [collectionView layoutSubviews];
     [collectionView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
@@ -6019,7 +6019,7 @@ NSIndexPath *selected;
                          }
                          completion:^(BOOL finished) {
                              [self configureLibraryView];
-                             [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
+                             [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
                              [activeLayoutView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
                          }];
     }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -933,7 +933,7 @@
     self.indexView.hidden = YES;
     button6.hidden = YES;
     button7.hidden = YES;
-    [self alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
+    [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
     [activityIndicatorView startAnimating];
     NSArray *buttonsIB = @[button1, button2, button3, button4, button5];
     if (choosedTab < buttonsIB.count) {
@@ -941,7 +941,7 @@
     }
     choosedTab = MAX_NORMAL_BUTTONS;
     [buttonsIB[choosedTab] setSelected:YES];
-    [self AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
+    [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
     int i;
     NSInteger count = [menuItem mainParameters].count;
     NSMutableArray *moreMenu = [NSMutableArray new];
@@ -970,7 +970,7 @@
         [detailView insertSubview:moreItemsViewController.view aboveSubview:dataList];
     }
 
-    [self AnimView:moreItemsViewController.view AnimDuration:0.3 Alpha:1.0 XPos:0];
+    [Utilities AnimView:moreItemsViewController.view AnimDuration:0.3 Alpha:1.0 XPos:0];
     NSString *labelText = [NSString stringWithFormat:LOCALIZED_STR(@"More (%d)"), (int)(count - MAX_NORMAL_BUTTONS)];
     [self setFilternameLabel:labelText runFullscreenButtonCheck:YES forceHide:YES];
     [activityIndicatorView stopAnimating];
@@ -1208,7 +1208,7 @@
         [longTimeout removeFromSuperview];
         longTimeout = nil;
     }
-    [self AnimView:moreItemsViewController.view AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
+    [Utilities AnimView:moreItemsViewController.view AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
     
     [activityIndicatorView startAnimating];
 
@@ -1223,7 +1223,7 @@
     if (newEnableCollectionView != enableCollectionView) {
         animDuration = 0.0;
     }
-    [self AnimTable:(UITableView*)activeLayoutView AnimDuration:animDuration Alpha:1.0 XPos:viewWidth];
+    [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:animDuration Alpha:1.0 XPos:viewWidth];
     enableCollectionView = newEnableCollectionView;
     recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
     [activeLayoutView setContentOffset:[(UITableView*)activeLayoutView contentOffset] animated:NO];
@@ -1262,7 +1262,7 @@
     }
     else {
         [activityIndicatorView stopAnimating];
-        [self AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
+        [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
     }
 }
 
@@ -1906,54 +1906,15 @@
 
 - (void)handleCollectionIndexStateBegin {
     if (stackscrollFullscreen) {
-        [self alphaView:sectionNameOverlayView AnimDuration:0.1 Alpha:1];
+        [Utilities alphaView:sectionNameOverlayView AnimDuration:0.1 Alpha:1];
     }
 }
 
 - (void)handleCollectionIndexStateEnded {
     if (stackscrollFullscreen) {
-        [self alphaView:sectionNameOverlayView AnimDuration:0.3 Alpha:0];
+        [Utilities alphaView:sectionNameOverlayView AnimDuration:0.3 Alpha:0];
     }
     _indexView.alpha = 1.0;
-}
-
-#pragma mark - Table Animation
-
-- (void)alphaImage:(UIImageView*)image AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue {
-    [UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:seconds];
-	image.alpha = alphavalue;
-    [UIView commitAnimations];
-}
-
-- (void)alphaView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue {
-    [UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:seconds];
-	view.alpha = alphavalue;
-    [UIView commitAnimations];
-}
-
-- (void)AnimTable:(UITableView*)tV AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:seconds];
-    tV.alpha = alphavalue;
-    CGRect frame;
-    frame = tV.frame;
-    frame.origin.x = X;
-    frame.origin.y = 0;
-    tV.frame = frame;
-    [UIView commitAnimations];
-}
-
-- (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
-	[UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:seconds];
-	view.alpha = alphavalue;
-	CGRect frame;
-	frame = view.frame;
-	frame.origin.x = X;
-	view.frame = frame;
-    [UIView commitAnimations];
 }
 
 #pragma mark - Cell Formatting 
@@ -3772,10 +3733,10 @@ NSIndexPath *selected;
                              [self choseParams];
                              if (forceCollection) {
                                  forceCollection = NO;
-                                 [self AnimTable:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:viewWidth];
+                                 [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:viewWidth];
                                  enableCollectionView = NO;
                                  [self configureLibraryView];
-                                 [self AnimTable:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:0];
+                                 [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:0];
                              }
                              [self setFlowLayoutParams];
                              [collectionView.collectionViewLayout invalidateLayout];
@@ -3819,10 +3780,10 @@ NSIndexPath *selected;
                              moreItemsViewController.view.hidden = YES;
                              if (!enableCollectionView) {
                                  forceCollection = YES;
-                                 [self AnimTable:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:viewWidth];
+                                 [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:viewWidth];
                                  enableCollectionView = YES;
                                  [self configureLibraryView];
-                                 [self AnimTable:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:0];
+                                 [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:0.0 XPos:0];
                              }
                              else {
                                  forceCollection = NO;
@@ -3975,7 +3936,7 @@ NSIndexPath *selected;
                [self deselectAtIndexPath:indexPath];
                if (error == nil && methodError == nil) {
                    [self.searchController setActive:NO];
-                   [self AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
+                   [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
                    [self startRetrieveDataWithRefresh:YES];
                }
                else {
@@ -4514,7 +4475,7 @@ NSIndexPath *selected;
     }
     else {
         [activityIndicatorView stopAnimating];
-        [self AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
+        [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
     }
 }
 
@@ -4702,7 +4663,7 @@ NSIndexPath *selected;
         }
     }
 
-    [self alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
+    [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
 //    NSLog(@"START");
     debugText.text = [NSString stringWithFormat:LOCALIZED_STR(@"METHOD\n%@\n\nPARAMETERS\n%@\n"), methodToCall, [[[NSString stringWithFormat:@"%@", parameters] stringByReplacingOccurrencesOfString:@" " withString:@""] stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
     elapsedTime = 0;
@@ -4910,7 +4871,7 @@ NSIndexPath *selected;
 }
 
 - (void)animateNoResultsFound {
-    [self alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
+    [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
     [activityIndicatorView stopAnimating];
 }
 
@@ -4924,7 +4885,7 @@ NSIndexPath *selected;
     self.sections[@""] = @[];
     [self animateNoResultsFound];
     [activeLayoutView reloadData];
-    [self AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
+    [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
 }
 
 - (BOOL)isEligibleForSections:(NSArray*)array {
@@ -5235,10 +5196,10 @@ NSIndexPath *selected;
     [self setFilternameLabel:labelText runFullscreenButtonCheck:NO forceHide:NO];
     
     if (!self.richResults.count) {
-        [self alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
+        [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
     }
     else {
-        [self alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
+        [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
     }
     NSDictionary *itemSizes = parameters [@"itemSizes"];
     if (IS_IPHONE) {
@@ -5264,7 +5225,7 @@ NSIndexPath *selected;
     [self setFlowLayoutParams];
     [activityIndicatorView stopAnimating];
     [activeLayoutView reloadData];
-    [self AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
+    [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
     [dataList setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
     [collectionView layoutSubviews];
     [collectionView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
@@ -6058,7 +6019,7 @@ NSIndexPath *selected;
                          }
                          completion:^(BOOL finished) {
                              [self configureLibraryView];
-                             [self AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
+                             [Utilities AnimTable:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
                              [activeLayoutView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
                          }];
     }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6010,12 +6010,13 @@ NSIndexPath *selected;
         enableCollectionView = [self collectionViewIsEnabled];
         recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
         [UIView animateWithDuration:0.2
+                              delay:0.0
+                            options:UIViewAnimationOptionCurveEaseIn
                          animations:^{
                              CGRect frame;
                              frame = [activeLayoutView frame];
                              frame.origin.x = viewWidth;
                              ((UITableView*)activeLayoutView).frame = frame;
-                             [UIView setAnimationCurve:UIViewAnimationCurveEaseIn];
                          }
                          completion:^(BOOL finished) {
                              [self configureLibraryView];

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -47,28 +47,6 @@
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     return self;
 }
-- (void)AnimLabel:(UIView*)Lab AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
-	[UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:seconds];
-	Lab.alpha = alphavalue;
-	CGRect frame;
-	frame = Lab.frame;
-	frame.origin.x = X;
-	Lab.frame = frame;
-    [UIView commitAnimations];
-    
-}
-
-- (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
-	[UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:seconds];
-	view.alpha = alphavalue;
-	CGRect frame;
-	frame = view.frame;
-	frame.origin.x = X;
-	view.frame = frame;
-    [UIView commitAnimations];
-}
 
 - (void)configureView {
     if (self.detailItem == nil) {
@@ -303,11 +281,11 @@
         }
         else {
             if (j == 0) {
-                [self AnimLabel:noInstances AnimDuration:0.3 Alpha:1.0 XPos:0];
+                [Utilities AnimLabel:noInstances AnimDuration:0.3 Alpha:1.0 XPos:0];
             }
             else {
                 [discoveredInstancesTableView reloadData];
-                [self AnimView:discoveredInstancesView AnimDuration:0.3 Alpha:1.0 XPos:0];
+                [Utilities AnimView:discoveredInstancesView AnimDuration:0.3 Alpha:1.0 XPos:0];
             }
         }
     }
@@ -405,7 +383,7 @@
                 NSURLSession *pingSession = [NSURLSession sharedSession];
                 NSURLSessionDataTask *pingConnection = [pingSession dataTaskWithURL:url];
                 [pingConnection resume];
-                [self AnimView:discoveredInstancesView AnimDuration:0.3 Alpha:1.0 XPos:self.view.frame.size.width];
+                [Utilities AnimView:discoveredInstancesView AnimDuration:0.3 Alpha:1.0 XPos:self.view.frame.size.width];
             }
         }
     }
@@ -422,8 +400,8 @@
     [activityIndicatorView startAnimating];
     [services removeAllObjects];
     startDiscover.enabled = NO;
-    [self AnimLabel:noInstances AnimDuration:0.3 Alpha:0.0 XPos:self.view.frame.size.width];
-    [self AnimView:discoveredInstancesView AnimDuration:0.3 Alpha:1.0 XPos:self.view.frame.size.width];
+    [Utilities AnimLabel:noInstances AnimDuration:0.3 Alpha:0.0 XPos:self.view.frame.size.width];
+    [Utilities AnimView:discoveredInstancesView AnimDuration:0.3 Alpha:1.0 XPos:self.view.frame.size.width];
 
     searching = NO;
     netServiceBrowser.delegate = self;
@@ -500,7 +478,7 @@
     timer = nil;
     netServiceBrowser = nil;
     services = nil;
-    [self AnimView:discoveredInstancesView AnimDuration:0.0 Alpha:1.0 XPos:self.view.frame.size.width];
+    [Utilities AnimView:discoveredInstancesView AnimDuration:0.0 Alpha:1.0 XPos:self.view.frame.size.width];
     descriptionUI.text = @"";
     usernameUI.text = @"";
     passwordUI.text = @"";
@@ -521,7 +499,7 @@
     mac_3_UI.textColor = [Utilities get1stLabelColor];
     mac_4_UI.textColor = [Utilities get1stLabelColor];
     mac_5_UI.textColor = [Utilities get1stLabelColor];
-    [self AnimLabel:noInstances AnimDuration:0.0 Alpha:0.0 XPos:self.view.frame.size.width];
+    [Utilities AnimLabel:noInstances AnimDuration:0.0 Alpha:0.0 XPos:self.view.frame.size.width];
 }
 
 - (void)viewDidLoad {

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -281,7 +281,7 @@
         }
         else {
             if (j == 0) {
-                [Utilities AnimLabel:noInstances AnimDuration:0.3 Alpha:1.0 XPos:0];
+                [Utilities AnimView:noInstances AnimDuration:0.3 Alpha:1.0 XPos:0];
             }
             else {
                 [discoveredInstancesTableView reloadData];
@@ -400,7 +400,7 @@
     [activityIndicatorView startAnimating];
     [services removeAllObjects];
     startDiscover.enabled = NO;
-    [Utilities AnimLabel:noInstances AnimDuration:0.3 Alpha:0.0 XPos:self.view.frame.size.width];
+    [Utilities AnimView:noInstances AnimDuration:0.3 Alpha:0.0 XPos:self.view.frame.size.width];
     [Utilities AnimView:discoveredInstancesView AnimDuration:0.3 Alpha:1.0 XPos:self.view.frame.size.width];
 
     searching = NO;
@@ -499,7 +499,7 @@
     mac_3_UI.textColor = [Utilities get1stLabelColor];
     mac_4_UI.textColor = [Utilities get1stLabelColor];
     mac_5_UI.textColor = [Utilities get1stLabelColor];
-    [Utilities AnimLabel:noInstances AnimDuration:0.0 Alpha:0.0 XPos:self.view.frame.size.width];
+    [Utilities AnimView:noInstances AnimDuration:0.0 Alpha:0.0 XPos:self.view.frame.size.width];
 }
 
 - (void)viewDidLoad {

--- a/XBMC Remote/KenBurns/JBKenBurnsView.m
+++ b/XBMC Remote/KenBurns/JBKenBurnsView.m
@@ -304,17 +304,18 @@
     [self addSubview:imageView];
     
     // Generates the animation
-    [UIView beginAnimations:nil context:NULL];
-    [UIView setAnimationDuration:self.timeTransition+2];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseIn];
-    CGAffineTransform rotate    = CGAffineTransformMakeRotation(rotation);
-    CGAffineTransform moveRight = CGAffineTransformMakeTranslation(moveX, moveY);
-    CGAffineTransform combo1    = CGAffineTransformConcat(rotate, moveRight);
-    CGAffineTransform zoomIn    = CGAffineTransformMakeScale(zoomInX, zoomInY);
-    CGAffineTransform transform = CGAffineTransformConcat(zoomIn, combo1);
-    imageView.transform = transform;
-    [UIView commitAnimations];
-    
+    [UIView animateWithDuration:self.timeTransition + 2
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseIn
+                     animations:^{
+        CGAffineTransform rotate    = CGAffineTransformMakeRotation(rotation);
+        CGAffineTransform moveRight = CGAffineTransformMakeTranslation(moveX, moveY);
+        CGAffineTransform combo1    = CGAffineTransformConcat(rotate, moveRight);
+        CGAffineTransform zoomIn    = CGAffineTransformMakeScale(zoomInX, zoomInY);
+        CGAffineTransform transform = CGAffineTransformConcat(zoomIn, combo1);
+        imageView.transform = transform;
+                     }
+                     completion:^(BOOL finished) {}];
     [self performSelector:@selector(_notifyDelegate:) withObject:num afterDelay:self.timeTransition];
 }
 

--- a/XBMC Remote/MessagesView.m
+++ b/XBMC Remote/MessagesView.m
@@ -46,20 +46,24 @@
 - (void)showMessage:(NSString*)message timeout:(NSTimeInterval)timeout color:(UIColor*)color {
     // first slide out
     CGRect frame = self.frame;
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-	[UIView setAnimationDuration:0.1];
-    self.frame = CGRectMake(frame.origin.x, -slideHeight, frame.size.width, frame.size.height);
-    [UIView commitAnimations];
+    [UIView animateWithDuration:0.1
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        self.frame = CGRectMake(frame.origin.x, -slideHeight, frame.size.width, frame.size.height);
+                     }
+                     completion:^(BOOL finished) {}];
     viewMessage.text = message;
     self.backgroundColor = color;
     // then slide in
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-	[UIView setAnimationDuration:0.2];
-    self.frame = CGRectMake(frame.origin.x, 0, frame.size.width, frame.size.height);
-    self.alpha = 1.0;
-    [UIView commitAnimations];
+    [UIView animateWithDuration:0.2
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        self.frame = CGRectMake(frame.origin.x, 0, frame.size.width, frame.size.height);
+        self.alpha = 1.0;
+                     }
+                     completion:^(BOOL finished) {}];
     //then slide out again after timeout seconds
     if (fadeoutTimer.valid) {
         [fadeoutTimer invalidate];
@@ -69,12 +73,14 @@
 
 - (void)fadeoutMessage:(NSTimer*)timer {
     CGRect frame = self.frame;
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-    [UIView setAnimationDuration:0.4];
-    self.frame = CGRectMake(frame.origin.x, -slideHeight, frame.size.width, frame.size.height);
-    self.alpha = 0.0;
-    [UIView commitAnimations];
+    [UIView animateWithDuration:0.4
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        self.frame = CGRectMake(frame.origin.x, -slideHeight, frame.size.width, frame.size.height);
+        self.alpha = 0.0;
+                     }
+                     completion:^(BOOL finished) {}];
     [fadeoutTimer invalidate];
     fadeoutTimer = nil;
 }

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -71,8 +71,8 @@
     IBOutlet UIButton *playlistButton;
     BOOL playlistHidden;
     BOOL nowPlayingHidden;
-    int anim;
-    int anim2;
+    int animationOptionFromView;
+    int animationOptionToView;
     BOOL startFlipDemo;
     IBOutlet OBSlider *ProgressSlider;
     NSIndexPath *selected;

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -71,8 +71,7 @@
     IBOutlet UIButton *playlistButton;
     BOOL playlistHidden;
     BOOL nowPlayingHidden;
-    int animationOptionFromView;
-    int animationOptionToView;
+    int animationOptionTransition;
     BOOL startFlipDemo;
     IBOutlet OBSlider *ProgressSlider;
     NSIndexPath *selected;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -974,7 +974,7 @@ long currentItemID;
         playerID = PLAYERID_UNKNOWN;
         selectedPlayerID = PLAYERID_UNKNOWN;
         storedItemID = 0;
-        [Utilities AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
+        [Utilities AnimView:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
         [playlistData performSelectorOnMainThread:@selector(removeAllObjects) withObject:nil waitUntilDone:YES];
         [self nothingIsPlaying];
         return;
@@ -1033,25 +1033,18 @@ long currentItemID;
     }];
 }
 
-- (void)alphaButton:(UIButton*)button AnimDuration:(NSTimeInterval)seconds show:(BOOL)show {
-    [UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:seconds];
-	button.hidden = show;
-    [UIView commitAnimations];
-}
-
 - (void)createPlaylist:(BOOL)forcePlaylistID animTableView:(BOOL)animTable { 
     if (!AppDelegate.instance.serverOnLine) {
         playerID = PLAYERID_UNKNOWN;
         selectedPlayerID = PLAYERID_UNKNOWN;
         storedItemID = 0;
-        [Utilities AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
+        [Utilities AnimView:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
         [playlistData performSelectorOnMainThread:@selector(removeAllObjects) withObject:nil waitUntilDone:YES];
         [self nothingIsPlaying];
         return;
     }
     if (!musicPartyMode && animTable) {
-        [Utilities AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
+        [Utilities AnimView:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
     }
     [activityIndicatorView startAnimating];
     GlobalData *obj = AppDelegate.instance.obj;
@@ -1068,17 +1061,17 @@ long currentItemID;
     if (playlistID == PLAYERID_MUSIC) {
         playerID = PLAYERID_MUSIC;
         playlistSegmentedControl.selectedSegmentIndex = PLAYERID_MUSIC;
-        [Utilities AnimButton:PartyModeButton AnimDuration:0.3 hidden:NO XPos:PARTYBUTTON_PADDING_LEFT];
+        [Utilities AnimView:PartyModeButton AnimDuration:0.3 Alpha:1.0 XPos:PARTYBUTTON_PADDING_LEFT];
     }
     else if (playlistID == PLAYERID_VIDEO) {
         playerID = PLAYERID_VIDEO;
         playlistSegmentedControl.selectedSegmentIndex = PLAYERID_VIDEO;
-        [Utilities AnimButton:PartyModeButton AnimDuration:0.3 hidden:YES XPos:-PartyModeButton.frame.size.width];
+        [Utilities AnimView:PartyModeButton AnimDuration:0.3 Alpha:0.0 XPos:-PartyModeButton.frame.size.width];
     }
     else if (playlistID == PLAYERID_PICTURES) {
         playerID = PLAYERID_PICTURES;
         playlistSegmentedControl.selectedSegmentIndex = PLAYERID_PICTURES;
-        [Utilities AnimButton:PartyModeButton AnimDuration:0.3 hidden:YES XPos:-PartyModeButton.frame.size.width];
+        [Utilities AnimView:PartyModeButton AnimDuration:0.3 Alpha:0.0 XPos:-PartyModeButton.frame.size.width];
     }
     [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
     [[Utilities getJsonRPC] callMethod:@"Playlist.GetItems"
@@ -1215,7 +1208,7 @@ long currentItemID;
         [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
     }
     else {
-        [Utilities AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:0];
+        [Utilities AnimView:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:0];
     }
     [playlistTableView performSelectorOnMainThread:@selector(reloadData) withObject:nil waitUntilDone:YES];
     [activityIndicatorView stopAnimating];
@@ -1819,21 +1812,14 @@ long currentItemID;
     }
 }
 
-- (void)changeAlphaView:(UIView*)view alpha:(CGFloat)value time:(NSTimeInterval)sec {
-    [UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:sec];
-	view.alpha = value;
-    [UIView commitAnimations];
-}
-
 - (IBAction)stopUpdateProgressBar:(id)sender {
     updateProgressBar = NO;
-    [self changeAlphaView:scrabbingView alpha:1.0 time:0.3];
+    [Utilities alphaView:scrabbingView AnimDuration:0.3 Alpha:1.0];
 }
 
 - (IBAction)startUpdateProgressBar:(id)sender {
     [self SimpleAction:@"Player.Seek" params:[Utilities buildPlayerSeekPercentageParams:playerID percentage:ProgressSlider.value] reloadPlaylist:NO startProgressBar:YES];
-    [self changeAlphaView:scrabbingView alpha:0.0 time:0.3];
+    [Utilities alphaView:scrabbingView AnimDuration:0.3 Alpha:0.0];
 }
 
 - (IBAction)updateCurrentTime:(id)sender {
@@ -2584,7 +2570,7 @@ long currentItemID;
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
-    [Utilities AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
+    [Utilities AnimView:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
     songDetailsView.alpha = 0;
     [playlistTableView setEditing:NO animated:YES];
     [[NSNotificationCenter defaultCenter] removeObserver: self];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1463,7 +1463,6 @@ long currentItemID;
     NSTimeInterval iOS7effectDuration = 1.0;
     if (!nowPlayingView.hidden) {
         iOS7effectDuration = 0.0;
-        nowPlayingView.hidden = YES;
         transitionView = nowPlayingView;
         transitionedView = playlistView;
         playlistHidden = NO;
@@ -1478,7 +1477,6 @@ long currentItemID;
         [self IOS7effect:effectColor barTintColor:barColor effectDuration:0.2];
     }
     else {
-        playlistView.hidden = YES;
         transitionView = playlistView;
         transitionedView = nowPlayingView;
         playlistHidden = YES;
@@ -1503,6 +1501,7 @@ long currentItemID;
                           delay:0.0
                         options:UIViewAnimationOptionCurveEaseIn
                      animations:^{
+        transitionView.alpha = 0.0;
         [UIView setAnimationTransition:anim forView:transitionView cache:YES];
                      }
                      completion:^(BOOL finished) {
@@ -1515,6 +1514,7 @@ long currentItemID;
                                               self.navigationItem.titleView.hidden = NO;
                                               playlistActionView.frame = playlistToolBarOriginY;
                                               playlistActionView.alpha = (int)nowPlayingHidden;
+                                              transitionedView.alpha = 1.0;
                                               [UIView setAnimationTransition:anim2 forView:transitionedView cache:YES];
                                           }
                                           completion:^(BOOL finished) {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -155,14 +155,13 @@ typedef enum {
 - (void)resizeCellBar:(CGFloat)width image:(UIImageView*)cellBarImage {
     NSTimeInterval time = (width == 0) ? 0.1 : 1.0;
     width = MIN(width, MAX_CELLBAR_WIDTH);
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:time];
-    [UIView setAnimationCurve:UIViewAnimationCurveLinear];
-    CGRect frame;
-    frame = cellBarImage.frame;
-    frame.size.width = width;
-    cellBarImage.frame = frame;
-    [UIView commitAnimations];
+    [UIView animateWithDuration:time
+                     animations:^{
+        CGRect frame;
+        frame = cellBarImage.frame;
+        frame.size.width = width;
+        cellBarImage.frame = frame;
+                     }];
 }
 
 - (IBAction)togglePartyMode:(id)sender {
@@ -1416,6 +1415,8 @@ long currentItemID;
         startFlipDemo = NO;
     }
     [UIView animateWithDuration:0.2
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseIn
                      animations:^{ 
                          button.hidden = YES;
                          if (nowPlayingHidden) {
@@ -1439,18 +1440,20 @@ long currentItemID;
                              [button setImage:image forState:UIControlStateHighlighted];
                              [button setImage:image forState:UIControlStateSelected];
                          }
-                         [UIView setAnimationCurve:UIViewAnimationCurveEaseIn];
                          [UIView setAnimationTransition:anim forView:button cache:YES];
                      } 
                      completion:^(BOOL finished) {
-                         [UIView beginAnimations:nil context:nil];
-                         button.hidden = NO;
-                         [UIView setAnimationDuration:0.5];
-                         [UIView setAnimationDelegate:self];
-                         [UIView setAnimationCurve:UIViewAnimationCurveEaseOut];
-                         [UIView setAnimationTransition:anim2 forView:button cache:YES];
-                         [UIView commitAnimations];
-                     }];
+                        [UIView animateWithDuration:0.5
+                                              delay:0.0
+                                            options:UIViewAnimationOptionCurveEaseOut
+                                         animations:^{
+                                            button.hidden = NO;
+                                            [UIView setAnimationTransition:anim2 forView:button cache:YES];
+                                         }
+                                         completion:^(BOOL finished) {}
+                        ];
+                     }
+    ];
 }
 
 - (void)animViews {
@@ -1497,14 +1500,16 @@ long currentItemID;
     [self IOS7colorProgressSlider:effectColor];
 
     [UIView animateWithDuration:0.2
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseIn
                      animations:^{
-                         [UIView setAnimationCurve:UIViewAnimationCurveEaseIn];
-                         [UIView setAnimationTransition:anim forView:transitionView cache:YES];
+        [UIView setAnimationTransition:anim forView:transitionView cache:YES];
                      }
                      completion:^(BOOL finished) {
                          [UIView animateWithDuration:0.5
+                                               delay:0.0
+                                             options:UIViewAnimationOptionCurveEaseOut
                                           animations:^{
-                                              [UIView setAnimationCurve:UIViewAnimationCurveEaseOut];
                                               playlistView.hidden = playlistHidden;
                                               nowPlayingView.hidden = nowPlayingHidden;
                                               self.navigationItem.titleView.hidden = NO;
@@ -1596,19 +1601,21 @@ long currentItemID;
     if ((nothingIsPlaying && songDetailsView.alpha == 0.0) || playerID == PLAYERID_PICTURES) {
         return;
     }
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-    [UIView setAnimationDuration:0.2];
-    if (songDetailsView.alpha == 0) {
-        songDetailsView.alpha = 1.0;
-        [self loadCodecView];
-        itemDescription.scrollsToTop = YES;
-    }
-    else {
-        songDetailsView.alpha = 0.0;
-        itemDescription.scrollsToTop = NO;
-    }
-    [UIView commitAnimations];
+    [UIView animateWithDuration:0.2
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        if (songDetailsView.alpha == 0) {
+            songDetailsView.alpha = 1.0;
+            [self loadCodecView];
+            itemDescription.scrollsToTop = YES;
+        }
+        else {
+            songDetailsView.alpha = 0.0;
+            itemDescription.scrollsToTop = NO;
+        }
+                     }
+                     completion:^(BOOL finished) {}];
 }
 
 - (void)toggleHighlight:(UIButton*)button {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -211,28 +211,6 @@ typedef enum {
     view.hidden = value;
 }
 
-- (void)AnimTable:(UITableView*)tV AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
-	[UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:seconds];
-	tV.alpha = alphavalue;
-	CGRect frame;
-	frame = tV.frame;
-	frame.origin.x = X;
-	tV.frame = frame;
-    [UIView commitAnimations];
-}
-
-- (void)AnimButton:(UIButton*)button AnimDuration:(NSTimeInterval)seconds hidden:(BOOL)hiddenValue XPos:(int)X {
-	[UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:seconds];
-	CGRect frame;
-	frame = button.frame;
-	frame.origin.x = X;
-	button.frame = frame;
-    button.hidden = hiddenValue;
-    [UIView commitAnimations];
-}
-
 - (UIImage*)resizeImage:(UIImage*)image width:(int)destWidth height:(int)destHeight padding:(int)destPadding {
 	int w = image.size.width;
     int h = image.size.height;
@@ -996,7 +974,7 @@ long currentItemID;
         playerID = PLAYERID_UNKNOWN;
         selectedPlayerID = PLAYERID_UNKNOWN;
         storedItemID = 0;
-        [self AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
+        [Utilities AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
         [playlistData performSelectorOnMainThread:@selector(removeAllObjects) withObject:nil waitUntilDone:YES];
         [self nothingIsPlaying];
         return;
@@ -1055,13 +1033,6 @@ long currentItemID;
     }];
 }
 
-- (void)alphaView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue {
-    [UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:seconds];
-	view.alpha = alphavalue;
-    [UIView commitAnimations];
-}
-
 - (void)alphaButton:(UIButton*)button AnimDuration:(NSTimeInterval)seconds show:(BOOL)show {
     [UIView beginAnimations:nil context:nil];
 	[UIView setAnimationDuration:seconds];
@@ -1074,13 +1045,13 @@ long currentItemID;
         playerID = PLAYERID_UNKNOWN;
         selectedPlayerID = PLAYERID_UNKNOWN;
         storedItemID = 0;
-        [self AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
+        [Utilities AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
         [playlistData performSelectorOnMainThread:@selector(removeAllObjects) withObject:nil waitUntilDone:YES];
         [self nothingIsPlaying];
         return;
     }
     if (!musicPartyMode && animTable) {
-        [self AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
+        [Utilities AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
     }
     [activityIndicatorView startAnimating];
     GlobalData *obj = AppDelegate.instance.obj;
@@ -1097,19 +1068,19 @@ long currentItemID;
     if (playlistID == PLAYERID_MUSIC) {
         playerID = PLAYERID_MUSIC;
         playlistSegmentedControl.selectedSegmentIndex = PLAYERID_MUSIC;
-        [self AnimButton:PartyModeButton AnimDuration:0.3 hidden:NO XPos:PARTYBUTTON_PADDING_LEFT];
+        [Utilities AnimButton:PartyModeButton AnimDuration:0.3 hidden:NO XPos:PARTYBUTTON_PADDING_LEFT];
     }
     else if (playlistID == PLAYERID_VIDEO) {
         playerID = PLAYERID_VIDEO;
         playlistSegmentedControl.selectedSegmentIndex = PLAYERID_VIDEO;
-        [self AnimButton:PartyModeButton AnimDuration:0.3 hidden:YES XPos:-PartyModeButton.frame.size.width];
+        [Utilities AnimButton:PartyModeButton AnimDuration:0.3 hidden:YES XPos:-PartyModeButton.frame.size.width];
     }
     else if (playlistID == PLAYERID_PICTURES) {
         playerID = PLAYERID_PICTURES;
         playlistSegmentedControl.selectedSegmentIndex = PLAYERID_PICTURES;
-        [self AnimButton:PartyModeButton AnimDuration:0.3 hidden:YES XPos:-PartyModeButton.frame.size.width];
+        [Utilities AnimButton:PartyModeButton AnimDuration:0.3 hidden:YES XPos:-PartyModeButton.frame.size.width];
     }
-    [self alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
+    [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
     [[Utilities getJsonRPC] callMethod:@"Playlist.GetItems"
                         withParameters:@{@"properties": @[@"thumbnail",
                                                           @"duration",
@@ -1135,10 +1106,10 @@ long currentItemID;
                    if ([NSJSONSerialization isValidJSONObject:methodResult]) {
                        NSArray *playlistItems = methodResult[@"items"];
                        if (playlistItems.count == 0) {
-                           [self alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
+                           [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
                        }
                        else {
-                           [self alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
+                           [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
                        }
                        NSString *serverURL;
                        serverURL = [NSString stringWithFormat:@"%@:%@/vfs/", obj.serverIP, obj.serverPort];
@@ -1241,10 +1212,10 @@ long currentItemID;
 - (void)showPlaylistTable {
     numResults = (int)playlistData.count;
     if (numResults == 0) {
-        [self alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
+        [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
     }
     else {
-        [self AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:0];
+        [Utilities AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:0];
     }
     [playlistTableView performSelectorOnMainThread:@selector(reloadData) withObject:nil waitUntilDone:YES];
     [activityIndicatorView stopAnimating];
@@ -2613,7 +2584,7 @@ long currentItemID;
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
-    [self AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
+    [Utilities AnimTable:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
     songDetailsView.alpha = 0;
     [playlistTableView setEditing:NO animated:YES];
     [[NSNotificationCenter defaultCenter] removeObserver: self];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -373,7 +373,7 @@ long currentItemID;
         [playlistButton setImage:buttonImage forState:UIControlStateHighlighted];
         [playlistButton setImage:buttonImage forState:UIControlStateSelected];
         if (startFlipDemo) {
-            [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(startFlipDemo) userInfo:nil repeats:NO];
+            [NSTimer scheduledTimerWithTimeInterval:0.5 target:self selector:@selector(startFlipDemo) userInfo:nil repeats:NO];
             startFlipDemo = NO;
         }
     }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1410,13 +1410,12 @@ long currentItemID;
 
 - (void)flipAnimButton:(UIButton*)button demo:(BOOL)demo {
     if (demo) {
-        animationOptionFromView = UIViewAnimationOptionTransitionFlipFromLeft;
-        animationOptionToView = UIViewAnimationOptionTransitionFlipFromLeft;
+        animationOptionTransition = UIViewAnimationOptionTransitionFlipFromLeft;
         startFlipDemo = NO;
     }
     [UIView transitionWithView:button
                       duration:0.2
-                       options:UIViewAnimationOptionCurveEaseIn | animationOptionFromView
+                       options:UIViewAnimationOptionCurveEaseIn | animationOptionTransition
                     animations:^{
                          button.hidden = YES;
                          if (nowPlayingHidden) {
@@ -1444,7 +1443,7 @@ long currentItemID;
                      completion:^(BOOL finished) {
                         [UIView transitionWithView:button
                                           duration:0.5
-                                           options:UIViewAnimationOptionCurveEaseOut | animationOptionToView
+                                           options:UIViewAnimationOptionCurveEaseOut | animationOptionTransition
                                         animations:^{
                                             button.hidden = NO;
                                         }
@@ -1467,8 +1466,7 @@ long currentItemID;
         nowPlayingHidden = YES;
         self.navigationItem.title = LOCALIZED_STR(@"Playlist");
         self.navigationItem.titleView.hidden = YES;
-        animationOptionFromView = UIViewAnimationOptionTransitionFlipFromRight;
-        animationOptionToView = UIViewAnimationOptionTransitionFlipFromRight;
+        animationOptionTransition = UIViewAnimationOptionTransitionFlipFromRight;
         effectColor = UIColor.clearColor;
         barColor = TINT_COLOR;
         playlistToolBarOriginY.origin.y = playlistTableView.frame.size.height - playlistTableView.scrollIndicatorInsets.bottom;
@@ -1481,8 +1479,7 @@ long currentItemID;
         nowPlayingHidden = NO;
         self.navigationItem.title = LOCALIZED_STR(@"Now Playing");
         self.navigationItem.titleView.hidden = YES;
-        animationOptionFromView = UIViewAnimationOptionTransitionFlipFromLeft;
-        animationOptionToView = UIViewAnimationOptionTransitionFlipFromLeft;
+        animationOptionTransition = UIViewAnimationOptionTransitionFlipFromLeft;
         if (foundEffectColor == nil) {
             effectColor = UIColor.clearColor;
             barColor = TINT_COLOR;
@@ -1497,14 +1494,14 @@ long currentItemID;
     
     [UIView transitionWithView:transitionView
                       duration:0.2
-                       options:UIViewAnimationOptionCurveEaseIn | animationOptionFromView
+                       options:UIViewAnimationOptionCurveEaseIn | animationOptionTransition
                     animations:^{
                           transitionView.alpha = 0.0;
                      }
                      completion:^(BOOL finished) {
                         [UIView transitionWithView:transitionedView
                                           duration:0.5
-                                           options:UIViewAnimationOptionCurveEaseOut | animationOptionToView
+                                           options:UIViewAnimationOptionCurveEaseOut | animationOptionTransition
                                         animations:^{
                                               playlistView.hidden = playlistHidden;
                                               nowPlayingView.hidden = nowPlayingHidden;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1410,14 +1410,14 @@ long currentItemID;
 
 - (void)flipAnimButton:(UIButton*)button demo:(BOOL)demo {
     if (demo) {
-        anim = UIViewAnimationTransitionFlipFromLeft;
-        anim2 = UIViewAnimationTransitionFlipFromLeft;
+        animationOptionFromView = UIViewAnimationOptionTransitionFlipFromLeft;
+        animationOptionToView = UIViewAnimationOptionTransitionFlipFromLeft;
         startFlipDemo = NO;
     }
-    [UIView animateWithDuration:0.2
-                          delay:0.0
-                        options:UIViewAnimationOptionCurveEaseIn
-                     animations:^{ 
+    [UIView transitionWithView:button
+                      duration:0.2
+                       options:UIViewAnimationOptionCurveEaseIn | animationOptionFromView
+                    animations:^{
                          button.hidden = YES;
                          if (nowPlayingHidden) {
                              UIImage *buttonImage;
@@ -1440,17 +1440,15 @@ long currentItemID;
                              [button setImage:image forState:UIControlStateHighlighted];
                              [button setImage:image forState:UIControlStateSelected];
                          }
-                         [UIView setAnimationTransition:anim forView:button cache:YES];
                      } 
                      completion:^(BOOL finished) {
-                        [UIView animateWithDuration:0.5
-                                              delay:0.0
-                                            options:UIViewAnimationOptionCurveEaseOut
-                                         animations:^{
+                        [UIView transitionWithView:button
+                                          duration:0.5
+                                           options:UIViewAnimationOptionCurveEaseOut | animationOptionToView
+                                        animations:^{
                                             button.hidden = NO;
-                                            [UIView setAnimationTransition:anim2 forView:button cache:YES];
-                                         }
-                                         completion:^(BOOL finished) {}
+                                        }
+                                        completion:^(BOOL finished) {}
                         ];
                      }
     ];
@@ -1469,8 +1467,8 @@ long currentItemID;
         nowPlayingHidden = YES;
         self.navigationItem.title = LOCALIZED_STR(@"Playlist");
         self.navigationItem.titleView.hidden = YES;
-        anim = UIViewAnimationTransitionFlipFromRight;
-        anim2 = UIViewAnimationTransitionFlipFromRight;
+        animationOptionFromView = UIViewAnimationOptionTransitionFlipFromRight;
+        animationOptionToView = UIViewAnimationOptionTransitionFlipFromRight;
         effectColor = UIColor.clearColor;
         barColor = TINT_COLOR;
         playlistToolBarOriginY.origin.y = playlistTableView.frame.size.height - playlistTableView.scrollIndicatorInsets.bottom;
@@ -1483,8 +1481,8 @@ long currentItemID;
         nowPlayingHidden = NO;
         self.navigationItem.title = LOCALIZED_STR(@"Now Playing");
         self.navigationItem.titleView.hidden = YES;
-        anim = UIViewAnimationTransitionFlipFromLeft;
-        anim2 = UIViewAnimationTransitionFlipFromLeft;
+        animationOptionFromView = UIViewAnimationOptionTransitionFlipFromLeft;
+        animationOptionToView = UIViewAnimationOptionTransitionFlipFromLeft;
         if (foundEffectColor == nil) {
             effectColor = UIColor.clearColor;
             barColor = TINT_COLOR;
@@ -1496,26 +1494,24 @@ long currentItemID;
         playlistToolBarOriginY.origin.y = playlistTableView.frame.size.height;
     }
     [self IOS7colorProgressSlider:effectColor];
-
-    [UIView animateWithDuration:0.2
-                          delay:0.0
-                        options:UIViewAnimationOptionCurveEaseIn
-                     animations:^{
-        transitionView.alpha = 0.0;
-        [UIView setAnimationTransition:anim forView:transitionView cache:YES];
+    
+    [UIView transitionWithView:transitionView
+                      duration:0.2
+                       options:UIViewAnimationOptionCurveEaseIn | animationOptionFromView
+                    animations:^{
+                          transitionView.alpha = 0.0;
                      }
                      completion:^(BOOL finished) {
-                         [UIView animateWithDuration:0.5
-                                               delay:0.0
-                                             options:UIViewAnimationOptionCurveEaseOut
-                                          animations:^{
+                        [UIView transitionWithView:transitionedView
+                                          duration:0.5
+                                           options:UIViewAnimationOptionCurveEaseOut | animationOptionToView
+                                        animations:^{
                                               playlistView.hidden = playlistHidden;
                                               nowPlayingView.hidden = nowPlayingHidden;
                                               self.navigationItem.titleView.hidden = NO;
                                               playlistActionView.frame = playlistToolBarOriginY;
                                               playlistActionView.alpha = (int)nowPlayingHidden;
                                               transitionedView.alpha = 1.0;
-                                              [UIView setAnimationTransition:anim2 forView:transitionedView cache:YES];
                                           }
                                           completion:^(BOOL finished) {
                                               if (iOS7effectDuration) {

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -403,24 +403,11 @@
 
 - (void)showSubInfo:(NSString*)message timeout:(NSTimeInterval)timeout color:(UIColor*)color {
     // first fadeout
-    [UIView animateWithDuration:0.1
-                          delay:0.0
-                        options:UIViewAnimationOptionCurveEaseInOut
-                     animations:^{
-        subsInfoLabel.alpha = 0;
-                     }
-                     completion:^(BOOL finished) {}];
+    [Utilities alphaView:subsInfoLabel AnimDuration:0.1 Alpha:0.0];
     subsInfoLabel.text = message;
     subsInfoLabel.textColor = color;
     // then fade in
-    [UIView animateWithDuration:0.1
-                          delay:0.0
-                        options:UIViewAnimationOptionCurveEaseInOut
-                     animations:^{
-        subsInfoLabel.hidden = NO;
-        subsInfoLabel.alpha = 0.8;
-                     }
-                     completion:^(BOOL finished) {}];
+    [Utilities alphaView:subsInfoLabel AnimDuration:0.1 Alpha:0.8];
     //then fade out again after timeout seconds
     if (fadeoutTimer.valid) {
         [fadeoutTimer invalidate];
@@ -430,13 +417,7 @@
 
 
 - (void)fadeoutSubs {
-    [UIView animateWithDuration:0.2
-                          delay:0.0
-                        options:UIViewAnimationOptionCurveEaseInOut
-                     animations:^{
-        subsInfoLabel.alpha = 0;
-                     }
-                     completion:^(BOOL finished) {}];
+    [Utilities alphaView:subsInfoLabel AnimDuration:0.2 Alpha:0.0];
     [fadeoutTimer invalidate];
     fadeoutTimer = nil;
 }
@@ -1156,23 +1137,11 @@ NSInteger buttonAction;
 - (IBAction)toggleQuickHelp:(id)sender {
     [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputFinished" object:nil userInfo:nil];
     if (quickHelpView.alpha == 0) {
-        [UIView animateWithDuration:0.2
-                              delay:0.0
-                            options:UIViewAnimationOptionCurveEaseInOut
-                         animations:^{
-            quickHelpView.alpha = 1.0;
-                         }
-                         completion:^(BOOL finished) {}];
+        [Utilities alphaView:quickHelpView AnimDuration:0.2 Alpha:1.0];
         [self.navigationController setNavigationBarHidden:NO animated:YES];
     }
     else {
-        [UIView animateWithDuration:0.2
-                              delay:0.0
-                            options:UIViewAnimationOptionCurveEaseInOut
-                         animations:^{
-            quickHelpView.alpha = 0.0;
-                         }
-                         completion:^(BOOL finished) {}];
+        [Utilities alphaView:quickHelpView AnimDuration:0.2 Alpha:0.0];
         [self.navigationController setNavigationBarHidden:NO animated:YES];
     }
 }

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -402,21 +402,25 @@
 # pragma mark - view Effects
 
 - (void)showSubInfo:(NSString*)message timeout:(NSTimeInterval)timeout color:(UIColor*)color {
-    // first fadeout 
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-	[UIView setAnimationDuration:0.1];
-    subsInfoLabel.alpha = 0;
-    [UIView commitAnimations];
+    // first fadeout
+    [UIView animateWithDuration:0.1
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        subsInfoLabel.alpha = 0;
+                     }
+                     completion:^(BOOL finished) {}];
     subsInfoLabel.text = message;
     subsInfoLabel.textColor = color;
     // then fade in
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-	[UIView setAnimationDuration:0.1];
-    subsInfoLabel.hidden = NO;
-    subsInfoLabel.alpha = 0.8;
-    [UIView commitAnimations];
+    [UIView animateWithDuration:0.1
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        subsInfoLabel.hidden = NO;
+        subsInfoLabel.alpha = 0.8;
+                     }
+                     completion:^(BOOL finished) {}];
     //then fade out again after timeout seconds
     if (fadeoutTimer.valid) {
         [fadeoutTimer invalidate];
@@ -426,11 +430,13 @@
 
 
 - (void)fadeoutSubs {
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-	[UIView setAnimationDuration:0.2];
-    subsInfoLabel.alpha = 0;
-    [UIView commitAnimations];
+    [UIView animateWithDuration:0.2
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        subsInfoLabel.alpha = 0;
+                     }
+                     completion:^(BOOL finished) {}];
     [fadeoutTimer invalidate];
     fadeoutTimer = nil;
 }
@@ -454,40 +460,43 @@
         frame = gestureZoneView.frame;
         frame.origin.x = -self.view.frame.size.width;
         gestureZoneView.frame = frame;
-        
-        [UIView beginAnimations:nil context:nil];
-        [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-        [UIView setAnimationDuration:0.3];
-        frame = gestureZoneView.frame;
-        frame.origin.x = 0;
-        gestureZoneView.frame = frame;
-        
-        frame = buttonZoneView.frame;
-        frame.origin.x = self.view.frame.size.width;
-        buttonZoneView.frame = frame;
-        
-        gestureZoneView.alpha = 1;
-        buttonZoneView.alpha = 0;
-        [UIView commitAnimations];
+        [UIView animateWithDuration:0.3
+                              delay:0.0
+                            options:UIViewAnimationOptionCurveEaseInOut
+                         animations:^{
+            CGRect frame = gestureZoneView.frame;
+            frame.origin.x = 0;
+            gestureZoneView.frame = frame;
+            
+            frame = buttonZoneView.frame;
+            frame.origin.x = self.view.frame.size.width;
+            buttonZoneView.frame = frame;
+            
+            gestureZoneView.alpha = 1;
+            buttonZoneView.alpha = 0;
+                         }
+                         completion:^(BOOL finished) {}];
         imageName = @"circle";
     }
     else {
         isGestureViewActive = NO;
-        CGRect frame;
-        [UIView beginAnimations:nil context:nil];
-        [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-        [UIView setAnimationDuration:0.3];
-        frame = gestureZoneView.frame;
-        frame.origin.x = -self.view.frame.size.width;
-        gestureZoneView.frame = frame;
-        
-        frame = buttonZoneView.frame;
-        frame.origin.x = 0;
-        buttonZoneView.frame = frame;
-        
-        gestureZoneView.alpha = 0;
-        buttonZoneView.alpha = 1;
-        [UIView commitAnimations];
+        [UIView animateWithDuration:0.3
+                              delay:0.0
+                            options:UIViewAnimationOptionCurveEaseInOut
+                         animations:^{
+            CGRect frame;
+            frame = gestureZoneView.frame;
+            frame.origin.x = -self.view.frame.size.width;
+            gestureZoneView.frame = frame;
+            
+            frame = buttonZoneView.frame;
+            frame.origin.x = 0;
+            buttonZoneView.frame = frame;
+            
+            gestureZoneView.alpha = 0;
+            buttonZoneView.alpha = 1;
+                         }
+                         completion:^(BOOL finished) {}];
         imageName = @"finger";
     }
     if ([sender isKindOfClass: [UIButton class]]) {
@@ -1147,19 +1156,23 @@ NSInteger buttonAction;
 - (IBAction)toggleQuickHelp:(id)sender {
     [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputFinished" object:nil userInfo:nil];
     if (quickHelpView.alpha == 0) {
-        [UIView beginAnimations:nil context:nil];
-        [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-        [UIView setAnimationDuration:0.2];
-        quickHelpView.alpha = 1.0;
-        [UIView commitAnimations];
+        [UIView animateWithDuration:0.2
+                              delay:0.0
+                            options:UIViewAnimationOptionCurveEaseInOut
+                         animations:^{
+            quickHelpView.alpha = 1.0;
+                         }
+                         completion:^(BOOL finished) {}];
         [self.navigationController setNavigationBarHidden:NO animated:YES];
     }
     else {
-        [UIView beginAnimations:nil context:nil];
-        [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-        [UIView setAnimationDuration:0.2];
-        quickHelpView.alpha = 0.0;
-        [UIView commitAnimations];
+        [UIView animateWithDuration:0.2
+                              delay:0.0
+                            options:UIViewAnimationOptionCurveEaseInOut
+                         animations:^{
+            quickHelpView.alpha = 0.0;
+                         }
+                         completion:^(BOOL finished) {}];
         [self.navigationController setNavigationBarHidden:NO animated:YES];
     }
 }

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -335,7 +335,7 @@
                         ];
                    }
                    [_tableView reloadData];
-                   [Utilities AnimTable:_tableView AnimDuration:0.3 Alpha:1.0 XPos:0];
+                   [Utilities AnimView:_tableView AnimDuration:0.3 Alpha:1.0 XPos:0];
                    [self scrollTableRow:settingOptions];
                }
            }];
@@ -756,19 +756,12 @@
 
 #pragma mark - UISlider
 
-- (void)changeAlphaView:(UIView*)view alpha:(CGFloat)value time:(NSTimeInterval)sec {
-    [UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:sec];
-	view.alpha = value;
-    [UIView commitAnimations];
-}
-
 - (void)startUpdateSlider:(id)sender {
-    [self changeAlphaView:scrubbingView alpha:1.0 time:0.3];
+    [Utilities alphaView:scrubbingView AnimDuration:0.3 Alpha:1.0];
 }
 
 - (void)stopUpdateSlider:(id)sender {
-    [self changeAlphaView:scrubbingView alpha:0.0 time:0.3];
+    [Utilities alphaView:scrubbingView AnimDuration:0.3 Alpha:0.0];
     NSString *command = @"Settings.SetSettingValue";
     self.detailItem[@"value"] = @(storeSliderValue);
     NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys: self.detailItem[@"id"], @"setting", self.detailItem[@"value"], @"value", nil];

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -335,7 +335,7 @@
                         ];
                    }
                    [_tableView reloadData];
-                   [self AnimTable:_tableView AnimDuration:0.3 Alpha:1.0 XPos:0];
+                   [Utilities AnimTable:_tableView AnimDuration:0.3 Alpha:1.0 XPos:0];
                    [self scrollTableRow:settingOptions];
                }
            }];
@@ -604,18 +604,6 @@
 }
 
 #pragma mark Table view delegate
-
-- (void)AnimTable:(UITableView*)tV AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
-	[UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:seconds];
-	tV.alpha = alphavalue;
-	CGRect frame;
-	frame = tV.frame;
-	frame.origin.x = X;
-    frame.origin.y = 0;
-	tV.frame = frame;
-    [UIView commitAnimations];
-}
 
 - (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -558,7 +558,7 @@ double round(double d) {
         // Ensure we draw the rounded edges around thumbnail images
         jewelView.image = [Utilities applyRoundedEdgesImage:imageToShow drawBorder:YES];
     }
-    [self alphaImage:jewelView AnimDuration:0.1 Alpha:1.0];
+    [Utilities alphaImage:jewelView AnimDuration:0.1 Alpha:1.0];
 }
 
 - (void)setIOS7barTintColor:(UIColor*)tintColor {
@@ -1311,7 +1311,7 @@ double round(double d) {
             if (strongSelf != nil && strongSelf->enableKenBurns) {
                 fanartView.alpha = 0;
                 [sf elabKenBurns:image];
-                [sf alphaView:sf.kenView AnimDuration:1.5 Alpha:0.2];
+                [Utilities alphaView:sf.kenView AnimDuration:1.5 Alpha:0.2];
             }
         }
         else {
@@ -1321,7 +1321,7 @@ double round(double d) {
                                   __auto_type strongSelf = sf;
                                   if (strongSelf != nil && strongSelf->enableKenBurns) {
                                       [sf elabKenBurns:image];
-                                      [sf alphaView:sf.kenView AnimDuration:1.5 Alpha:0.2];
+                                      [Utilities alphaView:sf.kenView AnimDuration:1.5 Alpha:0.2];
                                   }
                               }
              ];
@@ -1344,13 +1344,13 @@ double round(double d) {
         foundTag = [sender tag];
     }
     if (foundTag == 1) {
-        [self alphaView:closeButton AnimDuration:1.5 Alpha:0];
-        [self alphaView:scrollView AnimDuration:1.5 Alpha:1];
+        [Utilities alphaView:closeButton AnimDuration:1.5 Alpha:0];
+        [Utilities alphaView:scrollView AnimDuration:1.5 Alpha:1];
         if (!enableKenBurns) {
-            [self alphaImage:fanartView AnimDuration:1.5 Alpha:0.2];// cool
+            [Utilities alphaImage:fanartView AnimDuration:1.5 Alpha:0.2];// cool
         }
         else {
-            [self alphaView:self.kenView AnimDuration:1.5 Alpha:0.2];// cool
+            [Utilities alphaView:self.kenView AnimDuration:1.5 Alpha:0.2];// cool
         }
         [self.navigationController setNavigationBarHidden:NO animated:YES];
         if (IS_IPAD) {
@@ -1399,17 +1399,17 @@ double round(double d) {
                                  }
                                  completion:^(BOOL finished) {
                                      [self elabKenBurns:fanartView.image];
-                                     [self alphaView:self.kenView AnimDuration:1.5 Alpha:alphaValue];
+                                     [Utilities alphaView:self.kenView AnimDuration:1.5 Alpha:alphaValue];
                                  }
                  ];
             }
         }
-        [self alphaView:scrollView AnimDuration:1.5 Alpha:0];
+        [Utilities alphaView:scrollView AnimDuration:1.5 Alpha:0];
         if (!enableKenBurns) {
-            [self alphaImage:fanartView AnimDuration:1.5 Alpha:1];// cool
+            [Utilities alphaImage:fanartView AnimDuration:1.5 Alpha:1];// cool
         }
         else {
-            [self alphaView:self.kenView AnimDuration:1.5 Alpha:1];// cool
+            [Utilities alphaView:self.kenView AnimDuration:1.5 Alpha:1];// cool
         }
         if (closeButton == nil) {
             int cbWidth = clearLogoWidth / 2;
@@ -1436,7 +1436,7 @@ double round(double d) {
             closeButton.alpha = 0;
             [self.view addSubview:closeButton];
         }
-        [self alphaView:closeButton AnimDuration:1.5 Alpha:1];
+        [Utilities alphaView:closeButton AnimDuration:1.5 Alpha:1];
     }
     [self scrollDown:nil];
 }
@@ -1447,37 +1447,18 @@ double round(double d) {
     int scrolled = theScrollView.contentOffset.y;
     bool at_bottom = scrolled >= height_content - height_bounds;
     if (arrow_continue_down.alpha && at_bottom) {
-        [self alphaView:arrow_continue_down AnimDuration:0.3 Alpha:0];
+        [Utilities alphaView:arrow_continue_down AnimDuration:0.3 Alpha:0];
     }
     else if (!arrow_continue_down.alpha && !at_bottom) {
-        [self alphaView:arrow_continue_down AnimDuration:0.3 Alpha:ARROW_ALPHA];
+        [Utilities alphaView:arrow_continue_down AnimDuration:0.3 Alpha:ARROW_ALPHA];
     }
     bool at_top = theScrollView.contentOffset.y <= -scrollView.contentInset.top;
     if (arrow_back_up.alpha && at_top) {
-        [self alphaView:arrow_back_up AnimDuration:0.3 Alpha:0];
+        [Utilities alphaView:arrow_back_up AnimDuration:0.3 Alpha:0];
     }
     else if (!arrow_back_up.alpha && !at_top) {
-        [self alphaView:arrow_back_up AnimDuration:0.3 Alpha:ARROW_ALPHA];
+        [Utilities alphaView:arrow_back_up AnimDuration:0.3 Alpha:ARROW_ALPHA];
     }
-}
-
-- (void)alphaImage:(UIImageView*)image AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue {
-    [UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:seconds];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-	image.alpha = alphavalue;
-    if (alphavalue) {
-        image.hidden = NO;
-    }
-    [UIView commitAnimations];
-}
-
-- (void)alphaView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue {
-    [UIView beginAnimations:nil context:nil];
-	[UIView setAnimationDuration:seconds];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-	view.alpha = alphavalue;
-    [UIView commitAnimations];
 }
 
 #pragma mark - Actors UITableView data source & delegate
@@ -1776,14 +1757,14 @@ double round(double d) {
         [self.navigationController setNavigationBarHidden:YES animated:YES];
     }
     if (!enableKenBurns) {
-        [self alphaImage:fanartView AnimDuration:1.5 Alpha:alphaValue];// cool
+        [Utilities alphaImage:fanartView AnimDuration:1.5 Alpha:alphaValue];// cool
     }
     else {
         if (fanartView.image != nil && self.kenView == nil) {
             fanartView.alpha = 0;
             [self elabKenBurns:fanartView.image];
         }
-        [self alphaView:self.kenView AnimDuration:1.5 Alpha:alphaValue];// cool
+        [Utilities alphaView:self.kenView AnimDuration:1.5 Alpha:alphaValue];// cool
     }
     if ([self isModal]) {
         clearlogoButton.frame = CGRectMake((int)(self.view.frame.size.width / 2) - (int)(clearlogoButton.frame.size.width / 2),
@@ -1802,7 +1783,7 @@ double round(double d) {
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
-    [self alphaImage:fanartView AnimDuration:0.3 Alpha:0.0];
+    [Utilities alphaImage:fanartView AnimDuration:0.3 Alpha:0.0];
     if (self.kenView != nil) {
         [UIView animateWithDuration:0.3
                          animations:^{
@@ -1894,7 +1875,7 @@ double round(double d) {
                          }
                          completion:^(BOOL finished) {
                              [self elabKenBurns:fanartView.image];
-                             [self alphaView:self.kenView AnimDuration:0.2 Alpha:alphaValue];
+                             [Utilities alphaView:self.kenView AnimDuration:0.2 Alpha:alphaValue];
                          }
          ];
     }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -558,7 +558,8 @@ double round(double d) {
         // Ensure we draw the rounded edges around thumbnail images
         jewelView.image = [Utilities applyRoundedEdgesImage:imageToShow drawBorder:YES];
     }
-    [Utilities alphaImage:jewelView AnimDuration:0.1 Alpha:1.0];
+    jewelView.hidden = NO;
+    [Utilities alphaView:jewelView AnimDuration:0.1 Alpha:1.0];
 }
 
 - (void)setIOS7barTintColor:(UIColor*)tintColor {
@@ -1347,7 +1348,7 @@ double round(double d) {
         [Utilities alphaView:closeButton AnimDuration:1.5 Alpha:0];
         [Utilities alphaView:scrollView AnimDuration:1.5 Alpha:1];
         if (!enableKenBurns) {
-            [Utilities alphaImage:fanartView AnimDuration:1.5 Alpha:0.2];// cool
+            [Utilities alphaView:fanartView AnimDuration:1.5 Alpha:0.2];// cool
         }
         else {
             [Utilities alphaView:self.kenView AnimDuration:1.5 Alpha:0.2];// cool
@@ -1406,7 +1407,7 @@ double round(double d) {
         }
         [Utilities alphaView:scrollView AnimDuration:1.5 Alpha:0];
         if (!enableKenBurns) {
-            [Utilities alphaImage:fanartView AnimDuration:1.5 Alpha:1];// cool
+            [Utilities alphaView:fanartView AnimDuration:1.5 Alpha:1];// cool
         }
         else {
             [Utilities alphaView:self.kenView AnimDuration:1.5 Alpha:1];// cool
@@ -1757,7 +1758,7 @@ double round(double d) {
         [self.navigationController setNavigationBarHidden:YES animated:YES];
     }
     if (!enableKenBurns) {
-        [Utilities alphaImage:fanartView AnimDuration:1.5 Alpha:alphaValue];// cool
+        [Utilities alphaView:fanartView AnimDuration:1.5 Alpha:alphaValue];// cool
     }
     else {
         if (fanartView.image != nil && self.kenView == nil) {
@@ -1783,7 +1784,7 @@ double round(double d) {
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
-    [Utilities alphaImage:fanartView AnimDuration:0.3 Alpha:0.0];
+    [Utilities alphaView:fanartView AnimDuration:0.3 Alpha:0.0];
     if (self.kenView != nil) {
         [UIView animateWithDuration:0.3
                          animations:^{

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1358,14 +1358,7 @@ double round(double d) {
             if (![self isModal]) {
                 [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollFullScreenDisabled" object:self.view userInfo:nil];
             }
-            [UIView animateWithDuration:1.5
-                                  delay:0
-                                options:UIViewAnimationOptionCurveEaseInOut
-                             animations:^{
-                                 toolbar.alpha = 1.0;
-                             }
-                             completion:^(BOOL finished) {}
-             ];
+            [Utilities alphaView:toolbar AnimDuration:1.5 Alpha:1.0];
         }
     }
     else {

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -91,11 +91,7 @@ typedef enum {
 + (void)enableDefaultController:(id<UITableViewDelegate>)viewController tableView:(UITableView*)tableView menuItems:(NSArray*)menuItems;
 + (id)unarchivePath:(NSString*)path file:(NSString*)filename;
 + (void)archivePath:(NSString*)path file:(NSString*)filename data:(id)data;
-+ (void)AnimTable:(UITableView*)tV AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X;
 + (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X;
-+ (void)AnimLabel:(UIView*)Lab AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X;
-+ (void)AnimButton:(UIButton*)button AnimDuration:(NSTimeInterval)seconds hidden:(BOOL)hiddenValue XPos:(int)X;
 + (void)alphaView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue;
-+ (void)alphaImage:(UIImageView*)image AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue;
 
 @end

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -91,5 +91,11 @@ typedef enum {
 + (void)enableDefaultController:(id<UITableViewDelegate>)viewController tableView:(UITableView*)tableView menuItems:(NSArray*)menuItems;
 + (id)unarchivePath:(NSString*)path file:(NSString*)filename;
 + (void)archivePath:(NSString*)path file:(NSString*)filename data:(id)data;
++ (void)AnimTable:(UITableView*)tV AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X;
++ (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X;
++ (void)AnimLabel:(UIView*)Lab AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X;
++ (void)AnimButton:(UIButton*)button AnimDuration:(NSTimeInterval)seconds hidden:(BOOL)hiddenValue XPos:(int)X;
++ (void)alphaView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue;
++ (void)alphaImage:(UIImageView*)image AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue;
 
 @end

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -89,5 +89,7 @@ typedef enum {
 + (void)addShadowsToView:(UIView*)view viewFrame:(CGRect)frame;
 + (void)setStyleOfMenuItems:(UITableView*)tableView active:(BOOL)active;
 + (void)enableDefaultController:(id<UITableViewDelegate>)viewController tableView:(UITableView*)tableView menuItems:(NSArray*)menuItems;
++ (id)unarchivePath:(NSString*)path file:(NSString*)filename;
++ (void)archivePath:(NSString*)path file:(NSString*)filename data:(id)data;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1009,13 +1009,16 @@
 
 + (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
     [UIView animateWithDuration:seconds
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
                      animations:^{
         view.alpha = alphavalue;
         CGRect frame;
         frame = view.frame;
         frame.origin.x = X;
         view.frame = frame;
-                     }];
+                     }
+                     completion:^(BOOL finished) {}];
 }
 
 + (void)alphaView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue {

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1008,21 +1008,21 @@
 }
 
 + (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:seconds];
-    view.alpha = alphavalue;
-    CGRect frame;
-    frame = view.frame;
-    frame.origin.x = X;
-    view.frame = frame;
-    [UIView commitAnimations];
+    [UIView animateWithDuration:seconds
+                     animations:^{
+        view.alpha = alphavalue;
+        CGRect frame;
+        frame = view.frame;
+        frame.origin.x = X;
+        view.frame = frame;
+                     }];
 }
 
 + (void)alphaView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue {
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:seconds];
-    view.alpha = alphavalue;
-    [UIView commitAnimations];
+    [UIView animateWithDuration:seconds
+                     animations:^{
+        view.alpha = alphavalue;
+                     }];
 }
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1007,4 +1007,66 @@
     }
 }
 
++ (void)AnimTable:(UITableView*)tV AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
+    [UIView beginAnimations:nil context:nil];
+    [UIView setAnimationDuration:seconds];
+    tV.alpha = alphavalue;
+    CGRect frame;
+    frame = tV.frame;
+    frame.origin.x = X;
+    frame.origin.y = 0;
+    tV.frame = frame;
+    [UIView commitAnimations];
+}
+
++ (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
+    [UIView beginAnimations:nil context:nil];
+    [UIView setAnimationDuration:seconds];
+    view.alpha = alphavalue;
+    CGRect frame;
+    frame = view.frame;
+    frame.origin.x = X;
+    view.frame = frame;
+    [UIView commitAnimations];
+}
+
++ (void)AnimLabel:(UIView*)Lab AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
+    [UIView beginAnimations:nil context:nil];
+    [UIView setAnimationDuration:seconds];
+    Lab.alpha = alphavalue;
+    CGRect frame;
+    frame = Lab.frame;
+    frame.origin.x = X;
+    Lab.frame = frame;
+    [UIView commitAnimations];
+}
+
++ (void)AnimButton:(UIButton*)button AnimDuration:(NSTimeInterval)seconds hidden:(BOOL)hiddenValue XPos:(int)X {
+    [UIView beginAnimations:nil context:nil];
+    [UIView setAnimationDuration:seconds];
+    CGRect frame;
+    frame = button.frame;
+    frame.origin.x = X;
+    button.frame = frame;
+    button.hidden = hiddenValue;
+    [UIView commitAnimations];
+}
+
++ (void)alphaView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue {
+    [UIView beginAnimations:nil context:nil];
+    [UIView setAnimationDuration:seconds];
+    view.alpha = alphavalue;
+    [UIView commitAnimations];
+}
+
++ (void)alphaImage:(UIImageView*)image AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue {
+    [UIView beginAnimations:nil context:nil];
+    [UIView setAnimationDuration:seconds];
+    image.alpha = alphavalue;
+    if (alphavalue) {
+        image.hidden = NO;
+    }
+    [UIView commitAnimations];
+}
+
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1020,9 +1020,12 @@
 
 + (void)alphaView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue {
     [UIView animateWithDuration:seconds
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
                      animations:^{
         view.alpha = alphavalue;
-                     }];
+                     }
+                     completion:^(BOOL finished) {}];
 }
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1007,18 +1007,6 @@
     }
 }
 
-+ (void)AnimTable:(UITableView*)tV AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:seconds];
-    tV.alpha = alphavalue;
-    CGRect frame;
-    frame = tV.frame;
-    frame.origin.x = X;
-    frame.origin.y = 0;
-    tV.frame = frame;
-    [UIView commitAnimations];
-}
-
 + (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
     [UIView beginAnimations:nil context:nil];
     [UIView setAnimationDuration:seconds];
@@ -1030,42 +1018,10 @@
     [UIView commitAnimations];
 }
 
-+ (void)AnimLabel:(UIView*)Lab AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:seconds];
-    Lab.alpha = alphavalue;
-    CGRect frame;
-    frame = Lab.frame;
-    frame.origin.x = X;
-    Lab.frame = frame;
-    [UIView commitAnimations];
-}
-
-+ (void)AnimButton:(UIButton*)button AnimDuration:(NSTimeInterval)seconds hidden:(BOOL)hiddenValue XPos:(int)X {
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:seconds];
-    CGRect frame;
-    frame = button.frame;
-    frame.origin.x = X;
-    button.frame = frame;
-    button.hidden = hiddenValue;
-    [UIView commitAnimations];
-}
-
 + (void)alphaView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue {
     [UIView beginAnimations:nil context:nil];
     [UIView setAnimationDuration:seconds];
     view.alpha = alphavalue;
-    [UIView commitAnimations];
-}
-
-+ (void)alphaImage:(UIImageView*)image AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue {
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:seconds];
-    image.alpha = alphavalue;
-    if (alphavalue) {
-        image.hidden = NO;
-    }
     [UIView commitAnimations];
 }
 

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -977,4 +977,34 @@
     }
 }
 
++ (id)unarchivePath:(NSString*)path file:(NSString*)filename {
+    NSString *filePath = [path stringByAppendingPathComponent:filename];
+    id unarchived;
+    
+    if (@available(iOS 11.0, *)) {
+        NSData *data = [[NSFileManager defaultManager] contentsAtPath:filePath];
+        NSError *error;
+        unarchived = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class]
+                                                         fromData:data
+                                                            error:&error];
+    } else {
+        unarchived = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+    }
+    return unarchived;
+}
+
++ (void)archivePath:(NSString*)path file:(NSString*)filename data:(id)data {
+    NSString *filePath = [path stringByAppendingPathComponent:filename];
+    
+    if (@available(iOS 11.0, *)) {
+        NSError *error;
+        NSData *archiveData = [NSKeyedArchiver archivedDataWithRootObject:data requiringSecureCoding:NO error:&error];
+        if (!error) {
+            [archiveData writeToFile:filePath options:NSDataWritingAtomic error:&error];
+        }
+    } else {
+        [NSKeyedArchiver archiveRootObject:data toFile:filePath];
+    }
+}
+
 @end

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -609,12 +609,14 @@
 }
 
 - (void)hideSongInfoView {
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
-    [UIView setAnimationDuration:0.2];
-    self.nowPlayingController.songDetailsView.alpha = 0.0;
     self.nowPlayingController.itemDescription.scrollsToTop = NO;
-    [UIView commitAnimations];
+    [UIView animateWithDuration:0.2
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        self.nowPlayingController.songDetailsView.alpha = 0.0;
+                     }
+                     completion:^(BOOL finished) {}];
 }
 
 - (void)handleStackScrollOnScreen:(NSNotification*)sender {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -610,13 +610,7 @@
 
 - (void)hideSongInfoView {
     self.nowPlayingController.itemDescription.scrollsToTop = NO;
-    [UIView animateWithDuration:0.2
-                          delay:0.0
-                        options:UIViewAnimationOptionCurveEaseInOut
-                     animations:^{
-        self.nowPlayingController.songDetailsView.alpha = 0.0;
-                     }
-                     completion:^(BOOL finished) {}];
+    [Utilities alphaView:self.nowPlayingController.songDetailsView AnimDuration:0.2 Alpha:0.0];
 }
 
 - (void)handleStackScrollOnScreen:(NSNotification*)sender {

--- a/XBMC Remote/customButton.m
+++ b/XBMC Remote/customButton.m
@@ -10,6 +10,7 @@
 #import "NSString+MD5.h"
 #import "GlobalData.h"
 #import "AppDelegate.h"
+#import "Utilities.h"
 
 @implementation customButton
 
@@ -29,12 +30,9 @@
 
 - (void)loadData {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-    NSString *documentsDirectory = paths[0];
-    NSString *customButtonDatFile = [documentsDirectory stringByAppendingPathComponent:[NSString stringWithFormat:@"customButtons_%@.dat", [self getServerKey]]];
-    NSFileManager *fileManager1 = [NSFileManager defaultManager];
-    if ([fileManager1 fileExistsAtPath:customButtonDatFile]) {
-        NSMutableArray *tempArray;
-        tempArray = [NSKeyedUnarchiver unarchiveObjectWithFile: customButtonDatFile];
+    NSString *filename = [NSString stringWithFormat:@"customButtons_%@.dat", [self getServerKey]];
+    NSMutableArray *tempArray = [Utilities unarchivePath:paths[0] file:filename];
+    if (tempArray) {
         [self setButtons:tempArray];
     }
     else {
@@ -44,11 +42,8 @@
 
 - (void)saveData {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-    NSString *documentsDirectory = paths[0];
-    NSString *customButtonDatFile = [documentsDirectory stringByAppendingPathComponent:[NSString stringWithFormat:@"customButtons_%@.dat", [self getServerKey]]];
-    if (paths.count > 0) {
-        [NSKeyedArchiver archiveRootObject:buttons toFile:customButtonDatFile];
-    }
+    NSString *filename = [NSString stringWithFormat:@"customButtons_%@.dat", [self getServerKey]];
+    [Utilities archivePath:paths[0] file:filename data:buttons];
 }
 
 @end

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -276,10 +276,10 @@
 - (void)offView {
     CGFloat posX = (IS_PORTRAIT ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT) - PAD_MENU_TABLE_WIDTH;
     
-    [UIView animateWithDuration:0.2
-                     animations:^{ 
-                         [UIView setAnimationBeginsFromCurrentState:YES];
-                         [UIView setAnimationTransition:UIViewAnimationTransitionNone forView:self.view cache:YES];
+    [UIView transitionWithView:self.view
+                      duration:0.2
+                       options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionTransitionNone
+                    animations:^{
                          for (UIView* subview in slideViews.subviews) {
                              subview.frame = CGRectMake(posX, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
                          }
@@ -290,8 +290,8 @@
                          viewAtRight = nil;
                          viewAtLeft = nil;
                          viewAtRight2 = nil;
-                     }
-                     completion:^(BOOL finished) {
+                    }
+                    completion:^(BOOL finished) {
                          for (UIView* subview in slideViews.subviews) {
                              [subview removeFromSuperview];
                          }
@@ -300,7 +300,7 @@
                          [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
                          [viewControllersStack removeAllObjects];
                          [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollOffScreen" object: nil]; 
-                     }];
+                    }];
 }
 
 - (void)handlePanFrom:(UIPanGestureRecognizer*)recognizer {
@@ -484,199 +484,212 @@
 		if ([dragDirection isEqualToString:@"LEFT"]) {
 			if (viewAtRight != nil) {
 				if ([slideViews.subviews indexOfObject:viewAtLeft] == 0 && !(viewAtLeft.frame.origin.x == SLIDE_VIEWS_MINUS_X_POSITION || viewAtLeft.frame.origin.x == SLIDE_VIEWS_START_X_POS)) {
-					[UIView beginAnimations:nil context:NULL];
-					[UIView setAnimationDuration:0.2];
-					[UIView setAnimationTransition:UIViewAnimationTransitionNone forView:self.view cache:YES];
-					[UIView setAnimationBeginsFromCurrentState:YES];
-					if (viewAtLeft.frame.origin.x < SLIDE_VIEWS_START_X_POS && viewAtRight != nil) {
-						viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
-						viewAtRight.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-					}
-					else {
-						//Drop Card View Animation
-						if (slideViews.subviews[0].frame.origin.x - SLIDE_VIEWS_MINUS_X_POSITION >= self.view.frame.origin.x + slideViews.subviews[0].frame.size.width) {
-							NSInteger viewControllerCount = viewControllersStack.count;
-							
-							if (viewControllerCount > 1) {
-								for (int i = 1; i < viewControllerCount; i++) {
-									viewXPosition = self.view.frame.size.width - [slideViews viewWithTag:i + VIEW_TAG].frame.size.width;
-									[[slideViews viewWithTag:i + VIEW_TAG] removeFromSuperview];
-									[viewControllersStack removeLastObject];
-								}
-								
-								[borderViews viewWithTag:3 + VIEW_TAG].hidden = YES;
-								[borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
-								[borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
-							}
-							// Removes the selection of row for the first slide view
-							for (UIView* tableView in slideViews.subviews[0].subviews) {
-                                if ([tableView isKindOfClass:[UIView class]]) {
-                                    for (UIView* tableView2 in tableView.subviews) {
-                                        if ([tableView2 isKindOfClass:[UITableView class]]) {
-                                            NSIndexPath* selectedRow = [(UITableView*)tableView2 indexPathForSelectedRow];
-                                            [(UITableView*)tableView2 deselectRowAtIndexPath:selectedRow animated:YES];
-                                        }
-                                        if ([tableView2 isKindOfClass:[UICollectionView class]]) {
-                                            for (NSIndexPath* selection in [(UICollectionView*)tableView2 indexPathsForSelectedItems]) {
-                                                [(UICollectionView*)tableView2 deselectItemAtIndexPath:selection animated:YES];
+                    [UIView transitionWithView:self.view
+                                      duration:0.2
+                                       options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionTransitionNone
+                                    animations:^{
+                        if (viewAtLeft.frame.origin.x < SLIDE_VIEWS_START_X_POS && viewAtRight != nil) {
+                            viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                            viewAtRight.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
+                        }
+                        else {
+                            //Drop Card View Animation
+                            if (slideViews.subviews[0].frame.origin.x - SLIDE_VIEWS_MINUS_X_POSITION >= self.view.frame.origin.x + slideViews.subviews[0].frame.size.width) {
+                                NSInteger viewControllerCount = viewControllersStack.count;
+                                
+                                if (viewControllerCount > 1) {
+                                    for (int i = 1; i < viewControllerCount; i++) {
+                                        viewXPosition = self.view.frame.size.width - [slideViews viewWithTag:i + VIEW_TAG].frame.size.width;
+                                        [[slideViews viewWithTag:i + VIEW_TAG] removeFromSuperview];
+                                        [viewControllersStack removeLastObject];
+                                    }
+                                    
+                                    [borderViews viewWithTag:3 + VIEW_TAG].hidden = YES;
+                                    [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
+                                    [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
+                                }
+                                // Removes the selection of row for the first slide view
+                                for (UIView* tableView in slideViews.subviews[0].subviews) {
+                                    if ([tableView isKindOfClass:[UIView class]]) {
+                                        for (UIView* tableView2 in tableView.subviews) {
+                                            if ([tableView2 isKindOfClass:[UITableView class]]) {
+                                                NSIndexPath* selectedRow = [(UITableView*)tableView2 indexPathForSelectedRow];
+                                                [(UITableView*)tableView2 deselectRowAtIndexPath:selectedRow animated:YES];
                                             }
-                                            [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollCardDropNotification" object: nil];
+                                            if ([tableView2 isKindOfClass:[UICollectionView class]]) {
+                                                for (NSIndexPath* selection in [(UICollectionView*)tableView2 indexPathsForSelectedItems]) {
+                                                    [(UICollectionView*)tableView2 deselectItemAtIndexPath:selection animated:YES];
+                                                }
+                                                [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollCardDropNotification" object: nil];
 
+                                            }
                                         }
                                     }
-                                }
-								if ([tableView isKindOfClass:[UITableView class]]) {
-									NSIndexPath* selectedRow = [(UITableView*)tableView indexPathForSelectedRow];
-                                    [(UITableView*)tableView deselectRowAtIndexPath:selectedRow animated:YES];
-								}
-                                if ([tableView isKindOfClass:[UICollectionView class]]) {
-                                    for (NSIndexPath* selection in [(UICollectionView*)tableView indexPathsForSelectedItems]) {
-                                        [(UICollectionView*)tableView deselectItemAtIndexPath:selection animated:YES];
+                                    if ([tableView isKindOfClass:[UITableView class]]) {
+                                        NSIndexPath* selectedRow = [(UITableView*)tableView indexPathForSelectedRow];
+                                        [(UITableView*)tableView deselectRowAtIndexPath:selectedRow animated:YES];
                                     }
-                                    [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollCardDropNotification" object: nil];
+                                    if ([tableView isKindOfClass:[UICollectionView class]]) {
+                                        for (NSIndexPath* selection in [(UICollectionView*)tableView indexPathsForSelectedItems]) {
+                                            [(UICollectionView*)tableView deselectItemAtIndexPath:selection animated:YES];
+                                        }
+                                        [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollCardDropNotification" object: nil];
+                                    }
                                 }
-							}
-							viewAtLeft2 = nil;
-							viewAtRight = nil;
-							viewAtRight2 = nil;							 
-						}
-						
-						viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_START_X_POS, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
-						if (viewAtRight != nil) {
-							viewAtRight.frame = CGRectMake(SLIDE_VIEWS_START_X_POS + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-						}
-						
-					}
-					[UIView commitAnimations];
+                                viewAtLeft2 = nil;
+                                viewAtRight = nil;
+                                viewAtRight2 = nil;
+                            }
+                            
+                            viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_START_X_POS, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                            if (viewAtRight != nil) {
+                                viewAtRight.frame = CGRectMake(SLIDE_VIEWS_START_X_POS + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
+                            }
+                            
+                        }
+                                    }
+                                    completion:^(BOOL finished) {}
+                    ];
 				}
 				else if (viewAtLeft.frame.origin.x == SLIDE_VIEWS_MINUS_X_POSITION && viewAtRight.frame.origin.x + viewAtRight.frame.size.width > self.view.frame.size.width) {
-					[UIView beginAnimations:nil context:NULL];
-					[UIView setAnimationDuration:0.2];
-					[UIView setAnimationTransition:UIViewAnimationTransitionNone forView:self.view cache:YES];
-					[UIView setAnimationBeginsFromCurrentState:YES];
-					viewAtRight.frame = CGRectMake(self.view.frame.size.width - viewAtRight.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-					[UIView commitAnimations];						
-				}	
+                    [UIView transitionWithView:self.view
+                                      duration:0.2
+                                       options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionTransitionNone
+                                    animations:^{
+                        viewAtRight.frame = CGRectMake(self.view.frame.size.width - viewAtRight.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
+                                     }
+                                     completion:^(BOOL finished) {}
+                    ];
+				}
 				else if (viewAtLeft.frame.origin.x == SLIDE_VIEWS_MINUS_X_POSITION && viewAtRight.frame.origin.x + viewAtRight.frame.size.width < self.view.frame.size.width) {
-					[UIView beginAnimations:@"RIGHT-WITH-RIGHT" context:NULL];
-					[UIView setAnimationDuration:0.2];
-					[UIView setAnimationTransition:UIViewAnimationTransitionNone forView:self.view cache:YES];
-					[UIView setAnimationBeginsFromCurrentState:YES];
-					viewAtRight.frame = CGRectMake(self.view.frame.size.width - viewAtRight.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-					[UIView setAnimationDelegate:self];
-					[UIView setAnimationDidStopSelector:@selector(bounceBack:finished:context:)];
-					[UIView commitAnimations];
+                    [UIView transitionWithView:self.view
+                                      duration:0.2
+                                       options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionTransitionNone
+                                    animations:^{
+                        viewAtRight.frame = CGRectMake(self.view.frame.size.width - viewAtRight.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
+                                     }
+                                     completion:^(BOOL finished) {
+                        [self bounceBack:@"RIGHT-WITH-RIGHT" finished:@(finished) context:nil];
+                                    }
+                    ];
 				}
 				else if (viewAtLeft.frame.origin.x > SLIDE_VIEWS_MINUS_X_POSITION) {
-					[UIView setAnimationDuration:0.2];
-					[UIView setAnimationTransition:UIViewAnimationTransitionNone forView:self.view cache:YES];
-					[UIView setAnimationBeginsFromCurrentState:YES];
-					if ((viewAtLeft.frame.origin.x + viewAtLeft.frame.size.width > self.view.frame.size.width) && viewAtLeft.frame.origin.x < (self.view.frame.size.width - (viewAtLeft.frame.size.width)/2)) {
-						[UIView beginAnimations:@"LEFT-WITH-LEFT" context:nil];
-						viewAtLeft.frame = CGRectMake(self.view.frame.size.width - viewAtLeft.frame.size.width, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
-						
-						//Show bounce effect
-						viewAtRight.frame = CGRectMake(self.view.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-					}
-					else {
-						[UIView beginAnimations:@"LEFT-WITH-RIGHT" context:nil];	
-						viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
-						if (positionOfViewAtLeftAtTouchBegan.x + viewAtLeft.frame.size.width <= self.view.frame.size.width) {
-							viewAtRight.frame = CGRectMake((self.view.frame.size.width - viewAtRight.frame.size.width), viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-						}
-						else {
-							viewAtRight.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-						}
-						
-						//Show bounce effect
-						viewAtRight2.frame = CGRectMake(viewAtRight.frame.origin.x + viewAtRight.frame.size.width, viewAtRight2.frame.origin.y, viewAtRight2.frame.size.width, viewAtRight2.frame.size.height);
-					}
-					[UIView setAnimationDelegate:self];
-					[UIView setAnimationDidStopSelector:@selector(bounceBack:finished:context:)];
-					[UIView commitAnimations];
+                    __block NSString *animationDirection;
+                    [UIView transitionWithView:self.view
+                                      duration:0.2
+                                       options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionTransitionNone
+                                    animations:^{
+                        if ((viewAtLeft.frame.origin.x + viewAtLeft.frame.size.width > self.view.frame.size.width) && viewAtLeft.frame.origin.x < (self.view.frame.size.width - (viewAtLeft.frame.size.width)/2)) {
+                            animationDirection = @"LEFT-WITH-LEFT";
+                            viewAtLeft.frame = CGRectMake(self.view.frame.size.width - viewAtLeft.frame.size.width, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                            
+                            //Show bounce effect
+                            viewAtRight.frame = CGRectMake(self.view.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
+                        }
+                        else {
+                            animationDirection = @"LEFT-WITH-RIGHT";
+                            viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                            if (positionOfViewAtLeftAtTouchBegan.x + viewAtLeft.frame.size.width <= self.view.frame.size.width) {
+                                viewAtRight.frame = CGRectMake((self.view.frame.size.width - viewAtRight.frame.size.width), viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
+                            }
+                            else {
+                                viewAtRight.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
+                            }
+                            
+                            //Show bounce effect
+                            viewAtRight2.frame = CGRectMake(viewAtRight.frame.origin.x + viewAtRight.frame.size.width, viewAtRight2.frame.origin.y, viewAtRight2.frame.size.width, viewAtRight2.frame.size.height);
+                        }
+                                    }
+                                    completion:^(BOOL finished) {
+                        [self bounceBack:animationDirection finished:@(finished) context:nil];
+                                    }
+                    ];
 				}
-				
 			}
 			else {
-				[UIView beginAnimations:nil context:NULL];
-				[UIView setAnimationDuration:0.2];
-				[UIView setAnimationBeginsFromCurrentState:YES];
-				[UIView setAnimationTransition:UIViewAnimationTransitionNone forView:self.view cache:YES];
-				viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_START_X_POS, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
-				[UIView commitAnimations];
+                [UIView transitionWithView:self.view
+                                  duration:0.2
+                                   options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionTransitionNone
+                                animations:^{
+                    viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_START_X_POS, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                                 }
+                                 completion:^(BOOL finished) {}
+                ];
 			}
 		}
         else if ([dragDirection isEqualToString:@"RIGHT"]) {
 			if (viewAtLeft != nil) {
 				if ([slideViews.subviews indexOfObject:viewAtLeft] == 0 && !(viewAtLeft.frame.origin.x == SLIDE_VIEWS_MINUS_X_POSITION || viewAtLeft.frame.origin.x == SLIDE_VIEWS_START_X_POS)) {
-					[UIView beginAnimations:nil context:NULL];
-					[UIView setAnimationDuration:0.2];			
-					[UIView setAnimationBeginsFromCurrentState:YES];
-					[UIView setAnimationTransition:UIViewAnimationTransitionNone forView:self.view cache:YES];
-					if (viewAtLeft.frame.origin.x > SLIDE_VIEWS_MINUS_X_POSITION || viewAtRight == nil) {
-						//Drop Card View Animation
-                        CGFloat posX = SLIDE_VIEWS_START_X_POS;
-						if (slideViews.subviews[0].frame.origin.x + PAD_MENU_TABLE_WIDTH >= self.view.frame.origin.x + slideViews.subviews[0].frame.size.width) {
-//                            NSLog(@"ELIMINO 2");
-							NSInteger viewControllerCount = viewControllersStack.count;
-							if (viewControllerCount > 1) {
-								for (int i = 1; i < viewControllerCount; i++) {
-									viewXPosition = self.view.frame.size.width - [slideViews viewWithTag:i + VIEW_TAG].frame.size.width;
-									[[slideViews viewWithTag:i + VIEW_TAG] removeFromSuperview];
-									[viewControllersStack removeLastObject];
-								}
-								[borderViews viewWithTag:3 + VIEW_TAG].hidden = YES;
-								[borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
-								[borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
-							}
-							// Removes the selection of row for the first slide view
-							for (UIView* tableView in slideViews.subviews[0].subviews) {
-                                if ([tableView isKindOfClass:[UIView class]]) {
-                                    for (UIView* tableView2 in tableView.subviews) {
-                                        if ([tableView2 isKindOfClass:[UITableView class]]) {
-                                            NSIndexPath* selectedRow = [(UITableView*)tableView2 indexPathForSelectedRow];
-                                            [(UITableView*)tableView2 deselectRowAtIndexPath:selectedRow animated:YES];
-                                        }
-                                        if ([tableView2 isKindOfClass:[UICollectionView class]]) {
-                                            for (NSIndexPath* selection in [(UICollectionView*)tableView2 indexPathsForSelectedItems]) {
-                                                [(UICollectionView*)tableView2 deselectItemAtIndexPath:selection animated:YES];
+                    [UIView transitionWithView:self.view
+                                      duration:0.2
+                                       options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionTransitionNone
+                                    animations:^{
+                        if (viewAtLeft.frame.origin.x > SLIDE_VIEWS_MINUS_X_POSITION || viewAtRight == nil) {
+                            //Drop Card View Animation
+                            CGFloat posX = SLIDE_VIEWS_START_X_POS;
+                            if (slideViews.subviews[0].frame.origin.x + PAD_MENU_TABLE_WIDTH >= self.view.frame.origin.x + slideViews.subviews[0].frame.size.width) {
+    //                            NSLog(@"ELIMINO 2");
+                                NSInteger viewControllerCount = viewControllersStack.count;
+                                if (viewControllerCount > 1) {
+                                    for (int i = 1; i < viewControllerCount; i++) {
+                                        viewXPosition = self.view.frame.size.width - [slideViews viewWithTag:i + VIEW_TAG].frame.size.width;
+                                        [[slideViews viewWithTag:i + VIEW_TAG] removeFromSuperview];
+                                        [viewControllersStack removeLastObject];
+                                    }
+                                    [borderViews viewWithTag:3 + VIEW_TAG].hidden = YES;
+                                    [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
+                                    [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
+                                }
+                                // Removes the selection of row for the first slide view
+                                for (UIView* tableView in slideViews.subviews[0].subviews) {
+                                    if ([tableView isKindOfClass:[UIView class]]) {
+                                        for (UIView* tableView2 in tableView.subviews) {
+                                            if ([tableView2 isKindOfClass:[UITableView class]]) {
+                                                NSIndexPath* selectedRow = [(UITableView*)tableView2 indexPathForSelectedRow];
+                                                [(UITableView*)tableView2 deselectRowAtIndexPath:selectedRow animated:YES];
                                             }
-                                            [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollCardDropNotification" object: nil];
+                                            if ([tableView2 isKindOfClass:[UICollectionView class]]) {
+                                                for (NSIndexPath* selection in [(UICollectionView*)tableView2 indexPathsForSelectedItems]) {
+                                                    [(UICollectionView*)tableView2 deselectItemAtIndexPath:selection animated:YES];
+                                                }
+                                                [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollCardDropNotification" object: nil];
+                                            }
                                         }
                                     }
-                                }
-								if ([tableView isKindOfClass:[UITableView class]]) {
-									NSIndexPath* selectedRow = [(UITableView*)tableView indexPathForSelectedRow];
-                                    [(UITableView*)tableView deselectRowAtIndexPath:selectedRow animated:YES];
-								}
-                                if ([tableView isKindOfClass:[UICollectionView class]]) {
-                                    for (NSIndexPath* selection in [(UICollectionView*)tableView indexPathsForSelectedItems]) {
-                                        [(UICollectionView*)tableView deselectItemAtIndexPath:selection animated:YES];
+                                    if ([tableView isKindOfClass:[UITableView class]]) {
+                                        NSIndexPath* selectedRow = [(UITableView*)tableView indexPathForSelectedRow];
+                                        [(UITableView*)tableView deselectRowAtIndexPath:selectedRow animated:YES];
                                     }
-                                    [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollCardDropNotification" object: nil];
+                                    if ([tableView isKindOfClass:[UICollectionView class]]) {
+                                        for (NSIndexPath* selection in [(UICollectionView*)tableView indexPathsForSelectedItems]) {
+                                            [(UICollectionView*)tableView deselectItemAtIndexPath:selection animated:YES];
+                                        }
+                                        [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollCardDropNotification" object: nil];
+                                    }
                                 }
-							}
-							
-							viewAtLeft2 = nil;
-							viewAtRight = nil;
-							viewAtRight2 = nil;
-                            // MODDED BY JOE
-                            CGFloat marginPosX = (IS_PORTRAIT ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT) - PAD_MENU_TABLE_WIDTH - STACK_OVERLAP;
-                            if (slideViews.subviews[0].frame.origin.x + marginPosX / 2 >= marginPosX) {
-                                posX = marginPosX;
+                                
+                                viewAtLeft2 = nil;
+                                viewAtRight = nil;
+                                viewAtRight2 = nil;
+                                // MODDED BY JOE
+                                CGFloat marginPosX = (IS_PORTRAIT ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT) - PAD_MENU_TABLE_WIDTH - STACK_OVERLAP;
+                                if (slideViews.subviews[0].frame.origin.x + marginPosX / 2 >= marginPosX) {
+                                    posX = marginPosX;
+                                }
+                                //END MODDED
                             }
-                            //END MODDED
+                            viewAtLeft.frame = CGRectMake(posX, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                            if (viewAtRight != nil) {
+                                viewAtRight.frame = CGRectMake(SLIDE_VIEWS_START_X_POS + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
+                            }
                         }
-						viewAtLeft.frame = CGRectMake(posX, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
-						if (viewAtRight != nil) {
-							viewAtRight.frame = CGRectMake(SLIDE_VIEWS_START_X_POS + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-						}
-					}
-					else {
-						viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
-						viewAtRight.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-					}
-					[UIView commitAnimations];
+                        else {
+                            viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                            viewAtRight.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
+                        }
+                                    }
+                                    completion:^(BOOL finished) {}
+                    ];
 				}
 				else if (viewAtRight.frame.origin.x < self.view.frame.size.width) {
 					[self moveStack];
@@ -690,53 +703,57 @@
 
 - (void)moveStack {
     if ((viewAtRight.frame.origin.x < (viewAtLeft.frame.origin.x + viewAtLeft.frame.size.width)) && viewAtRight.frame.origin.x < (self.view.frame.size.width - (viewAtRight.frame.size.width/2))) {
-        [UIView beginAnimations:@"RIGHT-WITH-RIGHT" context:NULL];
-        [UIView setAnimationDuration:0.2];
-        [UIView setAnimationBeginsFromCurrentState:YES];
-        [UIView setAnimationTransition:UIViewAnimationTransitionNone forView:self.view cache:YES];
-        viewAtRight.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-        [UIView setAnimationDelegate:self];
-        [UIView setAnimationDidStopSelector:@selector(bounceBack:finished:context:)];
-        [UIView commitAnimations];
+        [UIView transitionWithView:self.view
+                          duration:0.2
+                           options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionTransitionNone
+                        animations:^{
+            viewAtRight.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
+                         }
+                         completion:^(BOOL finished) {
+            [self bounceBack:@"RIGHT-WITH-RIGHT" finished:@(finished) context:nil];
+                        }
+        ];
     }
     else {
-        [UIView beginAnimations:@"RIGHT-WITH-LEFT" context:NULL];
-        [UIView setAnimationDuration:0.2];
-        [UIView setAnimationBeginsFromCurrentState:YES];
-        [UIView setAnimationTransition:UIViewAnimationTransitionNone forView:self.view cache:YES];
-        if ([slideViews.subviews indexOfObject:viewAtLeft] > 0) {
-            if (positionOfViewAtRightAtTouchBegan.x + viewAtRight.frame.size.width <= self.view.frame.size.width) {
-                viewAtLeft.frame = CGRectMake(self.view.frame.size.width - viewAtLeft.frame.size.width, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+        [UIView transitionWithView:self.view
+                          duration:0.2
+                           options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionTransitionNone
+                        animations:^{
+            if ([slideViews.subviews indexOfObject:viewAtLeft] > 0) {
+                if (positionOfViewAtRightAtTouchBegan.x + viewAtRight.frame.size.width <= self.view.frame.size.width) {
+                    viewAtLeft.frame = CGRectMake(self.view.frame.size.width - viewAtLeft.frame.size.width, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                }
+                else {
+                    viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + viewAtLeft2.frame.size.width, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                }
+                viewAtRight.frame = CGRectMake(self.view.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
             }
             else {
-                viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + viewAtLeft2.frame.size.width, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                viewAtRight.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
             }
-            viewAtRight.frame = CGRectMake(self.view.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-        }
-        else {
-            viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
-            viewAtRight.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION + viewAtLeft.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-        }
-        [UIView setAnimationDelegate:self];
-        [UIView setAnimationDidStopSelector:@selector(bounceBack:finished:context:)];
-        [UIView commitAnimations];
+                        }
+                        completion:^(BOOL finished) {
+            [self bounceBack:@"RIGHT-WITH-LEFT" finished:@(finished) context:nil];
+                        }
+        ];
     }
 }
 
-- (void)bounceBack:(NSString*)animationID finished:(NSNumber*)finished context:(void*)context {	
-	
-	BOOL isBouncing = NO;
-	
-	if ([dragDirection isEqualToString:@""] && [finished boolValue]) {
-		[viewAtLeft.layer removeAllAnimations];
-		[viewAtRight.layer removeAllAnimations];
-		[viewAtRight2.layer removeAllAnimations];
-		[viewAtLeft2.layer removeAllAnimations];
+- (void)bounceBack:(NSString*)animationID finished:(NSNumber*)finished context:(void*)context {
+    
+    BOOL isBouncing = NO;
+    
+    if ([dragDirection isEqualToString:@""] && [finished boolValue]) {
+        [viewAtLeft.layer removeAllAnimations];
+        [viewAtRight.layer removeAllAnimations];
+        [viewAtRight2.layer removeAllAnimations];
+        [viewAtLeft2.layer removeAllAnimations];
             if ([animationID isEqualToString:@"LEFT-WITH-LEFT"] && viewAtLeft2.frame.origin.x == SLIDE_VIEWS_MINUS_X_POSITION) {
                 CABasicAnimation *bounceAnimation = [CABasicAnimation animationWithKeyPath:@"position.x"];
                 bounceAnimation.duration = 0.2;
                 bounceAnimation.fromValue = @(viewAtLeft.center.x);
-                bounceAnimation.toValue = @(viewAtLeft.center.x -10);
+                bounceAnimation.toValue = @(viewAtLeft.center.x - 10);
                 bounceAnimation.repeatCount = 0;
                 bounceAnimation.autoreverses = YES;
                 bounceAnimation.fillMode = kCAFillModeBackwards;
@@ -837,14 +854,12 @@
                 }
                 
             }
-		
-	}
-	[self arrangeVerticalBar];	
-	if ([slideViews.subviews indexOfObject:viewAtLeft2] == 1 && isBouncing) {
-		[borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
-	}
+    }
+    [self arrangeVerticalBar];
+    if ([slideViews.subviews indexOfObject:viewAtLeft2] == 1 && isBouncing) {
+        [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
+    }
 }
-
 
 - (void)callArrangeVerticalBar {
 	[self arrangeVerticalBar];
@@ -956,12 +971,14 @@
 			viewAtLeft = slideViews.subviews[slideViews.subviews.count - 1];
             controller.view.frame = CGRectMake(animX, 0, controller.view.frame.size.width, self.view.frame.size.height - bottomPadding);
 
-            [UIView beginAnimations:nil context:NULL];
-			[UIView setAnimationTransition:UIViewAnimationTransitionNone forView:viewAtLeft cache:YES];	
-			[UIView setAnimationBeginsFromCurrentState:NO];	
-            controller.view.frame = CGRectMake(viewXPosition, 0, controller.view.frame.size.width, self.view.frame.size.height - bottomPadding);
-
-            [UIView commitAnimations];
+            [UIView transitionWithView:viewAtLeft
+                              duration:0.2
+                               options:UIViewAnimationOptionTransitionNone
+                            animations:^{
+                controller.view.frame = CGRectMake(viewXPosition, 0, controller.view.frame.size.width, self.view.frame.size.height - bottomPadding);
+                            }
+                            completion:^(BOOL finished) {}
+            ];
 			viewAtLeft2 = nil;
 			viewAtRight = nil;
 			viewAtRight2 = nil;
@@ -972,13 +989,16 @@
 			viewAtLeft = slideViews.subviews[slideViews.subviews.count - 2];
 			viewAtLeft2 = nil;
 			viewAtRight2 = nil;
-			
-			[UIView beginAnimations:nil context:NULL];
-			[UIView setAnimationTransition:UIViewAnimationTransitionNone forView:viewAtLeft cache:YES];	
-			[UIView setAnimationBeginsFromCurrentState:NO];	
-			viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
-			viewAtRight.frame = CGRectMake(self.view.frame.size.width - viewAtRight.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-			[UIView commitAnimations];
+            
+            [UIView transitionWithView:viewAtLeft
+                              duration:0.2
+                               options:UIViewAnimationOptionTransitionNone
+                            animations:^{
+                viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                viewAtRight.frame = CGRectMake(self.view.frame.size.width - viewAtRight.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
+                             }
+                             completion:^(BOOL finished) {}
+            ];
 			slideStartPosition = SLIDE_VIEWS_MINUS_X_POSITION;
 		}
         else {
@@ -989,18 +1009,18 @@
             viewAtLeft2.hidden = NO;
             viewAtRight2 = nil;
             
-            [UIView beginAnimations:nil context:NULL];
-            [UIView setAnimationTransition:UIViewAnimationTransitionNone forView:viewAtLeft cache:YES];	
-            [UIView setAnimationBeginsFromCurrentState:NO];	
-            
-            if (viewAtLeft2.frame.origin.x != SLIDE_VIEWS_MINUS_X_POSITION) {
-                viewAtLeft2.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft2.frame.origin.y, viewAtLeft2.frame.size.width, viewAtLeft2.frame.size.height);
-            }
-            viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
-            viewAtRight.frame = CGRectMake(self.view.frame.size.width - viewAtRight.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
-            [UIView setAnimationDelegate:self];
-            [UIView setAnimationDidStopSelector:@selector(bounceBack:finished:context:)];
-            [UIView commitAnimations];				
+            [UIView transitionWithView:viewAtLeft
+                              duration:0.2
+                               options:UIViewAnimationOptionTransitionNone
+                            animations:^{
+                if (viewAtLeft2.frame.origin.x != SLIDE_VIEWS_MINUS_X_POSITION) {
+                    viewAtLeft2.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft2.frame.origin.y, viewAtLeft2.frame.size.width, viewAtLeft2.frame.size.height);
+                }
+                viewAtLeft.frame = CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION, viewAtLeft.frame.origin.y, viewAtLeft.frame.size.width, viewAtLeft.frame.size.height);
+                viewAtRight.frame = CGRectMake(self.view.frame.size.width - viewAtRight.frame.size.width, viewAtRight.frame.origin.y, viewAtRight.frame.size.width, viewAtRight.frame.size.height);
+                             }
+                             completion:^(BOOL finished) {}
+            ];
             slideStartPosition = SLIDE_VIEWS_MINUS_X_POSITION;	
             if (slideViews.subviews.count > 3) {
                 slideViews.subviews[slideViews.subviews.count - 4].hidden = YES;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/599.

This PR has four main sections:
1. Prepare migration of `NSKeyedArchiver` methods
The method `unarchiveObjectWithFile` and `archiveRootObject:toFile:` are deprecated since iOS 11. This PR refactors reading/writing persistent data and already prepares the migration to the newly introduced `unarchivedObjectOfClasses` and `archivedDataWithRootObject:requiringSecureCoding:error:`. 
2. Move duplicate animation related code to Utilities
This allows to remove code duplication and unneeded code, as well as prepares for the next third step.
3. Migrate to block-based animation
All parameters and options were taken over into the block-based animation.
4. Optimizations and bugfixes around animation in `NowPlaying`
The code was refactored to remove unneeded variables. In addition, the animation for the transition between playlist and NowPlaying view was corrected (now properly sliding out and in). As a further optimization the "demo" animation for the playlist/NowPlaying toggle button is starting earlier. This always bugged me.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Prepare migration of NSKeyedArchiver methods
Maintenance: Migrate to block-based animation
Bugfix: Fix flip in/out animation for playlist/NowPlaying view