### PR TITLE
Bugfix: Show sync animation until global search data is fully loaded

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4512,9 +4512,14 @@ NSIndexPath *selected;
         [self.richResults removeAllObjects];
         [self.filteredListContent removeAllObjects];
         self.richResults = richData;
+        
+        // Stop refresh animation
+        [((UITableView*)activeLayoutView).pullToRefreshView stopAnimating];
+        [activeLayoutView setUserInteractionEnabled:YES];
+        
+        // Save and display
         mainMenu *menuItem = self.detailItem;
         NSMutableDictionary *parameters = [[Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]] mutableCopy];
-        
         [self saveData:parameters];
         [self indexAndDisplayData];
         return;
@@ -4538,7 +4543,6 @@ NSIndexPath *selected;
      withParameters:mutableParameters
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
         if (error == nil && methodError == nil) {
-            BOOL forceRefresh = YES;
             if (error == nil && methodError == nil) {
                 [activeLayoutView reloadData];
                 if ([NSJSONSerialization isValidJSONObject:methodResult]) {
@@ -4590,10 +4594,6 @@ NSIndexPath *selected;
                                 }
                             }
                         }
-                    }
-                    if (forceRefresh) {
-                        [((UITableView*)activeLayoutView).pullToRefreshView stopAnimating];
-                        [activeLayoutView setUserInteractionEnabled:YES];
                     }
                 }
             }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4543,55 +4543,53 @@ NSIndexPath *selected;
      withParameters:mutableParameters
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
         if (error == nil && methodError == nil) {
-            if (error == nil && methodError == nil) {
-                [activeLayoutView reloadData];
-                if ([NSJSONSerialization isValidJSONObject:methodResult]) {
-                    NSString *itemid = @"";
-                    if (((NSNull*)mainFields[@"itemid"] != [NSNull null])) {
-                        itemid = mainFields[@"itemid"];
-                    }
-                    NSArray *itemDict = methodResult[itemid];
-                    NSString *serverURL = [Utilities getImageServerURL];
-                    int secondsToMinute = [Utilities getSec2Min:menuItem.noConvertTime];
-                    if ([itemDict isKindOfClass:[NSArray class]]) {
-                        for (NSDictionary *item in itemDict) {
-                            NSMutableDictionary *newDict = [self getNewDictionaryFromItem:item
-                                                                               mainFields:mainFields
-                                                                                serverURL:serverURL
-                                                                                  sec2min:secondsToMinute
-                                                                                useBanner:NO
-                                                                                  useIcon:NO];
-                            // Convert from array to string to allow searching globally
-                            if (newDict[@"artist"]) {
-                                newDict[@"artist"] = [Utilities getStringFromItem:newDict[@"artist"]];
-                            }
-                            if (newDict[@"director"]) {
-                                newDict[@"director"] = [Utilities getStringFromItem:newDict[@"director"]];
-                            }
-                            [self addItemGroup:newDict];
-                            [richData addObject:newDict];
+            [activeLayoutView reloadData];
+            if ([NSJSONSerialization isValidJSONObject:methodResult]) {
+                NSString *itemid = @"";
+                if (((NSNull*)mainFields[@"itemid"] != [NSNull null])) {
+                    itemid = mainFields[@"itemid"];
+                }
+                NSArray *itemDict = methodResult[itemid];
+                NSString *serverURL = [Utilities getImageServerURL];
+                int secondsToMinute = [Utilities getSec2Min:menuItem.noConvertTime];
+                if ([itemDict isKindOfClass:[NSArray class]]) {
+                    for (NSDictionary *item in itemDict) {
+                        NSMutableDictionary *newDict = [self getNewDictionaryFromItem:item
+                                                                           mainFields:mainFields
+                                                                            serverURL:serverURL
+                                                                              sec2min:secondsToMinute
+                                                                            useBanner:NO
+                                                                              useIcon:NO];
+                        // Convert from array to string to allow searching globally
+                        if (newDict[@"artist"]) {
+                            newDict[@"artist"] = [Utilities getStringFromItem:newDict[@"artist"]];
                         }
+                        if (newDict[@"director"]) {
+                            newDict[@"director"] = [Utilities getStringFromItem:newDict[@"director"]];
+                        }
+                        [self addItemGroup:newDict];
+                        [richData addObject:newDict];
                     }
-                    else if ([itemDict isKindOfClass:[NSDictionary class]]) {
-                        id itemType = methodResult[itemid][mainFields[@"typename"]];
-                        id itemField = mainFields[@"fieldname"];
-                        if ([itemType isKindOfClass:[NSDictionary class]]) {
-                            if ([itemType[itemField] isKindOfClass:[NSArray class]]) {
-                                itemDict = itemType[itemField];
-                                NSString *sublabel = [Utilities indexKeyedDictionaryFromArray:[self.detailItem mainParameters][choosedTab]][@"morelabel"];
-                                if (!sublabel || [sublabel isKindOfClass:[NSNull class]]) {
-                                    sublabel = @"";
-                                }
-                                for (NSDictionary *item in itemDict) {
-                                    [richData addObject:[NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                                                 item, @"label",
-                                                                 sublabel, @"genre",
-                                                                 @"file", @"family",
-                                                                 mainFields[@"thumbnail"], @"thumbnail",
-                                                                 @"", @"fanart",
-                                                                 @"", @"runtime",
-                                                                 nil]];
-                                }
+                }
+                else if ([itemDict isKindOfClass:[NSDictionary class]]) {
+                    id itemType = methodResult[itemid][mainFields[@"typename"]];
+                    id itemField = mainFields[@"fieldname"];
+                    if ([itemType isKindOfClass:[NSDictionary class]]) {
+                        if ([itemType[itemField] isKindOfClass:[NSArray class]]) {
+                            itemDict = itemType[itemField];
+                            NSString *sublabel = [Utilities indexKeyedDictionaryFromArray:[self.detailItem mainParameters][choosedTab]][@"morelabel"];
+                            if (!sublabel || [sublabel isKindOfClass:[NSNull class]]) {
+                                sublabel = @"";
+                            }
+                            for (NSDictionary *item in itemDict) {
+                                [richData addObject:[NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                                             item, @"label",
+                                                             sublabel, @"genre",
+                                                             @"file", @"family",
+                                                             mainFields[@"thumbnail"], @"thumbnail",
+                                                             @"", @"fanart",
+                                                             @"", @"runtime",
+                                                             nil]];
                             }
                         }
                     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3113064#pid3113064) (see the video).

The sync animation was stopped prematurely. This PR simply moves stopping the animation to the end of the load-activity for the global search data. The behaviour is now in line with other data sets loaded.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show sync animation until global search data is fully loaded