### PR TITLE
Bugfix: Fix visual glitches when scrolling collapsed seasons in episode view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2948,19 +2948,6 @@
         gradient.frame = albumDetailView.bounds;
         gradient.colors = @[(id)[[Utilities getSystemGray5] CGColor], (id)[[Utilities getSystemGray1] CGColor]];
         [albumDetailView.layer insertSublayer:gradient atIndex:0];
-        if (section > 0) {
-            UIView *lineView = [[UIView alloc] initWithFrame:CGRectMake(0, -1, viewWidth, 1)];
-            lineView.backgroundColor = [Utilities getGrayColor:242 alpha:1];
-            [albumDetailView addSubview:lineView];
-        }
-        CGRect toolbarShadowFrame = CGRectMake(0, albumViewHeight + 1, viewWidth, 8);
-        UIImageView *toolbarShadow = [[UIImageView alloc] initWithFrame:toolbarShadowFrame];
-        toolbarShadow.image = [UIImage imageNamed:@"tableUp"];
-        toolbarShadow.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-        toolbarShadow.opaque = YES;
-        toolbarShadow.alpha = 0.3;
-        [albumDetailView addSubview:toolbarShadow];
-        
         NSDictionary *item;
         if ([self doesShowSearchResults]) {
             item = self.richResults[0];
@@ -3116,7 +3103,7 @@
         return albumViewHeight + 2;
     }
     else if (episodesView && self.richResults.count > 0 && ![self doesShowSearchResults]) {
-        return albumViewHeight + 2;
+        return albumViewHeight;
     }
     else if (section != 0 || [self doesShowSearchResults]) {
         return sectionHeight;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes and issues reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3120534#pid3120534).

Remove shadow and separation line in episode view as this causes visual glitches when scrolling the collapsed seasons out of view. In the link above a video of the glitches is shared.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix visual glitches when scrolling collapsed seasons in episode view