### PR TITLE
Improvement: Select/Deselect behavior for remote in iPad main menu

### DIFF
--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -188,7 +188,20 @@
             remoteController.modalPresentationStyle = UIModalPresentationFormSheet;
             [remoteController setPreferredContentSize:remoteController.view.frame.size];
             [self presentViewController:remoteController animated:YES completion:nil];
-            lastSelected = -1;
+            if (IS_IPAD) {
+                if (lastSelected != -1) {
+                    // Restore the selected item and unselect remote again (remote is only a popover)
+                    indexPath = [NSIndexPath indexPathForRow:lastSelected inSection:0];
+                    [tableView selectRowAtIndexPath:indexPath animated:YES scrollPosition:UITableViewScrollPositionNone];
+                }
+                else {
+                    // Unselect remote again (remote is only a popover)
+                    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+                }
+            }
+            else {
+                lastSelected = -1;
+            }
             return;
         }
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
When selecting the remote in the iPad main menu, the former selected item shall be kept active. The remote on iPad is a popover, so there is is no reason to deselect the current active menu.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Select/Deselect behavior for remote in iPad main menu