### PR TITLE
Rework cell layout inside rightMenuViewController

### DIFF
--- a/XBMC Remote/RightMenuViewController.h
+++ b/XBMC Remote/RightMenuViewController.h
@@ -15,7 +15,6 @@
 
 @interface RightMenuViewController : UIViewController <UITableViewDelegate, UITableViewDataSource> {
     UITableView *menuTableView;
-    IBOutlet UITableViewCell *rightMenuCell;
     NSMutableArray *tableData;
     UILabel *infoLabel;
     VolumeSliderView *volumeSliderView;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -79,20 +79,22 @@
     if (cell == nil) {
         NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"rightCellView" owner:self options:nil];
         cell = nib[0];
+        
+        // Set background view
         UIView *backView = [[UIView alloc] initWithFrame:cell.frame];
         backView.backgroundColor = [Utilities getGrayColor:22 alpha:1];
         cell.selectedBackgroundView = backView;
-        UIImage *logo = [UIImage imageNamed:@"xbmc_logo"];
-        UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:44 width:self.view.bounds.size.width]];
-        xbmc_logo.alpha = 0.25;
-        xbmc_logo.image = logo;
-        xbmc_logo.tag = 101;
-        [cell.contentView insertSubview:xbmc_logo atIndex:0];
     }
+    UIImage *logo = [UIImage imageNamed:@"xbmc_logo"];
+    UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:44 width:self.view.bounds.size.width]];
+    xbmc_logo.alpha = 0.25;
+    xbmc_logo.image = logo;
+    xbmc_logo.tag = 101;
+    [cell.contentView insertSubview:xbmc_logo atIndex:0];
+    
     UIImageView *icon = (UIImageView*)[cell viewWithTag:1];
     UILabel *title = (UILabel*)[cell viewWithTag:3];
     UIImageView *line = (UIImageView*)[cell viewWithTag:4];
-    UIImageView *xbmc_logo = (UIImageView*)[cell viewWithTag:101];
     icon.hidden = NO;
     xbmc_logo.hidden = YES;
     cell.accessoryView = nil;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -85,23 +85,21 @@
         backView.backgroundColor = [Utilities getGrayColor:22 alpha:1];
         cell.selectedBackgroundView = backView;
     }
-    UIImage *logo = [UIImage imageNamed:@"xbmc_logo"];
-    UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:44 width:self.view.bounds.size.width]];
-    xbmc_logo.alpha = 0.25;
-    xbmc_logo.image = logo;
-    xbmc_logo.tag = 101;
-    [cell.contentView insertSubview:xbmc_logo atIndex:0];
     
     UIImageView *icon = (UIImageView*)[cell viewWithTag:1];
     UILabel *title = (UILabel*)[cell viewWithTag:3];
     UIImageView *line = (UIImageView*)[cell viewWithTag:4];
     icon.hidden = NO;
-    xbmc_logo.hidden = YES;
     cell.accessoryView = nil;
     NSString *iconName = @"blank";
     if ([tableData[indexPath.row][@"label"] isEqualToString:@"ServerInfo"]) {
-        cell.selectionStyle = UITableViewCellSelectionStyleNone;
+        UIImage *logo = [UIImage imageNamed:@"xbmc_logo"];
+        UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:44 width:self.view.bounds.size.width]];
+        xbmc_logo.alpha = 0.25;
+        xbmc_logo.image = logo;
         xbmc_logo.hidden = NO;
+        [cell.contentView insertSubview:xbmc_logo atIndex:0];
+        cell.selectionStyle = UITableViewCellSelectionStyleNone;
         iconName = [Utilities getConnectionStatusIconName];
         icon.alpha = 1;
         title.font = [UIFont fontWithName:@"Roboto-Regular" size:13];
@@ -141,16 +139,6 @@
         icon = (UIImageView*)[cell viewWithTag:1];
         title = (UILabel*)[cell viewWithTag:3];
         line = (UIImageView*)[cell viewWithTag:4];
-        UIView *backView = [[UIView alloc] initWithFrame:cell.frame];
-        backView.backgroundColor = [Utilities getGrayColor:22 alpha:1];
-        cell.selectedBackgroundView = backView;
-        UIImage *logo = [UIImage imageNamed:@"xbmc_logo"];
-        UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:44 width:self.view.bounds.size.width]];
-        xbmc_logo.alpha = 0.25;
-        xbmc_logo.image = logo;
-        xbmc_logo.tag = 101;
-        xbmc_logo.hidden = YES;
-        [cell.contentView insertSubview:xbmc_logo atIndex:0];
         
         UIViewAutoresizing storeMask = title.autoresizingMask;
         title.autoresizingMask = UIViewAutoresizingNone;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -115,8 +115,6 @@
         title.textAlignment = NSTextAlignmentLeft;
         title.text = AppDelegate.instance.serverName;
         title.numberOfLines = 2;
-        UIImageView *arrowRight = (UIImageView*)[cell viewWithTag:5];
-        arrowRight.frame = CGRectMake(arrowRight.frame.origin.x, (SERVER_INFO_HEIGHT - arrowRight.frame.size.height) / 2, arrowRight.frame.size.width, arrowRight.frame.size.height);
     }
     else if ([tableData[indexPath.row][@"label"] isEqualToString:@"VolumeControl"]) {
         cell.selectionStyle = UITableViewCellSelectionStyleNone;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -23,6 +23,7 @@
 #define RIGHT_MENU_CELL_SPACING 6.0
 #define BUTTON_SPACING 8.0
 #define BUTTON_WIDTH 100.0
+#define ONOFF_BUTTON_TAG_OFFSET 1000
 
 @interface RightMenuViewController ()
 @property (nonatomic, unsafe_unretained) CGFloat peekLeftAmount;
@@ -150,7 +151,7 @@
             [onoff addTarget: self action: @selector(toggleSwitch:) forControlEvents:UIControlEventValueChanged];
             onoff.frame = CGRectMake(0, (RIGHT_MENU_ITEM_HEIGHT - onoff.frame.size.height) / 2, onoff.frame.size.width, onoff.frame.size.height);
             onoff.hidden = NO;
-            onoff.tag = 1000 + indexPath.row;
+            onoff.tag = ONOFF_BUTTON_TAG_OFFSET + indexPath.row;
 
             UIView *onoffview = [[UIView alloc] initWithFrame: CGRectMake(0, 0, onoff.frame.size.width, RIGHT_MENU_ITEM_HEIGHT)];
             [onoffview addSubview:onoff];
@@ -302,7 +303,7 @@
 
 - (void)toggleSwitch:(id)sender {
     UISwitch *onoff = (UISwitch*)sender;
-    NSInteger tableIdx = onoff.tag - 1000;
+    NSInteger tableIdx = onoff.tag - ONOFF_BUTTON_TAG_OFFSET;
     if (tableIdx < tableData.count) {
         NSString *command = tableData[tableIdx][@"action"][@"command"];
         NSDictionary *parameters = [NSDictionary dictionaryWithObjectsAndKeys: tableData[tableIdx][@"action"][@"params"][@"setting"], @"setting", @(onoff.on), @"value", nil];
@@ -346,10 +347,10 @@
 }
 
 - (void)tableView:(UITableView*)tableView moveRowAtIndexPath:(NSIndexPath*)sourceIndexPath toIndexPath:(NSIndexPath*)destinationIndexPath {
-    UISwitch *onoffSource = (UISwitch*)[[[tableView cellForRowAtIndexPath:sourceIndexPath]accessoryView] viewWithTag:1000 + sourceIndexPath.row];
-    UISwitch *onoffDestination = (UISwitch*)[[[tableView cellForRowAtIndexPath:destinationIndexPath]accessoryView] viewWithTag:1000 + destinationIndexPath.row];
-    onoffSource.tag = 1000 + destinationIndexPath.row;
-    onoffDestination.tag = 1000 + sourceIndexPath.row;
+    UISwitch *onoffSource = (UISwitch*)[[[tableView cellForRowAtIndexPath:sourceIndexPath]accessoryView] viewWithTag:ONOFF_BUTTON_TAG_OFFSET + sourceIndexPath.row];
+    UISwitch *onoffDestination = (UISwitch*)[[[tableView cellForRowAtIndexPath:destinationIndexPath]accessoryView] viewWithTag:ONOFF_BUTTON_TAG_OFFSET + destinationIndexPath.row];
+    onoffSource.tag = ONOFF_BUTTON_TAG_OFFSET + destinationIndexPath.row;
+    onoffDestination.tag = ONOFF_BUTTON_TAG_OFFSET + sourceIndexPath.row;
 
     id objectMove = tableData[sourceIndexPath.row];
     [tableData removeObjectAtIndex:sourceIndexPath.row];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -93,6 +93,9 @@
     UIImageView *line = (UIImageView*)[cell viewWithTag:4];
     icon.hidden = NO;
     cell.accessoryView = nil;
+    if (@available(iOS 13.0, *)) {
+        cell.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+    }
     NSString *iconName = @"blank";
     if ([tableData[indexPath.row][@"label"] isEqualToString:@"ServerInfo"]) {
         UIImage *logo = [UIImage imageNamed:@"xbmc_logo"];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -137,9 +137,6 @@
         cell.backgroundColor = [Utilities getGrayColor:36 alpha:1];
         cell.tintColor = UIColor.lightGrayColor;
         cell.editingAccessoryType = UITableViewCellAccessoryDetailDisclosureButton;
-        icon = (UIImageView*)[cell viewWithTag:1];
-        title = (UILabel*)[cell viewWithTag:3];
-        line = (UIImageView*)[cell viewWithTag:4];
         
         UIViewAutoresizing storeMask = title.autoresizingMask;
         title.autoresizingMask = UIViewAutoresizingNone;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -20,6 +20,7 @@
 #define RIGHT_MENU_ITEM_HEIGHT 50.0
 #define RIGHT_MENU_ICON_SIZE 18.0
 #define RIGHT_MENU_ICON_SPACING 16.0
+#define RIGHT_MENU_CELL_SPACING 6.0
 #define BUTTON_SPACING 8.0
 #define BUTTON_WIDTH 100.0
 
@@ -94,7 +95,7 @@
     NSString *iconName = @"blank";
     if ([tableData[indexPath.row][@"label"] isEqualToString:@"ServerInfo"]) {
         UIImage *logo = [UIImage imageNamed:@"xbmc_logo"];
-        UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:44 width:self.view.bounds.size.width]];
+        UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:SERVER_INFO_HEIGHT width:self.view.bounds.size.width]];
         xbmc_logo.alpha = 0.25;
         xbmc_logo.image = logo;
         xbmc_logo.hidden = NO;
@@ -143,8 +144,8 @@
         UIViewAutoresizing storeMask = title.autoresizingMask;
         title.autoresizingMask = UIViewAutoresizingNone;
         CGRect frame = title.frame;
-        frame.origin.y = 6;
-        frame.size.height = frame.size.height - 12;
+        frame.origin.y = RIGHT_MENU_CELL_SPACING;
+        frame.size.height = frame.size.height - 2 * RIGHT_MENU_CELL_SPACING;
         if ([tableData[indexPath.row][@"type"] isEqualToString:@"boolean"]) {
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
             UISwitch *onoff = [[UISwitch alloc] initWithFrame: CGRectZero];
@@ -177,7 +178,7 @@
             cell.accessoryView = onoffview;
         }
         else {
-            frame.size.width = 202;
+            frame.size.width = cell.frame.size.width - frame.origin.x - RIGHT_MENU_ICON_SIZE - 2 * RIGHT_MENU_ICON_SPACING;
         }
         title.frame = frame;
         title.autoresizingMask = storeMask;

--- a/XBMC Remote/rightCellView.xib
+++ b/XBMC Remote/rightCellView.xib
@@ -7,11 +7,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="RightMenuViewController">
-            <connections>
-                <outlet property="rightMenuCell" destination="3" id="17"/>
-            </connections>
-        </placeholder>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="RightMenuViewController"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="gray" indentationWidth="10" reuseIdentifier="rightMenuCellIdentifier" editingAccessoryType="disclosureIndicator" rowHeight="50" id="3">
             <rect key="frame" x="0.0" y="0.0" width="280" height="50"/>

--- a/XBMC Remote/rightCellView.xib
+++ b/XBMC Remote/rightCellView.xib
@@ -20,6 +20,10 @@
                         <rect key="frame" x="240" y="12" width="25" height="25"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES"/>
                     </imageView>
+                    <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.60000002384185791" tag="2" contentMode="scaleAspectFit" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kca-dF-2Rb">
+                        <rect key="frame" x="10" y="12" width="25" height="25"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES"/>
+                    </imageView>
                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="3" contentMode="left" fixedFrame="YES" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="6">
                         <rect key="frame" x="24" y="0.0" width="202" height="50"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3120620#pid3120620).

The cell layout of `rightMenuCell` was inconsistent after App wakeup. To avoid this the code does not cache the few cells anymore, but re-creates them in `cellForRowAtIndexPath`. Alongside with this change, there were some cleanups added to remove magic numbers and not needed views.

Set `overrideUserInterfaceStyle` to `UIUserInterfaceStyleDark` for the custom remote button cells. These always have a dark background and ignore the system wide dark/light mode. This way the reorder icons are readable when in light mode.

Screenshots: https://abload.de/img/bildschirmfoto2022-12z5f82.png


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Layout issues after App wakeup in power menu and custom button menu
Improvement: Make reorder icon readable when editing custom button list in light mode