### PR TITLE
Feature: Automatic Wake-On-LAN on connection attempt

### DIFF
--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -24,6 +24,16 @@
 			<key>DefaultValue</key>
 			<false/>
 			<key>Key</key>
+			<string>wol_preference</string>
+			<key>Title</key>
+			<string>Send Wake-On-LAN automatically</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<false/>
+			<key>Key</key>
 			<string>song_preference</string>
 			<key>Title</key>
 			<string>Direct Play mode</string>

--- a/XBMC Remote/Settings.bundle/de.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/de.lproj/Root.strings
@@ -3,6 +3,7 @@
 "General" = "Allgemein";
 "Automatic" = "Automatisch";
 "Show connection notice" = "Verbindungshinweis zeigen";
+"Send Wake-On-LAN automatically" = "Wake-On-LAN automatisch senden";
 "Direct Play mode" = "„Sofort wiedergeben“-Modus";
 "Ken Burns effect" = "Ken Burns-Effekt";
 "Shake to clear playlist" = "Wiedergabeliste durch Schütteln löschen";

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -3,6 +3,7 @@
 "General" = "General";
 "Automatic" = "Automatic";
 "Show connection notice" = "Show connection notice";
+"Send Wake-On-LAN automatically" = "Send Wake-On-LAN automatically";
 "Direct Play mode" = "Direct Play mode";
 "Ken Burns effect" = "Ken Burns effect";
 "Shake to clear playlist" = "Shake to clear playlist";

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -176,6 +176,10 @@ NSOutputStream	*outStream;
     if (AppDelegate.instance.serverTCPConnectionOpen) {
         return;
     }
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"wol_preference"] &&
+        AppDelegate.instance.obj.serverHWAddr != nil) {
+        [AppDelegate.instance sendWOL:AppDelegate.instance.obj.serverHWAddr withPort:0];
+    }
     inCheck = YES;
 //    NSString *userPassword = [AppDelegate.instance.obj.serverPass isEqualToString:@""] ? @"" : [NSString stringWithFormat:@":%@", AppDelegate.instance.obj.serverPass];
 //    NSString *serverJSON = [NSString stringWithFormat:@"http://%@%@@%@:%@/jsonrpc", AppDelegate.instance.obj.serverUser, userPassword, AppDelegate.instance.obj.serverIP, AppDelegate.instance.obj.serverPort];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/602.

This PR adds the option to let the App send Wake-On-LAN when attempting to connect a server. The option is inactive per default.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Automatic Wake-On-LAN on connection attempt