### PR TITLE
Improvement: Brighter color for scrubbing rate to improve readability

### DIFF
--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -289,7 +289,7 @@
                                                             <rect key="frame" x="5" y="10" width="270" height="10"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
-                                                            <color key="textColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <nil key="highlightedColor"/>
                                                             <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <size key="shadowOffset" width="0.0" height="1"/>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Use `lightGrayColor` instead of `grayColor` for the scrubbing rate info.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Brighter color for scrubbing rate to improve readability