### PR TITLE
Improvement: Change navbar buttons for movie sets

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -105,6 +105,9 @@ double round(double d) {
                 extraButton = [[UIBarButtonItem alloc] initWithImage:extraButtonImg style:UIBarButtonItemStylePlain target:self action:@selector(showContent:)];
             }
         }
+        else if ([item[@"family"] isEqualToString:@"setid"]) {
+            actionSheetButtonItem = nil;
+        }
         else if ([item[@"family"] isEqualToString:@"broadcastid"]) {
             NSString *pvrAction = [item[@"hastimer"] boolValue] ? LOCALIZED_STR(@"Stop Recording") : LOCALIZED_STR(@"Record");
             sheetActions = [@[LOCALIZED_STR(@"Play"), pvrAction] mutableCopy];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/712.

Playing movie sets is not supported by Kodi API. Therefore hide the "Play" button in the navbar. Instead, show the "movie set" icon which brings the user back to the movie set list.

<a href="https://abload.de/image.php?img=bildschirmfoto2022-096gelf.png"><img src="https://abload.de/img/bildschirmfoto2022-096gelf.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Change navbar buttons for movie sets