### PR TITLE
Maintenance: Avoid code duplication when calculating elapsed percentage

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -227,9 +227,7 @@
     }
     ProgressPieView *progressView = (ProgressPieView*)[cell viewWithTag:103];
     if (![current.text isEqualToString:LOCALIZED_STR(@"Not Available")] && [channelEPG[@"starttime"] isKindOfClass:[NSDate class]] && [channelEPG[@"endtime"] isKindOfClass:[NSDate class]]) {
-        float total_seconds = [channelEPG[@"endtime"] timeIntervalSince1970] - [channelEPG[@"starttime"] timeIntervalSince1970];
-        float elapsed_seconds = [[NSDate date] timeIntervalSince1970] - [channelEPG[@"starttime"] timeIntervalSince1970];
-        float percent_elapsed = (elapsed_seconds/total_seconds) * 100.0f;
+        float percent_elapsed = [Utilities getPercentElapsed:channelEPG[@"starttime"] EndDate:channelEPG[@"endtime"]];
         [progressView updateProgressPercentage:percent_elapsed];
         progressView.hidden = NO;
         NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
@@ -2609,9 +2607,7 @@
         NSDate *starttime = [xbmcDateFormatter dateFromString:item[@"starttime"]];
         NSDate *endtime = [xbmcDateFormatter dateFromString:item[@"endtime"]];
         programStartTime.text = [localHourMinuteFormatter stringFromDate:starttime];
-        float total_seconds = [endtime timeIntervalSince1970] - [starttime timeIntervalSince1970];
-        float elapsed_seconds = [[NSDate date] timeIntervalSince1970] - [starttime timeIntervalSince1970];
-        float percent_elapsed = (elapsed_seconds/total_seconds) * 100.0f;
+        float percent_elapsed = [Utilities getPercentElapsed:starttime EndDate:endtime];
 
         if (percent_elapsed >= 0 && percent_elapsed < 100) {
             title.textColor = [Utilities getSystemBlue];
@@ -3960,9 +3956,7 @@ NSIndexPath *selected;
         storeChannelid = itemid;
         NSDate *starttime = [xbmcDateFormatter dateFromString:item[@"starttime"]];
         NSDate *endtime = [xbmcDateFormatter dateFromString:item[@"endtime"]];
-        float total_seconds = [endtime timeIntervalSince1970] - [starttime timeIntervalSince1970];
-        float elapsed_seconds = [[NSDate date] timeIntervalSince1970] - [starttime timeIntervalSince1970];
-        float percent_elapsed = (elapsed_seconds/total_seconds) * 100.0f;
+        float percent_elapsed = [Utilities getPercentElapsed:starttime EndDate:endtime];
         if (percent_elapsed < 0) {
             itemid = @([item[@"broadcastid"] longValue]);
             storeBroadcastid = itemid;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -451,9 +451,7 @@ double round(double d) {
         storeChannelid = itemid;
         NSDate *starttime = [xbmcDateFormatter dateFromString:self.detailItem[@"starttime"]];
         NSDate *endtime = [xbmcDateFormatter dateFromString:self.detailItem[@"endtime"]];
-        float total_seconds = [endtime timeIntervalSince1970] - [starttime timeIntervalSince1970];
-        float elapsed_seconds = [[NSDate date] timeIntervalSince1970] - [starttime timeIntervalSince1970];
-        float percent_elapsed = (elapsed_seconds/total_seconds) * 100.0f;
+        float percent_elapsed = [Utilities getPercentElapsed:starttime EndDate:endtime];
         if (percent_elapsed < 0) {
             itemid = @([self.detailItem[@"broadcastid"] longValue]);
             storeBroadcastid = itemid;

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -94,5 +94,6 @@ typedef enum {
 + (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X;
 + (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X YPos:(int)Y;
 + (void)alphaView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue;
++ (float)getPercentElapsed:(NSDate*)startDate EndDate:(NSDate*)endDate;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1032,4 +1032,11 @@
                      completion:^(BOOL finished) {}];
 }
 
++ (float)getPercentElapsed:(NSDate*)startDate EndDate:(NSDate*)endDate {
+    float total_seconds = [endDate timeIntervalSince1970] - [startDate timeIntervalSince1970];
+    float elapsed_seconds = [[NSDate date] timeIntervalSince1970] - [startDate timeIntervalSince1970];
+    float percent_elapsed = total_seconds > 0 ? (elapsed_seconds / total_seconds) * 100.0f : 0.0f;
+    return percent_elapsed;
+}
+
 @end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
While working on the fix for the crash when resuming I came across a potential division-by-0 and code duplication. This PR addresses both.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Avoid code duplication when calculating elapsed percentage