### PR TITLE
Improvement: Directly show details when selecting a TVShow in iPad fullscreen

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3511,7 +3511,7 @@
     ];
     
     menu_TVShows.showInfo = @[
-        @NO,
+        @YES,
         @YES,
         @NO,
         @NO,


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Taking care of a comment in [this forum thread](https://forum.kodi.tv/showthread.php?tid=359717&pid=3117187#pid3117187).

Configure TVShow-fullscreen to directly open `ShowInfoViewController` (TV Show details) instead of only showing an action sheet with only one single option ("TVShow Details").

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Directly show details when selecting a TVShow in iPad fullscreen