### PR TITLE
Bugfix: Avoid showing empty toolbars after using search

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5713,9 +5713,15 @@ NSIndexPath *selected;
     
     // Hide the toolbar and index while search is active with a non-empty string
     if (self.searchController.isActive) {
-        BOOL hideToolbarAndIndex = searchString.length > 0;
-        [self hideButtonList:hideToolbarAndIndex];
-        self.indexView.hidden = hideToolbarAndIndex;
+        BOOL hasNonEmptySearchString = searchString.length > 0;
+        
+        // Hide toolbar when search string is non-empty or no toolbar buttons exist
+        BOOL hasEmptyToolbar = button1.hidden && button2.hidden && button3.hidden && button4.hidden && button5.hidden && button6.hidden && button7.hidden;
+        BOOL hideToolbar = hasNonEmptySearchString || hasEmptyToolbar;
+        [self hideButtonList:hideToolbar];
+        
+        // Hide index when search string is non-empty
+        self.indexView.hidden = hasNonEmptySearchString;
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
It was possible to end up in a situation where either an active search with an empty string or even after cancelling such search an empty toolbar was shown. This was connected to the recently feature to keep showing the toolbar as long as the search string is empty.

This PR now adds some logic to hide the toolbar if either the search string is empty OR the toolbar is empty.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid showing empty toolbars after using search