### PR TITLE
Bugfix: Fixes crash when editing a custom button label

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -761,7 +761,7 @@
             NSNumber *isSetting = item[@"isSetting"] ?: @YES;
             NSDictionary *action = item[@"action"] ?: @{};
             
-            NSDictionary *itemDict = @{
+            NSMutableDictionary *itemDict = [@{
                 @"label": label,
                 @"bgColor": @{},
                 @"hideLineSeparator": @NO,
@@ -771,7 +771,7 @@
                 @"revealViewTop": @NO,
                 @"type": type,
                 @"action": action,
-            };
+            } mutableCopy];
             
             [tableData addObject:itemDict];
         }


### PR DESCRIPTION
Fixes crash when editing the custom button label.

## Description
<!--- Detailed info for reviewers and developers -->
Fixes a crash reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=370085&pid=3114896#pid3114896).

`tableData` element must be `mutable` as this is changed when editing a custom button label.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fixes crash when editing a custom button label