### PR TITLE
Rework button processing of songDetailsView

### DIFF
--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -77,6 +77,7 @@
     BOOL fromItself;
     IBOutlet UIButton *shuffleButton;
     IBOutlet UIButton *repeatButton;
+    IBOutlet UIButton *closeButton;
     BOOL shuffled;
     NSString *repeatStatus;
     BOOL updateProgressBar;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1586,21 +1586,33 @@ long currentItemID;
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
     UITouch *touch = [touches anyObject];
-    CGPoint locationPoint = [[touches anyObject] locationInView:self.view];
-    CGPoint viewPoint = [shuffleButton convertPoint:locationPoint fromView:self.view];
-    CGPoint viewPoint2 = [repeatButton convertPoint:locationPoint fromView:self.view];
-    CGPoint viewPoint3 = [itemLogoImage convertPoint:locationPoint fromView:self.view];
-    if ([shuffleButton pointInside:viewPoint withEvent:event] && songDetailsView.alpha > 0 && !shuffleButton.hidden) {
-        [self changeShuffle:nil];
-    }
-    else if ([repeatButton pointInside:viewPoint2 withEvent:event] && songDetailsView.alpha > 0 && !repeatButton.hidden) {
-        [self changeRepeat:nil];
-    }
-    else if ([itemLogoImage pointInside:viewPoint3 withEvent:event] && songDetailsView.alpha > 0 && itemLogoImage.image != nil) {
-        [self updateCurrentLogo];
-    }
-    else if ([touch.view isEqual:jewelView] || [touch.view isEqual:songDetailsView]) {
+    CGPoint locationPoint = [touch locationInView:songDetailsView];
+    CGPoint viewPoint1 = [shuffleButton convertPoint:locationPoint fromView:songDetailsView];
+    CGPoint viewPoint2 = [repeatButton convertPoint:locationPoint fromView:songDetailsView];
+    CGPoint viewPoint3 = [itemLogoImage convertPoint:locationPoint fromView:songDetailsView];
+    CGPoint viewPoint4 = [closeButton convertPoint:locationPoint fromView:songDetailsView];
+    if (songDetailsView.alpha == 0) {
+        // songDetailsView is not shown, bring it up
         [self toggleSongDetails];
+    }
+    else {
+        // songDetailsView is shown, process touches
+        if ([shuffleButton pointInside:viewPoint1 withEvent:event]&& !shuffleButton.hidden) {
+            [self changeShuffle:nil];
+        }
+        else if ([repeatButton pointInside:viewPoint2 withEvent:event] && !repeatButton.hidden) {
+            [self changeRepeat:nil];
+        }
+        else if ([itemLogoImage pointInside:viewPoint3 withEvent:event] && itemLogoImage.image != nil) {
+            [self updateCurrentLogo];
+        }
+        else if ([closeButton pointInside:viewPoint4 withEvent:event] && !closeButton.hidden) {
+            [self toggleSongDetails];
+        }
+        else if (![songDetailsView pointInside:locationPoint withEvent:event] && !closeButton.hidden) {
+            // touches outside of songDetailsView close it
+            [self toggleSongDetails];
+        }
     }
 }
 

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -17,6 +17,7 @@
                 <outlet property="albumName" destination="5" id="45"/>
                 <outlet property="artistName" destination="9" id="48"/>
                 <outlet property="backgroundImageView" destination="94" id="145"/>
+                <outlet property="closeButton" destination="Lna-Os-O4e" id="6DX-6t-qrC"/>
                 <outlet property="currentTime" destination="30" id="51"/>
                 <outlet property="duration" destination="31" id="49"/>
                 <outlet property="editTableButton" destination="117" id="137"/>

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -305,16 +305,7 @@
 #pragma mark - Touch Events
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
-    CGPoint locationPoint = [[touches anyObject] locationInView:self.view];
-    CGPoint viewPoint = [self.nowPlayingController.jewelView convertPoint:locationPoint fromView:self.view];
-    CGPoint viewPoint4 = [self.nowPlayingController.itemLogoImage convertPoint:locationPoint fromView:self.view];
-
-    if ([self.nowPlayingController.itemLogoImage pointInside:viewPoint4 withEvent:event] && self.nowPlayingController.songDetailsView.alpha > 0 && self.nowPlayingController.itemLogoImage.image != nil) {
-        [self.nowPlayingController updateCurrentLogo];
-    }
-    else if ([self.nowPlayingController.jewelView pointInside:viewPoint withEvent:event] && !AppDelegate.instance.windowController.stackScrollViewController.viewControllersStack.count) {
-        [self.nowPlayingController toggleSongDetails];
-    }
+    [self.nowPlayingController touchesEnded:touches withEvent:event];
 }
 
 #pragma mark - App clear disk cache methods
@@ -472,8 +463,6 @@
     [self.view addSubview:xbmcInfo];
     
     menuViewController.tableView.separatorInset = UIEdgeInsetsZero;
-    
-    [self.view insertSubview:self.nowPlayingController.songDetailsView aboveSubview:rootView];
     
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     BOOL clearCache = [userDefaults boolForKey:@"clearcache_preference"];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Do not insert `songDetailsView` above `rootView` on iPad. This resolves a problem with `scrubbingView` shown underneath the `songDetailsView` on iPad. Instead, forward `touchesEnded` to `nowPlayingViewController`. This requires to add `closeButton` as well, it allows to close `songDetailsView` when touching the area outside and it removes duplicate code.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Draw scrubbing message on top of song details view on iPad
Improvement: Close song details view when touching outside area