### PR TITLE
Maintenance: Raise frequency of review popup

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -886,8 +886,9 @@
         NSInteger count = [[NSUserDefaults standardUserDefaults] integerForKey:PERSISTENCE_KEY_PLAYBACK_ATTEMPTS] + 1;
         [[NSUserDefaults standardUserDefaults] setInteger:count forKey:PERSISTENCE_KEY_PLAYBACK_ATTEMPTS];
         
-        // Show review popup after 50th, 150th, 300th attempt, and each 300th from then on
-        if (count == 50 || count == 150 || count == 300 || count % 300 == 0) {
+        // Show review popup after 20th, 100th, 200th attempt, and each 200th from then on
+        // From AppStore metrics it is evident that 50 equals 3+ months for majority of users
+        if (count == 20 || count == 100 || count == 200 || count % 200 == 0) {
             [Utilities showReviewController];
         }
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
From AppStore metrics it is evident that a trigger count of 50 equals 3+ months for the majority of users. We aim to get the feedback 1-2 months after a release. This way there is enough headroom to provide hotfixes and enough time left before a next major release is coming up.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Raise frequency of review popup