### PR TITLE
Rework iPad fullscreen index

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1817,7 +1817,7 @@
 #pragma mark - BDKCollectionIndexView init
 
 - (void)initSectionNameOverlayView {
-    sectionNameOverlayView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width / 2, self.view.frame.size.width / 6)];
+    sectionNameOverlayView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width * 0.75, self.view.frame.size.width / 6)];
     sectionNameOverlayView.autoresizingMask = (UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleTopMargin);
     sectionNameOverlayView.backgroundColor = [Utilities getGrayColor:0 alpha:1.0];
     sectionNameOverlayView.center = UIApplication.sharedApplication.delegate.window.rootViewController.view.center;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -642,13 +642,6 @@
 
 - (void)setCollectionViewIndexVisibility {
     if (enableCollectionView) {
-        // Get the index titles
-        NSMutableArray *tmpArr = [[NSMutableArray alloc] initWithArray:self.sectionArray];
-        if (tmpArr.count > 1) {
-            [tmpArr replaceObjectAtIndex:0 withObject:@"🔍"];
-        }
-        self.indexView.indexTitles = [NSArray arrayWithArray:tmpArr];
-        
         // Only show the collection view index, if there are valid index titles to show
         if (self.indexView.indexTitles.count > 1) {
             self.indexView.hidden = NO;
@@ -1109,6 +1102,7 @@
         collectionView.scrollsToTop = YES;
         activeLayoutView = collectionView;
         [self initCollectionIndexView];
+        [self buildCollectionViewIndex];
         
         [self initSearchController];
         self.searchController.searchBar.backgroundColor = [Utilities getGrayColor:22 alpha:1];
@@ -1860,6 +1854,15 @@
     self.indexView.hidden = YES;
     [self.indexView addTarget:self action:@selector(indexViewValueChanged:) forControlEvents:UIControlEventValueChanged];
     [detailView addSubview:self.indexView];
+}
+
+- (void)buildCollectionViewIndex {
+    // Get the index titles
+    NSMutableArray *tmpArr = [[NSMutableArray alloc] initWithArray:self.sectionArray];
+    if (tmpArr.count > 1) {
+        [tmpArr replaceObjectAtIndex:0 withObject:@"🔍"];
+    }
+    self.indexView.indexTitles = [NSArray arrayWithArray:tmpArr];
 }
 
 - (void)indexViewValueChanged:(BDKCollectionIndexView*)sender {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1895,6 +1895,9 @@
         else if ([sortbymethod isEqualToString:@"playcount"]) {
             predExists = [NSPredicate predicateWithFormat: @"SELF.%@.intValue == %d", sortbymethod, [value intValue]];
         }
+        else if ([sortbymethod isEqualToString:@"year"]) {
+            predExists = [NSPredicate predicateWithFormat: @"SELF.%@.intValue >= %d", sortbymethod, [value intValue]];
+        }
         NSUInteger index = [sections[@""] indexOfObjectPassingTest:
                             ^(id obj, NSUInteger idx, BOOL *stop) {
                                 return [predExists evaluateWithObject:obj];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5649,6 +5649,9 @@ NSIndexPath *selected;
         [actionView dismissViewControllerAnimated:YES completion:nil];
     }
     
+    // Force reloading of index overlay after rotation
+    sectionNameOverlayView = nil;
+    
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         [self setFlowLayoutParams];
         [activeLayoutView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -643,12 +643,7 @@
 - (void)setCollectionViewIndexVisibility {
     if (enableCollectionView) {
         // Only show the collection view index, if there are valid index titles to show
-        if (self.indexView.indexTitles.count > 1) {
-            self.indexView.hidden = NO;
-        }
-        else {
-            self.indexView.hidden = YES;
-        }
+        self.indexView.hidden = self.indexView.indexTitles.count > 1 ? NO : YES;
     }
     else {
         self.indexView.hidden = YES;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3118289#pid3118289) and some more.

This PR applies fixes and improvements around the index in iPad fullscreen.
- Build `indexView` for grid view only during initialization
- Fix seeking via index in iPad fullscreen when sorted by year
- iPad fiullscreen section overlay `sectionNameOverlayView` needs to be re-initialized after rotation
- Enlarge iPad fullscreen section overlay `sectionNameOverlayView` for improved readability
- Coding style change (use conditional assignment)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Keep iPad fullscreen index when cancelling search
Bugfix: Correct layout of index seek layover after rotation in fullscreen
Bugfix: Correct index seek "by-year" in fullscreen
Improvement: Enlarge index seek layover in fullscreen