### PR TITLE
Bugfix: Hide iPad progress bar after selecting longpress action on a playlist item

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1180,6 +1180,7 @@ long currentItemID;
         [self.navigationController pushViewController:showInfoViewController animated:YES];
     }
     else {
+        [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollOnScreen" object: nil];
         ShowInfoViewController *iPadShowViewController = [[ShowInfoViewController alloc] initWithNibName:@"ShowInfoViewController" withItem:item withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
         [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadShowViewController invokeByController:self isStackStartView:YES];
         [AppDelegate.instance.windowController.stackScrollViewController enablePanGestureRecognizer];
@@ -1889,6 +1890,7 @@ long currentItemID;
             [self.navigationController pushViewController:detailViewController animated:YES];
         }
         else {
+            [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollOnScreen" object: nil];
             DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:menuItem.subItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
             [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:YES];
             [AppDelegate.instance.windowController.stackScrollViewController enablePanGestureRecognizer];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum thread](https://forum.kodi.tv/showthread.php?tid=359717&pid=3120534#pid3120534).

This PR will move the iPad prograss bar to the background when the user opened a stack view from an action sheet after long pressing a playlist item. It will send `StackScrollOnScreen` in such case.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Hide iPad progress bar after selecting longpress action on a playlist item