### PR TITLE
Maintenance: Remove compiler warning

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -885,7 +885,7 @@
     imgView.frame = frm;
 }
 
-- (void)setCellImageView:(UIImageView*)imgView cell:(jsonDataCell*)cell dictItem:(NSDictionary*)item url:(NSString*)stringURL size:(CGSize)viewSize defaultImg:(NSString*)displayThumb {
+- (void)setCellImageView:(UIImageView*)imgView cell:(UIView*)cell dictItem:(NSDictionary*)item url:(NSString*)stringURL size:(CGSize)viewSize defaultImg:(NSString*)displayThumb {
     if ([item[@"family"] isEqualToString:@"channelid"] || [item[@"family"] isEqualToString:@"type"]) {
         imgView.contentMode = UIViewContentModeScaleAspectFit;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Use `id` type for the parameter and cast to `UITableViewCell*` when accessing the `backgroundColor`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Remove compiler warning