### PR TITLE
Bugfix: Fix potential crashes reported from AppStore

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6170,6 +6170,9 @@ NSIndexPath *selected;
     [self.sections removeAllObjects];
     [channelListUpdateTimer invalidate];
     [[NSNotificationCenter defaultCenter] removeObserver: self];
+    self.searchController.searchResultsUpdater = nil;
+    self.searchController.searchBar.delegate = nil;
+    self.searchController.delegate = nil;
 }
 
 - (BOOL)shouldAutorotate {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4360,9 +4360,24 @@ NSIndexPath *selected;
 
 
 - (void)showAlbumActions:(UITapGestureRecognizer*)tap {
-    NSArray *sheetActions = @[LOCALIZED_STR(@"Queue after current"), LOCALIZED_STR(@"Queue"), LOCALIZED_STR(@"Play"), LOCALIZED_STR(@"Play in shuffle mode"), LOCALIZED_STR(@"Album Details"), LOCALIZED_STR(@"Search Wikipedia")];
+    if (self.sectionArray.count == 0) {
+        return;
+    };
+    id sectionKey = self.sectionArray[0];
+    id sectionItem = [self.sections[sectionKey] firstObject];
+    if (!sectionItem) {
+        return;
+    };
+    NSArray *sheetActions = @[
+        LOCALIZED_STR(@"Queue after current"),
+        LOCALIZED_STR(@"Queue"),
+        LOCALIZED_STR(@"Play"),
+        LOCALIZED_STR(@"Play in shuffle mode"),
+        LOCALIZED_STR(@"Album Details"),
+        LOCALIZED_STR(@"Search Wikipedia"),
+    ];
     selected = [NSIndexPath indexPathForRow:0 inSection:0];
-    NSMutableDictionary *item = [NSMutableDictionary dictionaryWithDictionary:[self.sections objectForKey:self.sectionArray[0]][0]];
+    NSMutableDictionary *item = [sectionItem mutableCopy];
     item[@"label"] = self.navigationItem.title;
     forceMusicAlbumMode = YES;
     int rectOrigin = (int)((albumViewHeight - (albumViewPadding * 2))/2);

--- a/XBMC Remote/FloatingHeaderFlowLayout.m
+++ b/XBMC Remote/FloatingHeaderFlowLayout.m
@@ -44,6 +44,9 @@
         if ([layoutAttributes.representedElementKind isEqualToString:UICollectionElementKindSectionHeader]) {
             
             NSInteger section = layoutAttributes.indexPath.section;
+            if (section >= cv.numberOfSections) {
+                return answer;
+            }
             NSInteger numberOfItemsInSection = [cv numberOfItemsInSection:section];
             
             NSIndexPath *firstCellIndexPath = [NSIndexPath indexPathForItem:0 inSection:section];

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -445,6 +445,9 @@
 }
 
 - (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath {
+    if (services.count == 0) {
+        return;
+    }
     [self resolveIPAddress:services[indexPath.row]];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR applies 3 confirmed fixes for crashes reported from AppStore (out of bounds access in `didSelectRowAtIndexPath`,  `showAlbumActions` and `layoutAttributesForElementsInRect`).

On top the PR also has two potential fixes which I found after research on www.stackoverflow.com. First is about setting some properties to `nil` in `dealloc` -- I am not sure, if this is relevant anymore. Second, is avoiding a potential recursive call in `textField:shouldChangeCharactersInRange:replacementString:` by using a copy of the object.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix potential crashes reported from AppStore