### PR TITLE
Improvement: Rework of main menu and app settings

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -125,7 +125,7 @@
     }
     else {
         title.font = [UIFont fontWithName:@"Roboto-Regular" size:20];
-        title.text = [item.mainLabel uppercaseString];
+        title.text = item.mainLabel;
         icon.highlightedImage = [UIImage imageNamed:iconName];
         icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:UIColor.grayColor];
     }

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -240,7 +240,7 @@
 		</dict>
 		<dict>
 			<key>Title</key>
-			<string>Main Menu</string>
+			<string>Main Menu Items</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>FooterText</key>
@@ -252,7 +252,7 @@
 			<key>Key</key>
 			<string>menu_music</string>
 			<key>Title</key>
-			<string>Show MUSIC</string>
+			<string>Music</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -262,7 +262,7 @@
 			<key>Key</key>
 			<string>menu_movies</string>
 			<key>Title</key>
-			<string>Show MOVIES</string>
+			<string>Movies</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -272,7 +272,7 @@
 			<key>Key</key>
 			<string>menu_videos</string>
 			<key>Title</key>
-			<string>Show VIDEOS</string>
+			<string>Videos</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -282,7 +282,7 @@
 			<key>Key</key>
 			<string>menu_tvshows</string>
 			<key>Title</key>
-			<string>Show TV SHOWS</string>
+			<string>TV Shows</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -292,7 +292,7 @@
 			<key>Key</key>
 			<string>menu_pictures</string>
 			<key>Title</key>
-			<string>Show PICTURES</string>
+			<string>Pictures</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -302,7 +302,7 @@
 			<key>Key</key>
 			<string>menu_livetv</string>
 			<key>Title</key>
-			<string>Show LIVE TV</string>
+			<string>Live TV</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -312,7 +312,7 @@
 			<key>Key</key>
 			<string>menu_radio</string>
 			<key>Title</key>
-			<string>Show RADIO</string>
+			<string>Radio</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -322,7 +322,7 @@
 			<key>Key</key>
 			<string>menu_favourites</string>
 			<key>Title</key>
-			<string>Show FAVOURITES</string>
+			<string>Favourites</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -332,7 +332,7 @@
 			<key>Key</key>
 			<string>menu_nowplaying</string>
 			<key>Title</key>
-			<string>Show NOW PLAYING</string>
+			<string>Now Playing</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -342,7 +342,7 @@
 			<key>Key</key>
 			<string>menu_remote</string>
 			<key>Title</key>
-			<string>Show REMOTE CONTROL</string>
+			<string>Remote Control</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -352,7 +352,7 @@
 			<key>Key</key>
 			<string>menu_search</string>
 			<key>Title</key>
-			<string>Show GLOBAL SEARCH</string>
+			<string>Global Search</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -24,6 +24,16 @@
 			<key>DefaultValue</key>
 			<false/>
 			<key>Key</key>
+			<string>lockscreen_preference</string>
+			<key>Title</key>
+			<string>Override Lockscreen</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<false/>
+			<key>Key</key>
 			<string>wol_preference</string>
 			<key>Title</key>
 			<string>Send Wake-On-LAN automatically</string>
@@ -42,11 +52,11 @@
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
-			<true/>
+			<false/>
 			<key>Key</key>
-			<string>ken_preference</string>
+			<string>shake_preference</string>
 			<key>Title</key>
-			<string>Ken Burns effect</string>
+			<string>Shake to clear playlist</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -54,9 +64,53 @@
 			<key>DefaultValue</key>
 			<false/>
 			<key>Key</key>
-			<string>shake_preference</string>
+			<string>vibrate_preference</string>
 			<key>Title</key>
-			<string>Shake to clear playlist</string>
+			<string>Vibrate remote control</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>Title</key>
+			<string>Cache Settings</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<true/>
+			<key>Key</key>
+			<string>diskcache_preference</string>
+			<key>Title</key>
+			<string>Enable contents cache</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<false/>
+			<key>Key</key>
+			<string>clearcache_preference</string>
+			<key>Title</key>
+			<string>Clear cache on next start</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>Title</key>
+			<string>Interface</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>FooterText</key>
+			<string>Filemode changes needs app restart</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<true/>
+			<key>Key</key>
+			<string>ken_preference</string>
+			<key>Title</key>
+			<string>Ken Burns effect</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>
@@ -112,6 +166,16 @@
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
+			<false/>
+			<key>Key</key>
+			<string>fileType_preference</string>
+			<key>Title</key>
+			<string>Show all files in filemode</string>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
 			<string>auto</string>
 			<key>Key</key>
 			<string>logo_background</string>
@@ -133,70 +197,6 @@
 				<string>light</string>
 				<string>trans</string>
 			</array>
-		</dict>
-		<dict>
-			<key>Title</key>
-			<string>Remote Control</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-		</dict>
-		<dict>
-			<key>DefaultValue</key>
-			<false/>
-			<key>Key</key>
-			<string>vibrate_preference</string>
-			<key>Title</key>
-			<string>Vibrate remote control</string>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-		</dict>
-		<dict>
-			<key>Title</key>
-			<string>App Settings</string>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-			<key>FooterText</key>
-			<string>Filemode changes needs app restart</string>
-		</dict>
-		<dict>
-			<key>DefaultValue</key>
-			<false/>
-			<key>Key</key>
-			<string>clearcache_preference</string>
-			<key>Title</key>
-			<string>Clear cache on next start</string>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-		</dict>
-		<dict>
-			<key>DefaultValue</key>
-			<true/>
-			<key>Key</key>
-			<string>diskcache_preference</string>
-			<key>Title</key>
-			<string>Enable contents cache</string>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-		</dict>
-		<dict>
-			<key>DefaultValue</key>
-			<false/>
-			<key>Key</key>
-			<string>lockscreen_preference</string>
-			<key>Title</key>
-			<string>Override Lockscreen</string>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-		</dict>
-		<dict>
-			<key>DefaultValue</key>
-			<false/>
-			<key>Key</key>
-			<string>fileType_preference</string>
-			<key>Title</key>
-			<string>Show all files in filemode</string>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
 		</dict>
 		<dict>
 			<key>DefaultValue</key>

--- a/XBMC Remote/Settings.bundle/de.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/de.lproj/Root.strings
@@ -18,7 +18,8 @@
 "Transparent" = "Transparent";
 "Remote Control" = "Fernbedienung";
 "Vibrate remote control" = "Fernbedienung vibriert";
-"App Settings" = "App-Einstellungen";
+"Interface" = "Benutzeroberfläche";
+"Cache Settings" = "Cache-Einstellungen";
 "Clear cache on next start" = "Cache beim Start löschen";
 "Enable contents cache" = "Inhalts-Cache aktivieren";
 "Override Lockscreen" = "Sperrbildschirm verhindern";

--- a/XBMC Remote/Settings.bundle/de.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/de.lproj/Root.strings
@@ -25,6 +25,7 @@
 "Show all files in filemode" = "Im Dateimodus alle Dateien anzeigen";
 "Filemode changes needs app restart" = "Dateimodus-Änderungen erfordern einen App-Neustart";
 "Main Menu" = "Hauptmenü";
+"Main Menu Items" = "Hauptmenüeinträge";
 "Start in view" = "Starten in Ansicht";
 "Music" = "Musik";
 "Movies" = "Filme";
@@ -37,14 +38,3 @@
 "Now Playing" = "Gerade läuft";
 "Global Search" = "Globale Suche";
 "Main Menu changes needs app restart" = "Hauptmenü-Änderungen erfordern einen App-Neustart";
-"Show MUSIC" = "MUSIK anzeigen";
-"Show MOVIES" = "FILME anzeigen";
-"Show VIDEOS" = "VIDEOS anzeigen";
-"Show TV SHOWS" = "SERIEN anzeigen";
-"Show PICTURES" = "BILDER anzeigen";
-"Show LIVE TV" = "TV anzeigen";
-"Show RADIO" = "RADIO anzeigen";
-"Show FAVOURITES" = "FAVORITEN anzeigen";
-"Show NOW PLAYING" = "GERADE LÄUFT anzeigen";
-"Show REMOTE CONTROL" = "FERNBEDIENUNG anzeigen";
-"Show GLOBAL SEARCH" = "GLOBALE SUCHE anzeigen";

--- a/XBMC Remote/Settings.bundle/en-us.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en-us.lproj/Root.strings
@@ -17,7 +17,8 @@
 "Transparent" = "Transparent";
 "Remote Control" = "Remote Control";
 "Vibrate remote control" = "Vibrate remote control";
-"App Settings" = "App Settings";
+"Interface" = "Interface";
+"Cache Settings" = "Cache Settings";
 "Clear cache on next start" = "Clear cache on next start";
 "Enable contents cache" = "Enable contents cache";
 "Override Lockscreen" = "Override Lockscreen";

--- a/XBMC Remote/Settings.bundle/en-us.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en-us.lproj/Root.strings
@@ -24,6 +24,7 @@
 "Show all files in filemode" = "Show all files in filemode";
 "Filemode changes needs app restart" = "Filemode changes needs app restart";
 "Main Menu" = "Main Menu";
+"Main Menu Items" = "Main Menu Items";
 "Start in view" = "Start in view";
 "Music" = "Music";
 "Movies" = "Movies";
@@ -36,14 +37,3 @@
 "Now Playing" = "Now Playing";
 "Global Search" = "Global Search";
 "Main Menu changes needs app restart" = "Main Menu changes needs app restart";
-"Show MUSIC" = "Show MUSIC";
-"Show MOVIES" = "Show MOVIES";
-"Show VIDEOS" = "Show VIDEOS";
-"Show TV SHOWS" = "Show TV SHOWS";
-"Show PICTURES" = "Show PICTURES";
-"Show LIVE TV" = "Show LIVE TV";
-"Show RADIO" = "Show RADIO";
-"Show FAVOURITES" = "Show FAVORITES";
-"Show NOW PLAYING" = "Show NOW PLAYING";
-"Show REMOTE CONTROL" = "Show REMOTE CONTROL";
-"Show GLOBAL SEARCH" = "Show GLOBAL SEARCH";

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -25,6 +25,7 @@
 "Show all files in filemode" = "Show all files in filemode";
 "Filemode changes needs app restart" = "Filemode changes needs app restart";
 "Main Menu" = "Main Menu";
+"Main Menu Items" = "Main Menu Items";
 "Start in view" = "Start in view";
 "Music" = "Music";
 "Movies" = "Movies";
@@ -37,14 +38,3 @@
 "Now Playing" = "Now Playing";
 "Global Search" = "Global Search";
 "Main Menu changes needs app restart" = "Main Menu changes needs app restart";
-"Show MUSIC" = "Show MUSIC";
-"Show MOVIES" = "Show MOVIES";
-"Show VIDEOS" = "Show VIDEOS";
-"Show TV SHOWS" = "Show TV SHOWS";
-"Show PICTURES" = "Show PICTURES";
-"Show LIVE TV" = "Show LIVE TV";
-"Show RADIO" = "Show RADIO";
-"Show FAVOURITES" = "Show FAVOURITES";
-"Show NOW PLAYING" = "Show NOW PLAYING";
-"Show REMOTE CONTROL" = "Show REMOTE CONTROL";
-"Show GLOBAL SEARCH" = "Show GLOBAL SEARCH";

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -18,7 +18,8 @@
 "Transparent" = "Transparent";
 "Remote Control" = "Remote Control";
 "Vibrate remote control" = "Vibrate remote control";
-"App Settings" = "App Settings";
+"Interface" = "Interface";
+"Cache Settings" = "Cache Settings";
 "Clear cache on next start" = "Clear cache on next start";
 "Enable contents cache" = "Enable contents cache";
 "Override Lockscreen" = "Override Lockscreen";

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -148,7 +148,7 @@
     UILabel *title = (UILabel*)[cell viewWithTag:3];
     NSString *iconName = item.icon;
     title.font = [UIFont fontWithName:@"Roboto-Regular" size:20];
-    title.text = [item.mainLabel uppercaseString];
+    title.text = item.mainLabel;
     icon.highlightedImage = [UIImage imageNamed:iconName];
     icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:UIColor.grayColor];
     return cell;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
To align the app look&feel with Kodi's default UI the main menu entries are not shown in capital letters anymore. This also allows to simplify the app settings related to the active main menu items. Instead of "Show MUSIC" it will only display "Music" left of the toggle button. This simplifies the translations and also avoid inconsistencies, if the drop-down list for the default view was not matching the entries listed in the main menu settings. This could happen, if translations were not finished.
The second change is re-grouping the app settings into meaningful sections: General, Cache Settings, Interface and Main Menu Items. Before, the grouping was a bit mixed up.

Screenshots:
https://abload.de/img/simulatorscreenshot-i3yjua.png (main menu)
https://abload.de/img/simulatorscreenshot-i7hj6e.png (app settings)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Main menu without capital letters to align with Kodi UI
Improvement: Re-grouping app settings