### PR TITLE
Bugfix: Use correct port for auto-WOL

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -43,6 +43,8 @@
 #define PAD_TV_SHOWS_BANNER_WIDTH IPAD_SCREEN_DESIGN_WIDTH
 #define PAD_TV_SHOWS_POSTER_WIDTH 53
 
+#define WOL_PORT 9
+
 + (AppDelegate*)instance;
 
 - (void)saveServerList;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -577,7 +577,7 @@
 }
 
 - (void)wakeUp:(NSString*)macAddress {
-    [AppDelegate.instance sendWOL:macAddress withPort:9];
+    [AppDelegate.instance sendWOL:macAddress withPort:WOL_PORT];
 }
 
 #pragma mark - LifeCycle

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -103,7 +103,7 @@
 }
 
 - (void)wakeUp:(NSString*)macAddress {
-    [AppDelegate.instance sendWOL:macAddress withPort:9];
+    [AppDelegate.instance sendWOL:macAddress withPort:WOL_PORT];
 }
 
 - (void)connectionStatus:(NSNotification*)note {

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -178,7 +178,7 @@ NSOutputStream	*outStream;
     }
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"wol_preference"] &&
         AppDelegate.instance.obj.serverHWAddr != nil) {
-        [AppDelegate.instance sendWOL:AppDelegate.instance.obj.serverHWAddr withPort:0];
+        [AppDelegate.instance sendWOL:AppDelegate.instance.obj.serverHWAddr withPort:WOL_PORT];
     }
     inCheck = YES;
 //    NSString *userPassword = [AppDelegate.instance.obj.serverPass isEqualToString:@""] ? @"" : [NSString stringWithFormat:@":%@", AppDelegate.instance.obj.serverPass];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Due to a typo the port 0 was used for auto-WOL instead of the desired port 9.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use correct port for auto-WOL