### PR TITLE
Bugfix: Fix writing of "Now Playing" in main menu

### DIFF
--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -10,7 +10,7 @@
 "Movies" = "Movies";
 "TV Shows" = "TV Shows";
 "Pictures" = "Pictures";
-"Now Playing" = "Now playing";
+"Now Playing" = "Now Playing";
 "Favourites" = "Favourites";
 "Global Search" = "Global Search";
 "Remote Control" = "Remote Control";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Use "Now Playing" instead of "Now playing".

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix writing of "Now Playing" in main menu for en and en-US
