### PR TITLE
Improvement: Make scrollbars readable in light/dark mode

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1639,6 +1639,7 @@
         collectionView.contentInset = dataList.contentInset;
         collectionView.scrollIndicatorInsets = dataList.scrollIndicatorInsets;
         collectionView.backgroundColor = [Utilities getGrayColor:0 alpha:0.5];
+        collectionView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
         collectionView.delegate = self;
         collectionView.dataSource = self;
         [collectionView registerClass:[PosterCell class] forCellWithReuseIdentifier:@"posterCell"];
@@ -5735,6 +5736,7 @@ NSIndexPath *selected;
     dataList.sectionIndexColor = UIColor.systemBlueColor;
     dataList.sectionIndexTrackingBackgroundColor = [Utilities getGrayColor:0 alpha:0.3];
     dataList.separatorInset = UIEdgeInsetsMake(0, 53, 0, 0);
+    dataList.indicatorStyle = UIScrollViewIndicatorStyleDefault;
     
     CGRect frame = dataList.frame;
     frame.size.height = self.view.bounds.size.height;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Improves an observation reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3118274#pid3118274).

List view scroll bar uses `UIScrollViewIndicatorStyleDefault` to follow light/dark mode. Grid view scroll bar always is set to `UIScrollViewIndicatorStyleWhite` due the dark background.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Make scrollbars readable in light/dark mode