### PR TITLE
Bugfix: Ensure proper fallback to default thumb

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -906,6 +906,11 @@
     BOOL isOnPVR = [item[@"path"] hasPrefix:@"pvr:"];
     [Utilities applyRoundedEdgesView:imgView drawBorder:showBorder];
     if (![stringURL isEqualToString:@""]) {
+        // In few cases stringURL does not hold an URL path but a loadable icon name. In this case
+        // ensure setImageWithURL falls back to this icon.
+        if ([UIImage imageNamed:stringURL]) {
+            displayThumb = stringURL;
+        }
         __auto_type __weak weakImageView = imgView;
         [imgView setImageWithURL:[NSURL URLWithString:stringURL]
                 placeholderImage:[UIImage imageNamed:displayThumb]
@@ -2741,6 +2746,11 @@
         NSString *stringURL = item[@"thumbnail"];
         NSString *displayThumb = @"coverbox_back";
         if (![stringURL isEqualToString:@""]) {
+            // In few cases stringURL does not hold an URL path but a loadable icon name. In this case
+            // ensure setImageWithURL falls back to this icon.
+            if ([UIImage imageNamed:stringURL]) {
+                displayThumb = stringURL;
+            }
             __weak UIImageView *weakThumbView = thumbImageView;
             [thumbImageView setImageWithURL:[NSURL URLWithString:stringURL]
                            placeholderImage:[UIImage imageNamed:displayThumb]
@@ -2927,6 +2937,11 @@
                 self.searchController.searchBar.tintColor = [Utilities get2ndLabelColor];
             }
             if (![stringURL isEqualToString:@""]) {
+                // In few cases stringURL does not hold an URL path but a loadable icon name. In this case
+                // ensure setImageWithURL falls back to this icon.
+                if ([UIImage imageNamed:stringURL]) {
+                    displayThumb = stringURL;
+                }
                 __weak UIImageView *weakThumbView = thumbImageView;
                 [thumbImageView setImageWithURL:[NSURL URLWithString:stringURL]
                                placeholderImage:[UIImage imageNamed:displayThumb]

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1735,12 +1735,7 @@
         
         defaultThumb = displayThumb = [self getTimerDefaultThumb:item];
         
-        if ([item[@"filetype"] length] != 0 || [item[@"family"] isEqualToString:@"file"] || [item[@"family"] isEqualToString:@"genreid"]) {
-            if (![stringURL isEqualToString:@""]) {
-                displayThumb = stringURL;
-            }
-        }
-        else if (channelListView) {
+        if (channelListView) {
             [cell setIsRecording:[item[@"isrecording"] boolValue]];
         }
         cell.posterThumbnail.frame = cell.bounds;
@@ -2502,9 +2497,6 @@
             [item[@"family"] isEqualToString:@"genreid"] ||
             [item[@"family"] isEqualToString:@"channelgroupid"] ||
             [item[@"family"] isEqualToString:@"roleid"]) {
-            if (![stringURL isEqualToString:@""]) {
-                displayThumb = stringURL;
-            }
             genre.hidden = YES;
             runtimeyear.hidden = YES;
             title.frame = CGRectMake(title.frame.origin.x, (int)((cellHeight/2) - (title.frame.size.height/2)), title.frame.size.width, title.frame.size.height);
@@ -2748,9 +2740,6 @@
     
         NSString *stringURL = item[@"thumbnail"];
         NSString *displayThumb = @"coverbox_back";
-        if ([item[@"filetype"] length] != 0) {
-            displayThumb = stringURL;
-        }
         if (![stringURL isEqualToString:@""]) {
             __weak UIImageView *weakThumbView = thumbImageView;
             [thumbImageView setImageWithURL:[NSURL URLWithString:stringURL]
@@ -2936,9 +2925,6 @@
             if (isFirstListedSeason) {
                 self.searchController.searchBar.backgroundColor = [Utilities getSystemGray6];
                 self.searchController.searchBar.tintColor = [Utilities get2ndLabelColor];
-            }
-            if ([item[@"filetype"] length] != 0) {
-                displayThumb = stringURL;
             }
             if (![stringURL isEqualToString:@""]) {
                 __weak UIImageView *weakThumbView = thumbImageView;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The App in few cases receives an invalid path to a thumb. For some item types this invalid path was used to overwrite the default thumb, resulting in no default thumb being loaded at all. Solution is to not overwrite the default thumb to allow the default thumb to fall back to a valid one -- e.g. a folder icon.

Screenshots (use case Video add-on "Library Data Provider"):
<a href="https://abload.de/image.php?img=bildschirmfoto2022-0755kmg.png"><img src="https://abload.de/img/bildschirmfoto2022-0755kmg.png" /></a>

Remark: To be able to test with "Library Data Provider" you need to apply a fix to the add-on which is described in [this forum post](https://forum.kodi.tv/showthread.php?tid=369077&pid=3105995#pid3105995).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Ensure proper fallback to default thumb