### PR TITLE
Bugfix: embedded remote not shown with Xcode 13 and iOS 15

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -124,10 +124,9 @@
         title.text = @"";
         if (remoteControllerView == nil) {
             remoteControllerView = [[RemoteController alloc] initWithNibName:@"RemoteController" withEmbedded:YES bundle:nil];
-            cell.selectionStyle = UITableViewCellSelectionStyleNone;
-            [cell.contentView addSubview:remoteControllerView.view];
             remoteControllerView.panFallbackImageView.frame = cell.frame;
         }
+        [cell.contentView addSubview:remoteControllerView.view];
     }
     else {
         cell = rightMenuCell;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/672.

`cell.contentView addSubview:` needs to be called outside of the singleton condition. This seems to be a change in behaviour only showing when running a Xcode 13 build on iOS 15. 

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: embedded remote not shown with Xcode 13 and iOS 15