### PR TITLE
Rework RightMenuViewController

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -157,7 +157,7 @@
     channelEPG[@"current"] = LOCALIZED_STR(@"Not Available");
     channelEPG[@"next"] = LOCALIZED_STR(@"Not Available");
     channelEPG[@"current_details"] = @"";
-    channelEPG[@"refresh_data"] = @(YES);
+    channelEPG[@"refresh_data"] = @YES;
     channelEPG[@"starttime"] = @"";
     channelEPG[@"endtime"] = @"";
     if (epgData != nil) {
@@ -206,7 +206,7 @@
                                        [localHourMinuteFormatter stringFromDate:nextFilteredArray[0][@"starttime"]],
                                        nextFilteredArray[0][@"title"]
                                        ];
-                channelEPG[@"refresh_data"] = @(NO);
+                channelEPG[@"refresh_data"] = @NO;
             }
         }
     }
@@ -3785,7 +3785,7 @@ NSIndexPath *selected;
                              [collectionView reloadData];
                              [collectionView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
                              NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
-                                                     @(NO), @"hideToolbar",
+                                                     @NO, @"hideToolbar",
                                                      @(animDuration), @"duration",
                                                      nil];
                              [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollFullScreenEnabled" object:self.view userInfo:params];
@@ -4141,7 +4141,7 @@ NSIndexPath *selected;
                 if (shuffled && AppDelegate.instance.serverVersion > 11) {
                     [[Utilities getJsonRPC]
                      callMethod:@"Player.SetPartymode"
-                     withParameters:[NSDictionary dictionaryWithObjectsAndKeys:@(0), @"playerid", @(NO), @"partymode", nil]
+                     withParameters:[NSDictionary dictionaryWithObjectsAndKeys:@(0), @"playerid", @NO, @"partymode", nil]
                      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *internalError) {
                          [self playlistAndPlay:[NSDictionary dictionaryWithObjectsAndKeys:
                                                 mainFields[@"playlistid"], @"playlistid",

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -724,7 +724,7 @@ static inline BOOL IsEmpty(id obj) {
     NSString *methodToCall = @"Settings.SetSettingValue";
     NSDictionary *parameters = [NSDictionary dictionaryWithObjectsAndKeys:
                                 @"services.esallinterfaces", @"setting",
-                                @(YES), @"value",
+                                @YES, @"value",
                                 nil];
     [[Utilities getJsonRPC] callMethod: methodToCall
          withParameters: parameters

--- a/XBMC Remote/RightMenuViewController.h
+++ b/XBMC Remote/RightMenuViewController.h
@@ -23,8 +23,8 @@
     BOOL torchIsOn;
     MessagesView *messagesView;
     NSUInteger editableRowStartAt;
-    UIBarButtonItem *editTableButton;
-    UIBarButtonItem *addButton;
+    UIButton *editTableButton;
+    UIButton *moreButton;
     NSDictionary *infoCustomButton;
 }
 

--- a/XBMC Remote/RightMenuViewController.h
+++ b/XBMC Remote/RightMenuViewController.h
@@ -27,7 +27,7 @@
     NSUInteger editableRowStartAt;
     UIBarButtonItem *editTableButton;
     UIBarButtonItem *addButton;
-    NSMutableDictionary *infoCustomButton;
+    NSDictionary *infoCustomButton;
 }
 
 @property (strong, nonatomic) NSMutableArray *rightMenuItems;

--- a/XBMC Remote/RightMenuViewController.h
+++ b/XBMC Remote/RightMenuViewController.h
@@ -15,14 +15,12 @@
 
 @interface RightMenuViewController : UIViewController <UITableViewDelegate, UITableViewDataSource> {
     UITableView *menuTableView;
-    NSMutableArray* _rightMenuItems;
     IBOutlet UITableViewCell *rightMenuCell;
     NSMutableArray *tableData;
     UILabel *infoLabel;
     VolumeSliderView *volumeSliderView;
     RemoteController *remoteControllerView;
     BOOL torchIsOn;
-    BOOL putXBMClogo;
     MessagesView *messagesView;
     NSUInteger editableRowStartAt;
     UIBarButtonItem *editTableButton;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -60,10 +60,11 @@
 }
 
 - (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
-    if ([tableData[indexPath.row][@"bgColor"] count]) {
-        cell.backgroundColor = [UIColor colorWithRed:[tableData[indexPath.row][@"bgColor"][@"red"] floatValue]
-                                               green:[tableData[indexPath.row][@"bgColor"][@"green"] floatValue]
-                                                blue:[tableData[indexPath.row][@"bgColor"][@"blue"] floatValue]
+    NSDictionary *rgbColor = tableData[indexPath.row][@"bgColor"];
+    if (rgbColor.count) {
+        cell.backgroundColor = [UIColor colorWithRed:[rgbColor[@"red"] floatValue]
+                                               green:[rgbColor[@"green"] floatValue]
+                                                blue:[rgbColor[@"blue"] floatValue]
                                                alpha:1];
     }
     else { // xcode xib bug with ipad?

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -452,14 +452,8 @@
             if (countdown_message != nil) {
                 countdown_message = [NSString stringWithFormat:@"%@ %d seconds.", countdown_message, [tableData[indexPath.row][@"action"][@"countdown_time"] intValue]];
             }
-            NSString *cancel_button = tableData[indexPath.row][@"action"][@"cancel_button"];
-            if (cancel_button == nil) {
-                cancel_button = LOCALIZED_STR(@"Cancel");
-            }
-            NSString *ok_button = tableData[indexPath.row][@"action"][@"ok_button"];
-            if (ok_button == nil) {
-                ok_button = LOCALIZED_STR(@"Yes");
-            }
+            NSString *cancel_button = tableData[indexPath.row][@"action"][@"cancel_button"] ?: LOCALIZED_STR(@"Cancel");
+            NSString *ok_button = tableData[indexPath.row][@"action"][@"ok_button"] ?: LOCALIZED_STR(@"Yes");
             UIAlertController *alertView = [UIAlertController alertControllerWithTitle:message message:countdown_message preferredStyle:UIAlertControllerStyleAlert];
             UIAlertAction *cancelButton = [UIAlertAction actionWithTitle:cancel_button style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {}];
             UIAlertAction *okButton = [UIAlertAction actionWithTitle:ok_button style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
@@ -490,10 +484,7 @@
                 [self addButtonToList:nil];
             }
             else if (command != nil) {
-                NSDictionary *parameters = tableData[indexPath.row][@"action"][@"params"];
-                if (parameters == nil) {
-                    parameters = [NSDictionary dictionary];
-                }
+                NSDictionary *parameters = tableData[indexPath.row][@"action"][@"params"] ?: @{};
                 [self xbmcAction:command params:parameters uiControl:nil];
             }
         }
@@ -741,40 +732,13 @@
     tableData = [[NSMutableArray alloc] initWithCapacity:0];
 
     for (NSDictionary *item in menuItem.mainMethod[0][key]) {
-        NSString *label = item[@"label"];
-        if (label == nil) {
-            label = @"";
-        }
-
-        NSMutableDictionary *bgColor = item[@"bgColor"];
-        if (bgColor == nil) {
-            bgColor = [[NSMutableDictionary alloc] initWithCapacity:0];
-        }
-        
-        NSNumber *hideLine = item[@"hideLineSeparator"];
-        if (hideLine == nil) {
-            hideLine = @(NO);
-        }
-        
-        NSMutableDictionary *fontColor = item[@"fontColor"];
-        if (fontColor == nil) {
-            fontColor = [[NSMutableDictionary alloc] initWithCapacity:0];
-        }
-
-        NSString *icon = item[@"icon"];
-        if (icon == nil) {
-            icon = @"blank";
-        }
-        
-        NSMutableDictionary *action = item[@"action"];
-        if (action == nil) {
-            action = [[NSMutableDictionary alloc] initWithCapacity:0];
-        }
-        
-        NSNumber *showTop = item[@"revealViewTop"];
-        if (showTop == nil) {
-            showTop = @(NO);
-        }
+        NSString *label = item[@"label"] ?: @"";
+        NSMutableDictionary *bgColor = item[@"bgColor"] ?: [[NSMutableDictionary alloc] initWithCapacity:0];
+        NSNumber *hideLine = item[@"hideLineSeparator"] ?: @NO;
+        NSMutableDictionary *fontColor = item[@"fontColor"] ?: [[NSMutableDictionary alloc] initWithCapacity:0];
+        NSString *icon = item[@"icon"] ?: @"blank";
+        NSMutableDictionary *action = item[@"action"] ?: [[NSMutableDictionary alloc] initWithCapacity:0];
+        NSNumber *showTop = item[@"revealViewTop"] ?: @NO;
         
         NSDictionary *itemDict = @{@"label": label,
                                    @"bgColor": bgColor,
@@ -806,22 +770,6 @@
             editTableButton.enabled = YES;
         }
         for (NSDictionary *item in arrayButtons.buttons) {
-            NSString *label = item[@"label"];
-            if (label == nil) {
-                label = @"";
-            }
-            NSString *icon = item[@"icon"];
-            if (icon == nil) {
-                icon = @"blank";
-            }
-            NSString *type = item[@"type"];
-            if (type == nil) {
-                type = @"";
-            }
-            NSNumber *isSetting = item[@"isSetting"];
-            if (isSetting == nil) {
-                isSetting = @(YES);
-            }
             [tableData addObject:[NSMutableDictionary dictionaryWithObjectsAndKeys:
                                   label, @"label",
                                   [[NSMutableDictionary alloc] initWithCapacity:0], @"bgColor",
@@ -833,6 +781,11 @@
                                   type, @"type",
                                   item[@"action"], @"action",
                                   nil]];
+            NSString *label = item[@"label"] ?: @"";
+            NSString *icon = item[@"icon"] ?: @"";
+            NSString *type = item[@"type"] ?: @"";
+            NSNumber *isSetting = item[@"isSetting"] ?: @YES;
+            NSMutableDictionary *action = item[@"action"] ?: [[NSMutableDictionary alloc] initWithCapacity:0];
         }
     }
 

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -651,7 +651,6 @@
     }
     else {
         infoLabel.alpha = 1;
-        putXBMClogo = YES;
         [self setRightMenuOption:@"utility" reloadTableData:NO];
     }
     messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, DEFAULT_MSG_HEIGHT + deltaY) deltaY:deltaY deltaX:deltaX];
@@ -860,7 +859,6 @@
         [tableData removeAllObjects];
         [menuTableView reloadData];
         infoLabel.alpha = 1;
-        putXBMClogo = YES;
         [self setRightMenuOption:@"utility" reloadTableData:YES];
     }
 }

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -418,7 +418,7 @@
         textField.placeholder = @"";
         textField.text = tableData[indexPath.row][@"label"];
     }];
-    UIAlertAction* updateButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Update label") style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
+    UIAlertAction *updateButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Update label") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
         tableData[indexPath.row][@"label"] = alertView.textFields[0].text;
             
             UITableViewCell *cell = [menuTableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:indexPath.row inSection:0]];
@@ -431,7 +431,7 @@
                 [arrayButtons saveData];
             }
         }];
-    UIAlertAction* cancelButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {}];
+    UIAlertAction *cancelButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {}];
     [alertView addAction:updateButton];
     [alertView addAction:cancelButton];
     [self presentViewController:alertView animated:YES completion:nil];
@@ -461,8 +461,8 @@
                 ok_button = LOCALIZED_STR(@"Yes");
             }
             UIAlertController *alertView = [UIAlertController alertControllerWithTitle:message message:countdown_message preferredStyle:UIAlertControllerStyleAlert];
-            UIAlertAction* cancelButton = [UIAlertAction actionWithTitle:cancel_button style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {}];
-            UIAlertAction* okButton = [UIAlertAction actionWithTitle:ok_button style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
+            UIAlertAction *cancelButton = [UIAlertAction actionWithTitle:cancel_button style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {}];
+            UIAlertAction *okButton = [UIAlertAction actionWithTitle:ok_button style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
                 NSIndexPath *commandIdx = [self getIndexPathForKey:@"ok_button" withValue:ok_button inArray:[tableData valueForKey:@"action"]];
                 NSString *command = [tableData valueForKey:@"action"][commandIdx.row][@"command"];
                 if (command != nil) {
@@ -539,7 +539,7 @@
     if ([sender respondsToSelector:@selector(setUserInteractionEnabled:)]) {
         [sender setUserInteractionEnabled:NO];
     }
-    [[Utilities getJsonRPC] callMethod:action withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
+    [[Utilities getJsonRPC] callMethod:action withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (methodError == nil && error == nil) {
             [messagesView showMessage:LOCALIZED_STR(@"Command executed") timeout:2.0 color:[Utilities getSystemGreen:0.95]];
         }
@@ -556,7 +556,7 @@
     if ([sender respondsToSelector:@selector(setUserInteractionEnabled:)]) {
         [sender setUserInteractionEnabled:NO];
     }
-    [[Utilities getJsonRPC] callMethod:action withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
+    [[Utilities getJsonRPC] callMethod:action withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (methodError == nil && error == nil) {
             [busyView stopAnimating];
             if ([sender respondsToSelector:@selector(setHidden:)]) {
@@ -669,18 +669,17 @@
                                              selector: @selector(connectionSuccess:)
                                                  name: @"XBMCServerConnectionSuccess"
                                                object: nil];
+    
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(connectionFailed:)
                                                  name: @"XBMCServerConnectionFailed"
                                                object: nil];
-//    [[NSNotificationCenter defaultCenter] addObserver: self
-//                                             selector: @selector(startTimer:)
-//                                                 name: @"ECSlidingViewUnderRightWillAppear"
-//                                               object: nil];
+    
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(stopTimer:)
                                                  name: @"ECSlidingViewUnderRightWillDisappear"
                                                object: nil];
+    
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(reloadCustomButtonTable:)
                                                  name: @"UIInterfaceCustomButtonAdded"

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -486,12 +486,12 @@
         [self.slidingViewController resetTopView];
     }
     else if ([tableData[indexPath.row][@"label"] isEqualToString:LOCALIZED_STR(@"Gesture Zone")]) {
-        NSDictionary *userInfo = [NSDictionary dictionaryWithObject:@(YES) forKey:@"forceGestureZone"];
+        NSDictionary *userInfo = [NSDictionary dictionaryWithObject:@YES forKey:@"forceGestureZone"];
         [[NSNotificationCenter defaultCenter] postNotificationName: @"UIToggleGestureZone" object:nil userInfo:userInfo];
         [self.slidingViewController resetTopView];
     }
     else if ([tableData[indexPath.row][@"label"] isEqualToString:LOCALIZED_STR(@"Button Pad")]) {
-        NSDictionary *userInfo = [NSDictionary dictionaryWithObject:@(NO) forKey:@"forceGestureZone"];
+        NSDictionary *userInfo = [NSDictionary dictionaryWithObject:@NO forKey:@"forceGestureZone"];
         [[NSNotificationCenter defaultCenter] postNotificationName: @"UIToggleGestureZone" object:nil userInfo:userInfo];
         [self.slidingViewController resetTopView];
     }
@@ -732,7 +732,7 @@
                                    @"icon": icon,
                                    @"action": action,
                                    @"revealViewTop": showTop,
-                                   @"isSetting": @(NO),
+                                   @"isSetting": @NO,
                                    @"type": @"embedded"};
          
         // Do not show the remoteToolBar items in the menu while in "online" state

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -20,6 +20,8 @@
 #define RIGHT_MENU_ITEM_HEIGHT 50.0
 #define RIGHT_MENU_ICON_SIZE 18.0
 #define RIGHT_MENU_ICON_SPACING 16.0
+#define BUTTON_SPACING 8.0
+#define BUTTON_WIDTH 100.0
 
 @interface RightMenuViewController ()
 @property (nonatomic, unsafe_unretained) CGFloat peekLeftAmount;
@@ -232,45 +234,31 @@
 
 - (UIView*)createTableFooterView:(CGFloat)footerHeight {
     CGRect frame = self.view.bounds;
-    UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem: UIBarButtonSystemItemFixedSpace
-                                                                                target: nil
-                                                                                action: nil];
-    fixedSpace.width = 50.0;
-    UIToolbar *toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, TOOLBAR_HEIGHT)];
-    toolbar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-    if (IS_IPAD) {
-        frame.size.width = STACKSCROLL_WIDTH;
-        fixedSpace.width = 0.0;
-        toolbar.frame = CGRectMake(0, 0, frame.size.width, TOOLBAR_HEIGHT);
-        toolbar.autoresizingMask = UIViewAutoresizingNone;
-    }
     UIView *newView = [[UIView alloc] initWithFrame:CGRectMake(0, frame.size.height - footerHeight, frame.size.width, footerHeight)];
     newView.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleWidth;
-    newView.backgroundColor = UIColor.clearColor;
-    toolbar.barStyle = UIBarStyleBlackTranslucent;
-    toolbar.tintColor = UIColor.lightGrayColor;
-
-    UIBarButtonItem *fixedSpace2 = [[UIBarButtonItem alloc] initWithBarButtonSystemItem: UIBarButtonSystemItemFixedSpace
-                                                                                 target: nil
-                                                                                 action: nil];
-    fixedSpace2.width = 2.0;
-
-    UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem: UIBarButtonSystemItemFlexibleSpace
-                                                                                   target: nil
-                                                                                   action: nil];
-    addButton = [[UIBarButtonItem alloc] initWithTitle: LOCALIZED_STR(@"...more")
-                                                 style: UIBarButtonItemStylePlain
-                                                target: self
-                                                action: @selector(addButtonToList:)];
+    newView.backgroundColor = [Utilities getGrayColor:36 alpha:1];
     
-    addButton.enabled = NO;
-    editTableButton = [[UIBarButtonItem alloc] initWithTitle: LOCALIZED_STR(@"Edit")
-                                                       style: UIBarButtonItemStylePlain
-                                                      target: self
-                                                      action: @selector(editTable:)];
-    toolbar.items = [NSArray arrayWithObjects:fixedSpace, addButton, flexibleSpace, editTableButton, fixedSpace2, nil];
+    // ...more button
+    CGFloat originX = self.peekLeftAmount + BUTTON_SPACING;
+    moreButton = [[UIButton alloc] initWithFrame:CGRectMake(originX, 0, BUTTON_WIDTH, TOOLBAR_HEIGHT)];
+    moreButton.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
+    moreButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
+    [moreButton setTitleColor:UIColor.darkGrayColor forState:UIControlStateDisabled];
+    [moreButton setTitleColor:UIColor.lightGrayColor forState:UIControlStateNormal];
+    [moreButton setTitle:LOCALIZED_STR(@"...more") forState:UIControlStateNormal];
+    [moreButton addTarget:self action:@selector(addButtonToList:) forControlEvents:UIControlEventTouchUpInside];
+    [newView addSubview:moreButton];
     
-    [newView insertSubview:toolbar atIndex:0];
+    // edit button
+    originX = newView.frame.size.width - BUTTON_WIDTH - BUTTON_SPACING;
+    editTableButton = [[UIButton alloc] initWithFrame:CGRectMake(originX, 0, BUTTON_WIDTH, TOOLBAR_HEIGHT)];
+    editTableButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
+    editTableButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
+    [editTableButton setTitleColor:UIColor.darkGrayColor forState:UIControlStateDisabled];
+    [editTableButton setTitleColor:UIColor.lightGrayColor forState:UIControlStateNormal];
+    [editTableButton setTitle:LOCALIZED_STR(@"Edit") forState:UIControlStateNormal];
+    [editTableButton addTarget:self action:@selector(editTable:) forControlEvents:UIControlEventTouchUpInside];
+    [newView addSubview:editTableButton];
     
     return newView;
 }
@@ -316,8 +304,7 @@
     [arrayButtons saveData];
     if (arrayButtons.buttons.count == 0) {
         [menuTableView setEditing:NO animated:YES];
-        editTableButton.title = LOCALIZED_STR(@"Edit");
-        editTableButton.style = UIBarButtonItemStylePlain;
+        [editTableButton setTitle:LOCALIZED_STR(@"Edit") forState:UIControlStateNormal];
         editTableButton.enabled = NO;
         [arrayButtons.buttons addObject:infoCustomButton];
         [self setRightMenuOption:@"online" reloadTableData:YES];
@@ -343,16 +330,14 @@
 #pragma mark Table view delegate
 
 - (void)editTable:(id)sender {
-    UIBarButtonItem *editButton = (UIBarButtonItem*)sender;
+    UIButton *editButton = (UIButton*)sender;
     if (menuTableView.editing) {
         [menuTableView setEditing:NO animated:YES];
-        editButton.title = LOCALIZED_STR(@"Edit");
-        editButton.style = UIBarButtonItemStylePlain;
+        [editButton setTitle:LOCALIZED_STR(@"Edit") forState:UIControlStateNormal];
     }
     else {
         [menuTableView setEditing:YES animated:YES];
-        editButton.title = LOCALIZED_STR(@"Done");
-        editButton.style = UIBarButtonItemStyleDone;
+        [editButton setTitle:LOCALIZED_STR(@"Done") forState:UIControlStateNormal];
     }
 }
 
@@ -642,11 +627,11 @@
     if (AppDelegate.instance.obj.serverIP.length != 0) {
         if (!AppDelegate.instance.serverOnLine) {
             [self setRightMenuOption:@"offline" reloadTableData:NO];
-            addButton.enabled = NO;
+            moreButton.enabled = NO;
         }
         else {
             [self setRightMenuOption:@"online" reloadTableData:NO];
-            addButton.enabled = YES;
+            moreButton.enabled = YES;
         }
     }
     else {
@@ -829,7 +814,7 @@
     }
     [self setRightMenuOption:@"online" reloadTableData:YES];
     infoLabel.alpha = 0;
-    addButton.enabled = YES;
+    moreButton.enabled = YES;
 }
 
 - (void)connectionFailed:(NSNotification*)note {
@@ -853,7 +838,7 @@
     if (AppDelegate.instance.obj.serverIP.length != 0) {
         infoLabel.alpha = 0;
         [self setRightMenuOption:@"offline" reloadTableData:YES];
-        addButton.enabled = NO;
+        moreButton.enabled = NO;
     }
     else {
         [tableData removeAllObjects];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -603,17 +603,17 @@
     infoLabel.alpha = 0;
     [self.view addSubview:infoLabel];
     
-    infoCustomButton = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                        LOCALIZED_STR(@"No custom button defined.\r\nPress \"...more\" below to add new ones."), @"label",
-                        [[NSMutableDictionary alloc] initWithCapacity:0], @"bgColor",
-                        @(NO), @"hideLineSeparator",
-                        [[NSMutableDictionary alloc] initWithCapacity:0], @"fontColor",
-                        @"default-right-menu-icon", @"icon",
-                        [[NSMutableDictionary alloc] initWithCapacity:0], @"action",
-                        @(NO), @"revealViewTop",
-                        @(NO), @"isSetting",
-                        @"", @"type",
-                        nil];
+    infoCustomButton = [@{
+        @"label": LOCALIZED_STR(@"No custom button defined.\r\nPress \"...more\" below to add new ones."),
+        @"bgColor": [[NSMutableDictionary alloc] initWithCapacity:0],
+        @"hideLineSeparator": @NO,
+        @"fontColor": [[NSMutableDictionary alloc] initWithCapacity:0],
+        @"icon": @"default-right-menu-icon",
+        @"action": [[NSMutableDictionary alloc] initWithCapacity:0],
+        @"revealViewTop": @NO,
+        @"isSetting": @NO,
+        @"type": @"",
+    } mutableCopy];
     
     mainMenu *menuItems = self.rightMenuItems[0];
     CGFloat bottomPadding = [Utilities getBottomPadding];
@@ -770,22 +770,25 @@
             editTableButton.enabled = YES;
         }
         for (NSDictionary *item in arrayButtons.buttons) {
-            [tableData addObject:[NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                  label, @"label",
-                                  [[NSMutableDictionary alloc] initWithCapacity:0], @"bgColor",
-                                  @(NO), @"hideLineSeparator",
-                                  [[NSMutableDictionary alloc] initWithCapacity:0], @"fontColor",
-                                  icon, @"icon",
-                                  isSetting, @"isSetting",
-                                  @(NO), @"revealViewTop",
-                                  type, @"type",
-                                  item[@"action"], @"action",
-                                  nil]];
             NSString *label = item[@"label"] ?: @"";
             NSString *icon = item[@"icon"] ?: @"";
             NSString *type = item[@"type"] ?: @"";
             NSNumber *isSetting = item[@"isSetting"] ?: @YES;
             NSMutableDictionary *action = item[@"action"] ?: [[NSMutableDictionary alloc] initWithCapacity:0];
+            
+            NSDictionary *itemDict = @{
+                @"label": label,
+                @"bgColor": [[NSMutableDictionary alloc] initWithCapacity:0],
+                @"hideLineSeparator": @NO,
+                @"fontColor": [[NSMutableDictionary alloc] initWithCapacity:0],
+                @"icon": icon,
+                @"isSetting": isSetting,
+                @"revealViewTop": @NO,
+                @"type": type,
+                @"action": action,
+            };
+            
+            [tableData addObject:itemDict];
         }
     }
 

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -603,17 +603,17 @@
     infoLabel.alpha = 0;
     [self.view addSubview:infoLabel];
     
-    infoCustomButton = [@{
+    infoCustomButton = @{
         @"label": LOCALIZED_STR(@"No custom button defined.\r\nPress \"...more\" below to add new ones."),
-        @"bgColor": [[NSMutableDictionary alloc] initWithCapacity:0],
+        @"bgColor": @{},
         @"hideLineSeparator": @NO,
-        @"fontColor": [[NSMutableDictionary alloc] initWithCapacity:0],
+        @"fontColor": @{},
         @"icon": @"default-right-menu-icon",
-        @"action": [[NSMutableDictionary alloc] initWithCapacity:0],
+        @"action": @{},
         @"revealViewTop": @NO,
         @"isSetting": @NO,
         @"type": @"",
-    } mutableCopy];
+    };
     
     mainMenu *menuItems = self.rightMenuItems[0];
     CGFloat bottomPadding = [Utilities getBottomPadding];
@@ -733,11 +733,11 @@
 
     for (NSDictionary *item in menuItem.mainMethod[0][key]) {
         NSString *label = item[@"label"] ?: @"";
-        NSMutableDictionary *bgColor = item[@"bgColor"] ?: [[NSMutableDictionary alloc] initWithCapacity:0];
+        NSDictionary *bgColor = item[@"bgColor"] ?: @{};
         NSNumber *hideLine = item[@"hideLineSeparator"] ?: @NO;
-        NSMutableDictionary *fontColor = item[@"fontColor"] ?: [[NSMutableDictionary alloc] initWithCapacity:0];
+        NSDictionary *fontColor = item[@"fontColor"] ?: @{};
         NSString *icon = item[@"icon"] ?: @"blank";
-        NSMutableDictionary *action = item[@"action"] ?: [[NSMutableDictionary alloc] initWithCapacity:0];
+        NSDictionary *action = item[@"action"] ?: @{};
         NSNumber *showTop = item[@"revealViewTop"] ?: @NO;
         
         NSDictionary *itemDict = @{@"label": label,
@@ -774,13 +774,13 @@
             NSString *icon = item[@"icon"] ?: @"";
             NSString *type = item[@"type"] ?: @"";
             NSNumber *isSetting = item[@"isSetting"] ?: @YES;
-            NSMutableDictionary *action = item[@"action"] ?: [[NSMutableDictionary alloc] initWithCapacity:0];
+            NSDictionary *action = item[@"action"] ?: @{};
             
             NSDictionary *itemDict = @{
                 @"label": label,
-                @"bgColor": [[NSMutableDictionary alloc] initWithCapacity:0],
+                @"bgColor": @{},
                 @"hideLineSeparator": @NO,
-                @"fontColor": [[NSMutableDictionary alloc] initWithCapacity:0],
+                @"fontColor": @{},
                 @"icon": icon,
                 @"isSetting": isSetting,
                 @"revealViewTop": @NO,

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -81,7 +81,7 @@
             [self retrieveXBMCData: @"Addons.GetAddons"
                         parameters: [NSDictionary dictionaryWithObjectsAndKeys:
                                      self.detailItem[@"addontype"], @"type",
-                                     @(YES), @"enabled",
+                                     @YES, @"enabled",
                                      @[@"name"], @"properties",
                                      nil]
                            itemKey: @"addons"];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -314,7 +314,7 @@ double round(double d) {
                                         nil], @"parameters",
                                        blackTableSeparator, @"blackTableSeparator",
                                        parameters[@"label"], @"label",
-                                       @(YES), @"fromShowInfo",
+                                       @YES, @"fromShowInfo",
                                        [NSString stringWithFormat:@"%d", [parameters[@"enableCollectionView"] boolValue]], @"enableCollectionView",
                                        [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
                                        parameters[@"extra_info_parameters"], @"extra_info_parameters",
@@ -1362,8 +1362,8 @@ double round(double d) {
         if (IS_IPAD) {
             if (![self isModal]) {
                 NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
-                                        @(YES), @"hideToolbar",
-                                        @(YES), @"clipsToBounds",
+                                        @YES, @"hideToolbar",
+                                        @YES, @"clipsToBounds",
                                         nil];
                 [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollFullScreenEnabled" object:self.view userInfo:params];
             }

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -188,14 +188,14 @@
         if (string.length != 0) {
             int x = (unichar) [string characterAtIndex: 0];
             if (x == 10) {
-                [self GUIAction:@"Input.SendText" params:[NSDictionary dictionaryWithObjectsAndKeys:[stringToSend substringToIndex:stringToSend.length - 1], @"text", @(YES), @"done", nil] httpAPIcallback:nil];
+                [self GUIAction:@"Input.SendText" params:[NSDictionary dictionaryWithObjectsAndKeys:[stringToSend substringToIndex:stringToSend.length - 1], @"text", @YES, @"done", nil] httpAPIcallback:nil];
                 [backgroundTextField resignFirstResponder];
                 [xbmcVirtualKeyboard resignFirstResponder];
                 theTextField.text = @"";
                 return YES;
             }
         }
-        [self GUIAction:@"Input.SendText" params:[NSDictionary dictionaryWithObjectsAndKeys:stringToSend, @"text", @(NO), @"done", nil] httpAPIcallback:nil];
+        [self GUIAction:@"Input.SendText" params:[NSDictionary dictionaryWithObjectsAndKeys:stringToSend, @"text", @NO, @"done", nil] httpAPIcallback:nil];
         return YES;
     }
 }

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -154,7 +154,7 @@ NSOutputStream	*outStream;
 - (void)noConnectionNotifications {
     NSString *infoText = LOCALIZED_STR(@"No connection");
     NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
-                            @(NO), @"status",
+                            @NO, @"status",
                             infoText, @"message",
                             @"connection_off", @"icon_connection",
                             nil];
@@ -166,7 +166,7 @@ NSOutputStream	*outStream;
         return;
     }
     if (AppDelegate.instance.obj.serverIP.length == 0) {
-        NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys: @(YES), @"showSetup", nil];
+        NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys: @YES, @"showSetup", nil];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
         if (AppDelegate.instance.serverOnLine) {
             [self noConnectionNotifications];
@@ -208,19 +208,19 @@ NSOutputStream	*outStream;
                                           serverInfo[@"minor"],
                                           serverInfo[@"tag"]];//, serverInfo[@"revision"]
                      NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
-                                             @(YES), @"status",
+                                             @YES, @"status",
                                              infoTitle, @"message",
                                              @"connection_on_notcp", @"icon_connection",
                                              nil];
                      [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCChangeServerStatus" object:nil userInfo:params];
-                     params = [NSDictionary dictionaryWithObjectsAndKeys: @(NO), @"showSetup", nil];
+                     params = [NSDictionary dictionaryWithObjectsAndKeys: @NO, @"showSetup", nil];
                      [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
                  }
                  else {
                      if (AppDelegate.instance.serverOnLine) {
                          [self noConnectionNotifications];
                      }
-                     NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys: @(YES), @"showSetup", nil];
+                     NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys: @YES, @"showSetup", nil];
                      [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
                  }
              }
@@ -233,7 +233,7 @@ NSOutputStream	*outStream;
              if (AppDelegate.instance.serverOnLine) {
                  [self noConnectionNotifications];
              }
-             NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys: @(YES), @"showSetup", nil];
+             NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys: @YES, @"showSetup", nil];
              [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
          }
      }];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/644.

Resolves some auto-layout problems with moving button labels and transparencies. Now the button labels do not change their positions and the safe area stays colored correctly after coming back from Kodi settings menu.

In addition applies coding style changes:
- Use literals
- Unify spaces and new lines
- Remove commented code
- Remove obsolete variables
- ...     

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix moving button labels and transparency in custom button view