### PR TITLE
Bugfix: Fix start/stop recording from channel guide

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3918,7 +3918,7 @@ NSIndexPath *selected;
 
 - (void)deleteTimer:(NSDictionary*)item indexPath:(NSIndexPath*)indexPath {
     NSNumber *itemid = @([item[@"timerid"] longValue]);
-    if ([itemid isEqualToValue:@(0)]) {
+    if ([itemid longValue] == 0) {
         return;
     }
     id cell = [self getCell:indexPath];
@@ -3961,9 +3961,9 @@ NSIndexPath *selected;
     NSNumber *itemid = @([item[@"channelid"] longValue]);
     NSNumber *storeChannelid = itemid;
     NSNumber *storeBroadcastid = @([item[@"broadcastid"] longValue]);
-    if ([itemid isEqualToValue:@(0)]) {
+    if ([itemid longValue] == 0) {
         itemid = @([item[@"pvrExtraInfo"][@"channelid"] longValue]);
-        if ([itemid isEqualToValue:@(0)]) {
+        if ([itemid longValue] == 0) {
             return;
         }
         storeChannelid = itemid;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -437,7 +437,7 @@ double round(double d) {
 
 - (void)recordChannel {
     NSNumber *channelid = @([self.detailItem[@"pvrExtraInfo"][@"channelid"] longValue]);
-    if ([channelid isEqualToValue:@(0)]) {
+    if ([channelid longValue] == 0) {
         return;
     }
     NSString *methodToCall = @"PVR.Record";
@@ -445,9 +445,9 @@ double round(double d) {
     NSNumber *itemid = @([self.detailItem[@"channelid"] longValue]);
     NSNumber *storeChannelid = itemid;
     NSNumber *storeBroadcastid = @([self.detailItem[@"broadcastid"] longValue]);
-    if ([itemid isEqualToValue:@(0)]) {
+    if ([itemid longValue] == 0) {
         itemid = @([self.detailItem[@"pvrExtraInfo"][@"channelid"] longValue]);
-        if ([itemid isEqualToValue:@(0)]) {
+        if ([itemid longValue] == 0) {
             return;
         }
         storeChannelid = itemid;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/629.

Regression of build 1.10-b7. Fix is to use `longValue` for correct comparison.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix start/stop recording from channel guide