### PR TITLE
Improvement: Avoid multiple custom button views on iPad

### DIFF
--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -899,6 +899,17 @@
 		[viewControllersStack removeAllObjects];
 	}
 	
+    // Special treatment to not have multiple remote custom button views.
+    // Removes topmost custom button view and pushes the new one on top of the stack.
+    if ([controller.nibName isEqualToString:@"RightMenuViewController"]) {
+        NSInteger index = viewControllersStack.count - 1;
+        UIViewController *indexController = viewControllersStack[index];
+        if ([indexController.nibName isEqualToString:@"RightMenuViewController"]) {
+            [[slideViews viewWithTag:index + VIEW_TAG] removeFromSuperview];
+            [viewControllersStack removeObjectAtIndex:index];
+            viewXPosition = self.view.frame.size.width - controller.view.frame.size.width;
+        }
+    }
 	
 	if (viewControllersStack.count > 1) {
 //        NSLog(@"DUE");


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3117483#pid3117483).

Introduce a special treatment for custom button view on iPad. This pushes the latest requested custom button view on top of the stack and removes all other already existing instances of the custom button view from the stack.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Avoid multiple custom button views on iPad