### PR TITLE
Fix and improve keyboard / search behaviour

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6024,6 +6024,7 @@ NSIndexPath *selected;
     if ([self doesShowSearchResults]) {
         return;
     }
+    [self.searchController setActive:NO];
     mainMenu *menuItem = self.detailItem;
     NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1653,7 +1653,6 @@
         }];
         [collectionView setShowsPullToRefresh:enableDiskCache];
         collectionView.alwaysBounceVertical = YES;
-        collectionView.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
         [detailView insertSubview:collectionView belowSubview:buttonsView];
     }
 }
@@ -2061,6 +2060,10 @@
 }
 
 #pragma mark - Table Management
+
+- (void)scrollViewDidScroll:(UIScrollView*)theScrollView {
+    [self.searchController.searchBar resignFirstResponder];
+}
 
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
     return cellHeight;
@@ -5712,7 +5715,6 @@ NSIndexPath *selected;
     localHourMinuteFormatter.dateFormat = @"HH:mm";
     localHourMinuteFormatter.timeZone = [NSTimeZone systemTimeZone];
     dataList.tableFooterView = [UIView new];
-    dataList.keyboardDismissMode = UIScrollViewKeyboardDismissModeOnDrag;
     
     [self initSearchController];
     self.navigationController.view.backgroundColor = UIColor.blackColor;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
### Fix potentially blocked searchbar

Since the change to not hide the toolbar while having an empty search string it was possible to toggle grid/list view in a state where a search was active (even though with an empty string). It is important to call `setActive:NO` when toggling the view to ensure the old searchController is inactive before the new is created and initialized. Otherwise the searchbar in the targeted view could be blocked.

Way to reproduce was:
- Go to list (grid) view
- Clock into searchbar
- Drag the list (grid) to dismiss keyboard
- Toggle view to grid (list) view
Now the searchbar is not working anymore.

### Dismiss also split and floating keyboards on drag

The setting `keyboardDismissMode` does not properly work for split keyboard. Dismiss the keyboard via `resignFirstResponder`, if `scrollViewDidScroll` is called. This works for all kind of keyboards.


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid possibly blocked search after toggling grid/list view while a search with an empty string
Improvement: Also dismiss split / floating keyboard on drag