### PR TITLE
Bugfix: Fix potential crash when resuming

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -65,7 +65,7 @@ double round(double d) {
         NSDictionary *resumePointDict = item[@"resume"];
         if (resumePointDict != nil) {
             if (((NSNull*)resumePointDict[@"position"] != [NSNull null])) {
-                if ([resumePointDict[@"position"] floatValue] > 0) {
+                if ([resumePointDict[@"position"] floatValue] > 0 && [resumePointDict[@"total"] floatValue] > 0) {
                     resumePointPercentage = ([resumePointDict[@"position"] floatValue] * 100) / [resumePointDict[@"total"] floatValue];
                     [sheetActions addObject:[NSString stringWithFormat:LOCALIZED_STR(@"Resume from %@"), [Utilities convertTimeFromSeconds: @([resumePointDict[@"position"] floatValue])]]];
                 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/655.

Avoid division by 0 and `resumePointPercentage` becoming `+Inf` as this crashes in `NSJSONSerialization dataWithJSONObject:options:error:` when handing over `+Inf` or `NaN` over as a `NSNumber`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
Bugfix: Fix potential crash when resuming
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
