### PR TITLE
Maintenance: easy to use check methods for Kodi and API versions

### DIFF
--- a/XBMC Remote/VersionCheck.h
+++ b/XBMC Remote/VersionCheck.h
@@ -9,8 +9,18 @@
 #import <Foundation/Foundation.h>
 #import "AppDelegate.h"
 
+typedef enum {
+    earlierThan,
+    earlierOrSameAs,
+    sameAs,
+    laterOrSameAs,
+    laterThan
+} VersionComparisonType;
+
 @interface VersionCheck : NSObject
 
++ (BOOL)isAPIVersion:(VersionComparisonType)compare version:(NSString*)targetVersion;
++ (BOOL)isKodiVersion:(VersionComparisonType)compare version:(NSString*)targetVersion;
 + (BOOL)hasRecordingIdPlaylistSupport;
 
 @end

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -12,6 +12,66 @@
 
 @implementation VersionCheck
 
++ (BOOL)evaluateComparisonRequest:(VersionComparisonType)compare againstComparison:(NSComparisonResult)comparison {
+    BOOL result;
+    switch (compare) {
+        case earlierThan:
+            result = comparison == NSOrderedAscending;
+            break;
+        case earlierOrSameAs:
+            result = comparison != NSOrderedDescending;
+            break;
+        case sameAs:
+            result = comparison == NSOrderedSame;
+            break;
+        case laterOrSameAs:
+            result = comparison != NSOrderedAscending;
+            break;
+        case laterThan:
+            result = comparison == NSOrderedDescending;
+            break;
+        default:
+            NSAssert(NO, @"evaluateComparisonRequest: unknown comparison mode %d", compare);
+            break;
+    }
+    return result;
+}
+
++ (BOOL)compareVersion:(int)major minor:(int)minor patch:(int)patch compare:(VersionComparisonType)compare targetVersion:(NSString*)targetVersion {
+    NSUInteger num = [targetVersion componentsSeparatedByString:@"."].count;
+    NSString *systemVersion = @"";
+    switch (num) {
+        case 3:
+            systemVersion = [NSString stringWithFormat:@".%d", patch];
+        case 2:
+            systemVersion = [NSString stringWithFormat:@".%d%@", minor, systemVersion];
+        case 1:
+            systemVersion = [NSString stringWithFormat:@"%d%@", major, systemVersion];
+            break;
+        default:
+            NSAssert(NO, @"compareVersion: called with non supported version string.");
+        break;
+    }
+    NSComparisonResult comparisonResult = [systemVersion compare:targetVersion options:NSNumericSearch];
+    return [VersionCheck evaluateComparisonRequest:compare againstComparison:comparisonResult];
+}
+
++ (BOOL)isAPIVersion:(VersionComparisonType)compare version:(NSString*)targetVersion {
+    return [self compareVersion:AppDelegate.instance.APImajorVersion
+                          minor:AppDelegate.instance.APIminorVersion
+                          patch:AppDelegate.instance.APIpatchVersion
+                        compare:compare
+                  targetVersion:targetVersion];
+}
+
++ (BOOL)isKodiVersion:(VersionComparisonType)compare version:(NSString*)targetVersion {
+    return [self compareVersion:AppDelegate.instance.serverVersion
+                          minor:AppDelegate.instance.serverMinorVersion
+                          patch:0
+                        compare:compare
+                  targetVersion:targetVersion];
+}
+
 + (BOOL)hasRecordingIdPlaylistSupport {
     // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
     return (AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 7) || AppDelegate.instance.APImajorVersion > 12;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/547.

This PR adds easy to use and easy to read methods to check for a certain Kodi or API version.

`if (Utilities isAPIVersion:laterOrSameAs version:@"6.32.4"])` 
equals 
`if ((AppDelegate.instance.APImajorVersion >= 7) || (AppDelegate.instance.APImajorVersion == 6 && AppDelegate.instance.APIminorVersion >= 33) || (AppDelegate.instance.APImajorVersion == 6 && AppDelegate.instance.APIminorVersion == 32 && AppDelegate.instance.APIpatchVersion >= 4))`

`if (Utilities isAPIVersion:earlierThan version:@"12.1"])`
equals
`if ((AppDelegate.instance.APImajorVersion < 12) || ((AppDelegate.instance.APImajorVersion == 12) && (AppDelegate.instance.APIminorVersion < 1)))`

`if (Utilities isKodiVersion:laterOrSameAs version:@"17.1"])` 
equals 
`if ((AppDelegate.instance.serverVersion == 17 && AppDelegate.instance.serverVersion >= 1) || AppDelegate.instance.serverVersion > 17)`


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: easy to use check methods for Kodi and API versions