### PR TITLE
Bugfix: Leave fullscreen on iPad when entering remote settings

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3669,6 +3669,12 @@ NSIndexPath *selected;
     return UIScreen.mainScreen.bounds;
 }
 
+- (void)leaveFullscreen {
+    if (stackscrollFullscreen) {
+        [self toggleFullscreen:nil];
+    }
+}
+
 - (void)toggleFullscreen:(id)sender {
     [activityIndicatorView startAnimating];
     NSTimeInterval animDuration = 0.5;
@@ -5845,6 +5851,11 @@ NSIndexPath *selected;
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleEnterForeground:)
                                                  name: @"UIApplicationWillEnterForegroundNotification"
+                                               object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(leaveFullscreen)
+                                                 name: @"LeaveFullscreen"
                                                object: nil];
     if (channelListView || channelGuideView) {
         [[NSNotificationCenter defaultCenter] addObserver: self

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1428,6 +1428,8 @@ NSInteger buttonAction;
         }
         rightMenuViewController.view.frame = CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height);
         [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:rightMenuViewController invokeByController:self isStackStartView:NO];
+        
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"LeaveFullscreen" object:nil userInfo:nil];
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3115912#pid3115912).

When in fullscreen mode on iPad it is important to properly leave the fullscreen mode when entering the remote setting ("gear" button). Otherwise an inconsistent UI state is entered.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Leave fullscreen on iPad when entering remote settings