### PR TITLE
Improvement: Do not animate settings list after a swipe-attempt

### DIFF
--- a/XBMC Remote/SettingsValuesViewController.h
+++ b/XBMC Remote/SettingsValuesViewController.h
@@ -35,6 +35,7 @@ typedef enum {
     UILabel *scrubbingRate;
     MessagesView *messagesView;
     NSString *footerMessage;
+    BOOL fromItself;
 }
 
 - (id)initWithFrame:(CGRect)frame withItem:(id)item;

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -125,6 +125,7 @@
         
         _tableView = [[UITableView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height) style:UITableViewStylePlain];
         cellLabelOffset = 8;
+        _tableView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
 		_tableView.delegate = self;
 		_tableView.dataSource = self;
         _tableView.backgroundColor = UIColor.clearColor;

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -749,8 +749,7 @@
 - (void)scrollTableRow:(NSArray*)list {
     NSIndexPath *optionIndex = [self getCurrentSelectedOption:list];
     if (optionIndex != nil) {
-        [_tableView scrollToRowAtIndexPath:optionIndex atScrollPosition:UITableViewScrollPositionMiddle animated:YES];
-        
+        [_tableView scrollToRowAtIndexPath:optionIndex atScrollPosition:UITableViewScrollPositionMiddle animated:!fromItself];
     }
 }
 
@@ -824,6 +823,11 @@
     }];
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    fromItself = YES;
+}
+
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     if ([self presentingViewController] != nil) {
@@ -853,6 +857,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    fromItself = NO;
     footerHeight = -1;
     selectedSetting = nil;
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -125,6 +125,11 @@
         
         _tableView = [[UITableView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height) style:UITableViewStylePlain];
         cellLabelOffset = 8;
+        
+        // Let the list end before the safe area. This avoids list items being shown under the footer.
+        UIEdgeInsets insets = UIEdgeInsetsMake(0, 0, [Utilities getBottomPadding], 0);
+        _tableView.frame = UIEdgeInsetsInsetRect(_tableView.frame, insets);
+        
         _tableView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
 		_tableView.delegate = self;
 		_tableView.dataSource = self;

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -834,15 +834,6 @@
         UIBarButtonItem * doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismissAddAction:)];
         self.navigationItem.rightBarButtonItem = doneButton;
     }
-    _tableView.separatorInset = UIEdgeInsetsMake(0, cellLabelOffset, 0, 0);
-    UIEdgeInsets tableViewInsets = UIEdgeInsetsZero;
-    tableViewInsets.top = CGRectGetMaxY(self.navigationController.navigationBar.frame);
-    if (@available(iOS 11.0, *)) {
-        tableViewInsets.top = 0;
-    }
-    _tableView.contentInset = tableViewInsets;
-    _tableView.scrollIndicatorInsets = tableViewInsets;
-    [_tableView setContentOffset:CGPointMake(0, - tableViewInsets.top) animated:NO];
     if (xbmcSetting == cMultiselect) {
         [_tableView reloadData];
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/647.

`viewWillDisappear` indicates a swipe-attempt is made. When snapping back from such attempt the animation in `scrollToRowAtIndexPath` should be switched off. This keeps the list representation unchanged after a swipe-attempt, but keep the animation when entering the list for the first time.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Do not animate settings list after a swipe-attempt
Bugfix: Correct inset of settings list after a swipe-attempt