### PR TITLE
Bugfix: iPad fullscreen rotation (iOS 15 and earlier)

### DIFF
--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -63,6 +63,7 @@
     float resumePointPercentage;
     KenBurnsView *kenView;
     BOOL enableKenBurns;
+    BOOL isFullscreenFanArt;
     UIButton *closeButton;
     UIButton *clearlogoButton;
     UIImageView *clearLogoImageView;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -30,6 +30,7 @@
 #define REC_DOT_PADDING 4
 #define ARROW_ALPHA 0.5
 #define IPAD_NAVBAR_SPACING 120
+#define FANART_FULLSCREEN_DISABLE 1
 
 @interface ShowInfoViewController ()
 @end
@@ -1341,7 +1342,7 @@ double round(double d) {
         foundTag = [sender tag];
     }
     // Close then fullscreen fanart view
-    if (foundTag == 1) {
+    if (foundTag == FANART_FULLSCREEN_DISABLE) {
         // 1. Fade in the navbar.
         // 2. Fade out the fanart and send StackScrollFullScreenDisabled to iPad screen handler.
         // 3. Fade in scrollview and up arrow (we are always on the bottom of the scrollview when fading in).
@@ -1350,6 +1351,7 @@ double round(double d) {
                               delay:0
                             options:UIViewAnimationOptionCurveEaseInOut
                          animations:^{
+                            isFullscreenFanArt = NO;
                             closeButton.alpha = 0.0;
                             if (!enableKenBurns) {
                                 fanartView.alpha = 0.2;
@@ -1395,6 +1397,7 @@ double round(double d) {
                             }
                          }
                          completion:^(BOOL finished) {
+                            isFullscreenFanArt = YES;
                             [self.navigationController setNavigationBarHidden:YES animated:YES];
                             if (IS_IPAD && self.kenView != nil) {
                                 [self elabKenBurns:fanartView.image];
@@ -1443,7 +1446,7 @@ double round(double d) {
                 closeButton.imageView.contentMode = UIViewContentModeScaleAspectFit;
             }
             [closeButton addTarget:self action:@selector(showBackground:) forControlEvents:UIControlEventTouchUpInside];
-            closeButton.tag = 1;
+            closeButton.tag = FANART_FULLSCREEN_DISABLE;
             closeButton.alpha = 0;
             [self.view addSubview:closeButton];
         }
@@ -1706,6 +1709,14 @@ double round(double d) {
     [self.view insertSubview:self.kenView atIndex:1];
 }
 
+- (void)leaveFullscreen {
+    if (isFullscreenFanArt) {
+        UIButton *button = [UIButton alloc];
+        button.tag = FANART_FULLSCREEN_DISABLE;
+        [self showBackground:button];
+    }
+}
+
 # pragma mark - Life Cycle
 
 - (void)setDetailItem:(id)newDetailItem {
@@ -1854,6 +1865,11 @@ double round(double d) {
     localEndDateFormatter = [NSDateFormatter new];
     localEndDateFormatter.timeZone = [NSTimeZone systemTimeZone];
     localEndDateFormatter.dateFormat = @"HH:mm";
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(leaveFullscreen)
+                                                 name: @"LeaveFullscreen"
+                                               object: nil];
 }
 
 - (void)didReceiveMemoryWarning {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1883,7 +1883,8 @@ double round(double d) {
 }
 
 - (BOOL)shouldAutorotate {
-    return YES;
+    // Do not rotate if fullscreen fanart is shown or we are model (only active during iPad fullscreen)
+    return !isFullscreenFanArt && ![self isModal];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
1. Leave iPad's fullscreen fanart view on pressing remote gear to avoid non-responsive UI2. 
2. Do not rotate iPad's fullscreen fanart view
3. Do not rotate popovers on top of iPad fullscreen view

Remark: Due to API changes with iOS 16 the fixes 2 and 3 only work for iOS 15 and earlier.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Leave iPad's fullscreen fanart view on pressing remote gear
Bugfix: Do not rotate iPad's fullscreen fanart view (iOS15 and earlier)
Bugfix: Do not rotate popovers on top of iPad fullscreen view (iOS15 and earlier)