### PR TITLE
Bugfix: Fix crash in NSBundle(UINSBundleAdditions) loadNibNamed:owner:options

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -837,31 +837,9 @@
         }
     }
 
-    [UIView animateWithDuration:0.2
-                     animations:^{
-                         NSInteger n = [menuTableView numberOfRowsInSection:0];
-                         for (int i = 1; i < n; i++) {
-                             UITableViewCell *cell = [menuTableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:i inSection:0]];
-                             if (cell != nil) {
-                                 cell.alpha = 0;
-                             }
-                         }
-                     }
-                     completion:^(BOOL finished) {
-                         if (reload) {
-                             [menuTableView reloadData];
-                         }
-                         [UIView animateWithDuration:0.2
-                                          animations:^{
-                                              NSInteger n = [menuTableView numberOfRowsInSection:0];
-                                              for (int i = 1; i < n; i++) {
-                                                  UITableViewCell *cell = [menuTableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:i inSection:0]];
-                                                  if (cell != nil) {
-                                                      cell.alpha = 1;
-                                                  }
-                                              }
-                                          }];
-                     }];
+    if (reload) {
+        [menuTableView reloadData];
+    }
 }
 
 - (NSIndexPath*)getIndexPathForKey:(NSString*)key withValue:(NSString*)value inArray:(NSMutableArray*)array {

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -22,10 +22,9 @@
 @synthesize timer, holdVolumeTimer;
 
 - (id)initWithFrame:(CGRect)frame leftAnchor:(CGFloat)leftAnchor isSliderType:(BOOL)isSliderType {
-    self = [super initWithFrame:frame];
+    NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"VolumeSliderView" owner:nil options:nil];
+    self = nib[0];
     if (self) {
-        NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"VolumeSliderView" owner:self options:nil];
-		self = nib[0];
         UIImage *img = [UIImage imageNamed:@"pgbar_thumb_iOS7"];
         img = [Utilities colorizeImage:img withColor:SLIDER_DEFAULT_COLOR];
         volumeSlider.minimumTrackTintColor = SLIDER_DEFAULT_COLOR;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/678.

Main amount of reported crashes with App version 1.10.1 is this one. the majority of crashes happen when `cellForRowAtIndexPath` is called from an animation. This PR removes this and simply updates the table list without an animation. In addition the initialization of `VolumeSliderView` is reworked to not overwrite the instance itself.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix potential crash in remote's custom button view