### PR TITLE
Feature: Support clearart for movie set details

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -2038,7 +2038,8 @@
             @[@"VideoLibrary.GetMovies", @"method",
               @"VideoLibrary.GetMovieDetails", @"extra_info_method"],
             @[@"VideoLibrary.GetGenres", @"method"],
-            @[@"VideoLibrary.GetMovieSets", @"method"],
+            @[@"VideoLibrary.GetMovieSets", @"method",
+              @"VideoLibrary.GetMovieSetDetails", @"extra_info_method"],
             @[@"VideoLibrary.GetRecentlyAddedMovies", @"method",
               @"VideoLibrary.GetMovieDetails", @"extra_info_method"],
             @[@"Files.GetSources", @"method"],
@@ -2127,6 +2128,13 @@
                         @"fanart",
                         @"playcount"]
             }, @"parameters",
+            @{
+                @"properties": @[
+                    @"thumbnail",
+                    @"plot",
+                    @"fanart",
+                    @"playcount"]
+            }, @"extra_info_parameters",
             @{
                 @"label": @[
                         LOCALIZED_STR(@"Name"),
@@ -2283,7 +2291,8 @@
             @"row8": @"setid",
             @"row9": @"setid",
             @"row10": @"playcount",
-            @"row11": @"plot"
+            @"row11": @"plot",
+            @"itemid_extra_info": @"setdetails"
         },
 
         @{


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
For movie sets the configuration to pull and process mpvie set details and art was missing. Configuring the method `VideoLibrary.GetMovieSetDetails` and related items adds support to show clearart in the movie set details view.

Screenshots before/after:
<a href="https://abload.de/image.php?img=bildschirmfoto2022-08k2cni.png"><img src="https://abload.de/img/bildschirmfoto2022-08k2cni.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Support clearart for movie set details