### PR TITLE
Bugfix: Correct API version check to support major versions >13

### DIFF
--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		C703692927148CEF0049F9BF /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C703692827148CEF0049F9BF /* StoreKit.framework */; };
 		C718444625FFD06400F5A060 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C718444525FFD06300F5A060 /* SafariServices.framework */; };
 		C7478BF9257258E700161C1E /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C7478BF8257258E700161C1E /* Launch Screen.storyboard */; };
+		C78C30F528F877870055CD95 /* VersionCheck.m in Sources */ = {isa = PBXBuildFile; fileRef = C78C30F428F877870055CD95 /* VersionCheck.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -291,6 +292,8 @@
 		C7478BF8257258E700161C1E /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		C7868BB627491FB7001B35B6 /* en-US */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-US"; path = "en-US.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C7868BB727491FB7001B35B6 /* en-US */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-US"; path = "en-US.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		C78C30F428F877870055CD95 /* VersionCheck.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VersionCheck.m; sourceTree = "<group>"; };
+		C78C30F628F8779A0055CD95 /* VersionCheck.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VersionCheck.h; sourceTree = "<group>"; };
 		C7A030F128B60DB200B27764 /* ca-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ca-ES"; path = "ca-ES.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C7A030F228B60DB200B27764 /* ca-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ca-ES"; path = "ca-ES.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C7A030F328B60EB900B27764 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -518,6 +521,8 @@
 				0FB133A9165EC1E5003756C1 /* tcpJSONRPC.m */,
 				0FEA79FA165FBBEC00BB281F /* XBMCVirtualKeyboard.h */,
 				0FEA79FB165FBBEC00BB281F /* XBMCVirtualKeyboard.m */,
+				C78C30F628F8779A0055CD95 /* VersionCheck.h */,
+				C78C30F428F877870055CD95 /* VersionCheck.m */,
 				0F90904316E53C580021EFA9 /* Utilities.h */,
 				0F90904416E53C580021EFA9 /* Utilities.m */,
 				0F4019AE18F3ECEB0064E4DC /* customButton.h */,
@@ -820,6 +825,7 @@
 				0F32092816FE181300636BA2 /* SDWebImageDecoder.m in Sources */,
 				0F32092916FE181300636BA2 /* SDWebImageDownloader.m in Sources */,
 				0F32092A16FE181300636BA2 /* SDWebImageDownloaderOperation.m in Sources */,
+				C78C30F528F877870055CD95 /* VersionCheck.m in Sources */,
 				0F32092B16FE181300636BA2 /* SDWebImageManager.m in Sources */,
 				0F4019B318F415A50064E4DC /* MessagesView.m in Sources */,
 				0F32092C16FE181300636BA2 /* SDWebImagePrefetcher.m in Sources */,

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -28,6 +28,7 @@
 #import "ProgressPieView.h"
 #import "SettingsValuesViewController.h"
 #import "customButton.h"
+#import "VersionCheck.h"
 
 @interface DetailViewController ()
 - (void)configureView;
@@ -3997,9 +3998,8 @@ NSIndexPath *selected;
     if ([item[@"filetype"] isEqualToString:@"directory"]) {
         key = @"directory";
     }
-    // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
-    // Before, the JSON parameters must use the file path.
-    else if (!((AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 7) || AppDelegate.instance.APImajorVersion > 12) && [mainFields[@"row9"] isEqualToString:@"recordingid"]) {
+    // If Playlist.Insert and Playlist.Add for recordingid is not supported, use file path.
+    else if (![VersionCheck hasRecordingIdPlaylistSupport] && [mainFields[@"row9"] isEqualToString:@"recordingid"]) {
         key = @"file";
         value = item[@"file"];
     }
@@ -4112,9 +4112,8 @@ NSIndexPath *selected;
                 if ([item[@"filetype"] isEqualToString:@"directory"]) {
                     key = @"directory";
                 }
-                // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
-                // Before, the JSON parameters must use the file path.
-                else if (!((AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 7) || AppDelegate.instance.APImajorVersion > 12) && [mainFields[@"row8"] isEqualToString:@"recordingid"]) {
+                // If Playlist.Insert and Playlist.Add for recordingid is not supported, use file path.
+                else if (![VersionCheck hasRecordingIdPlaylistSupport] && [mainFields[@"row8"] isEqualToString:@"recordingid"]) {
                     key = @"file";
                     value = item[@"file"];
                 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3999,7 +3999,7 @@ NSIndexPath *selected;
     }
     // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
     // Before, the JSON parameters must use the file path.
-    else if (!(AppDelegate.instance.APImajorVersion >= 12 && AppDelegate.instance.APIminorVersion >= 7) && [mainFields[@"row9"] isEqualToString:@"recordingid"]) {
+    else if (!((AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 7) || AppDelegate.instance.APImajorVersion > 12) && [mainFields[@"row9"] isEqualToString:@"recordingid"]) {
         key = @"file";
         value = item[@"file"];
     }
@@ -4114,7 +4114,7 @@ NSIndexPath *selected;
                 }
                 // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
                 // Before, the JSON parameters must use the file path.
-                else if (!(AppDelegate.instance.APImajorVersion >= 12 && AppDelegate.instance.APIminorVersion >= 7) && [mainFields[@"row8"] isEqualToString:@"recordingid"]) {
+                else if (!((AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 7) || AppDelegate.instance.APImajorVersion > 12) && [mainFields[@"row8"] isEqualToString:@"recordingid"]) {
                     key = @"file";
                     value = item[@"file"];
                 }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -19,6 +19,7 @@
 #import "StackScrollViewController.h"
 #import "ActorCell.h"
 #import "Utilities.h"
+#import "VersionCheck.h"
 
 #define PLAY_BUTTON_SIZE 20
 #define TV_LOGO_SIZE_REC_DETAILS 72
@@ -1542,9 +1543,8 @@ double round(double d) {
     NSDictionary *item = self.detailItem;
     NSString *param = item[@"family"];
     id value = item[item[@"family"]];
-    // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
-    // Before, the JSON parameters must use the file path.
-    if (!((AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 7) || AppDelegate.instance.APImajorVersion > 12) && [self.detailItem[@"family"] isEqualToString:@"recordingid"]) {
+    // If Playlist.Insert and Playlist.Add for recordingid is not supported, use file path.
+    if (![VersionCheck hasRecordingIdPlaylistSupport] && [self.detailItem[@"family"] isEqualToString:@"recordingid"]) {
         param = @"file";
         value = item[@"file"];
     }
@@ -1613,9 +1613,8 @@ double round(double d) {
             if (error == nil && methodError == nil) {
                 NSString *param = item[@"family"];
                 id value = item[item[@"family"]];
-                // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
-                // Before, the JSON parameters must use the file path.
-                if (!((AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 7) || AppDelegate.instance.APImajorVersion > 12) && [self.detailItem[@"family"] isEqualToString:@"recordingid"]) {
+                // If Playlist.Insert and Playlist.Add for recordingid is not supported, use file path.
+                if (![VersionCheck hasRecordingIdPlaylistSupport] && [self.detailItem[@"family"] isEqualToString:@"recordingid"]) {
                     param = @"file";
                     value = item[@"file"];
                 }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1544,7 +1544,7 @@ double round(double d) {
     id value = item[item[@"family"]];
     // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
     // Before, the JSON parameters must use the file path.
-    if (!(AppDelegate.instance.APImajorVersion >= 12 && AppDelegate.instance.APIminorVersion >= 7) && [self.detailItem[@"family"] isEqualToString:@"recordingid"]) {
+    if (!((AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 7) || AppDelegate.instance.APImajorVersion > 12) && [self.detailItem[@"family"] isEqualToString:@"recordingid"]) {
         param = @"file";
         value = item[@"file"];
     }
@@ -1615,7 +1615,7 @@ double round(double d) {
                 id value = item[item[@"family"]];
                 // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
                 // Before, the JSON parameters must use the file path.
-                if (!(AppDelegate.instance.APImajorVersion >= 12 && AppDelegate.instance.APIminorVersion >= 7) && [self.detailItem[@"family"] isEqualToString:@"recordingid"]) {
+                if (!((AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 7) || AppDelegate.instance.APImajorVersion > 12) && [self.detailItem[@"family"] isEqualToString:@"recordingid"]) {
                     param = @"file";
                     value = item[@"file"];
                 }

--- a/XBMC Remote/VersionCheck.h
+++ b/XBMC Remote/VersionCheck.h
@@ -1,0 +1,16 @@
+//
+//  VersionCheck.h
+//  Kodi Remote
+//
+//  Created by Andree Buschmann on 13.10.22.
+//  Copyright © 2022 Team Kodi. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "AppDelegate.h"
+
+@interface VersionCheck : NSObject
+
++ (BOOL)hasRecordingIdPlaylistSupport;
+
+@end

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -1,0 +1,20 @@
+//
+//  VersionCheck.m
+//  Kodi Remote
+//
+//  Created by Andree Buschmann on 13.10.22.
+//  Copyright © 2022 Team Kodi. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "AppDelegate.h"
+#import "VersionCheck.h"
+
+@implementation VersionCheck
+
++ (BOOL)hasRecordingIdPlaylistSupport {
+    // Since API 12.7.0 Kodi server can handle Playlist.Insert and Playlist.Add for recordingid.
+    return (AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 7) || AppDelegate.instance.APImajorVersion > 12;
+}
+
+@end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes a problem with a version check which was not correctly handling major versions from 13 on, e.g. the check would have failed for version 13.0 to 13.6. Currently there is no JSON API 13, but the code must be future proof.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct API version check to support major versions >13