### PR TITLE
Bugfix: Correct handling of status bar color (Xcode 13 and iOS 15)

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3648,10 +3648,6 @@ NSIndexPath *selected;
 
 #pragma mark - View Configuration
 
-- (UIStatusBarStyle)preferredStatusBarStyle {
-    return UIStatusBarStyleLightContent;
-}
-
 - (void)setDetailItem:(id)newDetailItem {
     if (_detailItem != newDetailItem) {
         _detailItem = newDetailItem;

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -24,10 +24,6 @@
     return self;
 }
 
-- (UIStatusBarStyle)preferredStatusBarStyle {
-    return UIStatusBarStyleLightContent;
-}
-
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [Utilities addShadowsToView:navController.view viewFrame:self.view.frame];

--- a/XBMC Remote/Kodi Remote-Info.plist
+++ b/XBMC Remote/Kodi Remote-Info.plist
@@ -81,6 +81,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<true/>
+	<false/>
 </dict>
 </plist>

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -341,10 +341,6 @@
 
 #pragma mark - Lifecycle
 
-- (UIStatusBarStyle)preferredStatusBarStyle {
-    return UIStatusBarStyleLightContent;
-}
-
 - (void)viewDidLoad {
     [super viewDidLoad];
     int deltaY = UIApplication.sharedApplication.statusBarFrame.size.height + 2; // + 2 used by horizontanLineView


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/673.

Status bar color is set to `UIStatusBarStyleLightContent` application wide. Tested on iOS 15.2 and 14.5 simulators with Xcode 13.2.1 builds.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct handling of status bar color (Xcode 13 and iOS 15)