### PR TITLE
Bugfix: Fix Global Search navigation bar title

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -5100,6 +5100,7 @@
             @{
                 @"sort": [self sortmethod:@"itemgroup" order:@"ascending" ignorearticle:NO],
             }, @"parameters",
+            LOCALIZED_STR(@"Global Search"), @"label",
             @{
                 @"label": @[
                         LOCALIZED_STR(@"Type"),


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Define the "label" key for "Global Search" which is used for the navigation title bar.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix Global Search navigation bar title