### PR TITLE
Bugfix: Fix searchbar not showing the Cancel button on iPad when not yet active

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5578,8 +5578,8 @@ NSIndexPath *selected;
 
 - (void)showSearchBar {
     UISearchBar *searchbar = self.searchController.searchBar;
+    searchbar.frame = CGRectMake(0, 0, self.view.frame.size.width, searchbar.frame.size.height);
     if (showbar) {
-        searchbar.frame = CGRectMake(0, 0, self.view.frame.size.width, searchbar.frame.size.height);
         [self.view addSubview:searchbar];
     }
     else {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Set the correct searchbar dimensions also while not being active.

Screenshots: https://abload.de/img/bildschirmfoto2022-10hyf6p.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix searchbar not showing the Cancel button on iPad when not yet active