### PR TITLE
Bugfix: Re-enable grid view for Kodi settings

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -5228,6 +5228,7 @@
             LOCALIZED_STR(@"XBMC Settings"), @"label",
             @"nocover_settings", @"defaultThumb",
             [self itemSizes_insets:@"53"], @"itemSizes",
+            @"YES", @"enableCollectionView",
             animationStartX, @"animationStartX",
             animationStartBottomScreen, @"animationStartBottomScreen"
         ],


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3118274#pid3118274).

The Kodi settings was not correctly configured to support grid view. Because of this the grid view when entering "Add-on" was not working properly since version 1.11.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Re-enable grid view for Kodi settings