### PR TITLE
Fix NSSecureCoding warning while unarchiving

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -987,13 +987,32 @@
 
 + (id)unarchivePath:(NSString*)path file:(NSString*)filename {
     NSString *filePath = [path stringByAppendingPathComponent:filename];
-    id unarchived = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+    id unarchived;
+    
+    if (@available(iOS 11.0, *)) {
+        NSData *data = [[NSFileManager defaultManager] contentsAtPath:filePath];
+        NSError *error;
+        unarchived = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class]
+                                                         fromData:data
+                                                            error:&error];
+    } else {
+        unarchived = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+    }
     return unarchived;
 }
 
 + (void)archivePath:(NSString*)path file:(NSString*)filename data:(id)data {
     NSString *filePath = [path stringByAppendingPathComponent:filename];
-    [NSKeyedArchiver archiveRootObject:data toFile:filePath];
+    
+    if (@available(iOS 11.0, *)) {
+        NSError *error;
+        NSData *archiveData = [NSKeyedArchiver archivedDataWithRootObject:data requiringSecureCoding:NO error:&error];
+        if (!error) {
+            [archiveData writeToFile:filePath options:NSDataWritingAtomic error:&error];
+        }
+    } else {
+        [NSKeyedArchiver archiveRootObject:data toFile:filePath];
+    }
 }
 
 + (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -992,7 +992,20 @@
     if (@available(iOS 11.0, *)) {
         NSData *data = [[NSFileManager defaultManager] contentsAtPath:filePath];
         NSError *error;
-        unarchived = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class]
+        NSSet *objectClasses = [NSSet setWithArray:@[
+            // Supported non-mutable classes
+            [NSDictionary class],
+            [NSString class],
+            [NSArray class],
+            [NSNumber class],
+            [NSDate class],
+            [NSData class],
+            // Supported mutable classes
+            [NSMutableDictionary class],
+            [NSMutableString class],
+            [NSMutableArray class],
+        ]];
+        unarchived = [NSKeyedUnarchiver unarchivedObjectOfClasses:objectClasses
                                                          fromData:data
                                                             error:&error];
     } else {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
When loading persistent file in simulator a security warning pops up:

> NSSecureCoding allowed classes list contains [NSObject class], which bypasses security by allowing any Objective-C class to be implicitly decoded. Consider reducing the scope of allowed classes during decoding by listing only the classes you expect to decode, or a more specific base class than NSObject.

`NSKeyedUnarchiver:unarchivedObjectOfClass:fromaData:error:` throws a warning when `[NSObject call]` is used as this covers all object classes. Instead, list the classes which shall be unarchived.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix NSSecureCoding warning while unarchiving
Bugfix: Resolve performance issues when reading cached data