### PR TITLE
Bugfix: Fix crashes in GlobalSearch

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4436,6 +4436,9 @@ NSIndexPath *selected;
         [activeLayoutView setUserInteractionEnabled:NO];
     }
     mainMenu *menuItem = self.detailItem;
+    if (choosedTab >= menuItem.mainParameters.count) {
+        return;
+    }
     NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
     NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
@@ -6070,6 +6073,9 @@ NSIndexPath *selected;
 - (void)handleChangeSortLibrary {
     selected = nil;
     mainMenu *menuItem = self.detailItem;
+    if (choosedTab >= menuItem.mainParameters.count) {
+        return;
+    }
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
     NSDictionary *sortDictionary = parameters[@"available_sort_methods"];
     NSDictionary *item = [NSDictionary dictionaryWithObjectsAndKeys:

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1583,6 +1583,10 @@
             }
         }
     }
+    // In case of Global Search restore choosedTab after processing
+    if (globalSearchView) {
+        choosedTab = 0;
+    }
 }
 
 - (NSMutableArray*)getPlaylistActions:(NSMutableArray*)sheetActions item:(NSDictionary*)item params:(NSMutableDictionary*)parameters {
@@ -3218,6 +3222,10 @@ NSIndexPath *selected;
                     selectedPoint = enableCollectionView ? p : [lpgr locationInView:showfromview];
                 }
                 [self showActionSheetOptions:title options:sheetActions recording:isRecording point:selectedPoint fromcontroller:showFromCtrl fromview:showfromview];
+            }
+            // In case of Global Search restore choosedTab after processing
+            if (globalSearchView) {
+                choosedTab = 0;
             }
         }
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/776.
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/778.

First, adds out-of-bounds-checks for resilience. Second, fixes the handling of ivar `choosedTab` in case global search view is shown. This might need a better solution, but it is good enough for now to avoid crashes and improve usability.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix crashes in GlobalSearch