### PR TITLE
Improvement: Show year as part of recording date

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1829,7 +1829,7 @@ double round(double d) {
     
     localStartDateFormatter = [NSDateFormatter new];
     localStartDateFormatter.timeZone = [NSTimeZone systemTimeZone];
-    localStartDateFormatter.dateFormat = @"ccc dd MMM, HH:mm";
+    localStartDateFormatter.dateFormat = @"ccc, dd MMM YYYY, HH:mm";
     
     localEndDateFormatter = [NSDateFormatter new];
     localEndDateFormatter.timeZone = [NSTimeZone systemTimeZone];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Improve information shared in recording details by showing the year of the recording in addition to day of the week, day and month.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-03yykb9.png"><img src="https://abload.de/img/bildschirmfoto2022-03yykb9.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Show year as part of recording date