### PR TITLE
Rework building the toolbar button list

### DIFF
--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -53,7 +53,6 @@
     int viewWidth;
     IBOutlet UIView *detailView;
     MoreItemsViewController* moreItemsViewController;
-    UIButton *selectedMoreTab;
     UIImageView *longTimeout;
     NSTimeInterval startTime;
     NSTimeInterval elapsedTime;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -806,10 +806,7 @@
     [self buildButtons:activeTab];
     
     // Show grid/list button when grid view is possible
-    button6.hidden = YES;
-    if ([self collectionViewCanBeEnabled]) {
-        button6.hidden = NO;
-    }
+    button6.hidden = [self collectionViewCanBeEnabled] ? NO : YES;
     
     // Set up sorting
     sortMethodIndex = -1;
@@ -818,10 +815,7 @@
     [self setUpSort:methods parameters:parameters];
     
     // Show sort button when sorting is possible
-    button7.hidden = YES;
-    if (parameters[@"available_sort_methods"] != nil) {
-        button7.hidden = NO;
-    }
+    button7.hidden = parameters[@"available_sort_methods"] ? NO : YES;
     
     [self hideButtonListWhenEmpty];
 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1045,8 +1045,7 @@
     NSIndexPath *choice = notification.object;
     choosedTab = 0;
     NSInteger selectedIdx = MAX_NORMAL_BUTTONS + choice.row;
-    selectedMoreTab.tag = selectedIdx;
-    [self changeTab:selectedMoreTab];
+    [self handleChangeTab:(int)selectedIdx];
 }
 
 - (void)changeViewMode:(ViewModes)newViewMode forceRefresh:(BOOL)refresh {
@@ -1170,6 +1169,11 @@
 }
 
 - (IBAction)changeTab:(id)sender {
+    NSInteger newChoosedTab = [sender tag];
+    [self handleChangeTab:(int)newChoosedTab];
+}
+
+- (void)handleChangeTab:(int)newChoosedTab {
     if ([self doesShowSearchResults] || self.searchController.isActive) {
         return;
     }
@@ -1188,7 +1192,6 @@
     
     // Read new tab index
     numTabs = (int)menuItem.mainMethod.count;
-    int newChoosedTab = (int)[sender tag];
     newChoosedTab = newChoosedTab % numTabs;
     
     // Handle modes (pressing same tab) or changed tabs
@@ -5453,7 +5456,6 @@ NSIndexPath *selected;
             [buttonsIB.lastObject setBackgroundImage:imageOn forState:UIControlStateSelected];
             [buttonsIB.lastObject setBackgroundImage:imageOn forState:UIControlStateHighlighted];
             [buttonsIB.lastObject setEnabled:YES];
-            selectedMoreTab = [UIButton new];
             break;
     }
 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -797,10 +797,13 @@
     [button7 setBackgroundImage:image forState:UIControlStateNormal];
 }
 
-- (void)setButtonViewContent {
+- (void)setButtonViewContent:(int)activeTab {
     mainMenu *menuItem = self.detailItem;
     NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    
+    // Build basic button list
+    [self buildButtons:activeTab];
     
     // Show grid/list button when grid view is possible
     button6.hidden = YES;
@@ -1258,7 +1261,7 @@
     }
 
     BOOL newEnableCollectionView = [self collectionViewIsEnabled];
-    [self setButtonViewContent];
+    [self setButtonViewContent:choosedTab];
     [self checkDiskCache];
     NSTimeInterval animDuration = 0.3;
     if (newEnableCollectionView != enableCollectionView) {
@@ -5392,7 +5395,7 @@ NSIndexPath *selected;
     if (showkeyboard) {
         [[self getSearchTextField] performSelector:@selector(becomeFirstResponder) withObject:nil afterDelay:0.1];
     }
-    [self setButtonViewContent];
+    [self setButtonViewContent:choosedTab];
 }
 
 - (void)didReceiveMemoryWarning {
@@ -5405,7 +5408,7 @@ NSIndexPath *selected;
     [self.slidingViewController anchorTopViewTo:ECRight];
 }
 
-- (void)buildButtons {
+- (void)buildButtons:(int)activeTab {
     mainMenu *menuItem = self.detailItem;
     NSArray *buttons = menuItem.mainButtons;
     NSArray *buttonsIB = @[button1, button2, button3, button4, button5];
@@ -5415,7 +5418,7 @@ NSIndexPath *selected;
     CGRect frame;
     NSInteger count = buttons.count;
     count = MIN(count, MAX_NORMAL_BUTTONS);
-    choosedTab = MIN(choosedTab, MAX_NORMAL_BUTTONS);
+    activeTab = MIN(activeTab, MAX_NORMAL_BUTTONS);
     for (int i = 0; i < count; i++) {
         img = [UIImage imageNamed:buttons[i]];
         imageOff = [Utilities colorizeImage:img withColor:UIColor.lightGrayColor];
@@ -5425,7 +5428,8 @@ NSIndexPath *selected;
         [buttonsIB[i] setBackgroundImage:imageOn forState:UIControlStateHighlighted];
         [buttonsIB[i] setEnabled:YES];
     }
-    [buttonsIB[choosedTab] setSelected:YES];
+    [buttonsIB[activeTab] setSelected:YES];
+    button1.hidden = button2.hidden = button3.hidden = button4.hidden = button5.hidden = NO;
     switch (buttons.count) {
         case 0:
             // no button, no toolbar
@@ -5780,7 +5784,6 @@ NSIndexPath *selected;
     }
     self.view.userInteractionEnabled = YES;
     choosedTab = 0;
-    [self buildButtons]; // TEMP ?
     mainMenu *menuItem = self.detailItem;
     numTabs = (int)menuItem.mainMethod.count;
     if (menuItem.chooseTab) {
@@ -5799,10 +5802,6 @@ NSIndexPath *selected;
         numberOfStars = [parameters[@"numberOfStars"] intValue];
     }
     
-    button6.hidden = YES;
-    button7.hidden = YES;
-    [self hideButtonListWhenEmpty];
-
     if ([methods[@"albumView"] boolValue]) {
         albumView = YES;
     }

--- a/XBMC Remote/DetailViewController.xib
+++ b/XBMC Remote/DetailViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -90,11 +90,11 @@
                                     <items>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="OQd-aJ-obl"/>
                                         <barButtonItem style="plain" id="yuj-lW-yot">
-                                            <button key="customView" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="117" userLabel="Button1">
+                                            <button key="customView" hidden="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="117" userLabel="Button1">
                                                 <rect key="frame" x="60" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                                <state key="normal">
+                                                <state key="normal" backgroundImage="st_album">
                                                     <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
@@ -108,11 +108,11 @@
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="IVe-28-sl6"/>
                                         <barButtonItem style="plain" id="cRW-wf-x2D">
-                                            <button key="customView" tag="1" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="119" userLabel="Button2">
+                                            <button key="customView" hidden="YES" tag="1" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="119" userLabel="Button2">
                                                 <rect key="frame" x="154.5" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                                <state key="normal">
+                                                <state key="normal" backgroundImage="st_artist">
                                                     <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
@@ -126,11 +126,11 @@
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="dSm-ED-j5s"/>
                                         <barButtonItem style="plain" id="4He-Lr-2WZ">
-                                            <button key="customView" tag="2" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="121" userLabel="Button3">
+                                            <button key="customView" hidden="YES" tag="2" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="121" userLabel="Button3">
                                                 <rect key="frame" x="248.5" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                                <state key="normal">
+                                                <state key="normal" backgroundImage="st_genre">
                                                     <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
@@ -144,11 +144,11 @@
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="Gi1-6Y-y4k"/>
                                         <barButtonItem style="plain" id="TE7-pJ-4WE">
-                                            <button key="customView" tag="3" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="122" userLabel="Button4">
+                                            <button key="customView" hidden="YES" tag="3" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="122" userLabel="Button4">
                                                 <rect key="frame" x="342.5" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                                <state key="normal">
+                                                <state key="normal" backgroundImage="st_filemode">
                                                     <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
@@ -162,11 +162,11 @@
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="ZdQ-hl-bWG"/>
                                         <barButtonItem style="plain" id="d4P-SH-Im4">
-                                            <button key="customView" tag="4" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="123" userLabel="Button5">
+                                            <button key="customView" hidden="YES" tag="4" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="123" userLabel="Button5">
                                                 <rect key="frame" x="436.5" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                                                <state key="normal">
+                                                <state key="normal" backgroundImage="st_more">
                                                     <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
@@ -180,16 +180,18 @@
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="C79-Cc-JFa"/>
                                         <barButtonItem style="plain" id="rHQ-LZ-GMb">
-                                            <button key="customView" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="kky-5P-ej6" userLabel="Button6">
+                                            <button key="customView" hidden="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="kky-5P-ej6" userLabel="Button6">
                                                 <rect key="frame" x="531" y="5" width="34" height="34"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <state key="normal" backgroundImage="st_view_list"/>
                                             </button>
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="bQB-y4-wNs"/>
                                         <barButtonItem style="plain" id="WWo-3h-QTx">
-                                            <button key="customView" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="17m-9l-ySa" userLabel="Button7">
+                                            <button key="customView" hidden="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="17m-9l-ySa" userLabel="Button7">
                                                 <rect key="frame" x="625" y="5" width="34" height="34"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <state key="normal" backgroundImage="st_sort_asc"/>
                                             </button>
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="vF6-OW-tqm"/>
@@ -200,7 +202,7 @@
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <activityIndicatorView contentMode="scaleToFill" fixedFrame="YES" hidesWhenStopped="YES" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="95">
-                            <rect key="frame" x="399" y="285" width="37" height="37"/>
+                            <rect key="frame" x="398" y="285" width="37" height="37"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         </activityIndicatorView>
                         <textView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="160">
@@ -224,6 +226,13 @@
     <resources>
         <image name="icon_dark" width="37.5" height="37.5"/>
         <image name="shiny_black_back" width="240" height="408"/>
+        <image name="st_album" width="34" height="30"/>
+        <image name="st_artist" width="34" height="30"/>
+        <image name="st_filemode" width="34" height="30"/>
+        <image name="st_genre" width="34" height="30"/>
+        <image name="st_more" width="34" height="30"/>
+        <image name="st_sort_asc" width="34" height="34"/>
+        <image name="st_view_list" width="34" height="34"/>
         <image name="tableDown" width="480" height="8"/>
     </resources>
 </document>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3118274#pid3118274).

The toolbar's buttons were moving after entering a view for the first time. This was very prominent when pressing "...more" in the custom button view. Reason for this was that the building of the toolbar via `buildButtons`  was already called in `viewDidLoad`. Now the xib already loads the hidden button background default images to support the layout, and `buildButtons` -- which loads the background images and unhides the desired buttons -- is called in `viewDidAppear` or when the tab is changed. This resolves the animation glitch.

In addition, this PR does some refactoring for improved code readability and to avoid the tacky use of `UIButton` to transfer a tab index.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Animation glitch of toolbar buttons
Maintenance: Rework the building of the button list