### PR TITLE
Improvement: Show same music video thumbnails in NowPlaying, playlist and while browsing

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -108,6 +108,10 @@ typedef enum {
 - (NSString*)getNowPlayingThumbnailPath:(NSDictionary*)item {
     // If a recording is played, we can use the iocn (typically the station logo)
     BOOL useIcon = [item[@"type"] isEqualToString:@"recording"] || [item[@"recordingid"] longValue] > 0;
+    // If we are showing a music video and we have a "thumbnail", take "thumbnail" to avoid fallback to "poster"
+    if ([item[@"thumbnail"] length] && [item[@"type"] isEqualToString:@"musicvideo"]) {
+        return item[@"thumbnail"];
+    }
     return [Utilities getThumbnailFromDictionary:item useBanner:NO useIcon:useIcon];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The chosen playlist thumbnail for music videos shall be same as while browsing the database. This can be achieved via showing the `"thubmnail"` key's object and not calling `getThumbnailFromDictionary` to ignore unwanted `"poster"` from `"art"` key.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-034mkwg.png"><img src="https://abload.de/img/bildschirmfoto2022-034mkwg.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Show same music video thumbnails in NowPlaying, playlist and while browsing