### PR TITLE
Bugfix: Resync in iPad fullscreen only works one time when coming from list view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5202,7 +5202,6 @@ NSIndexPath *selected;
 - (void)displayData {
     [self configureLibraryView];
     [self choseParams];
-    enableCollectionView = [self collectionViewIsEnabled];
     numResults = (int)self.richResults.count;
     mainMenu *menuItem = self.detailItem;
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];


### PR DESCRIPTION


## Description
<!--- Detailed info for reviewers and developers -->
Do not reload grid view flag in `displayData`. This is not needed and fixes a problem with resynchronizing data (pull down) in fullscreen mode when the fullscreen mode was entered from a  list view.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Resync in iPad fullscreen only works one time when coming from list view