### PR TITLE
Improvement: Support "art" for Music Videos

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -2835,7 +2835,10 @@
                         @"plot",
                         @"file",
                         @"fanart",
-                        @"resume"]
+                        @"resume"],
+                @"kodiExtrasPropertiesMinimumVersion": @{
+                    @"18": @[@"art"]
+                },
             }, @"extra_info_parameters",
             @{
                 @"label": @[
@@ -2851,6 +2854,9 @@
                             @"year",
                             @"playcount"]
             }, @"available_sort_methods",
+            @{
+                @"18": @[@"art"]
+            }, @"kodiExtrasPropertiesMinimumVersion",
             LOCALIZED_STR(@"Music Videos"), @"label",
             LOCALIZED_STR(@"Music Videos"), @"morelabel",
             @"YES", @"enableCollectionView",
@@ -2876,6 +2882,9 @@
                                 @"fanart",
                                 @"resume"]
             }, @"parameters",
+            @{
+                @"18": @[@"art"]
+            }, @"kodiExtrasPropertiesMinimumVersion",
             LOCALIZED_STR(@"Added Music Videos"), @"label",
             @"YES", @"enableCollectionView",
             @"YES", @"collectionViewRecentlyAdded",

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -2798,7 +2798,8 @@
     menu_Videos.mainMethod = @[
             @[@"VideoLibrary.GetMusicVideos", @"method",
               @"VideoLibrary.GetMusicVideoDetails", @"extra_info_method"],
-            @[@"VideoLibrary.GetRecentlyAddedMusicVideos", @"method"],
+            @[@"VideoLibrary.GetRecentlyAddedMusicVideos", @"method",
+              @"VideoLibrary.GetMusicVideoDetails", @"extra_info_method"],
             @[@"Files.GetSources", @"method"],
             @[@"Files.GetDirectory", @"method"],
             @[@"Files.GetDirectory", @"method"]
@@ -2882,6 +2883,24 @@
                                 @"fanart",
                                 @"resume"]
             }, @"parameters",
+            @{
+                @"properties": @[
+                        @"artist",
+                        @"year",
+                        @"playcount",
+                        @"thumbnail",
+                        @"genre",
+                        @"runtime",
+                        @"studio",
+                        @"director",
+                        @"plot",
+                        @"file",
+                        @"fanart",
+                        @"resume"],
+                @"kodiExtrasPropertiesMinimumVersion": @{
+                    @"18": @[@"art"]
+                },
+            }, @"extra_info_parameters",
             @{
                 @"18": @[@"art"]
             }, @"kodiExtrasPropertiesMinimumVersion",
@@ -2982,7 +3001,8 @@
             @"row14": @"resume",
             @"row15": @"votes",
             @"row16": @"artist",
-            @"row7": @"file"
+            @"row7": @"file",
+            @"itemid_extra_info": @"musicvideodetails"
         },
         
         @{

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -111,10 +111,6 @@ typedef enum {
 - (NSString*)getNowPlayingThumbnailPath:(NSDictionary*)item {
     // If a recording is played, we can use the iocn (typically the station logo)
     BOOL useIcon = [item[@"type"] isEqualToString:@"recording"] || [item[@"recordingid"] longValue] > 0;
-    // If we are showing a music video and we have a "thumbnail", take "thumbnail" to avoid fallback to "poster"
-    if ([item[@"thumbnail"] length] && [item[@"type"] isEqualToString:@"musicvideo"]) {
-        return item[@"thumbnail"];
-    }
     return [Utilities getThumbnailFromDictionary:item useBanner:NO useIcon:useIcon];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
With this PR "art" is supported (needs Kodi 18+). This will now prefer "poster" above "thumbnail" as already done for movies. This also enables "fanart" and "clearlogo" support for the `ShowInfoViewController`.

Screenshots:
https://abload.de/img/simulatorscreenshot-iyaen7.png
https://abload.de/img/simulatorscreenshot-imwd1m.png
https://abload.de/img/simulatorscreenshot-inhe18.png
https://abload.de/img/simulatorscreenshot-iyid4z.png

Note: Kodi's built-in scrapers do not provide most of this information. For the full experience metadata needs to be added following [this guide](https://kodi.wiki/view/NFO_files/Music_videos).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Support "art" for Music Videos