### PR TITLE
Bugfix: Keep music, artists and movie set filters active after synchronizing

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1156,35 +1156,11 @@
         NSArray *buttonsIB = @[button1, button2, button3, button4, button5];
         [buttonsIB[choosedTab] setImage:[UIImage imageNamed:menuItem.filterModes[choosedTab][@"icons"][filterModeIndex]] forState:UIControlStateSelected];
         
-        // Artist filter is active. We change the API call parameters and continue.
+        // Artist filter is inactive. We simply filter results via helper function changeViewMode and return.
         filterModeType = [menuItem.filterModes[choosedTab][@"modes"][filterModeIndex] intValue];
-        if (filterModeType == ViewModeAlbumArtists ||
-            filterModeType == ViewModeSongArtists ||
-            filterModeType == ViewModeDefaultArtists) {
-            if (AppDelegate.instance.APImajorVersion >= 4) {
-                switch (filterModeType) {
-                    case ViewModeAlbumArtists:
-                        mutableParameters[@"albumartistsonly"] = @YES;
-                        refresh = YES;
-                        break;
-                        
-                    case ViewModeSongArtists:
-                        mutableParameters[@"albumartistsonly"] = @NO;
-                        refresh = YES;
-                        break;
-                        
-                    case ViewModeDefaultArtists:
-                        [mutableParameters removeObjectForKey:@"albumartistsonly"];
-                        break;
-                        
-                    default:
-                        NSAssert(NO, @"changeTab: unexpected mode %d", filterModeType);
-                        break;
-                }
-            }
-        }
-        // Some other filter is active. We simply filter results via helper function changeViewMode and return.
-        else {
+        if (!(filterModeType == ViewModeAlbumArtists ||
+              filterModeType == ViewModeSongArtists ||
+              filterModeType == ViewModeDefaultArtists)) {
             [self changeViewMode:filterModeType forceRefresh:NO];
             return;
         }
@@ -4608,6 +4584,33 @@ NSIndexPath *selected;
     if (mutableParameters[@"file_properties"] != nil) {
         mutableParameters[@"properties"] = mutableParameters[@"file_properties"];
         [mutableParameters removeObjectForKey: @"file_properties"];
+    }
+    
+    // Artist filter is active. We change the API call parameters and continue.
+    if (filterModeType == ViewModeAlbumArtists ||
+        filterModeType == ViewModeSongArtists ||
+        filterModeType == ViewModeDefaultArtists) {
+        if (AppDelegate.instance.APImajorVersion >= 4) {
+            switch (filterModeType) {
+                case ViewModeAlbumArtists:
+                    mutableParameters[@"albumartistsonly"] = @YES;
+                    forceRefresh = YES;
+                    break;
+                    
+                case ViewModeSongArtists:
+                    mutableParameters[@"albumartistsonly"] = @NO;
+                    forceRefresh = YES;
+                    break;
+                    
+                case ViewModeDefaultArtists:
+                    [mutableParameters removeObjectForKey:@"albumartistsonly"];
+                    break;
+                    
+                default:
+                    NSAssert(NO, @"retrieveData: unexpected mode %d", filterModeType);
+                    break;
+            }
+        }
     }
     
     if ([self loadedDataFromDisk:methodToCall parameters:(sectionParameters == nil) ? mutableParameters : [NSMutableDictionary dictionaryWithDictionary:sectionParameters] refresh:forceRefresh]) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4780,12 +4780,7 @@ NSIndexPath *selected;
                                  return;
                              }
                              // Store and show results
-                             if (forceRefresh == YES){
-                                 [((UITableView*)activeLayoutView).pullToRefreshView stopAnimating];
-                                 [activeLayoutView setUserInteractionEnabled:YES];
-                             }
-                             [self saveData:mutableParameters];
-                             [self indexAndDisplayData];
+                             [self saveAndShowResultsRefresh:forceRefresh params:mutableParameters];
                          });
                      }
                  }
@@ -4824,22 +4819,9 @@ NSIndexPath *selected;
                  if (SectionMethodToCall != nil) {
                      [self retrieveData:SectionMethodToCall parameters:sectionParameters sectionMethod:nil sectionParameters:nil resultStore:self.extraSectionRichResults extraSectionCall:YES refresh:forceRefresh];
                  }
-                 else if (filterModeType == ViewModeWatched ||
-                          filterModeType == ViewModeUnwatched) {
-                     if (forceRefresh) {
-                         [((UITableView*)activeLayoutView).pullToRefreshView stopAnimating];
-                         [activeLayoutView setUserInteractionEnabled:YES];
-                         [self saveData:mutableParameters];
-                     }
-                     [self changeViewMode:filterModeType forceRefresh:forceRefresh];
-                 }
                  else {
-                     if (forceRefresh) {
-                         [((UITableView*)activeLayoutView).pullToRefreshView stopAnimating];
-                         [activeLayoutView setUserInteractionEnabled:YES];
-                     }
-                     [self saveData:mutableParameters];
-                     [self indexAndDisplayData];
+                     // Store and show results
+                     [self saveAndShowResultsRefresh:forceRefresh params:mutableParameters];
                  }
              }
              else {
@@ -4861,6 +4843,26 @@ NSIndexPath *selected;
              [self showNoResultsFound:resultStoreArray refresh:forceRefresh];
          }
      }];
+}
+
+- (void)saveAndShowResultsRefresh:(BOOL)forceRefresh params:(NSMutableDictionary*)mutableParameters {
+    if (filterModeType == ViewModeWatched ||
+        filterModeType == ViewModeUnwatched) {
+        if (forceRefresh) {
+            [((UITableView*)activeLayoutView).pullToRefreshView stopAnimating];
+            [activeLayoutView setUserInteractionEnabled:YES];
+            [self saveData:mutableParameters];
+        }
+        [self changeViewMode:filterModeType forceRefresh:forceRefresh];
+    }
+    else {
+        if (forceRefresh) {
+            [((UITableView*)activeLayoutView).pullToRefreshView stopAnimating];
+            [activeLayoutView setUserInteractionEnabled:YES];
+        }
+        [self saveData:mutableParameters];
+        [self indexAndDisplayData];
+    }
 }
 
 - (void)animateNoResultsFound {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4850,7 +4850,9 @@ NSIndexPath *selected;
 
 - (void)saveAndShowResultsRefresh:(BOOL)forceRefresh params:(NSMutableDictionary*)mutableParameters {
     if (filterModeType == ViewModeWatched ||
-        filterModeType == ViewModeUnwatched) {
+        filterModeType == ViewModeUnwatched ||
+        filterModeType == ViewModeListened ||
+        filterModeType == ViewModeNotListened) {
         if (forceRefresh) {
             [((UITableView*)activeLayoutView).pullToRefreshView stopAnimating];
             [activeLayoutView setUserInteractionEnabled:YES];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/725.

This PR reworks the synchronization processing to keep filters for music, artists and movie sets active -- like done already for movies, music videos, TV shows and episodes. Details are described in the commit messages.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Keep music, artists and movie set filters active after synchronizing