### PR TITLE
Maintenance: Less aggressive trigger for the app review popup

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -872,8 +872,8 @@
         NSInteger count = [[NSUserDefaults standardUserDefaults] integerForKey:PERSISTENCE_KEY_PLAYBACK_ATTEMPTS] + 1;
         [[NSUserDefaults standardUserDefaults] setInteger:count forKey:PERSISTENCE_KEY_PLAYBACK_ATTEMPTS];
         
-        // Show review popup each 50th playback attempt
-        if (count % 50 == 0) {
+        // Show review popup after 50th, 150th, 300th attempt, and each 300th from then on
+        if (count == 50 || count == 150 || count == 300 || count % 300 == 0) {
             [Utilities showReviewController];
         }
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The review popup counter will increase faster in app versions after 1.9. Therefore use a less aggressive condition to show the app review popup. Review requests come after 50/150/300 attempts, followed by each 300th attempt.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Less aggressive trigger for the app review popup