### PR TITLE
Bugfixes: Grid view layout glitch and invisible search bar

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1063,12 +1063,12 @@
 - (void)configureLibraryView {
     NSString *imgName = nil;
     if (enableCollectionView) {
-        [self initCollectionView];
         if (longPressGesture == nil) {
             longPressGesture = [UILongPressGestureRecognizer new];
             [longPressGesture addTarget:self action:@selector(handleLongPress)];
         }
         [collectionView addGestureRecognizer:longPressGesture];
+        collectionView.contentInset = dataList.contentInset;
         dataList.delegate = nil;
         dataList.dataSource = nil;
         collectionView.delegate = self;
@@ -1649,7 +1649,6 @@
         collectionView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
         [detailView insertSubview:collectionView belowSubview:buttonsView];
     }
-    activeLayoutView = collectionView;
 }
 
 - (NSInteger)numberOfSectionsInCollectionView:(UICollectionView*)collectionView {
@@ -5800,7 +5799,7 @@ NSIndexPath *selected;
     dataList.frame = frame;
     recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
     enableCollectionView = [self collectionViewIsEnabled];
-    if ([self collectionViewCanBeEnabled]) { // TEMP FIX
+    if ([self collectionViewCanBeEnabled]) {
         [self initCollectionView];
     }
     activeLayoutView = dataList;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1077,10 +1077,8 @@
         collectionView.scrollsToTop = YES;
         activeLayoutView = collectionView;
         [self initCollectionIndexView];
-        // Need to remove the searchController from the dataList header view. Otherwise the search
-        // will not correctly show on top of the grid view.
-        dataList.tableHeaderView = nil;
         
+        [self initSearchController];
         self.searchController.searchBar.backgroundColor = [Utilities getGrayColor:22 alpha:1];
         self.searchController.searchBar.tintColor = UIColor.lightGrayColor;
         imgName = @"st_view_grid";
@@ -1097,6 +1095,7 @@
         // Ensure the searchController is properly attached to the dataList header view.
         dataList.tableHeaderView = self.searchController.searchBar;
         
+        [self initSearchController];
         self.searchController.searchBar.backgroundColor = [Utilities getSystemGray6];
         self.searchController.searchBar.tintColor = [Utilities get2ndLabelColor];
         imgName = @"st_view_list";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/571.
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/728.

Clean up initialization and update of `UICollectionView`
- Only initialize grid view in `viewDidLoad` when supported in this view
- Remove obsolete assignment while initializing grid view
- Update `contentInset` when switching to grid view. This fixes a glitch when first synchronizing in list view and then switching to grid view.

Force re-initialization of `UISearchController`
- Remove workaround
- Re-create search controller each time when toggling between grid and list view.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Wrong grid view layout after refresh in list view
Bugfix: Sometime search bar not visible in grid view