### PR TITLE
Bugfix: Only process dispatch_group_notify when ignoreSingleMovieSets is enabled

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4771,21 +4771,23 @@ NSIndexPath *selected;
                          }
                      }
                      // Finish the processing for 1-movie sets
-                     dispatch_group_notify(group, dispatch_get_main_queue(), ^{
-                         storeRichResults = [resultStoreArray mutableCopy];
-                         // Show "no results found", if results are empty, and leave
-                         if (!resultStoreArray.count) {
-                             [self showNoResultsFound:resultStoreArray refresh:forceRefresh];
-                             return;
-                         }
-                         // Store and show results
-                         if (forceRefresh == YES){
-                             [((UITableView*)activeLayoutView).pullToRefreshView stopAnimating];
-                             [activeLayoutView setUserInteractionEnabled:YES];
-                         }
-                         [self saveData:mutableParameters];
-                         [self indexAndDisplayData];
-                     });
+                     if (ignoreSingleMovieSets) {
+                         dispatch_group_notify(group, dispatch_get_main_queue(), ^{
+                             storeRichResults = [resultStoreArray mutableCopy];
+                             // Show "no results found", if results are empty, and leave
+                             if (!resultStoreArray.count) {
+                                 [self showNoResultsFound:resultStoreArray refresh:forceRefresh];
+                                 return;
+                             }
+                             // Store and show results
+                             if (forceRefresh == YES){
+                                 [((UITableView*)activeLayoutView).pullToRefreshView stopAnimating];
+                                 [activeLayoutView setUserInteractionEnabled:YES];
+                             }
+                             [self saveData:mutableParameters];
+                             [self indexAndDisplayData];
+                         });
+                     }
                  }
                  else if ([itemDict isKindOfClass:[NSDictionary class]]) {
                      id itemType = methodResult[itemid][mainFields[@"typename"]];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/717.

With the introduction of `dispatch_group_notify` for a thread safe processing of 1-movie sets a bug was introduced which causes the some issues with the displayed list of item after sync. In this case some items are shown twice and the also the sections are screwed up. This is only seen when showing lists with sections (typically > 100 items).

To fix this the processing of `dispatch_group_notify` must only run if `ignoreSingleMovieSets` is set.

Screenshot (left = bug, right = fixed):
<a href="https://abload.de/image.php?img=bildschirmfoto2022-101cif2.png"><img src="https://abload.de/img/bildschirmfoto2022-101cif2.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Only process dispatch_group_notify when ignoreSingleMovieSets is enabled