### PR TITLE
Bugfix: Fix flickering playlist when pausing in partymode

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -278,7 +278,7 @@ typedef enum {
 int lastPlayerID = PLAYERID_UNKNOWN;
 long lastSelected = SELECTED_NONE;
 int currentPlayerID = PLAYERID_UNKNOWN;
-float storePercentage;
+int storePosSeconds;
 long storedItemID;
 long currentItemID;
 
@@ -783,10 +783,12 @@ long currentItemID;
                                  if (playlistPosition > -1) {
                                      playlistPosition += 1;
                                  }
-                                 if (musicPartyMode && percentage < storePercentage) { // BLEAH!!!
+                                 // Detect start of new song to update party mode playlist
+                                 int posSeconds = ((hours * 60) + minutes) * 60 + seconds;
+                                 if (musicPartyMode && posSeconds < storePosSeconds) {
                                      [self checkPartyMode];
                                  }
-                                 storePercentage = percentage;
+                                 storePosSeconds = posSeconds;
                                  if (playlistPosition != lastSelected && playlistPosition > 0) {
                                      if (playlistData.count >= playlistPosition && currentPlayerID == playerID) {
                                          [self hidePlaylistProgressbarWithDeselect:NO];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3115570#pid3115570).

The `percentage` property reports fluctuating values when pausing playback. This causes the playlist to be reloaded while in partymode. As a fix, use the playtime (position in seconds) instead of the `percentage`. This still allows to detect the start of a new song, which is needed to reload the partymode playlist.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix flickering playlist when pausing in partymode