### PR TITLE
Fix notification of selected or missing subtitle and audio stream

### DIFF
--- a/XBMC Remote/RemoteController.h
+++ b/XBMC Remote/RemoteController.h
@@ -17,7 +17,6 @@ typedef enum {
 @interface RemoteController : UIViewController <UIGestureRecognizerDelegate> {
     IBOutlet UIView *remoteControlView;
     IBOutlet UILabel *subsInfoLabel;
-    NSTimer *fadeoutTimer;
     IBOutlet UIView *quickHelpView;
     IBOutlet UIImageView *quickHelpImageView;
     IBOutlet UIView *gestureZoneView;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -402,24 +402,25 @@
 # pragma mark - view Effects
 
 - (void)showSubInfo:(NSString*)message timeout:(NSTimeInterval)timeout color:(UIColor*)color {
-    // first fadeout
-    [Utilities alphaView:subsInfoLabel AnimDuration:0.1 Alpha:0.0];
-    subsInfoLabel.text = message;
-    subsInfoLabel.textColor = color;
-    // then fade in
-    [Utilities alphaView:subsInfoLabel AnimDuration:0.1 Alpha:0.8];
-    //then fade out again after timeout seconds
-    if (fadeoutTimer.valid) {
-        [fadeoutTimer invalidate];
+    // first fade in
+    [UIView animateWithDuration:0.1
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        subsInfoLabel.alpha = 0.8;
+        subsInfoLabel.text = message;
+        subsInfoLabel.textColor = color;
     }
-    fadeoutTimer = [NSTimer scheduledTimerWithTimeInterval:timeout target:self selector:@selector(fadeoutSubs) userInfo:nil repeats:NO];
-}
-
-
-- (void)fadeoutSubs {
-    [Utilities alphaView:subsInfoLabel AnimDuration:0.2 Alpha:0.0];
-    [fadeoutTimer invalidate];
-    fadeoutTimer = nil;
+                     completion:^(BOOL finished) {
+        // then fade out
+        [UIView animateWithDuration:0.2
+                              delay:timeout
+                            options:UIViewAnimationOptionCurveEaseInOut
+                         animations:^{
+            subsInfoLabel.alpha = 0.0;
+        }
+                         completion:^(BOOL finished) {}];
+    }];
 }
 
 # pragma mark - ToolBar

--- a/XBMC Remote/RemoteController.xib
+++ b/XBMC Remote/RemoteController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -423,7 +423,7 @@
                                 <action selector="startVibrate:" destination="-1" eventType="touchUpInside" id="68"/>
                             </connections>
                         </button>
-                        <label hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="subtitles info" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="136" userLabel="Label - subs info">
+                        <label clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.0" contentMode="left" fixedFrame="YES" text="subtitles info" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="136" userLabel="Label - subs info">
                             <rect key="frame" x="0.0" y="270" width="320" height="50"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
When migrating to block based animation unhiding the label was missed. Now the label is unhidden by default, but with an alpha of 0. The animation is now simply setting the alpha values and does not need a timer anymore.

Screenshot: 
<a href="https://abload.de/image.php?img=bildschirmfoto2022-04h1jvg.png"><img src="https://abload.de/img/bildschirmfoto2022-04h1jvg.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix missing notification of selected or missing subtitle and audio stream