### PR TITLE
Bugfix: Do not dismiss remote when rotating iPad in fullscreen

### DIFF
--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -130,6 +130,7 @@
     dispatch_queue_t epglockqueue;
     LogoBackgroundType logoBackgroundMode;
     BOOL showkeyboard;
+    __weak UIAlertController *actionView;
 }
 
 - (id)initWithFrame:(CGRect)frame;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3226,7 +3226,8 @@ NSIndexPath *selected;
 - (void)showActionSheetOptions:(NSString*)title options:(NSArray*)sheetActions recording:(BOOL)isRecording point:(CGPoint)origin fromcontroller:(UIViewController*)fromctrl fromview:(UIView*)fromview {
     NSInteger numActions = sheetActions.count;
     if (numActions) {
-        UIAlertController *actionView = [UIAlertController alertControllerWithTitle:title message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+        UIAlertController *actionTemp = [UIAlertController alertControllerWithTitle:title message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+        actionView = actionTemp;
         
         UIAlertAction* action_cancel = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
             forceMusicAlbumMode = NO;
@@ -5644,9 +5645,8 @@ NSIndexPath *selected;
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     
     // Dismiss any visible action sheet as the origin is not corrected in fullscreen
-    if (IS_IPAD && stackscrollFullscreen) {
-        UIViewController *showFromCtrl = [self topMostController];
-        [showFromCtrl dismissViewControllerAnimated:YES completion:nil];
+    if (IS_IPAD && stackscrollFullscreen && [actionView isViewLoaded]) {
+        [actionView dismissViewControllerAnimated:YES completion:nil];
     }
     
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a problem reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3117483#pid3117483).

The former solution also dismissed the remote popover. With this PR the dismissal is only applied to the action sheet when shown.

Remind: The action sheet is dismissed because the origin is not matching anymore as `FlowLayout`  changes with a rotation (different amount of columns and rows).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not dismiss remote when rotating iPad in fullscreen