### PR TITLE
Improvement: Dismiss keyboard when leaving NowPlaying remote

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1215,6 +1215,10 @@ NSInteger buttonAction;
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(hideKeyboard:)
+                                                 name: @"ECSlidingViewTopWillReset"
+                                               object: nil];
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(hideKeyboard:)
                                                  name: @"ECSlidingViewUnderRightWillAppear"
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Improves an observation reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3116387#pid3116387).

Dismiss keyboard when leaving NowPlaying remote. This results in a consistent behavior for both full screen and "under right" (aka NowPlaying) remote.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Dismiss keyboard when leaving NowPlaying remote