### PR TITLE
Bugfix: Fix marking TV Shows as watched/unwatched

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3262,28 +3262,30 @@ NSIndexPath *selected;
     [queuing startAnimating];
 
     NSString *methodToCall = @"";
-    if ([item[@"family"] isEqualToString:@"episodeid"]) {
+    NSString *family = item[@"family"];
+    if ([family isEqualToString:@"episodeid"]) {
         methodToCall = @"VideoLibrary.SetEpisodeDetails";
     }
-    else if ([item[@"family"] isEqualToString:@"tvshowid"]) {
+    else if ([family isEqualToString:@"tvshowid"]) {
         methodToCall = @"VideoLibrary.SetTVShowDetails";
     }
-    else if ([item[@"family"] isEqualToString:@"movieid"]) {
+    else if ([family isEqualToString:@"movieid"]) {
         methodToCall = @"VideoLibrary.SetMovieDetails";
     }
-    else if ([item[@"family"] isEqualToString:@"musicvideoid"]) {
+    else if ([family isEqualToString:@"musicvideoid"]) {
         methodToCall = @"VideoLibrary.SetMusicVideoDetails";
     }
     else {
         [queuing stopAnimating];
         return;
     }
+    NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
+                            item[family], family,
+                            @(watched), @"playcount",
+                            nil];
     [[Utilities getJsonRPC]
      callMethod:methodToCall
-     withParameters:[NSDictionary dictionaryWithObjectsAndKeys:
-                     item[item[@"family"]], item[@"family"],
-                     @(watched), @"playcount",
-                     nil]
+     withParameters:params
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
          if (error == nil && methodError == nil) {
              if (isTableView) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3278,12 +3278,10 @@ NSIndexPath *selected;
                      onCompletion:nil];
                 }
                 [self updateCellAndSaveRichData:indexPath watched:watched item:item];
-                [queuing stopAnimating];
             }
-            else {
-                [queuing stopAnimating];
-            }
+            [queuing stopAnimating];
          }];
+        return;
     }
     else if ([family isEqualToString:@"episodeid"]) {
         methodToCall = @"VideoLibrary.SetEpisodeDetails";
@@ -3308,11 +3306,8 @@ NSIndexPath *selected;
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
          if (error == nil && methodError == nil) {
              [self updateCellAndSaveRichData:indexPath watched:watched item:item];
-             [queuing stopAnimating];
          }
-         else {
-             [queuing stopAnimating];
-         }
+        [queuing stopAnimating];
      }];
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3277,31 +3277,7 @@ NSIndexPath *selected;
                      withParameters:params
                      onCompletion:nil];
                 }
-                BOOL wasWatched = watched > 0;
-                if (enableCollectionView) {
-                    [cell setOverlayWatched:wasWatched];
-                    [collectionView deselectItemAtIndexPath:indexPath animated:YES];
-                }
-                else {
-                    UIImageView *flagView = (UIImageView*)[cell viewWithTag:9];
-                    flagView.hidden = !wasWatched;
-                    [dataList deselectRowAtIndexPath:indexPath animated:YES];
-                }
-                item[@"playcount"] = @(watched);
-                
-                mainMenu *menuItem = [self getMainMenu:item];
-                NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
-                NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
-                NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
-                if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
-                    [mutableProperties addObject:@"art"];
-                    mutableParameters[@"properties"] = mutableProperties;
-                }
-                if (mutableParameters[@"file_properties"] != nil) {
-                    mutableParameters[@"properties"] = mutableParameters[@"file_properties"];
-                    [mutableParameters removeObjectForKey: @"file_properties"];
-                }
-                [self saveData:mutableParameters];
+                [self updateCellAndSaveRichData:indexPath watched:watched item:item];
                 [queuing stopAnimating];
             }
             else {
@@ -3331,37 +3307,47 @@ NSIndexPath *selected;
      withParameters:params
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
          if (error == nil && methodError == nil) {
-             BOOL wasWatched = watched > 0;
-             if (enableCollectionView) {
-                 [cell setOverlayWatched:wasWatched];
-                 [collectionView deselectItemAtIndexPath:indexPath animated:YES];
-             }
-             else {
-                 UIImageView *flagView = (UIImageView*)[cell viewWithTag:9];
-                 flagView.hidden = !wasWatched;
-                 [dataList deselectRowAtIndexPath:indexPath animated:YES];
-             }
-             item[@"playcount"] = @(watched);
-             
-             mainMenu *menuItem = [self getMainMenu:item];
-             NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
-             NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
-             NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
-             if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
-                 [mutableProperties addObject:@"art"];
-                 mutableParameters[@"properties"] = mutableProperties;
-             }
-             if (mutableParameters[@"file_properties"] != nil) {
-                 mutableParameters[@"properties"] = mutableParameters[@"file_properties"];
-                 [mutableParameters removeObjectForKey: @"file_properties"];
-             }
-             [self saveData:mutableParameters];
+             [self updateCellAndSaveRichData:indexPath watched:watched item:item];
              [queuing stopAnimating];
          }
          else {
              [queuing stopAnimating];
          }
      }];
+}
+
+- (void)updateCellAndSaveRichData:(NSIndexPath*)indexPath watched:(int)watched item:(id)item {
+    id cell = [self getCell:indexPath];
+    BOOL wasWatched = watched > 0;
+    
+    // Set or unset the ckeck mark icon
+    if (enableCollectionView) {
+        [cell setOverlayWatched:wasWatched];
+        [collectionView deselectItemAtIndexPath:indexPath animated:YES];
+    }
+    else {
+        UIImageView *flagView = (UIImageView*)[cell viewWithTag:9];
+        flagView.hidden = !wasWatched;
+        [dataList deselectRowAtIndexPath:indexPath animated:YES];
+    }
+    
+    // Set the new playcount for the item inside the rich data
+    item[@"playcount"] = @(watched);
+    
+    // Store the rich data
+    mainMenu *menuItem = [self getMainMenu:item];
+    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
+    NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
+    if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
+        [mutableProperties addObject:@"art"];
+        mutableParameters[@"properties"] = mutableProperties;
+    }
+    if (mutableParameters[@"file_properties"] != nil) {
+        mutableParameters[@"properties"] = mutableParameters[@"file_properties"];
+        [mutableParameters removeObjectForKey: @"file_properties"];
+    }
+    [self saveData:mutableParameters];
 }
 
 - (void)saveSortMethod:(NSString*)sortMethod parameters:(NSDictionary*)parameters {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3288,23 +3288,14 @@ NSIndexPath *selected;
      withParameters:params
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
          if (error == nil && methodError == nil) {
+             BOOL wasWatched = watched > 0;
              if (isTableView) {
                  UIImageView *flagView = (UIImageView*)[cell viewWithTag:9];
-                 if (watched > 0) {
-                     flagView.hidden = NO;
-                 }
-                 else {
-                     flagView.hidden = YES;
-                 }
+                 flagView.hidden = !wasWatched;
                  [tableView deselectRowAtIndexPath:indexPath animated:YES];
              }
              else {
-                 if (watched > 0) {
-                     [cell setOverlayWatched:YES];
-                 }
-                 else {
-                     [cell setOverlayWatched:NO];
-                 }
+                 [cell setOverlayWatched:wasWatched];
                  [collectionView deselectItemAtIndexPath:indexPath animated:YES];
              }
              item[@"playcount"] = @(watched);

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3253,11 +3253,6 @@ NSIndexPath *selected;
 
 - (void)markVideo:(NSMutableDictionary*)item indexPath:(NSIndexPath*)indexPath watched:(int)watched {
     id cell = [self getCell:indexPath];
-    UITableView *tableView = dataList;
-    BOOL isTableView = YES;
-    if (enableCollectionView) {
-        isTableView = NO;
-    }
     UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
     [queuing startAnimating];
 
@@ -3337,14 +3332,14 @@ NSIndexPath *selected;
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
          if (error == nil && methodError == nil) {
              BOOL wasWatched = watched > 0;
-             if (isTableView) {
-                 UIImageView *flagView = (UIImageView*)[cell viewWithTag:9];
-                 flagView.hidden = !wasWatched;
-                 [tableView deselectRowAtIndexPath:indexPath animated:YES];
-             }
-             else {
+             if (enableCollectionView) {
                  [cell setOverlayWatched:wasWatched];
                  [collectionView deselectItemAtIndexPath:indexPath animated:YES];
+             }
+             else {
+                 UIImageView *flagView = (UIImageView*)[cell viewWithTag:9];
+                 flagView.hidden = !wasWatched;
+                 [dataList deselectRowAtIndexPath:indexPath animated:YES];
              }
              item[@"playcount"] = @(watched);
              

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3263,11 +3263,11 @@ NSIndexPath *selected;
 
     NSString *methodToCall = @"";
     NSString *family = item[@"family"];
-    if ([family isEqualToString:@"episodeid"]) {
-        methodToCall = @"VideoLibrary.SetEpisodeDetails";
-    }
-    else if ([family isEqualToString:@"tvshowid"]) {
+    if ([family isEqualToString:@"tvshowid"]) {
         methodToCall = @"VideoLibrary.SetTVShowDetails";
+    }
+    else if ([family isEqualToString:@"episodeid"]) {
+        methodToCall = @"VideoLibrary.SetEpisodeDetails";
     }
     else if ([family isEqualToString:@"movieid"]) {
         methodToCall = @"VideoLibrary.SetMovieDetails";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
As reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3106513#pid3106513) it is not possible to mark a complete TV Show as watched/unwatched with Kodi 19.4. Even though the App is sending the valid command

`{"jsonrpc":"2.0","method":"VideoLibrary.SetTVShowDetails","params":{"tvshowid":11, "playcount":1}, "id":2}`

and receives the response `"OK"` from the API, Kodi server does not change the playcount.

This PR implements a solution similar to Chorus Web Interface which simply sets the playcount for each episode of a TV Show. As I am not sure if Kodi server itself should be fixed (in case the JSON command from above should suffice), or if the App shall work around this, I am keeping this draft for now.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix marking TV Shows as watched/unwatched