### PR TITLE
Maintenance: Rework NowPlaying

### DIFF
--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -69,8 +69,6 @@
     IBOutlet UIImageView *xbmcOverlayImage;
     IBOutlet UIImageView *xbmcOverlayImage_iphone;
     IBOutlet UIButton *playlistButton;
-    BOOL playlistHidden;
-    BOOL nowPlayingHidden;
     int animationOptionTransition;
     BOOL startFlipDemo;
     IBOutlet OBSlider *ProgressSlider;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -395,41 +395,11 @@ long currentItemID;
                                 [ProgressSlider setThumbImage:image forState:UIControlStateNormal];
                                 [ProgressSlider setThumbImage:image forState:UIControlStateHighlighted];
                             }
-                            [UIView transitionWithView:albumName
-                                              duration:1.0
-                                               options:UIViewAnimationOptionTransitionCrossDissolve
-                                            animations:^{
-                                                albumName.textColor = UIColor.whiteColor;
-                                            }
-                                            completion:NULL];
-                            [UIView transitionWithView:songName
-                                              duration:1.0
-                                               options:UIViewAnimationOptionTransitionCrossDissolve
-                                            animations:^{
-                                                songName.textColor = [Utilities getGrayColor:230 alpha:1];
-                                            }
-                                            completion:NULL];
-                            [UIView transitionWithView:artistName
-                                              duration:1.0
-                                               options:UIViewAnimationOptionTransitionCrossDissolve
-                                            animations:^{
-                                                artistName.textColor = UIColor.lightGrayColor;
-                                            }
-                                            completion:NULL];
-                            [UIView transitionWithView:currentTime
-                                              duration:1.0
-                                               options:UIViewAnimationOptionTransitionCrossDissolve
-                                            animations:^{
-                                                currentTime.textColor = UIColor.lightGrayColor;
-                                            }
-                                            completion:NULL];
-                            [UIView transitionWithView:duration
-                                              duration:1.0
-                                               options:UIViewAnimationOptionTransitionCrossDissolve
-                                            animations:^{
-                                                duration.textColor = UIColor.lightGrayColor;
-                                            }
-                                            completion:NULL];
+                            [Utilities colorLabel:albumName AnimDuration:1.0 Color:UIColor.whiteColor];
+                            [Utilities colorLabel:songName AnimDuration:1.0 Color:[Utilities getGrayColor:230 alpha:1]];
+                            [Utilities colorLabel:artistName AnimDuration:1.0 Color:UIColor.lightGrayColor];
+                            [Utilities colorLabel:currentTime AnimDuration:1.0 Color:UIColor.lightGrayColor];
+                            [Utilities colorLabel:duration AnimDuration:1.0 Color:UIColor.lightGrayColor];
                         }
                         else {
                             UIColor *lighterColor = [Utilities lighterColorForColor:color];
@@ -442,41 +412,11 @@ long currentItemID;
                                 [ProgressSlider setThumbImage:thumbImage forState:UIControlStateNormal];
                                 [ProgressSlider setThumbImage:thumbImage forState:UIControlStateHighlighted];
                             }
-                            [UIView transitionWithView:albumName
-                                              duration:1.0
-                                               options:UIViewAnimationOptionTransitionCrossDissolve
-                                            animations:^{
-                                                albumName.textColor = pgThumbColor;
-                                            }
-                                            completion:NULL];
-                            [UIView transitionWithView:songName
-                                              duration:1.0
-                                               options:UIViewAnimationOptionTransitionCrossDissolve
-                                            animations:^{
-                                                songName.textColor = pgThumbColor;
-                                            }
-                                            completion:NULL];
-                            [UIView transitionWithView:artistName
-                                              duration:1.0
-                                               options:UIViewAnimationOptionTransitionCrossDissolve
-                                            animations:^{
-                                                artistName.textColor = progressColor;
-                                            }
-                                            completion:NULL];
-                            [UIView transitionWithView:currentTime
-                                              duration:1.0
-                                               options:UIViewAnimationOptionTransitionCrossDissolve
-                                            animations:^{
-                                                currentTime.textColor = progressColor;
-                                            }
-                                            completion:NULL];
-                            [UIView transitionWithView:duration
-                                              duration:1.0
-                                               options:UIViewAnimationOptionTransitionCrossDissolve
-                                            animations:^{
-                                                duration.textColor = progressColor;
-                                            }
-                                            completion:NULL];
+                            [Utilities colorLabel:albumName AnimDuration:1.0 Color:pgThumbColor];
+                            [Utilities colorLabel:songName AnimDuration:1.0 Color:pgThumbColor];
+                            [Utilities colorLabel:artistName AnimDuration:1.0 Color:progressColor];
+                            [Utilities colorLabel:currentTime AnimDuration:1.0 Color:progressColor];
+                            [Utilities colorLabel:duration AnimDuration:1.0 Color:progressColor];
                         }
                     }
                     completion:NULL];
@@ -489,13 +429,7 @@ long currentItemID;
                          iOS7navBarEffect.backgroundColor = color;
                          if ([color isEqual:UIColor.clearColor]) {
                              self.navigationController.navigationBar.tintColor = TINT_COLOR;
-                             [UIView transitionWithView:backgroundImageView
-                                               duration:1.0
-                                                options:UIViewAnimationOptionTransitionCrossDissolve
-                                             animations:^{
-                                                 backgroundImageView.image = [UIImage imageNamed:@"shiny_black_back"];
-                                             }
-                                             completion:NULL];
+                             [Utilities imageView:backgroundImageView AnimDuration:1.0 Image:[UIImage imageNamed:@"shiny_black_back"]];
                              if (IS_IPAD) {
                                  NSDictionary *params = @{@"startColor": [Utilities getGrayColor:36 alpha:1],
                                                           @"endColor": [Utilities getGrayColor:22 alpha:1]};
@@ -506,13 +440,7 @@ long currentItemID;
                          else {
                              UIColor *lighterColor = [Utilities lighterColorForColor:color];
                              self.navigationController.navigationBar.tintColor = lighterColor;
-                             [UIView transitionWithView:backgroundImageView
-                                               duration:1.0
-                                                options:UIViewAnimationOptionTransitionCrossDissolve
-                                             animations:^{
-                                                 backgroundImageView.image = [Utilities colorizeImage:[UIImage imageNamed:@"shiny_black_back"] withColor:lighterColor];
-                                             }
-                                             completion:NULL];
+                             [Utilities imageView:backgroundImageView AnimDuration:1.0 Image:[Utilities colorizeImage:[UIImage imageNamed:@"shiny_black_back"] withColor:lighterColor]];
                              if (IS_IPAD) {
                                  CGFloat hue, saturation, brightness, alpha;
                                  BOOL ok = [color getHue:&hue saturation:&saturation brightness:&brightness alpha:&alpha];
@@ -538,13 +466,7 @@ long currentItemID;
 }
 
 - (void)changeImage:(UIImageView*)imageView image:(UIImage*)newImage {
-    [UIView transitionWithView:jewelView
-                      duration:0.2
-                       options:UIViewAnimationOptionTransitionCrossDissolve
-                    animations:^{
-                        imageView.image = newImage;
-                    }
-                    completion:NULL];
+    [Utilities imageView:jewelView AnimDuration:0.2 Image:newImage];
 }
 
 - (void)getActivePlayers {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1419,39 +1419,38 @@ long currentItemID;
         animationOptionTransition = UIViewAnimationOptionTransitionFlipFromLeft;
         startFlipDemo = NO;
     }
+    UIImage *buttonImage;
+    if (!nowPlayingView.hidden && !demo) {
+        if ([self enableJewelCases] && thumbnailView.image.size.width) {
+            buttonImage = [self resizeToolbarThumb:[self imageWithBorderFromImage:thumbnailView.image]];
+        }
+        else if (jewelView.image.size.width) {
+            buttonImage = [self resizeToolbarThumb:jewelView.image];
+        }
+        if (!buttonImage.size.width) {
+            buttonImage = [self resizeToolbarThumb:[UIImage imageNamed:@"st_kodi_window"]];
+        }
+    }
+    else {
+        buttonImage = [UIImage imageNamed:@"now_playing_playlist"];
+    }
     [UIView transitionWithView:button
                       duration:0.2
                        options:UIViewAnimationOptionCurveEaseIn | animationOptionTransition
                     animations:^{
-                         button.hidden = YES;
-                         if (!nowPlayingView.hidden && !demo) {
-                             UIImage *buttonImage;
-                             if ([self enableJewelCases] && thumbnailView.image.size.width) {
-                                 buttonImage = [self resizeToolbarThumb:[self imageWithBorderFromImage:thumbnailView.image]];
-                             }
-                             else if (jewelView.image.size.width) {
-                                 buttonImage = [self resizeToolbarThumb:jewelView.image];
-                             }
-                             if (!buttonImage.size.width) {
-                                 buttonImage = [self resizeToolbarThumb:[UIImage imageNamed:@"st_kodi_window"]];
-                             }
-                             [button setImage:buttonImage forState:UIControlStateNormal];
-                             [button setImage:buttonImage forState:UIControlStateHighlighted];
-                             [button setImage:buttonImage forState:UIControlStateSelected];
-                         }
-                         else {
-                             UIImage *image = [UIImage imageNamed:@"now_playing_playlist"];
-                             [button setImage:image forState:UIControlStateNormal];
-                             [button setImage:image forState:UIControlStateHighlighted];
-                             [button setImage:image forState:UIControlStateSelected];
-                         }
+                         // fade out current button image
+                         button.alpha = 0.0;
                      } 
                      completion:^(BOOL finished) {
                         [UIView transitionWithView:button
                                           duration:0.5
                                            options:UIViewAnimationOptionCurveEaseOut | animationOptionTransition
                                         animations:^{
-                                            button.hidden = NO;
+                                            // fade in new button image
+                                            button.alpha = 1.0;
+                                            [button setImage:buttonImage forState:UIControlStateNormal];
+                                            [button setImage:buttonImage forState:UIControlStateHighlighted];
+                                            [button setImage:buttonImage forState:UIControlStateSelected];
                                         }
                                         completion:^(BOOL finished) {}
                         ];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -55,6 +55,9 @@
 #define TAG_SEEK_FORWARD 7
 #define TAG_ID_EDIT 88
 #define SELECTED_NONE -1
+#define FLIP_DEMO_DELAY 0.5
+#define FADE_OUT_TIME 0.2
+#define FADE_IN_TIME 0.5
 
 typedef enum {
     PLAYERID_UNKNOWN = -1,
@@ -321,7 +324,7 @@ long currentItemID;
         [playlistButton setImage:image forState:UIControlStateNormal];
         [playlistButton setImage:image forState:UIControlStateHighlighted];
         [playlistButton setImage:image forState:UIControlStateSelected];
-        [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(startFlipDemo) userInfo:nil repeats:NO];
+        [NSTimer scheduledTimerWithTimeInterval:FLIP_DEMO_DELAY target:self selector:@selector(startFlipDemo) userInfo:nil repeats:NO];
         startFlipDemo = NO;
     }
     if (nothingIsPlaying) {
@@ -377,7 +380,7 @@ long currentItemID;
         [playlistButton setImage:buttonImage forState:UIControlStateHighlighted];
         [playlistButton setImage:buttonImage forState:UIControlStateSelected];
         if (startFlipDemo) {
-            [NSTimer scheduledTimerWithTimeInterval:0.5 target:self selector:@selector(startFlipDemo) userInfo:nil repeats:NO];
+            [NSTimer scheduledTimerWithTimeInterval:FLIP_DEMO_DELAY target:self selector:@selector(startFlipDemo) userInfo:nil repeats:NO];
             startFlipDemo = NO;
         }
     }
@@ -1357,7 +1360,7 @@ long currentItemID;
         buttonImage = [UIImage imageNamed:@"now_playing_playlist"];
     }
     [UIView transitionWithView:button
-                      duration:0.2
+                      duration:FADE_OUT_TIME
                        options:UIViewAnimationOptionCurveEaseIn | animationOptionTransition
                     animations:^{
                          // fade out current button image
@@ -1365,7 +1368,7 @@ long currentItemID;
                      } 
                      completion:^(BOOL finished) {
                         [UIView transitionWithView:button
-                                          duration:0.5
+                                          duration:FADE_IN_TIME
                                            options:UIViewAnimationOptionCurveEaseOut | animationOptionTransition
                                         animations:^{
                                             // fade in new button image
@@ -1416,14 +1419,14 @@ long currentItemID;
     [self IOS7colorProgressSlider:effectColor];
     
     [UIView transitionWithView:transitionView
-                      duration:0.2
+                      duration:FADE_OUT_TIME
                        options:UIViewAnimationOptionCurveEaseIn | animationOptionTransition
                     animations:^{
                           transitionView.alpha = 0.0;
                      }
                      completion:^(BOOL finished) {
                         [UIView transitionWithView:transitionedView
-                                          duration:0.5
+                                          duration:FADE_IN_TIME
                                            options:UIViewAnimationOptionCurveEaseOut | animationOptionTransition
                                         animations:^{
                                               transitionView.hidden = YES;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2324,6 +2324,7 @@ long currentItemID;
     CGRect frame = playlistActionView.frame;
     frame.origin.y = CGRectGetMaxY(playlistToolbar.frame);
     playlistActionView.frame = frame;
+    playlistActionView.alpha = 1.0;
 }
 
 - (void)setIpadInterface {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -372,7 +372,7 @@ long currentItemID;
 }
 
 - (void)setButtonImageAndStartDemo:(UIImage*)buttonImage {
-    if (nowPlayingHidden || startFlipDemo) {
+    if (nowPlayingView.hidden || startFlipDemo) {
         [playlistButton setImage:buttonImage forState:UIControlStateNormal];
         [playlistButton setImage:buttonImage forState:UIControlStateHighlighted];
         [playlistButton setImage:buttonImage forState:UIControlStateSelected];
@@ -1424,7 +1424,7 @@ long currentItemID;
                        options:UIViewAnimationOptionCurveEaseIn | animationOptionTransition
                     animations:^{
                          button.hidden = YES;
-                         if (nowPlayingHidden) {
+                         if (!nowPlayingView.hidden && !demo) {
                              UIImage *buttonImage;
                              if ([self enableJewelCases] && thumbnailView.image.size.width) {
                                  buttonImage = [self resizeToolbarThumb:[self imageWithBorderFromImage:thumbnailView.image]];
@@ -1468,8 +1468,6 @@ long currentItemID;
         iOS7effectDuration = 0.0;
         transitionView = nowPlayingView;
         transitionedView = playlistView;
-        playlistHidden = NO;
-        nowPlayingHidden = YES;
         self.navigationItem.title = LOCALIZED_STR(@"Playlist");
         self.navigationItem.titleView.hidden = YES;
         animationOptionTransition = UIViewAnimationOptionTransitionFlipFromRight;
@@ -1481,8 +1479,6 @@ long currentItemID;
     else {
         transitionView = playlistView;
         transitionedView = nowPlayingView;
-        playlistHidden = YES;
-        nowPlayingHidden = NO;
         self.navigationItem.title = LOCALIZED_STR(@"Now Playing");
         self.navigationItem.titleView.hidden = YES;
         animationOptionTransition = UIViewAnimationOptionTransitionFlipFromLeft;
@@ -1509,12 +1505,11 @@ long currentItemID;
                                           duration:0.5
                                            options:UIViewAnimationOptionCurveEaseOut | animationOptionTransition
                                         animations:^{
-                                              playlistView.hidden = playlistHidden;
-                                              nowPlayingView.hidden = nowPlayingHidden;
+                                              transitionView.hidden = YES;
+                                              transitionedView.hidden = NO;
+                                              transitionedView.alpha = 1.0;
                                               self.navigationItem.titleView.hidden = NO;
                                               playlistActionView.frame = playlistToolBarOriginY;
-                                              playlistActionView.alpha = (int)nowPlayingHidden;
-                                              transitionedView.alpha = 1.0;
                                           }
                                           completion:^(BOOL finished) {
                                               if (iOS7effectDuration) {
@@ -2678,8 +2673,8 @@ long currentItemID;
     else {
         [self setIpadInterface];
     }
-    nowPlayingView.hidden = nowPlayingHidden = NO;
-    playlistView.hidden = playlistHidden = IS_IPHONE;
+    nowPlayingView.hidden = NO;
+    playlistView.hidden = IS_IPHONE;
     self.navigationItem.title = LOCALIZED_STR(@"Now Playing");
     if (IS_IPHONE) {
         startFlipDemo = YES;

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -94,6 +94,8 @@ typedef enum {
 + (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X;
 + (void)AnimView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue XPos:(int)X YPos:(int)Y;
 + (void)alphaView:(UIView*)view AnimDuration:(NSTimeInterval)seconds Alpha:(CGFloat)alphavalue;
++ (void)imageView:(UIImageView*)view AnimDuration:(NSTimeInterval)seconds Image:(UIImage*)image;
++ (void)colorLabel:(UILabel*)view AnimDuration:(NSTimeInterval)seconds Color:(UIColor*)color;
 + (float)getPercentElapsed:(NSDate*)startDate EndDate:(NSDate*)endDate;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1032,6 +1032,26 @@
                      completion:^(BOOL finished) {}];
 }
 
++ (void)imageView:(UIImageView*)view AnimDuration:(NSTimeInterval)seconds Image:(UIImage*)image {
+    [UIView transitionWithView:view
+                      duration:seconds
+                       options:UIViewAnimationOptionTransitionCrossDissolve
+                    animations:^{
+        view.image = image;
+                    }
+                    completion:^(BOOL finished) {}];
+}
+
++ (void)colorLabel:(UILabel*)view AnimDuration:(NSTimeInterval)seconds Color:(UIColor*)color {
+    [UIView transitionWithView:view
+                      duration:seconds
+                       options:UIViewAnimationOptionTransitionCrossDissolve
+                    animations:^{
+        view.textColor = color;
+                    }
+                    completion:^(BOOL finished) {}];
+}
+
 + (float)getPercentElapsed:(NSDate*)startDate EndDate:(NSDate*)endDate {
     float total_seconds = [endDate timeIntervalSince1970] - [startDate timeIntervalSince1970];
     float elapsed_seconds = [[NSDate date] timeIntervalSince1970] - [startDate timeIntervalSince1970];

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -567,13 +567,7 @@
 }
 
 - (void)handleChangeBackgroundImage:(NSNotification*)sender {
-    [UIView transitionWithView: fanartBackgroundImage
-                      duration: 1.0
-                       options: UIViewAnimationOptionTransitionCrossDissolve
-                    animations: ^{
-                        fanartBackgroundImage.image = [sender.userInfo objectForKey:@"image"];
-                    }
-                    completion: NULL];
+    [Utilities imageView:fanartBackgroundImage AnimDuration:1.0 Image:[sender.userInfo objectForKey:@"image"]];
 }
 
 - (void)handleChangeBackgroundGradientColor:(NSNotification*)sender {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR mainly reworks the NowPlaying animations for the iPhone's playlist / now playing toggle button. In the course of doing this there are magic numbers and unneeded variables removed, as well as helper functions introduced to avoid code duplication.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Rework NowPlaying