### PR TITLE
Bugfix: Avoid non-updated cell connection icon in server list

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -108,9 +108,10 @@
         return cell;
     }
     else {
-        ((UIImageView*)[cell viewWithTag:1]).hidden = NO;
+        UIImageView *iconView = (UIImageView*)[cell viewWithTag:1];
         UILabel *cellLabel = (UILabel*)[cell viewWithTag:2];
         UILabel *cellIP = (UILabel*)[cell viewWithTag:3];
+        iconView.hidden = NO;
         cellLabel.textAlignment = NSTextAlignmentLeft;
         NSDictionary *item = AppDelegate.instance.arrayServerList[indexPath.row];
         cellLabel.text = item[@"serverDescription"];
@@ -119,10 +120,11 @@
         if (selection && indexPath.row == selection.row) {
             cell.accessoryType = UITableViewCellAccessoryCheckmark;
             NSString *iconName = [Utilities getConnectionStatusIconName];
-            ((UIImageView*)[cell viewWithTag:1]).image = [UIImage imageNamed:iconName];
+            iconView.image = [UIImage imageNamed:iconName];
         }
         else {
             cell.accessoryType = UITableViewCellAccessoryNone;
+            iconView.image = [UIImage imageNamed:@"connection_off"];
         }
         editTableButton.enabled = YES;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Avoids showing multiple active server connections, which was caused by the fact that `dequeueReusableCellWithIdentifier` can result in re-ordered cells.

Screenshot: https://abload.de/img/bildschirmfoto2022-11g0dnb.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid non-updated cell connection icon in server list