### PR TITLE
Bugfix: Fix flickering playlist when long pressing the "burger" in edit mode

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2022,7 +2022,8 @@ long currentItemID;
 
 - (void)tableView:(UITableView*)tableView moveRowAtIndexPath:(NSIndexPath*)sourceIndexPath toIndexPath:(NSIndexPath*)destinationIndexPath {
     
-    if (sourceIndexPath.row >= playlistData.count) {
+    if (sourceIndexPath.row >= playlistData.count ||
+        sourceIndexPath.row == destinationIndexPath.row) {
         return;
     }
     NSDictionary *objSource = playlistData[sourceIndexPath.row];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Ignore moving playlist item to same position. This resolves a flickering playlist when long pressing the "burger" in edit mode.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix flickering playlist when long pressing the "burger" in edit mode