### PR TITLE
Rework and fix open/close of sections in episode view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -847,12 +847,15 @@
 
 - (void)toggleOpen:(UITapGestureRecognizer*)sender {
     NSInteger section = [sender.view tag];
+    // Toggle the section's state (open/close)
     [self.sectionArrayOpen replaceObjectAtIndex:section withObject:@(![self.sectionArrayOpen[section] boolValue])];
+    // Build the section content
     NSInteger countEpisodes = [[self.sections objectForKey:self.sectionArray[section]] count];
     NSMutableArray *indexPaths = [NSMutableArray new];
     for (NSInteger i = 0; i < countEpisodes; i++) {
         [indexPaths addObject:[NSIndexPath indexPathForRow:i inSection:section]];
     }
+    // Add/remove the section content
     UIButton *toggleButton = (UIButton*)[sender.view viewWithTag:99];
     if ([self.sectionArrayOpen[section] boolValue]) {
         [dataList beginUpdates];
@@ -865,11 +868,13 @@
         [dataList beginUpdates];
         [dataList deleteRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationTop];
         [dataList endUpdates];
-        if (section > 0) {
-            CGRect sectionRect = [dataList rectForSection:section - 1];
-            [dataList scrollRectToVisible:sectionRect animated:YES];
-        }
     }
+    // Refresh leyout
+    [self configureLibraryView];
+    [dataList setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
+    // Scroll to section
+    CGRect sectionRect = [dataList rectForSection:section];
+    [dataList scrollRectToVisible:sectionRect animated:YES];
 }
 
 - (void)goBack:(id)sender {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Changes to method `toggleOpen:` which handles opening and closing season sections inside the episode view. Add dedicated refreshing of layout, setting the inset and scrolling to the desired section. This fixes multiple issues:
- Search not working after expanding one section
- Wrong inset after expanding section
- Wrong position of expanded sections when not fully visible during selection

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Search not working after expanding one section inside episode view
Bugfix: Fix scrolling to opened section in episode view
Bugfix: Fix potentially wrong vertical inset after opening a section