### PR TITLE
Bugfix: Fix action sheets not showing on few filtered lists

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -412,6 +412,16 @@
 
 #pragma mark - Utility
 
+- (UIViewController*)topMostController {
+    UIViewController *topController = UIApplication.sharedApplication.keyWindow.rootViewController;
+
+    while (topController.presentedViewController) {
+        topController = topController.presentedViewController;
+    }
+
+    return topController;
+}
+
 - (void)setFilternameLabel:(NSString*)labelText runFullscreenButtonCheck:(BOOL)check forceHide:(BOOL)forceHide {
     self.navigationItem.title = labelText;
     if (IS_IPHONE) {
@@ -3212,22 +3222,11 @@ NSIndexPath *selected;
                 UIViewController *showFromCtrl = nil;
                 UIView *showfromview = nil;
                 if (IS_IPHONE) {
-                    showFromCtrl = self;
+                    showFromCtrl = [self topMostController];
                     showfromview = self.view;
                 }
                 else {
-                    if ([self doesShowSearchResults] || [self getSearchTextField].editing) {
-                        // We are searching an must present from searchController
-                        showFromCtrl = self.searchController;
-                    }
-                    else if ([self isModal]) {
-                        // We are in modal view (e.g. fullscreen) and must present from ourself
-                        showFromCtrl = self;
-                    }
-                    else {
-                        // We are in stackview and must present from rootVC
-                        showFromCtrl = self.view.window.rootViewController;
-                    }
+                    showFromCtrl = [self topMostController];
                     showfromview = enableCollectionView ? collectionView : [showFromCtrl.view superview];
                     selectedPoint = enableCollectionView ? p : [lpgr locationInView:showfromview];
                 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3134,13 +3134,7 @@ NSIndexPath *selected;
         UIImageView *isRecordingImageView = (UIImageView*)[cell viewWithTag:104];
         BOOL isRecording = isRecordingImageView == nil ? NO : !isRecordingImageView.hidden;
         CGPoint sheetOrigin = CGPointMake(rectOriginX, rectOriginY);
-        UIViewController *showFromCtrl = nil;
-        if (IS_IPHONE) {
-            showFromCtrl = self;
-        }
-        else {
-            showFromCtrl = self.view.window.rootViewController;
-        }
+        UIViewController *showFromCtrl = [self topMostController];
         [self showActionSheetOptions:title options:sheetActions recording:isRecording point:sheetOrigin fromcontroller:showFromCtrl fromview:self.view];
     }
     else if (indexPath != nil) { // No actions found, revert back to standard play action
@@ -3219,14 +3213,12 @@ NSIndexPath *selected;
                 }
                 UIImageView *isRecordingImageView = (UIImageView*)[cell viewWithTag:104];
                 BOOL isRecording = isRecordingImageView == nil ? NO : !isRecordingImageView.hidden;
-                UIViewController *showFromCtrl = nil;
+                UIViewController *showFromCtrl = [self topMostController];
                 UIView *showfromview = nil;
                 if (IS_IPHONE) {
-                    showFromCtrl = [self topMostController];
                     showfromview = self.view;
                 }
                 else {
-                    showFromCtrl = [self topMostController];
                     showfromview = enableCollectionView ? collectionView : [showFromCtrl.view superview];
                     selectedPoint = enableCollectionView ? p : [lpgr locationInView:showfromview];
                 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Action sheets shall be presented from `self.searchController` while a search is active -- change is only needed for iPhone as the same is already done for iPad. This fixes few lists not showing the actions sheet while active search. One case related to adding custom buttons is described in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3091345#pid3091345).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix action sheets not showing on few filtered lists