### PR TITLE
Bugfix: Fix iPad main menu selection

### DIFF
--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -191,8 +191,8 @@
             lastSelected = -1;
             return;
         }
-        lastSelected = (int)indexPath.row;
     }
+    lastSelected = (int)indexPath.row;
 }
 
 - (void)setLastSelected:(int)selection {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The selection of menu A was not working in the following sequence: menu A > NowPlaying > menu A. Root cause was the local variable `lastSelected` not being updated when entering NowPlaying.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix iPad main menu selection