### PR TITLE
Bugfix: Undefined states when using toolbar buttons during search

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -972,6 +972,9 @@
 //    if ([sender tag] == choosedTab) {
 //        return;
 //    }
+    if ([self doesShowSearchResults] || self.searchController.isActive) {
+        return;
+    }
     mainMenu *menuItem = self.detailItem;
     self.indexView.hidden = YES;
     button6.hidden = YES;
@@ -1153,6 +1156,9 @@
 }
 
 - (IBAction)changeTab:(id)sender {
+    if ([self doesShowSearchResults] || self.searchController.isActive) {
+        return;
+    }
     if (!activityIndicatorView.hidden) {
         return;
     }
@@ -3708,6 +3714,9 @@ NSIndexPath *selected;
 }
 
 - (void)toggleFullscreen:(id)sender {
+    if ([self doesShowSearchResults] || self.searchController.isActive) {
+        return;
+    }
     [activityIndicatorView startAnimating];
     NSTimeInterval animDuration = 0.5;
     if (stackscrollFullscreen) {
@@ -6022,10 +6031,9 @@ NSIndexPath *selected;
 }
 
 - (void)handleChangeLibraryView {
-    if ([self doesShowSearchResults]) {
+    if ([self doesShowSearchResults] || self.searchController.isActive) {
         return;
     }
-    [self.searchController setActive:NO];
     mainMenu *menuItem = self.detailItem;
     NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
@@ -6068,6 +6076,9 @@ NSIndexPath *selected;
 }
 
 - (void)handleChangeSortLibrary {
+    if ([self doesShowSearchResults] || self.searchController.isActive) {
+        return;
+    }
     selected = nil;
     mainMenu *menuItem = self.detailItem;
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2068,7 +2068,13 @@
 #pragma mark - Table Management
 
 - (void)scrollViewDidScroll:(UIScrollView*)theScrollView {
+    // Hide keyboard on drag
     [self.searchController.searchBar resignFirstResponder];
+    // Stop an empty search on drag
+    NSString *searchString = self.searchController.searchBar.text;
+    if (searchString.length == 0) {
+        [self.searchController setActive:NO];
+    }
 }
 
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3118274#pid3118274).

### Block toolbar buttons while having an (empty) search active
This avoids to enter an undefined state of the search bar. It is important to do this with an empty as well as non-empty search string.

### End search when dragging while having an empty search
The keyboard is already dismissed when dragging while a search with an empty string is active. As the user cannot visually differentiate between an empty search and no search, but an active search will block the toolbar buttons, it is desired to also end the search in such case.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Undefined states when using toolbar buttons during search
Bugfix: Section layout glitches when toggling between grid and list view