### PR TITLE
Improvement: Align GlobalSearch thumb size and content

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4545,6 +4545,16 @@ NSIndexPath *selected;
     if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
         [mutableProperties addObject:@"art"];
     }
+    if (parameters[@"kodiExtrasPropertiesMinimumVersion"] != nil) {
+        for (id key in parameters[@"kodiExtrasPropertiesMinimumVersion"]) {
+            if (AppDelegate.instance.serverVersion >= [key integerValue]) {
+                id arrayProperties = parameters[@"kodiExtrasPropertiesMinimumVersion"][key];
+                for (id value in arrayProperties) {
+                    [mutableProperties addObject:value];
+                }
+            }
+        }
+    }
     if (mutableProperties != nil) {
         mutableParameters[@"properties"] = mutableProperties;
     }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -413,6 +413,25 @@
 
 #pragma mark - Utility
 
+- (void)addExtraProperties:(NSMutableArray*)mutableProperties newParams:(NSMutableDictionary*)mutableParameters params:(NSDictionary*)parameters {
+    if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
+        [mutableProperties addObject:@"art"];
+    }
+    if (parameters[@"kodiExtrasPropertiesMinimumVersion"] != nil) {
+        for (id key in parameters[@"kodiExtrasPropertiesMinimumVersion"]) {
+            if (AppDelegate.instance.serverVersion >= [key integerValue]) {
+                id arrayProperties = parameters[@"kodiExtrasPropertiesMinimumVersion"][key];
+                for (id value in arrayProperties) {
+                    [mutableProperties addObject:value];
+                }
+            }
+        }
+    }
+    if (mutableProperties != nil) {
+        mutableParameters[@"properties"] = mutableProperties;
+    }
+}
+
 - (UIViewController*)topMostController {
     UIViewController *topController = UIApplication.sharedApplication.keyWindow.rootViewController;
 
@@ -1248,22 +1267,7 @@
     [activeLayoutView setContentOffset:[(UITableView*)activeLayoutView contentOffset] animated:NO];
     NSString *labelText = parameters[@"label"];
     [self setFilternameLabel:labelText runFullscreenButtonCheck:YES forceHide:NO];
-    if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
-        [mutableProperties addObject:@"art"];
-    }
-    if (parameters[@"kodiExtrasPropertiesMinimumVersion"] != nil) {
-        for (id key in parameters[@"kodiExtrasPropertiesMinimumVersion"]) {
-            if (AppDelegate.instance.serverVersion >= [key integerValue]) {
-                id arrayProperties = parameters[@"kodiExtrasPropertiesMinimumVersion"][key];
-                for (id value in arrayProperties) {
-                    [mutableProperties addObject:value];
-                }
-            }
-        }
-    }
-    if (mutableProperties != nil) {
-        mutableParameters[@"properties"] = mutableProperties;
-    }
+    [self addExtraProperties:mutableProperties newParams:mutableParameters params:parameters];
     if ([parameters[@"blackTableSeparator"] boolValue] && ![Utilities getPreferTvPosterMode]) {
         blackTableSeparator = YES;
         dataList.separatorColor = [Utilities getGrayColor:38 alpha:1];
@@ -4441,22 +4445,7 @@ NSIndexPath *selected;
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
     NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
     NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
-    if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
-        [mutableProperties addObject:@"art"];
-    }
-    if (parameters[@"kodiExtrasPropertiesMinimumVersion"] != nil) {
-        for (id key in parameters[@"kodiExtrasPropertiesMinimumVersion"]) {
-            if (AppDelegate.instance.serverVersion >= [key integerValue]) {
-                id arrayProperties = parameters[@"kodiExtrasPropertiesMinimumVersion"][key];
-                for (id value in arrayProperties) {
-                    [mutableProperties addObject:value];
-                }
-            }
-        }
-    }
-    if (mutableProperties != nil) {
-        mutableParameters[@"properties"] = mutableProperties;
-    }
+    [self addExtraProperties:mutableProperties newParams:mutableParameters params:parameters];
     NSString *methodToCall = methods[@"method"];
     if (parameters[@"exploreCommand"] != nil) {
         methodToCall = parameters[@"exploreCommand"];
@@ -4542,22 +4531,7 @@ NSIndexPath *selected;
     NSString *methodToCall = methods[@"method"];
     NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
     NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
-    if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
-        [mutableProperties addObject:@"art"];
-    }
-    if (parameters[@"kodiExtrasPropertiesMinimumVersion"] != nil) {
-        for (id key in parameters[@"kodiExtrasPropertiesMinimumVersion"]) {
-            if (AppDelegate.instance.serverVersion >= [key integerValue]) {
-                id arrayProperties = parameters[@"kodiExtrasPropertiesMinimumVersion"][key];
-                for (id value in arrayProperties) {
-                    [mutableProperties addObject:value];
-                }
-            }
-        }
-    }
-    if (mutableProperties != nil) {
-        mutableParameters[@"properties"] = mutableProperties;
-    }
+    [self addExtraProperties:mutableProperties newParams:mutableParameters params:parameters];
     [[Utilities getJsonRPC]
      callMethod:methodToCall
      withParameters:mutableParameters

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -574,6 +574,7 @@
     CGPoint thumbSize = CGPointMake(53, 53);
     if ([item[@"family"] isEqualToString:@"movieid"] ||
         [item[@"family"] isEqualToString:@"setid"] ||
+        [item[@"family"] isEqualToString:@"musicvideoid"] ||
         [item[@"family"] isEqualToString:@"tvshowid"]) {
         thumbSize.x = 53;
         thumbSize.y = 76;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR align the music video's thumb size of GlobalSearch view with the standard list view, as well as the thumb content with other views and NowPlaying.

Screenshots:
[https://abload.de/img/bildschirmfoto2022-11v0c64.png (thumb content)](https://abload.de/img/bildschirmfoto2022-11rydyx.png)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Align GlobalSearch thumb size and content