### PR TITLE
Bugfix: Stuttering list scrolling

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2440,6 +2440,7 @@
 
     frame = title.frame;
     frame.origin.x = labelPosition;
+    frame.origin.y = 0;
     frame.size.width = menuItem.widthLabel;
     title.frame = frame;
     if (channelListView && item[@"channelnumber"]) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1459,7 +1459,8 @@
                     }
                 }
             }
-            else if ([item[@"genre"] isEqualToString:@"file"] || [item[@"filetype"] isEqualToString:@"file"]) {
+            else if ([item[@"genre"] isEqualToString:@"file"] ||
+                     [item[@"filetype"] isEqualToString:@"file"]) {
                 NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
                 if (![userDefaults boolForKey:@"song_preference"]) {
                     [self showActionSheet:indexPath sheetActions:sheetActions item:item rectOriginX:rectOriginX rectOriginY:rectOriginY];
@@ -2532,7 +2533,8 @@
             runtimeyear.hidden = YES;
             title.frame = CGRectMake(title.frame.origin.x, (int)((cellHeight/2) - (title.frame.size.height/2)), title.frame.size.width, title.frame.size.height);
         }
-        else if ([item[@"family"] isEqualToString:@"recordingid"] || [item[@"family"] isEqualToString:@"timerid"]) {
+        else if ([item[@"family"] isEqualToString:@"recordingid"] ||
+                 [item[@"family"] isEqualToString:@"timerid"]) {
             cell.urlImageView.contentMode = UIViewContentModeScaleAspectFit;
             runtimeyear.hidden = YES;
             runtime.hidden = YES;
@@ -2588,7 +2590,10 @@
             genre.minimumScaleFactor = 10.0 / 11.0;
             [genre sizeToFit];
         }
-        else if ([item[@"family"] isEqualToString:@"sectionid"] || [item[@"family"] isEqualToString:@"categoryid"] || [item[@"family"] isEqualToString:@"id"] || [item[@"family"] isEqualToString:@"addonid"]) {
+        else if ([item[@"family"] isEqualToString:@"sectionid"] ||
+                 [item[@"family"] isEqualToString:@"categoryid"] ||
+                 [item[@"family"] isEqualToString:@"id"] ||
+                 [item[@"family"] isEqualToString:@"addonid"]) {
             CGRect frame;
             if ([item[@"family"] isEqualToString:@"id"]) {
                 frame = title.frame;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2091,7 +2091,7 @@
     [self.searchController.searchBar resignFirstResponder];
     // Stop an empty search on drag
     NSString *searchString = self.searchController.searchBar.text;
-    if (searchString.length == 0) {
+    if (searchString.length == 0 && self.searchController.isActive) {
         [self.searchController setActive:NO];
     }
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Since https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/774 list scrolling stuttered. Reason for this is that `[self.searchController setActive:NO]` triggers a layout of all cells again. So, this should only be called if the search is really active. Otherwise each scrolling gesture will trigger a layout of the cells again in high frequency.

This bug became quite visible due to another layout issue which is now also fixed. The y origin needs to be reset to 0 for the title when laying out the cell. Only for a few types this is changed alter.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Stuttering list scrolling