### PR TITLE
Bugfix: Fix crashes reported via AppStore

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -546,7 +546,7 @@ long currentItemID;
 - (void)getActivePlayers {
     [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:[NSDictionary dictionary] withTimeout:2.0 onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
         if (error == nil && methodError == nil) {
-            if ([methodResult count] > 0) {
+            if ([methodResult isKindOfClass:[NSArray class]] && [methodResult count] > 0) {
                 nothingIsPlaying = NO;
                 NSNumber *response;
                 if (methodResult[0][@"playerid"] != [NSNull null]) {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2117,6 +2117,9 @@ long currentItemID;
 
 - (void)tableView:(UITableView*)tableView moveRowAtIndexPath:(NSIndexPath*)sourceIndexPath toIndexPath:(NSIndexPath*)destinationIndexPath {
     
+    if (sourceIndexPath.row >= playlistData.count) {
+        return;
+    }
     NSDictionary *objSource = playlistData[sourceIndexPath.row];
     NSDictionary *itemToMove;
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
- Avoid out-of-bounds access in `moveRowAtIndexPath`
- Ensure dealing with proper `NSArray` type before accessing the variable

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix crashes reported via AppStore