### PR TITLE
Bugfix: Wrong inset in album/episode view after album/tvshow details

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5686,9 +5686,11 @@ NSIndexPath *selected;
     [activeLayoutView reloadData];
     
     // Hide the toolbar and index while search is active with a non-empty string
-    BOOL hideToolbarAndIndex = searchString.length > 0;
-    [self hideButtonList:hideToolbarAndIndex];
-    self.indexView.hidden = enableCollectionView ? hideToolbarAndIndex : YES;
+    if (self.searchController.isActive) {
+        BOOL hideToolbarAndIndex = searchString.length > 0;
+        [self hideButtonList:hideToolbarAndIndex];
+        self.indexView.hidden = enableCollectionView ? hideToolbarAndIndex : YES;
+    }
 }
 
 - (void)searchForText:(NSString*)searchText {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5345,6 +5345,7 @@ NSIndexPath *selected;
         UIBarButtonItem * doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismissAddAction:)];
         self.navigationItem.rightBarButtonItem = doneButton;
     }
+    [self hideButtonListWhenEmpty];
 // TRICK WHEN CHILDREN WAS FORCED TO PORTRAIT
 //    UIViewController *c = [[UIViewController alloc]init];
 //    [self presentViewController:c animated:NO completion:nil];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3118780#pid3118780).

Setting a search inactive via `[searchController setActive:NO]` triggers `updateSearchResultsForSearchController`. To avoid the hide/unhide of the toolbar inside `updateSearchResultsForSearchController` while a search is inactive, it is desired to check for an active search.

In addition, restore the animation of the toolbar when entering a child view (e.g. selecting an album or a genre). The desired animation is to first hide the toolbar (done in `viewWillAppear`), followed by showing the desired child view's toolbar Done in `viewDidAppear`).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Wrong inset in album/episode view after album/tvshow details