### PR TITLE
Hotfix: Solve performance problem with unarchivedObjectOfClass

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -987,32 +987,13 @@
 
 + (id)unarchivePath:(NSString*)path file:(NSString*)filename {
     NSString *filePath = [path stringByAppendingPathComponent:filename];
-    id unarchived;
-    
-    if (@available(iOS 11.0, *)) {
-        NSData *data = [[NSFileManager defaultManager] contentsAtPath:filePath];
-        NSError *error;
-        unarchived = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class]
-                                                         fromData:data
-                                                            error:&error];
-    } else {
-        unarchived = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
-    }
+    id unarchived = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
     return unarchived;
 }
 
 + (void)archivePath:(NSString*)path file:(NSString*)filename data:(id)data {
     NSString *filePath = [path stringByAppendingPathComponent:filename];
-    
-    if (@available(iOS 11.0, *)) {
-        NSError *error;
-        NSData *archiveData = [NSKeyedArchiver archivedDataWithRootObject:data requiringSecureCoding:NO error:&error];
-        if (!error) {
-            [archiveData writeToFile:filePath options:NSDataWritingAtomic error:&error];
-        }
-    } else {
-        [NSKeyedArchiver archiveRootObject:data toFile:filePath];
-    }
+    [NSKeyedArchiver archiveRootObject:data toFile:filePath];
 }
 
 + (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Since introduction of `unarchivedObjectOfClass` #609 in combination with the unspecific `[NSObject class]` a huge amount of runtime warnings is thrown which impacts the performance of reading cache data. The real fix is to specify all classes explicitly. To not risk the 1.10.1 bugfix version for now `unarchivedObjectOfClass` is rolled back (partial revert of 01bbb1d).

The real fix will come via https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/640.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Hotfix: Solve performance problem when reading cached data