### PR TITLE
Feature: Support rotation for iPad fullscreen

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5641,6 +5641,13 @@ NSIndexPath *selected;
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    
+    // Dismiss any visible action sheet as the origin is not corrected in fullscreen
+    if (IS_IPAD && stackscrollFullscreen) {
+        UIViewController *showFromCtrl = [self topMostController];
+        [showFromCtrl dismissViewControllerAnimated:YES completion:nil];
+    }
+    
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         [self setFlowLayoutParams];
         [activeLayoutView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5642,6 +5642,7 @@ NSIndexPath *selected;
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        [self setFlowLayoutParams];
         [activeLayoutView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
     }
                                  completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {}];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1890,21 +1890,25 @@ double round(double d) {
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-    if (self.kenView != nil && ![self isModal]) {
-        CGFloat alphaValue = 0.2;
-        if (closeButton.alpha == 1) {
-            alphaValue = 1;
+    
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {}
+                                 completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        if (self.kenView != nil && ![self isModal]) {
+            CGFloat alphaValue = 0.2;
+            if (closeButton.alpha == 1) {
+                alphaValue = 1;
+            }
+            [UIView animateWithDuration:0.1
+                             animations:^{
+                                 self.kenView.alpha = 0;
+                             }
+                             completion:^(BOOL finished) {
+                                 [self elabKenBurns:fanartView.image];
+                                 [Utilities alphaView:self.kenView AnimDuration:0.2 Alpha:alphaValue];
+                             }
+             ];
         }
-        [UIView animateWithDuration:0.1
-                         animations:^{
-                             self.kenView.alpha = 0;
-                         }
-                         completion:^(BOOL finished) {
-                             [self elabKenBurns:fanartView.image];
-                             [Utilities alphaView:self.kenView AnimDuration:0.2 Alpha:alphaValue];
-                         }
-         ];
-    }
+    }];
 }
 
 @end

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1890,7 +1890,7 @@ double round(double d) {
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-    if (self.kenView != nil) {
+    if (self.kenView != nil && ![self isModal]) {
         CGFloat alphaValue = 0.2;
         if (closeButton.alpha == 1) {
             alphaValue = 1;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1895,7 +1895,7 @@ double round(double d) {
         if (closeButton.alpha == 1) {
             alphaValue = 1;
         }
-        [UIView animateWithDuration:0.2
+        [UIView animateWithDuration:0.1
                          animations:^{
                              self.kenView.alpha = 0;
                          }

--- a/XBMC Remote/ViewControllerIPad.h
+++ b/XBMC Remote/ViewControllerIPad.h
@@ -38,7 +38,6 @@
     BOOL firstRun;
     NSTimer* extraTimer;
     HostManagementViewController *_hostPickerViewController;
-    BOOL stackScrollIsFullscreen;
     BOOL serverPicker;
     BOOL appInfo;
     UIImageView *fanartBackgroundImage;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -546,14 +546,6 @@
                                                  name: @"XBMCServerConnectionFailed"
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(handleStackScrollFullScreenEnabled:)
-                                                 name: @"StackScrollFullScreenEnabled"
-                                               object: nil];
-    [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(handleStackScrollFullScreenDisabled:)
-                                                 name: @"StackScrollFullScreenDisabled"
-                                               object: nil];
-    [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleChangeBackgroundGradientColor:)
                                                  name: @"UIViewChangeBackgroundGradientColor"
                                                object: nil];
@@ -575,14 +567,6 @@
     UIColor *endColor = (UIColor*)[sender.userInfo objectForKey:@"endColor"];
     [(gradientUIView*)self.view setColoursWithCGColors:startColor.CGColor endColor:endColor.CGColor];
     [(gradientUIView*)self.view setNeedsDisplay];
-}
-
-- (void)handleStackScrollFullScreenEnabled:(NSNotification*)sender {
-    stackScrollIsFullscreen = YES;
-}
-
-- (void)handleStackScrollFullScreenDisabled:(NSNotification*)sender {
-    stackScrollIsFullscreen = NO;
 }
 
 - (void)handleTcpJSONRPCShowSetup:(NSNotification*)sender {
@@ -610,7 +594,6 @@
 }
 
 - (void)handleStackScrollOffScreen:(NSNotification*)sender {
-    stackScrollIsFullscreen = NO;
     [self.view insertSubview:self.nowPlayingController.BottomView aboveSubview:rootView];
 }
 
@@ -689,7 +672,7 @@
 }
 
 - (BOOL)shouldAutorotate {
-    return !stackScrollIsFullscreen;
+    return YES;
 }
 
 @end

--- a/XBMC Remote/iPad/StackScrollViewController.h
+++ b/XBMC Remote/iPad/StackScrollViewController.h
@@ -66,7 +66,8 @@
     CGRect originalFrame;
     BOOL stackScrollIsFullscreen;
     
-    NSMutableArray *stackViewsFrames;
+    UIView *fullscreenView;
+    BOOL hideToolbar;
     
     CGFloat bottomPadding;
 }

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -148,8 +148,9 @@
                                  CGRect frame = subview.frame;
                                  frame.origin.x = 0 - PAD_MENU_TABLE_WIDTH;
                                  if (hideToolbar) {
-                                     frame.origin.y = frame.origin.y - 22;
-                                     frame.size.height = frame.size.height + 22;
+                                     CGFloat statusbarHeight = UIApplication.sharedApplication.statusBarFrame.size.height;
+                                     frame.origin.y -= statusbarHeight;
+                                     frame.size.height += statusbarHeight;
                                  }
                                  frame.size.width = self.view.frame.size.width + PAD_MENU_TABLE_WIDTH;
                                  subview.frame = frame;
@@ -1040,8 +1041,9 @@
             frame.size.width += PAD_MENU_TABLE_WIDTH;
             frame.origin.x -= PAD_MENU_TABLE_WIDTH;
             if (hideToolbar) {
-                frame.origin.y = frame.origin.y - 22;
-                frame.size.height = frame.size.height + 22;
+                CGFloat statusbarHeight = UIApplication.sharedApplication.statusBarFrame.size.height;
+                frame.origin.y -= statusbarHeight;
+                frame.size.height += statusbarHeight;
             }
             subController.view.frame = frame;
         }

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -59,7 +59,6 @@
         bottomPadding = [Utilities getBottomPadding];
         
 		viewControllersStack = [NSMutableArray new];
-        stackViewsFrames = [NSMutableArray new];
 		borderViews = [[UIView alloc] initWithFrame:CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION - 2, -2, 2, self.view.frame.size.height + 2)];
 		borderViews.backgroundColor = UIColor.clearColor;
         borderViews.autoresizingMask = UIViewAutoresizingFlexibleHeight;
@@ -125,7 +124,7 @@
     if ([[sender object] isKindOfClass:[UIView class]]) {
         senderView = [sender object];
     }
-    BOOL hideToolbar = [[sender.userInfo objectForKey:@"hideToolbar"] boolValue];
+    hideToolbar = [[sender.userInfo objectForKey:@"hideToolbar"] boolValue];
     BOOL clipsToBounds = [[sender.userInfo objectForKey:@"clipsToBounds"] boolValue];
     NSTimeInterval duration = [[sender.userInfo objectForKey:@"duration"] doubleValue];
     if (!duration) {
@@ -136,15 +135,15 @@
     }
 //    [senderView viewWithTag:2002].hidden = YES;
     stackScrollIsFullscreen = YES;
-    [stackViewsFrames removeAllObjects];
     [UIView animateWithDuration:duration
                           delay:0
                         options:UIViewAnimationOptionCurveEaseInOut
                      animations:^{
                          int i = 0;
-                         NSInteger numViews = slideViews.subviews.count;
+                         // Find the view requesting fullscreen and expand the frame
                          for (UIView* subview in slideViews.subviews) {
                              if ([subview isEqual:[sender object]]) {
+                                 fullscreenView = subview;
                                  originalFrame = subview.frame;
                                  CGRect frame = subview.frame;
                                  frame.origin.x = 0 - PAD_MENU_TABLE_WIDTH;
@@ -158,20 +157,12 @@
                              }
                              i++;
                          }
-                         if (i + 1 < numViews) {
-                             CGRect frame = CGRectZero;
-                             for (int j = i + 1; j < numViews; j++) {
-                                 frame = slideViews.subviews[j].frame;
-                                 [stackViewsFrames addObject:[NSValue valueWithCGRect:frame]];
-                                 frame.origin.x = self.view.frame.size.width;
-                                 if (hideToolbar) {
-                                     frame.origin.y = frame.origin.y - 20;
-                                     frame.size.height = frame.size.height + 20;
-                                 }
-                                 slideViews.subviews[j].frame = frame;
-                             }
+        
+                         // Remove all views right of the fullscreen
+                         NSInteger numViews = slideViews.subviews.count;
+                         for (int j = i + 1; j < numViews; j++) {
+                             [slideViews.subviews[i + 1] removeFromSuperview];
                          }
-                         
                      }
                      completion:^(BOOL finished) {}
      ];
@@ -194,21 +185,19 @@
                         options:UIViewAnimationOptionCurveEaseInOut
                      animations:^{
                          int i = 0;
-                         NSInteger numViews = slideViews.subviews.count;
+                         // Find the view leaving fullscreen and restore the frame
                          for (UIView* subview in slideViews.subviews) {
                              if ([subview isEqual:[sender object]]) {
-                                 subview.frame = originalFrame;
+                                 fullscreenView = nil;
+                                 CGRect frame = subview.frame;
+                                 frame.origin.x = 0;
+                                 frame.origin.y = 0;
+                                 frame.size.height = self.view.frame.size.height;
+                                 frame.size.width = originalFrame.size.width;
+                                 subview.frame = frame;
                                  break;
                              }
                              i++;
-                         }
-                         if (i + 1 < numViews) {
-                             int k = 0;
-                             NSInteger numStoredFrames = stackViewsFrames.count;
-                             for (int j = i + 1; j < numViews && k < numStoredFrames; j++) {
-                                 slideViews.subviews[j].frame = [stackViewsFrames[k] CGRectValue];
-                                 k ++;
-                             }
                          }
                      }
                      completion:^(BOOL finished) {}
@@ -1045,7 +1034,18 @@
         posX = slideViews.subviews[0].frame.origin.x;
     }
     for (UIViewController* subController in viewControllersStack) {
-        if (viewAtRight != nil && [viewAtRight isEqual:subController.view]) {
+        // If we have a view in fullscreen, keep it fullscreen
+        if (fullscreenView != nil && [fullscreenView isEqual:subController.view]) {
+            CGRect frame = self.view.frame;
+            frame.size.width += PAD_MENU_TABLE_WIDTH;
+            frame.origin.x -= PAD_MENU_TABLE_WIDTH;
+            if (hideToolbar) {
+                frame.origin.y = frame.origin.y - 22;
+                frame.size.height = frame.size.height + 22;
+            }
+            subController.view.frame = frame;
+        }
+        else if (viewAtRight != nil && [viewAtRight isEqual:subController.view]) {
             if (viewAtRight.frame.origin.x <= (viewAtLeft.frame.origin.x + viewAtLeft.frame.size.width)) {
                 subController.view.frame = CGRectMake(self.view.frame.size.width - subController.view.frame.size.width, subController.view.frame.origin.y, subController.view.frame.size.width, self.view.frame.size.height - bottomPadding);
             }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/215.

This PR implements rotation for iPad fullscreen, e.g. fullscreen grid view including related popovers and fullscreen fanart.

_Note:_
Still one final issue to resolve, but personally I can live with this: When you have 2 or 3 stack views active (e.g. albums > album titles > album info) and then start the fullscreen from the first view (e.g. albums), I currently need to drop the views and 2 and 3. After ending the fullscreen you only will have the first screen (e.g. albums) visible.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Support rotation for iPad fullscreen