### PR TITLE
Improvement : Show amount of Global Search items on iPad

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -5139,7 +5139,7 @@
     menu_Search.mainLabel = LOCALIZED_STR(@"Global Search");
     menu_Search.icon = @"icon_menu_search";
     menu_Search.family = FamilyDetailView;
-    menu_Search.enableSection = NO;
+    menu_Search.enableSection = YES;
     menu_Search.rowHeight = 53;
     menu_Search.thumbWidth = 53;
     menu_Search.defaultThumb = @"nocover_filemode";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
`enableSection` needs to be set to show the amount of items on iPad.

Screenshots: https://abload.de/img/bildschirmfoto2022-11n7f9z.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement : Show amount of Global Search items on iPad