### PR TITLE
Bugfix: Avoid potential crash when showing server info

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -371,7 +371,7 @@ static inline BOOL IsEmpty(id obj) {
                                    @"System.HddTemperature",
                                    @"System.OSVersionInfo"]}
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
-        if (error == nil && methodError == nil) {
+        if (error == nil && methodError == nil && [methodResult isKindOfClass:[NSDictionary class]]) {
             NSMutableAttributedString *infoString = [NSMutableAttributedString new];
             NSAttributedString *newLine = [[NSAttributedString alloc] initWithString:@"\n"];
             [infoString appendAttributedString:[self formatInfo:@"Name" text:methodResult[@"System.FriendlyName"]]];
@@ -404,6 +404,10 @@ static inline BOOL IsEmpty(id obj) {
         }
         else if (error != nil){
             serverInfoView.attributedText = [self formatInfo:LOCALIZED_STR(@"No connection") text:error.localizedDescription];
+        }
+        else if (![methodResult isKindOfClass:[NSDictionary class]]) {
+            NSString *errorText = [NSString stringWithFormat:@"Unexpected class '%@' received.", NSStringFromClass([methodResult class])];
+            serverInfoView.attributedText = [self formatInfo:LOCALIZED_STR(@"ERROR") text:errorText];
         }
     }];
 }

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -403,9 +403,7 @@ static inline BOOL IsEmpty(id obj) {
             serverInfoView.attributedText = infoString;
         }
         else if (error != nil){
-            NSMutableAttributedString *infoString = [NSMutableAttributedString new];
-            [infoString appendAttributedString:[self formatInfo:LOCALIZED_STR(@"No connection") text:error.localizedDescription]];
-            serverInfoView.attributedText = infoString;
+            serverInfoView.attributedText = [self formatInfo:LOCALIZED_STR(@"No connection") text:error.localizedDescription];
         }
     }];
 }

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -402,11 +402,17 @@ static inline BOOL IsEmpty(id obj) {
             
             serverInfoView.attributedText = infoString;
         }
-        else if (error != nil){
-            serverInfoView.attributedText = [self formatInfo:LOCALIZED_STR(@"No connection") text:error.localizedDescription];
-        }
-        else if (![methodResult isKindOfClass:[NSDictionary class]]) {
-            NSString *errorText = [NSString stringWithFormat:@"Unexpected class '%@' received.", NSStringFromClass([methodResult class])];
+        else {
+            NSString *errorText = @"";
+            if (error) {
+                errorText = [NSString stringWithFormat:@"%@\n\n", error.localizedDescription];
+            }
+            if (methodError) {
+                errorText = [NSString stringWithFormat:@"%@%@\n\n", errorText, methodError];
+            }
+            if (methodResult && ![methodResult isKindOfClass:[NSDictionary class]]) {
+                errorText = [NSString stringWithFormat:@"%@Unexpected class '%@' received.", errorText, NSStringFromClass([methodResult class])];
+            }
             serverInfoView.attributedText = [self formatInfo:LOCALIZED_STR(@"ERROR") text:errorText];
         }
     }];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/655.

Ensure `methodResult` is of class NSDictionary before accessing it. In other case throw an error message.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid potential crash when showing server info