### PR TITLE
Bugfix: Avoid crash when calling custom button view from empty stack on iPad

### DIFF
--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -901,7 +901,7 @@
 	
     // Special treatment to not have multiple remote custom button views.
     // Removes topmost custom button view and pushes the new one on top of the stack.
-    if ([controller.nibName isEqualToString:@"RightMenuViewController"]) {
+    if ([controller.nibName isEqualToString:@"RightMenuViewController"] && viewControllersStack.count > 0) {
         NSInteger index = viewControllersStack.count - 1;
         UIViewController *indexController = viewControllersStack[index];
         if ([indexController.nibName isEqualToString:@"RightMenuViewController"]) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Entering the custom button view on iPad with an empty view stack caused a crash. Could easily be reproduced by starting the App on iPad, calling remote and then pressing gear.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid crash when calling custom button view from empty stack on iPad