### PR TITLE
Bugfix: TV Show layout and animation grid/list view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -886,19 +886,27 @@
 }
 
 - (void)layoutTVShowCell:(UIView*)cell useDefaultThumb:(BOOL)useFallback imgView:(UIImageView*)imgView {
-    // Exception handling for TVShow banner view (not grid or fullscreen view)
-    if (tvshowsView && !enableCollectionView && !stackscrollFullscreen) {
+    // Exception handling for TVShow banner view
+    if (tvshowsView) {
         // First tab shows the banner
         if (choosedTab == 0) {
-            // If loaded, we use a dark background
-            if (!useFallback) {
+            // When not in grid and not in fullscreen view
+            if (!enableCollectionView && !stackscrollFullscreen) {
+                // If loaded, we use a dark background
+                if (!useFallback) {
+                    // Gray:28 is similar to systemGray6 in Dark Mode
+                    cell.backgroundColor = [Utilities getGrayColor:28 alpha:1.0];
+                }
+                // If not loaded, use default background color and poster dimensions for default thumb
+                else {
+                    cell.backgroundColor = [Utilities getSystemGray6];
+                    [self showTVShowDefaultThumbInsteadBanner:imgView];
+                }
+            }
+            // When in grid or fullscreen view
+            else {
                 // Gray:28 is similar to systemGray6 in Dark Mode
                 cell.backgroundColor = [Utilities getGrayColor:28 alpha:1.0];
-            }
-            // If not loaded, use default background color and poster dimensions for default thumb
-            else {
-                cell.backgroundColor = [Utilities getSystemGray6];
-                [self showTVShowDefaultThumbInsteadBanner:imgView];
             }
         }
         // Other tabs (e.g. list of episodes) use default layout

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6056,8 +6056,6 @@ NSIndexPath *selected;
         NSString *viewKey = [NSString stringWithFormat:@"%@_grid_preference", [self getCacheKey:methods[@"method"] parameters:tempDict]];
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
         [userDefaults setBool:![userDefaults boolForKey:viewKey] forKey:viewKey];
-        enableCollectionView = [self collectionViewIsEnabled];
-        recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
         [UIView animateWithDuration:0.2
                               delay:0.0
                             options:UIViewAnimationOptionCurveEaseIn
@@ -6068,6 +6066,8 @@ NSIndexPath *selected;
                              ((UITableView*)activeLayoutView).frame = frame;
                          }
                          completion:^(BOOL finished) {
+                             recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
+                             enableCollectionView = [self collectionViewIsEnabled];
                              [self configureLibraryView];
                              [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
                              [activeLayoutView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3118274#pid3118274).

### Layout fix
First, this PR corrects TV Show background color for grid view and fullscreen when falling back to default thumb. Root cause was a not handled condition.

### Animation fix
Second, it fixes an animation glitch when toggling between grid and list view in the TV Show view. Root cause was a long existing race condition when setting the variable `enableCollectionView` during the animation process. This needs to be set after the current view was faded out, and before the new view is faded in. Otherwise the layout of the current view is changed before it is faded out, which caused the visual glitch.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: TV Show background color when falling back to default thumb
Bugfix: TV Show animation glitch when toggling between list and grid view