### PR TITLE
Bugfix: Playlist edit button might show wrong label

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1022,6 +1022,7 @@ long currentItemID;
                        if (playlistItems.count == 0) {
                            [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
                            editTableButton.enabled = NO;
+                           editTableButton.selected = NO;
                        }
                        else {
                            [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
@@ -2097,7 +2098,6 @@ long currentItemID;
                 if ((storeSelection) && (indexPath.row<storeSelection.row)) {
                     storeSelection = [NSIndexPath indexPathForRow:storeSelection.row-1 inSection:storeSelection.section];
                 }
-                editTableButton.selected = editTableButton.enabled = playlistData.count > 0;
             }
             else {
                 [playlistTableView performSelectorOnMainThread:@selector(reloadData) withObject:nil waitUntilDone:YES];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR sets the visibility of the playlist edit button only after reading the playlist content. This avoids possible race conditions, e.g. with Kodi 17 the edit button was showing "Edit" after changing the playlist, even though still being in editing state.

Screenshot: https://abload.de/img/bildschirmfoto2022-10zoeoe.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Playlist edit button might show wrong label