### PR TITLE
Bugfix: Fix layout for Kodi settings layout (type = "list")

### DIFF
--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -103,7 +103,7 @@
         else if ([itemControls[@"type"] isEqualToString:@"list"] && settingOptions == nil) {
             xbmcSetting = cSlider;
             storeSliderValue = [self.detailItem[@"value"] intValue];
-            cellHeight = 184.0;
+            cellHeight = 242.0;
         }
         else {
             self.navigationItem.title = self.detailItem[@"label"];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3092438#pid3092438).

For the setting type "list" a slider is used for the visualization. Therefor use the same (still hardcoded) `cellHeight` as for "spinner" which also is visualized a slider.

<a href="https://abload.de/image.php?img=bildschirmfoto2022-03irj8h.png"><img src="https://abload.de/img/bildschirmfoto2022-03irj8h.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix layout for slider-type Kodi setting