### PR TITLE
Bugfix: Correct layout when showing "no results found"

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4862,7 +4862,7 @@ NSIndexPath *selected;
     self.sections[@""] = @[];
     [self animateNoResultsFound];
     [activeLayoutView reloadData];
-    [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
+    [self displayData];
 }
 
 - (BOOL)isEligibleForSections:(NSArray*)array {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
In [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3105963#pid3105963) a layout issue was reported when showing "no results found". In this screen the searchBar layout was not correct, and in many cases the searchBar was shown as the inset was not set properly.

This PR fixes this by calling `displayData` after preparing the "no results found" message. This set the layout and inset properly. In effect, the now correctly colored searchBar is not shown per default anymore and you need to pull down the menu. This is in line with other views.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct layout when showing "no results found"