### PR TITLE
Bugfix: Correct fade-in animation for toolbar when leaving fullscreen

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3714,11 +3714,10 @@ NSIndexPath *selected;
                          animations:^{
                              collectionView.alpha = 0;
                              dataList.alpha = 0;
-                             button1.alpha = button2.alpha = button3.alpha = button4.alpha = button5.alpha = button6.alpha = button7.alpha = buttonsViewBgToolbar.alpha = topNavigationLabel.alpha = 1.0;
-                            
                          }
                          completion:^(BOOL finished) {
                              viewWidth = STACKSCROLL_WIDTH;
+                             button1.alpha = button2.alpha = button3.alpha = button4.alpha = button5.alpha = button6.alpha = button7.alpha = buttonsViewBgToolbar.alpha = topNavigationLabel.alpha = 1.0;
                              if ([self collectionViewCanBeEnabled]) {
                                  button6.hidden = NO;
                              }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3117275#pid3117275).

This fixes an animation glitch where the toolbar was shortly showing with fullscreen width before animating back to standard width. Now the toolbar only shows after the animation to standard width finished.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct fade-in animation for toolbar when leaving fullscreen