### PR TITLE
Bugfix: Align clearart behaviour with Kodi UI

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -663,6 +663,19 @@
 }
 
 + (NSString*)getClearArtFromDictionary:(NSDictionary*)dict type:(NSString*)type {
+    // 1st preference: "albumartist.clearart" to prefer albumartist clearart.
+    NSString *albumArtistClearArtPath = dict[[NSString stringWithFormat:@"albumartist.%@", type]];
+    if (albumArtistClearArtPath) {
+        return albumArtistClearArtPath;
+    }
+    
+    // 2nd preference: "clearart" w/o any prefix to prefer movie over set clearart.
+    NSString *pureClearArtPath = dict[type];
+    if (pureClearArtPath) {
+        return pureClearArtPath;
+    }
+    
+    // Search for any "clearart"
     NSString *path = @"";
     for (NSString *key in dict) {
         if ([key rangeOfString:type].location != NSNotFound) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
As reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3109151#pid3109151) the clear art and clear logo shown by the Remote App was not matching Kodi UI.

This PR adds preferences for clear art:
1. Select `"albumartist.clearart"` if available. This will kick in only for music and will avoid picking `"artist.clearart"`.
2. Select `"clearart"` if available. This will avoid picking `"set.clearart"` for movies sets.

As default take the first matching object for key containing "clearart".

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-08axdzw.png"><img src="https://abload.de/img/bildschirmfoto2022-08axdzw.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Prefer album artist over artist clear art
Bugfix: Prefer movie over movie set clear art