### PR TITLE
Bugfix: Fix visible progress bar on iPad after enabling remote from bottom toolbar

### DIFF
--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -188,6 +188,7 @@
 }
 
 - (void)showRemote {
+    [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollOnScreen" object: nil]; 
     RemoteController *remoteController = [[RemoteController alloc] initWithNibName:@"RemoteController" bundle:nil];
     remoteController.modalPresentationStyle = UIModalPresentationFormSheet;
     [remoteController setPreferredContentSize:remoteController.view.frame.size];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
When enabling the remote from the iPad's bottom toolbar we need to explicitly send the "StackScrollOnScreen" notification to move the NowPlaying view under the rootView.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix visible progress bar on iPad after enabling remote from bottom toolbar
