### PR TITLE
Feature: Add auto-color setting for UI

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -722,7 +722,7 @@
 - (void)setViewColor:(UIView*)view image:(UIImage*)image isTopMost:(BOOL)isTopMost lab12color:(UIColor*)lab12color label34Color:(UIColor*)lab34color fontshadow:(UIColor*)shadow label1:(UILabel*)label1 label2:(UILabel*)label2 label3:(UILabel*)label3 label4:(UILabel*)label4 {
 
     // Gather average cover color and limit saturation
-    UIColor* mainColor = [Utilities averageColor:image inverse:NO];
+    UIColor* mainColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
     mainColor = [Utilities limitSaturation:mainColor satmax:0.33];
     
     // Create gradient based on average color
@@ -1778,7 +1778,7 @@
                                  placeholderImage:[UIImage imageNamed:displayThumb]
                                         andResize:CGSizeMake(posterWidth, cellthumbHeight)
                                         completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-                UIColor *averageColor = [Utilities averageColor:image inverse:NO];
+                UIColor *averageColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
                 CGFloat hue, saturation, brightness, alpha;
                 BOOL ok = [averageColor getHue:&hue saturation:&saturation brightness:&brightness alpha:&alpha];
                 if (ok) {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -689,7 +689,7 @@ long currentItemID;
                                                      buttonImage = [self resizeToolbarThumb:jewelView.image];
                                                  }
                                                  [self setButtonImageAndStartDemo:buttonImage];
-                                                 UIColor *effectColor = [Utilities averageColor:image inverse:NO];
+                                                 UIColor *effectColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
                                                  [self setIOS7backgroundEffect:effectColor barTintColor:effectColor];
                                              }
                                              else {
@@ -703,7 +703,7 @@ long currentItemID;
                                                                                   
                                                                                   UIImage *buttonImage = [sf resizeToolbarThumb:[sf imageWithBorderFromImage:image]];
                                                                                   [sf setButtonImageAndStartDemo:buttonImage];
-                                                                                  newColor = [Utilities averageColor:image inverse:NO];
+                                                                                  newColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
                                                                                   [sf setIOS7backgroundEffect:newColor barTintColor:newColor];
                                                                               }
                                                                           }];
@@ -717,7 +717,7 @@ long currentItemID;
                                                               [sf changeImage:jV image:[sf imageWithBorderFromImage:image]];
                                                               UIImage *buttonImage = [sf resizeToolbarThumb:jV.image];
                                                               [sf setButtonImageAndStartDemo:buttonImage];
-                                                              newColor = [Utilities averageColor:image inverse:NO];
+                                                              newColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
                                                               [sf setIOS7backgroundEffect:newColor barTintColor:newColor];
                                                           }
                                                       }];

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -158,6 +158,16 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
+			<string>Colorize UI automatically</string>
+			<key>Key</key>
+			<string>autocolor_ui_preference</string>
+			<key>DefaultValue</key>
+			<true/>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
 			<string>Use thumbnail when fanart is missing</string>
 			<key>Key</key>
 			<string>fanart_fallback_preference</string>

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -11,6 +11,7 @@
 "Hide labels in wall view" = "Hide labels in wall view";
 "Prefer posters for TV shows" = "Prefer posters for TV shows";
 "Use rounded corner images" = "Use rounded corner images";
+"Colorize UI automatically" = "Colorize UI automatically";
 "Use thumbnail when fanart is missing" = "Use thumbnail when fanart is missing";
 "TV logo background" = "TV logo background";
 "Dark" = "Dark";

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1254,7 +1254,7 @@ double round(double d) {
     }
     [[SDImageCache sharedImageCache] queryDiskCacheForKey:thumbnailPath done:^(UIImage *image, SDImageCacheType cacheType) {
         if (image != nil) {
-            foundTintColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO]];
+            foundTintColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO autoColorCheck:YES]];
             [self setIOS7barTintColor:foundTintColor];
             if (enableJewel) {
                 coverView.image = image;
@@ -1274,7 +1274,7 @@ double round(double d) {
                           placeholderImage:[UIImage imageNamed:placeHolderImage]
                                  completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
                                     if (image != nil) {
-                                        newColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO]];
+                                        newColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO autoColorCheck:YES]];
                                         [sf setIOS7barTintColor:newColor];
                                         foundTintColor = newColor;
                                     }
@@ -1288,7 +1288,7 @@ double round(double d) {
                           placeholderImage:[UIImage imageNamed:placeHolderImage]
                                  completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
                                     if (image != nil) {
-                                        newColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO]];
+                                        newColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO autoColorCheck:YES]];
                                         [sf setIOS7barTintColor:newColor];
                                         foundTintColor = newColor;
                                     }

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -26,7 +26,7 @@ typedef enum {
 
 @interface Utilities : NSObject
 
-+ (UIColor*)averageColor:(UIImage*)image inverse:(BOOL)inverse;
++ (UIColor*)averageColor:(UIImage*)image inverse:(BOOL)inverse autoColorCheck:(BOOL)autoColorCheck;
 + (UIColor*)limitSaturation:(UIColor*)c satmax:(CGFloat)satmax;
 + (UIColor*)slightLighterColorForColor:(UIColor*)c;
 + (UIColor*)lighterColorForColor:(UIColor*)c;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -50,10 +50,16 @@
     return imageRef;
 }
 
-+ (UIColor*)averageColor:(UIImage*)image inverse:(BOOL)inverse {
++ (UIColor*)averageColor:(UIImage*)image inverse:(BOOL)inverse autoColorCheck:(BOOL)autoColorCheck {
     CGImageRef rawImageRef = [image CGImage];
     if (rawImageRef == nil) {
         return UIColor.clearColor;
+    }
+    
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    BOOL autocolor_preference = [userDefaults boolForKey:@"autocolor_ui_preference"];
+    if (autoColorCheck && !autocolor_preference) {
+        return [Utilities getSystemGray2];
     }
     
     CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(rawImageRef);
@@ -246,7 +252,7 @@
     switch (mode) {
         case bgAuto:
             // get background color and colorize the image background
-            imgcolor = [Utilities averageColor:imageview.image inverse:NO];
+            imgcolor = [Utilities averageColor:imageview.image inverse:NO autoColorCheck:NO];
             bgcolor = [Utilities updateColor:imgcolor lightColor:bglight darkColor:bgdark trigger:0.4];
             break;
         case bgLight:


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/545.

The UI colorization follows the average color of images (e.g. thumbnails or artwork). Now let the average color be returning a fixed gray color (which supports LightMode and DarkMode) in case the UI-colorization feature is switched off. As the same method is also used to determine TV logo background a new parameter is introduced to allow ignoring the UI-colorization setting in this case.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-03fukwc.png"><img src="https://abload.de/img/bildschirmfoto2022-03fukwc.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Add auto-color setting for UI