### PR TITLE
Bugfix: Fix missing extra button for TV Show details view

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -164,16 +164,14 @@ double round(double d) {
         }
         else {
             self.navigationItem.title = item[@"label"];
-            if (extraButton == nil) {
-                self.navigationItem.rightBarButtonItems = [NSArray arrayWithObjects:
-                                                           actionSheetButtonItem,
-                                                           nil];
+            if (actionSheetButtonItem && extraButton) {
+                self.navigationItem.rightBarButtonItems = @[actionSheetButtonItem, extraButton];
             }
-            else {
-                self.navigationItem.rightBarButtonItems = [NSArray arrayWithObjects:
-                                                           actionSheetButtonItem,
-                                                           extraButton,
-                                                           nil];
+            else if (actionSheetButtonItem) {
+                self.navigationItem.rightBarButtonItems = @[actionSheetButtonItem];
+            }
+            else if (extraButton) {
+                self.navigationItem.rightBarButtonItems = @[extraButton];
             }
             UISwipeGestureRecognizer *rightSwipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFromRight:)];
             rightSwipe.numberOfTouchesRequired = 1;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
In case `actionSheetButtonItem` was nil an existing `extraButton` was not shown.

Screenshot:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-04suj9j.png"><img src="https://abload.de/img/bildschirmfoto2022-04suj9j.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix missing extra button for TV Show details view