### PR TITLE
Bugfix: Avoid empty safe area in Ken Burns fullscreen on iPhone

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -872,13 +872,6 @@ double round(double d) {
     
     [self loadThumbnail:item[@"thumbnail"] placeHolder:placeHolderImage jewelType:jeweltype jewelEnabled:enableJewel];
     
-    NSString *fanart = item[@"fanart"];
-    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    if (fanart.length == 0 && [userDefaults boolForKey:@"fanart_fallback_preference"]) {
-        fanart = item[@"thumbnail"];
-    }
-    [self loadFanart:fanart];
-    
     voteLabel.text = [Utilities getStringFromItem:item[@"rating"]];
     starsView.image = [UIImage imageNamed:[NSString stringWithFormat:@"stars_%.0f", roundf([item[@"rating"] floatValue])]];
     NSString *numVotes = [Utilities getStringFromItem:item[@"votes"]];
@@ -1774,14 +1767,17 @@ double round(double d) {
         alphaValue = 1;
         [self.navigationController setNavigationBarHidden:YES animated:YES];
     }
+    
+    NSString *fanart = self.detailItem[@"fanart"];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    if (fanart.length == 0 && [userDefaults boolForKey:@"fanart_fallback_preference"]) {
+        fanart = self.detailItem[@"thumbnail"];
+    }
+    [self loadFanart:fanart];
     if (!enableKenBurns) {
         [Utilities alphaView:fanartView AnimDuration:1.5 Alpha:alphaValue];// cool
     }
     else {
-        if (fanartView.image != nil && self.kenView == nil) {
-            fanartView.alpha = 0;
-            [self elabKenBurns:fanartView.image];
-        }
         [Utilities alphaView:self.kenView AnimDuration:1.5 Alpha:alphaValue];// cool
     }
     if ([self isModal]) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Initialize fanart and Ken Burns view only in `viewDidAppear`. This ensures the correct view dimensions are used and avoids a blank safe area when enabling Ken Burns fullscreen for _music albums detail view_ (for other views this worked).

Screenshots: https://abload.de/img/bildschirmfoto2022-11ybdoj.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid empty safe area in Ken Burns fullscreen on iPhone