### PR TITLE
Bugfix: Avoid crash when updating station list

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5219,17 +5219,8 @@ NSIndexPath *selected;
 }
 
 - (void)updateChannelListTableCell {
-    NSArray* indexPaths = [dataList indexPathsForVisibleRows];
-    if ([dataList numberOfSections] > 0 && indexPaths.count > 0) {
-        [dataList beginUpdates];
-        [dataList reloadRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationNone];
-        [dataList endUpdates];
-    }
-
-    indexPaths = [collectionView indexPathsForVisibleItems];
-    if ([collectionView numberOfSections] > 0 && indexPaths.count > 0) {
-        [collectionView reloadItemsAtIndexPaths:indexPaths];
-    }
+    [dataList reloadData];
+    [collectionView reloadData];
 }
 
 # pragma mark - Life-Cycle


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/682.

As per documentation it is not allowed to call `reloadData` between `beginUpdate`/`endUpdate`, which might happen in the current implementation. To avoid this situation we now simply use `reloadData` instead of `beginUpdate`/`endUpdate`. In consequence now the full TV station list is updated each minute, and not only the visible list.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid crash when updating station list