### PR TITLE
Maintenance: Unify WOL naming to "Wake on LAN"

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -5496,7 +5496,7 @@
                     @"hideLineSeparator": @YES
                 },
                 @{
-                    @"label": LOCALIZED_STR(@"Wake On Lan"),
+                    @"label": LOCALIZED_STR(@"Send Wake-On-LAN"),
                     @"bgColor": [self setColorRed:0.741 Green:0.141 Blue:0.141],
                     @"fontColor": [self setColorRed:1.0 Green:1.0 Blue:1.0],
                     @"hideLineSeparator": @YES,

--- a/XBMC Remote/Settings.bundle/de.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/de.lproj/Root.strings
@@ -3,7 +3,7 @@
 "General" = "Allgemein";
 "Automatic" = "Automatisch";
 "Show connection notice" = "Verbindungshinweis zeigen";
-"Send Wake-On-LAN automatically" = "„Wake on LAN“ automatisch senden";
+"Send Wake-On-LAN automatically" = "Wake-On-LAN automatisch senden";
 "Direct Play mode" = "„Sofort wiedergeben“-Modus";
 "Ken Burns effect" = "„Ken Burns“-Effekt";
 "Shake to clear playlist" = "Wiedergabeliste durch Schütteln löschen";

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -216,7 +216,7 @@
     UIAlertController *actionView = [UIAlertController alertControllerWithTitle:title message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     
     if (!AppDelegate.instance.serverOnLine) {
-        UIAlertAction* action_wake = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Wake On Lan") style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
+        UIAlertAction* action_wake = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Send Wake-On-LAN") style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
             if (AppDelegate.instance.obj.serverHWAddr != nil) {
                 [self wakeUp:AppDelegate.instance.obj.serverHWAddr];
                 UIAlertController *alertView = [Utilities createAlertOK:LOCALIZED_STR(@"Command executed") message:nil];

--- a/XBMC Remote/cs.lproj/Localizable.strings
+++ b/XBMC Remote/cs.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Command executed" = "Příkaz proveden";
 "Warning" = "Varování";
 "Cannot do that" = "Nelze udělat";
-"Wake On Lan" = "Wake On Lan";
+"Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "Nebyly nalezeni žádní uložení hostitelé";
 "Are you sure you want to clear the playlist?" = "Opravdu chcete zrušit playlist?";
 "Are you sure you want to clear the music playlist?" = "Opravdu chcete zrušit hudba playlist?";

--- a/XBMC Remote/cs.lproj/Localizable.strings
+++ b/XBMC Remote/cs.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Command executed" = "Příkaz proveden";
 "Warning" = "Varování";
 "Cannot do that" = "Nelze udělat";
-"Send Wake-On-LAN" = "Send Wake-On-LAN";
+"Send Wake-On-LAN" = "Odeslat Wake-On-LAN";
 "No saved hosts found" = "Nebyly nalezeni žádní uložení hostitelé";
 "Are you sure you want to clear the playlist?" = "Opravdu chcete zrušit playlist?";
 "Are you sure you want to clear the music playlist?" = "Opravdu chcete zrušit hudba playlist?";

--- a/XBMC Remote/de.lproj/Localizable.strings
+++ b/XBMC Remote/de.lproj/Localizable.strings
@@ -109,7 +109,7 @@
 "Command executed" = "Kommando ausgeführt";
 "Warning" = "Achtung";
 "Cannot do that" = "Dies ist nicht möglich";
-"Wake On Lan" = "Wake-On-LAN";
+"Send Wake-On-LAN" = "Wake-On-LAN senden";
 "No saved hosts found" = "Keine gespeicherten Server gefunden";
 "Are you sure you want to clear the playlist?" = "Soll die Wiedergabeliste gelöscht werden?";
 "Are you sure you want to clear the music playlist?" = "Soll die Musik-Wiedergabeliste gelöscht werden?";

--- a/XBMC Remote/en-US.lproj/Localizable.strings
+++ b/XBMC Remote/en-US.lproj/Localizable.strings
@@ -108,7 +108,7 @@
 "Command executed" = "Command executed";
 "Warning" = "Warning";
 "Cannot do that" = "Cannot do that";
-"Wake On Lan" = "Wake On Lan";
+"Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "No saved hosts found";
 "Are you sure you want to clear the playlist?" = "Are you sure you want to clear the playlist?";
 "Are you sure you want to clear the music playlist?" = "Are you sure you want to clear the music playlist?";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -119,7 +119,7 @@
 "Command executed" = "Command executed";
 "Warning" = "Warning";
 "Cannot do that" = "Cannot do that";
-"Wake On Lan" = "Wake On Lan";
+"Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "No saved hosts found";
 
 "Are you sure you want to clear the playlist?" = "Are you sure you want to clear the playlist?";

--- a/XBMC Remote/es.lproj/Localizable.strings
+++ b/XBMC Remote/es.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Command executed" = "Comando ejecutado";
 "Warning" = "Aviso";
 "Cannot do that" = "No puedes hacer eso";
-"Wake On Lan" = "Activación de LAN";
+"Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "No se encontraron hosts guardados";
 "Are you sure you want to clear the playlist?" = "¿Estás seguro de que quieres limpiar la lista?";
 "Are you sure you want to clear the music playlist?" = "¿Estás seguro de que quieres limpiar la lista de música?";

--- a/XBMC Remote/es.lproj/Localizable.strings
+++ b/XBMC Remote/es.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Command executed" = "Comando ejecutado";
 "Warning" = "Aviso";
 "Cannot do that" = "No puedes hacer eso";
-"Send Wake-On-LAN" = "Send Wake-On-LAN";
+"Send Wake-On-LAN" = "Enviar Wake-On-LAN";
 "No saved hosts found" = "No se encontraron hosts guardados";
 "Are you sure you want to clear the playlist?" = "¿Estás seguro de que quieres limpiar la lista?";
 "Are you sure you want to clear the music playlist?" = "¿Estás seguro de que quieres limpiar la lista de música?";

--- a/XBMC Remote/fr.lproj/Localizable.strings
+++ b/XBMC Remote/fr.lproj/Localizable.strings
@@ -99,7 +99,7 @@
 "Command executed" = "Commande executée";
 "Warning" = "Attention";
 "Cannot do that" = "Impossible de faire ceci";
-"Wake On Lan" = "Wake On Lan";
+"Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "Aucun serveur enregistré";
 "Are you sure you want to clear the playlist?" = "Etes-vous sur de vouloir nettoyer playlist ?";
 "Are you sure you want to clear the music playlist?" = "Etes-vous sur de vouloir nettoyer playlist musique ?";

--- a/XBMC Remote/fr.lproj/Localizable.strings
+++ b/XBMC Remote/fr.lproj/Localizable.strings
@@ -99,7 +99,7 @@
 "Command executed" = "Commande executée";
 "Warning" = "Attention";
 "Cannot do that" = "Impossible de faire ceci";
-"Send Wake-On-LAN" = "Send Wake-On-LAN";
+"Send Wake-On-LAN" = "Envoyer Wake-On-LAN";
 "No saved hosts found" = "Aucun serveur enregistré";
 "Are you sure you want to clear the playlist?" = "Etes-vous sur de vouloir nettoyer playlist ?";
 "Are you sure you want to clear the music playlist?" = "Etes-vous sur de vouloir nettoyer playlist musique ?";

--- a/XBMC Remote/it.lproj/Localizable.strings
+++ b/XBMC Remote/it.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Command executed" = "Comando eseguito";
 "Warning" = "Attenzione";
 "Cannot do that" = "Non lo posso fare";
-"Send Wake-On-LAN" = "Send Wake-On-LAN";
+"Send Wake-On-LAN" = "Invia Wake-On-LAN";
 "No saved hosts found" = "Nessun server trovato";
 "Are you sure you want to clear the playlist?" = "Sei sicuro di voler cancellare la playlist?";
 "Are you sure you want to clear the music playlist?" = "Sei sicuro di voler cancellare la playlist musica?";

--- a/XBMC Remote/it.lproj/Localizable.strings
+++ b/XBMC Remote/it.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Command executed" = "Comando eseguito";
 "Warning" = "Attenzione";
 "Cannot do that" = "Non lo posso fare";
-"Wake On Lan" = "Wake On Lan";
+"Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "Nessun server trovato";
 "Are you sure you want to clear the playlist?" = "Sei sicuro di voler cancellare la playlist?";
 "Are you sure you want to clear the music playlist?" = "Sei sicuro di voler cancellare la playlist musica?";

--- a/XBMC Remote/nl.lproj/Localizable.strings
+++ b/XBMC Remote/nl.lproj/Localizable.strings
@@ -102,7 +102,7 @@
 "Command executed" = "Commando uitgevoerd";
 "Warning" = "Waarschuwing";
 "Cannot do that" = "Dat is niet mogelijk";
-"Send Wake-On-LAN" = "Send Wake-On-LAN";
+"Send Wake-On-LAN" = "Wake-On-LAN verzenden";
 "No saved hosts found" = "Geen opgeslagen hosts gevonden";
 "Are you sure you want to clear the playlist?" = "Weet je zeker dat je playlist wil leegmaken?";
 "Are you sure you want to clear the music playlist?" = "Weet je zeker dat je muziek playlist wil leegmaken?";

--- a/XBMC Remote/nl.lproj/Localizable.strings
+++ b/XBMC Remote/nl.lproj/Localizable.strings
@@ -102,7 +102,7 @@
 "Command executed" = "Commando uitgevoerd";
 "Warning" = "Waarschuwing";
 "Cannot do that" = "Dat is niet mogelijk";
-"Wake On Lan" = "Wake On Lan";
+"Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "Geen opgeslagen hosts gevonden";
 "Are you sure you want to clear the playlist?" = "Weet je zeker dat je playlist wil leegmaken?";
 "Are you sure you want to clear the music playlist?" = "Weet je zeker dat je muziek playlist wil leegmaken?";

--- a/XBMC Remote/pl.lproj/Localizable.strings
+++ b/XBMC Remote/pl.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Command executed" = "Wykonano polecenie";
 "Warning" = "Ostrzeżenie";
 "Cannot do that" = "Nie można wykonać";
-"Wake On Lan" = "Wake-on-LAN (WoL)";
+"Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "Nie znaleziono zapisanych hostów";
 "Are you sure you want to clear the playlist?" = "Czy na pewno chcesz wyczyścić listę odtwarzania?";
 "Are you sure you want to clear the music playlist?" = "Czy na pewno chcesz wyczyścić listę odtwarzania muzyki?";

--- a/XBMC Remote/pl.lproj/Localizable.strings
+++ b/XBMC Remote/pl.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Command executed" = "Wykonano polecenie";
 "Warning" = "Ostrzeżenie";
 "Cannot do that" = "Nie można wykonać";
-"Send Wake-On-LAN" = "Send Wake-On-LAN";
+"Send Wake-On-LAN" = "Wyślij Wake-On-LAN";
 "No saved hosts found" = "Nie znaleziono zapisanych hostów";
 "Are you sure you want to clear the playlist?" = "Czy na pewno chcesz wyczyścić listę odtwarzania?";
 "Are you sure you want to clear the music playlist?" = "Czy na pewno chcesz wyczyścić listę odtwarzania muzyki?";

--- a/XBMC Remote/pt-PT.lproj/Localizable.strings
+++ b/XBMC Remote/pt-PT.lproj/Localizable.strings
@@ -103,7 +103,7 @@
 "Command executed" = "Comando executado";
 "Warning" = "Aviso";
 "Cannot do that" = "Não é possível fazer isso";
-"Wake On Lan" = "Ligar via rede local (WoL)";
+"Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "Nenhum servidor guardado encontrado";
 "Are you sure you want to clear the playlist?" = "Tem a certeza de que quer apagar a playlist?";
 "Are you sure you want to clear the music playlist?" = "Tem a certeza de que quer apagar a playlist de música?";

--- a/XBMC Remote/pt-PT.lproj/Localizable.strings
+++ b/XBMC Remote/pt-PT.lproj/Localizable.strings
@@ -103,7 +103,7 @@
 "Command executed" = "Comando executado";
 "Warning" = "Aviso";
 "Cannot do that" = "Não é possível fazer isso";
-"Send Wake-On-LAN" = "Send Wake-On-LAN";
+"Send Wake-On-LAN" = "Enviar Wake-On-LAN";
 "No saved hosts found" = "Nenhum servidor guardado encontrado";
 "Are you sure you want to clear the playlist?" = "Tem a certeza de que quer apagar a playlist?";
 "Are you sure you want to clear the music playlist?" = "Tem a certeza de que quer apagar a playlist de música?";

--- a/XBMC Remote/sv.lproj/Localizable.strings
+++ b/XBMC Remote/sv.lproj/Localizable.strings
@@ -103,7 +103,7 @@
 "Command executed" = "Kommandot kördes";
 "Warning" = "Varning";
 "Cannot do that" = "Kan inte göra detta";
-"Send Wake-On-LAN" = "Send Wake-On-LAN";
+"Send Wake-On-LAN" = "Skicka Wake-On-LAN";
 "No saved hosts found" = "Inga sparade värddatorer hittades";
 "Are you sure you want to clear the playlist?" = "Är du säker på att du vill tömma playlist?";
 "Are you sure you want to clear the music playlist?" = "Är du säker på att du vill tömma musik playlist?";

--- a/XBMC Remote/sv.lproj/Localizable.strings
+++ b/XBMC Remote/sv.lproj/Localizable.strings
@@ -103,7 +103,7 @@
 "Command executed" = "Kommandot kördes";
 "Warning" = "Varning";
 "Cannot do that" = "Kan inte göra detta";
-"Wake On Lan" = "Wake On Lan";
+"Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "Inga sparade värddatorer hittades";
 "Are you sure you want to clear the playlist?" = "Är du säker på att du vill tömma playlist?";
 "Are you sure you want to clear the music playlist?" = "Är du säker på att du vill tömma musik playlist?";

--- a/XBMC Remote/tr.lproj/Localizable.strings
+++ b/XBMC Remote/tr.lproj/Localizable.strings
@@ -99,7 +99,7 @@
 "Command executed" = "Komut uygulandı";
 "Warning" = "Uyarı";
 "Cannot do that" = "Yapılamıyor";
-"Wake On Lan" = "Ağ bağlantısında uyan";
+"Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "Kayıtlı sunucu bulunamadı";
 "Are you sure you want to clear the playlist?" = "Temizlensin mi: playlist ?";
 "Are you sure you want to clear the music playlist?" = "Temizlensin mi: müzik playlist ?";

--- a/XBMC Remote/tr.lproj/Localizable.strings
+++ b/XBMC Remote/tr.lproj/Localizable.strings
@@ -99,7 +99,7 @@
 "Command executed" = "Komut uygulandı";
 "Warning" = "Uyarı";
 "Cannot do that" = "Yapılamıyor";
-"Send Wake-On-LAN" = "Send Wake-On-LAN";
+"Send Wake-On-LAN" = "Wake-On-LAN gönder";
 "No saved hosts found" = "Kayıtlı sunucu bulunamadı";
 "Are you sure you want to clear the playlist?" = "Temizlensin mi: playlist ?";
 "Are you sure you want to clear the music playlist?" = "Temizlensin mi: müzik playlist ?";

--- a/XBMC Remote/zh-Hans.lproj/Localizable.strings
+++ b/XBMC Remote/zh-Hans.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Command executed" = "命令已执行";
 "Warning" = "注意";
 "Cannot do that" = "无法做到";
-"Send Wake-On-LAN" = "Send Wake-On-LAN";
+"Send Wake-On-LAN" = "发送局域网唤醒";
 "No saved hosts found" = "未找到保存的主机";
 "Are you sure you want to clear the playlist?" = "确定要清除playlist?";
 "Are you sure you want to clear the music playlist?" = "确定要清除音乐playlist?";

--- a/XBMC Remote/zh-Hans.lproj/Localizable.strings
+++ b/XBMC Remote/zh-Hans.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Command executed" = "命令已执行";
 "Warning" = "注意";
 "Cannot do that" = "无法做到";
-"Wake On Lan" = "网络唤醒";
+"Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "未找到保存的主机";
 "Are you sure you want to clear the playlist?" = "确定要清除playlist?";
 "Are you sure you want to clear the music playlist?" = "确定要清除音乐playlist?";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Different naming conventions are used for WOL: "Wake On Lan", "Wake-On-LAN", "Wake on LAN". This PR unifies the naming to "Wake on LAN".

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Unify WOL naming to "Wake on LAN"