### PR TITLE
Bugfix: Avoid potential crash when loading GlobalSearch

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4516,6 +4516,7 @@ NSIndexPath *selected;
         [activeLayoutView setUserInteractionEnabled:YES];
         
         // Save and display
+        choosedTab = 0;
         mainMenu *menuItem = self.detailItem;
         NSMutableDictionary *parameters = [[Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]] mutableCopy];
         [self saveData:parameters];


### PR DESCRIPTION


## Description
<!--- Detailed info for reviewers and developers -->
Avoid a potential crash in `loadDetailedData` reported from AppStore. We are in GlobalSearch view which only supports `choosedTab = 0`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid potential crash when loading GlobalSearch