### PR TITLE
Feature: Add option to select dark/light/automatic theme

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -458,6 +458,9 @@
     
     self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
     
+    // Set interface style for window
+    [self setInterfaceStyleFromUserDefaults];
+    
     int thumbWidth;
     int tvshowHeight;
     NSString *filemodeRowHeight= @"44";
@@ -6281,6 +6284,23 @@
 
 - (void)setIdleTimerFromUserDefaults {
     UIApplication.sharedApplication.idleTimerDisabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"lockscreen_preference"];
+}
+
+- (void)setInterfaceStyleFromUserDefaults {
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    NSString *mode = [userDefaults stringForKey:@"theme_mode"];
+    if (@available(iOS 13.0, *)) {
+        UIUserInterfaceStyle style = UIUserInterfaceStyleUnspecified;
+        if (mode.length) {
+            if ([mode isEqualToString:@"dark_mode"]) {
+                style = UIUserInterfaceStyleDark;
+            }
+            else if ([mode isEqualToString:@"light_mode"]) {
+                style = UIUserInterfaceStyleLight;
+            }
+        }
+        self.window.overrideUserInterfaceStyle = style;
+    }
 }
     
 - (NSNumber*)getGlobalSearchTab:(mainMenu*)menuItem label:(NSString*)subLabel {

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -102,7 +102,29 @@
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>FooterText</key>
-			<string>Filemode changes needs app restart</string>
+			<string>Filemode and Theme changes need app restart.</string>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
+			<string>automatic</string>
+			<key>Key</key>
+			<string>theme_mode</string>
+			<key>Title</key>
+			<string>Theme (iOS 13+)</string>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Titles</key>
+			<array>
+				<string>Automatic</string>
+				<string>Dark</string>
+				<string>Light</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<string>automatic</string>
+				<string>dark_mode</string>
+				<string>light_mode</string>
+			</array>
 		</dict>
 		<dict>
 			<key>DefaultValue</key>

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -25,7 +25,8 @@
 "Enable contents cache" = "Enable contents cache";
 "Override Lockscreen" = "Override Lockscreen";
 "Show all files in filemode" = "Show all files in filemode";
-"Filemode changes needs app restart" = "Filemode changes needs app restart";
+"Theme (iOS 13+)" = "Theme (iOS 13+)";
+"Filemode and Theme changes need app restart" = "Filemode and Theme changes need app restart";
 "Main Menu" = "Main Menu";
 "Main Menu Items" = "Main Menu Items";
 "Start in view" = "Start in view";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR adds a new setting option "Theme" which allows to set `UIUserInterfaceStyle` for the whole app. Possible settings are:
- Automatic (use the system mode, default)
- Dark (use Dark Mode)
- Light (use Light Mode)

As this only works on devices running iOS 13 or higher the setting itself is named "Theme (iOS13+)".

Screenshots: https://abload.de/img/bildschirmfoto2022-107afrd.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Add option to select dark/light/automatic theme