### PR TITLE
Bugfix: Avoid doubled index

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5663,7 +5663,7 @@ NSIndexPath *selected;
     // Hide the toolbar and index while search is active with a non-empty string
     BOOL hideToolbarAndIndex = searchString.length > 0;
     [self hideButtonList:hideToolbarAndIndex];
-    self.indexView.hidden = hideToolbarAndIndex;
+    self.indexView.hidden = enableCollectionView ? hideToolbarAndIndex : YES;
 }
 
 - (void)searchForText:(NSString*)searchText {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3118274#pid3118274).

The underlying issue was that with the latest change to align the index visibility behaviour of list view and grid view the grid view could be made visible in list view as well (first go to grid view, then to list view, then click into searchbar). Now the grid view's index is always hidden when in list view.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid doubled index