### PR TITLE
Bugfix: Fix getting MAC address

### DIFF
--- a/XBMC Remote/HostViewController.h
+++ b/XBMC Remote/HostViewController.h
@@ -11,7 +11,7 @@
 
 #define SERVERPOPUP_BOTTOMPADDING 10
 
-@interface HostViewController : UIViewController <UITextFieldDelegate, NSNetServiceDelegate, NSNetServiceBrowserDelegate, UITableViewDataSource, UITableViewDelegate, NSURLConnectionDataDelegate>{
+@interface HostViewController : UIViewController <UITextFieldDelegate, NSNetServiceDelegate, NSNetServiceBrowserDelegate, UITableViewDataSource, UITableViewDelegate>{
 //    GlobalData *obj;
     IBOutlet UITextField *descriptionUI;
     IBOutlet UITextField *ipUI;

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -381,7 +381,12 @@
                 NSString *serverJSON = [NSString stringWithFormat:@"http://%@:%@/jsonrpc", ipUI.text, portUI.text];
                 NSURL *url = [[NSURL alloc] initWithString:serverJSON];
                 NSURLSession *pingSession = [NSURLSession sharedSession];
-                NSURLSessionDataTask *pingConnection = [pingSession dataTaskWithURL:url];
+                NSURLSessionDataTask *pingConnection = [pingSession dataTaskWithURL:url
+                                                                  completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [self fillMacAddressInfo];
+                    });
+                }];
                 [pingConnection resume];
                 [Utilities AnimView:discoveredInstancesView AnimDuration:0.3 Alpha:1.0 XPos:self.view.frame.size.width];
             }
@@ -441,20 +446,6 @@
 
 - (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath {
     [self resolveIPAddress:services[indexPath.row]];
-}
-
-#pragma mark - NSURLConnection Delegate Methods
-
-- (void)connection:(NSURLConnection*)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge*)challenge {
-    [self fillMacAddressInfo];
-}
-
-- (void)connection:(NSURLConnection*)connection didFailWithError:(NSError*)error {
-    [self fillMacAddressInfo];
-}
-
-- (void)connectionDidFinishLoading:(NSURLConnection*)connection {
-    [self fillMacAddressInfo];
 }
 
 #pragma mark - LifeCycle


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
To get the MAC address we need to wait for the result of a ping which is done via `NSURLSessionDataTask`. For this we need to implement a delegate handler and use a dedicated `NSURLSession` instead of `sharedSession`.

This function broke already with 1.6.2 which was never reported as broken -- most like because many users either keep using the old setups or entered the MAC address manually.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix reading MAC address during "Find Kodi"