### PR TITLE
Bugfix: Start with grayed out iPad main menu

### DIFF
--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -151,6 +151,14 @@
     title.text = item.mainLabel;
     icon.highlightedImage = [UIImage imageNamed:iconName];
     icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:UIColor.grayColor];
+    if (AppDelegate.instance.serverOnLine) {
+        icon.alpha = 1.0;
+        title.alpha = 1.0;
+    }
+    else {
+        icon.alpha = 0.3;
+        title.alpha = 0.3;
+    }
     return cell;
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Set iPad menu item alpha in `cellForRowAtIndexPath`. Ensure the main menu cells are initialized properly when becoming visible.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Start with grayed out iPad main menu