### PR TITLE
Bugfix: Fix creation of custom buttons

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -634,6 +634,14 @@
     else if ([item isKindOfClass:[NSArray class]]) {
         year = [item componentsJoinedByString:@" / "];
     }
+    // Begin special treatment
+    // Adding custom button mis-uses the key "year" to transport the type of button which
+    // is added. Allowed are "list", "integer" and "boolean".
+    else if ([item isKindOfClass:[NSString class]] &&
+             ([item isEqualToString:@"boolean"] || [item isEqualToString:@"integer"] || [item isEqualToString:@"list"])) {
+        year = item;
+    }
+    // End special treatment
     else if ([item integerValue] > 0) {
         year = item;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/649.

When handling Kodi server settings the key `"year"` is mis-used for the type of custom button created. The allowed values are `"boolean"` (on/off toggle), `"integer"` (indexed list or a value) and `"list"` (named list items). The missing special treatment broke on/off toggle and indexed list selection.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix creation of custom buttons