### PR TITLE
Rework index

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1875,7 +1875,30 @@
     if (tmpArr.count > 1) {
         [tmpArr replaceObjectAtIndex:0 withObject:@"🔍"];
     }
-    self.indexView.indexTitles = [NSArray arrayWithArray:tmpArr];
+    if (self.sectionArray.count > 1 && !episodesView && !channelGuideView) {
+        self.indexView.indexTitles = [NSArray arrayWithArray:tmpArr];
+    }
+    else if (channelGuideView) {
+        if (self.sectionArray.count > 0) {
+            NSMutableArray *channelGuideTableIndexTitles = [NSMutableArray new];
+            for (NSString *label in tmpArr) {
+                NSString *dateString = label;
+                NSDateFormatter *format = [NSDateFormatter new];
+                format.locale = [NSLocale currentLocale];
+                format.dateFormat = @"yyyy-MM-dd";
+                NSDate *date = [format dateFromString:label];
+                format.dateFormat = @"EEE";
+                if ([format stringFromDate:date] != nil) {
+                    dateString = [format stringFromDate:date];
+                }
+                [channelGuideTableIndexTitles addObject:dateString];
+            }
+            self.indexView.indexTitles = channelGuideTableIndexTitles;
+        }
+    }
+    else {
+        self.indexView.indexTitles = @[];
+    }
 }
 
 - (void)indexViewValueChanged:(BDKCollectionIndexView*)sender {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1881,10 +1881,10 @@
     else if (channelGuideView) {
         if (self.sectionArray.count > 0) {
             NSMutableArray *channelGuideTableIndexTitles = [NSMutableArray new];
+            NSDateFormatter *format = [NSDateFormatter new];
+            format.locale = [NSLocale currentLocale];
             for (NSString *label in tmpArr) {
                 NSString *dateString = label;
-                NSDateFormatter *format = [NSDateFormatter new];
-                format.locale = [NSLocale currentLocale];
                 format.dateFormat = @"yyyy-MM-dd";
                 NSDate *date = [format dateFromString:label];
                 format.dateFormat = @"EEE";

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1934,7 +1934,18 @@
     else {
         NSIndexPath *path = [NSIndexPath indexPathForItem:0 inSection:sender.currentIndex];
         [collectionView scrollToItemAtIndexPath:path atScrollPosition:UICollectionViewScrollPositionTop animated:NO];
-        collectionView.contentOffset = CGPointMake(collectionView.contentOffset.x, collectionView.contentOffset.y - GRID_SECTION_HEADER_HEIGHT);
+        CGFloat offset = collectionView.contentOffset.y - GRID_SECTION_HEADER_HEIGHT;
+        
+        // Use correct scroll to bottom (not hiding a portion underneath the toolbar)
+        CGFloat height_content = collectionView.contentSize.height;
+        CGFloat height_bounds = collectionView.bounds.size.height;
+        CGFloat bottom = buttonsView.frame.size.height;
+        CGFloat bottom_scroll = MAX(height_content - height_bounds + bottom, 0);
+        if (offset > height_content - height_bounds) {
+            offset = bottom_scroll;
+        }
+        
+        collectionView.contentOffset = CGPointMake(collectionView.contentOffset.x, offset);
     }
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2322,36 +2322,7 @@
 }
 
 - (NSArray*)sectionIndexTitlesForTableView:(UITableView*)tableView {
-    if ([self doesShowSearchResults]) {
-        return nil;
-    }
-    else {
-        if (self.sectionArray.count > 1 && !episodesView && !channelGuideView) {
-            return self.sectionArray;
-        }
-        else if (channelGuideView) {
-            if (self.sectionArray.count > 0) {
-                NSMutableArray *channelGuideTableIndexTitles = [NSMutableArray new];
-                for (NSString *label in self.sectionArray) {
-                        NSString *dateString = label;
-                        NSDateFormatter *format = [NSDateFormatter new];
-                        format.locale = [NSLocale currentLocale];
-                        format.dateFormat = @"yyyy-MM-dd";
-                        NSDate *date = [format dateFromString:label];
-                        format.dateFormat = @"EEE";
-                    if ([format stringFromDate:date] != nil) {
-                        dateString = [format stringFromDate:date];
-                    }
-                    [channelGuideTableIndexTitles addObject:dateString];
-                }
-                return channelGuideTableIndexTitles;
-            }
-            return self.sectionArray;
-        }
-        else {
-            return nil;
-        }
-    }
+    return nil;
 }
 
 - (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
@@ -5782,9 +5753,6 @@ NSIndexPath *selected;
     [button7 addTarget:self action:@selector(handleChangeSortLibrary) forControlEvents:UIControlEventTouchUpInside];
     self.edgesForExtendedLayout = UIRectEdgeNone;
     dataList.backgroundView = [[UIView alloc] initWithFrame:CGRectZero];
-    dataList.sectionIndexBackgroundColor = UIColor.clearColor;
-    dataList.sectionIndexColor = UIColor.systemBlueColor;
-    dataList.sectionIndexTrackingBackgroundColor = UIColor.clearColor;
     dataList.separatorInset = UIEdgeInsetsMake(0, 53, 0, 0);
     dataList.indicatorStyle = UIScrollViewIndicatorStyleDefault;
     

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1866,7 +1866,6 @@
     self.indexView.alpha = 1.0;
     self.indexView.hidden = YES;
     [self.indexView addTarget:self action:@selector(indexViewValueChanged:) forControlEvents:UIControlEventValueChanged];
-    [detailView addSubview:self.indexView];
 }
 
 - (void)buildIndexView {
@@ -1877,6 +1876,7 @@
     }
     if (self.sectionArray.count > 1 && !episodesView && !channelGuideView) {
         self.indexView.indexTitles = [NSArray arrayWithArray:tmpArr];
+        [detailView addSubview:self.indexView];
     }
     else if (channelGuideView) {
         if (self.sectionArray.count > 0) {
@@ -1894,10 +1894,12 @@
                 [channelGuideTableIndexTitles addObject:dateString];
             }
             self.indexView.indexTitles = channelGuideTableIndexTitles;
+            [detailView addSubview:self.indexView];
         }
     }
     else {
         self.indexView.indexTitles = @[];
+        [self.indexView removeFromSuperview];
     }
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -59,6 +59,8 @@
 #define GLOBALSEARCH_INDEX_ARTISTS 4
 #define GLOBALSEARCH_INDEX_ALBUMS 5
 #define GLOBALSEARCH_INDEX_SONGS 6
+#define INDEX_WIDTH 40
+#define INDEX_PADDING 2
 
 - (id)initWithFrame:(CGRect)frame {
     if (self = [super init]) {
@@ -1855,11 +1857,10 @@
     if (self.indexView) {
         return;
     }
-    CGFloat indexWidth = 40;
     UITableView *activeView = activeLayoutView;
-    CGRect frame = CGRectMake(CGRectGetWidth(activeView.frame) - indexWidth,
+    CGRect frame = CGRectMake(CGRectGetWidth(activeView.frame) - INDEX_WIDTH - INDEX_PADDING,
                               CGRectGetMinY(activeView.frame) + activeView.contentInset.top,
-                              indexWidth,
+                              INDEX_WIDTH,
                               CGRectGetHeight(activeView.frame) - activeView.contentInset.top - activeView.contentInset.bottom - bottomPadding);
     self.indexView = [BDKCollectionIndexView indexViewWithFrame:frame indexTitles:@[]];
     self.indexView.autoresizingMask = (UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleLeftMargin);

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1934,7 +1934,7 @@
     else {
         NSIndexPath *path = [NSIndexPath indexPathForItem:0 inSection:sender.currentIndex];
         [collectionView scrollToItemAtIndexPath:path atScrollPosition:UICollectionViewScrollPositionTop animated:NO];
-        collectionView.contentOffset = CGPointMake(collectionView.contentOffset.x, collectionView.contentOffset.y - GRID_SECTION_HEADER_HEIGHT + 4);
+        collectionView.contentOffset = CGPointMake(collectionView.contentOffset.x, collectionView.contentOffset.y - GRID_SECTION_HEADER_HEIGHT);
     }
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1856,10 +1856,11 @@
         return;
     }
     CGFloat indexWidth = 40;
-    CGRect frame = CGRectMake(CGRectGetWidth(collectionView.frame) - indexWidth,
-                              CGRectGetMinY(collectionView.frame) + collectionView.contentInset.top,
+    UITableView *activeView = activeLayoutView;
+    CGRect frame = CGRectMake(CGRectGetWidth(activeView.frame) - indexWidth,
+                              CGRectGetMinY(activeView.frame) + activeView.contentInset.top,
                               indexWidth,
-                              CGRectGetHeight(collectionView.frame) - collectionView.contentInset.top - collectionView.contentInset.bottom - bottomPadding);
+                              CGRectGetHeight(activeView.frame) - activeView.contentInset.top - activeView.contentInset.bottom - bottomPadding);
     self.indexView = [BDKCollectionIndexView indexViewWithFrame:frame indexTitles:@[]];
     self.indexView.autoresizingMask = (UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleLeftMargin);
     self.indexView.alpha = 1.0;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Use `BDKCollectionIndexView` for `UITableView` as well. This improves and unifies the overall index usability.
- Same position when switching between list/grid view
- Transparent overlay for TVShow banner view

In addition, fix the inset for grid view after jumping to top or to bottom via index and improve the readability on iPad via adding a small padding on the right side of the index.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct inset for grid when jumping to top/bottom via index
Bugfix: Avoids issue with iOS16 index when minimizing App in iPhone
Improvement: Transparent index overlay for TVShow banners
Maintenance: Use same same index implementation for grid/list view

