### PR TITLE
Feature: Support languages ca-es and es-mx

### DIFF
--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -293,6 +293,8 @@
 		C7868BB727491FB7001B35B6 /* en-US */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-US"; path = "en-US.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C7A030F128B60DB200B27764 /* ca-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ca-ES"; path = "ca-ES.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C7A030F228B60DB200B27764 /* ca-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ca-ES"; path = "ca-ES.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		C7A030F328B60EB900B27764 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		C7A030F428B60EB900B27764 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C7F28D4826961FE50004B112 /* ConvenienceMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConvenienceMacros.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -720,6 +722,7 @@
 				"fi-FI",
 				"ko-KR",
 				"ca-ES",
+				"es-MX",
 			);
 			mainGroup = 0F5548EB151D1187007E633F;
 			productRefGroup = 0F5548F7151D1187007E633F /* Products */;
@@ -854,6 +857,7 @@
 				C746406727E6200200F6AD47 /* fi-FI */,
 				C746406927E6209C00F6AD47 /* ko-KR */,
 				C7A030F128B60DB200B27764 /* ca-ES */,
+				C7A030F328B60EB900B27764 /* es-MX */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -877,6 +881,7 @@
 				C746406827E6200200F6AD47 /* fi-FI */,
 				C746406A27E6209C00F6AD47 /* ko-KR */,
 				C7A030F228B60DB200B27764 /* ca-ES */,
+				C7A030F428B60EB900B27764 /* es-MX */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -291,6 +291,8 @@
 		C7478BF8257258E700161C1E /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		C7868BB627491FB7001B35B6 /* en-US */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-US"; path = "en-US.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C7868BB727491FB7001B35B6 /* en-US */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-US"; path = "en-US.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		C7A030F128B60DB200B27764 /* ca-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ca-ES"; path = "ca-ES.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		C7A030F228B60DB200B27764 /* ca-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ca-ES"; path = "ca-ES.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C7F28D4826961FE50004B112 /* ConvenienceMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConvenienceMacros.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -717,6 +719,7 @@
 				"en-US",
 				"fi-FI",
 				"ko-KR",
+				"ca-ES",
 			);
 			mainGroup = 0F5548EB151D1187007E633F;
 			productRefGroup = 0F5548F7151D1187007E633F /* Products */;
@@ -850,6 +853,7 @@
 				C7868BB627491FB7001B35B6 /* en-US */,
 				C746406727E6200200F6AD47 /* fi-FI */,
 				C746406927E6209C00F6AD47 /* ko-KR */,
+				C7A030F128B60DB200B27764 /* ca-ES */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -872,6 +876,7 @@
 				C7868BB727491FB7001B35B6 /* en-US */,
 				C746406827E6200200F6AD47 /* fi-FI */,
 				C746406A27E6209C00F6AD47 /* ko-KR */,
+				C7A030F228B60DB200B27764 /* ca-ES */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes #705.

This PR adds support for two more languages which reached a high translation grade:
- ca-es, Catalan (Spain)
- es-mx, Spanish (Mexico)

This PR shall be merged after #704. 

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Support languages ca-es and es-mx