### PR TITLE
Improvement: Make reorder icon readable when editing custom button list in light mode

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -136,6 +136,9 @@
         cell.backgroundColor = [Utilities getGrayColor:36 alpha:1];
         cell.tintColor = UIColor.lightGrayColor;
         cell.editingAccessoryType = UITableViewCellAccessoryDetailDisclosureButton;
+        if (@available(iOS 13.0, *)) {
+            cell.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+        }
         icon = (UIImageView*)[cell viewWithTag:1];
         title = (UILabel*)[cell viewWithTag:3];
         line = (UIImageView*)[cell viewWithTag:4];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Set `overrideUserInterfaceStyle` to `UIUserInterfaceStyleDark` for the custom remote button cells. These always have a dark background and ignore the system wide dark/light mode. This way the reorder icons are readable when in light mode.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Make reorder icon readable when editing custom button list in light mode