### PR TITLE
Improvement: Hiding toolbar only with non-empty searchbar field

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5587,8 +5587,6 @@ NSIndexPath *selected;
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar*)searchbar {
     showkeyboard = YES;
-    // Hide the toolbar while search is active
-    [self hideButtonList:YES];
 }
 
 #pragma mark UISearchController Delegate Methods
@@ -5659,6 +5657,9 @@ NSIndexPath *selected;
     NSString *searchString = searchController.searchBar.text;
     [self searchForText:searchString];
     [activeLayoutView reloadData];
+    
+    // Hide the toolbar while search is active with a non-empty string
+    [self hideButtonList:searchString.length > 0];
 }
 
 - (void)searchForText:(NSString*)searchText {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5656,9 +5656,9 @@ NSIndexPath *selected;
 }
 
 - (void)updateSearchResultsForSearchController:(UISearchController*)searchController {
-  NSString *searchString = searchController.searchBar.text;
-  [self searchForText:searchString];
-  [activeLayoutView reloadData];
+    NSString *searchString = searchController.searchBar.text;
+    [self searchForText:searchString];
+    [activeLayoutView reloadData];
 }
 
 - (void)searchForText:(NSString*)searchText {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Improving a glitch reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3117275#pid3117275).

This PR changes the toolbar behaviour while searching. It will now only hide the toolbar when a search is active with a _non-empty string_ in the searchbar. This improves the behaviour when dismissing the keyboard (either via scrolling or hiding the keyboard) while the searchbar field is empty. In such case the full item list is shown, but without the toolbar. For a user it is not clear why the toolbar is not visible.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Hiding toolbar only with non-empty searchbar field