### PR TITLE
Improvement: Align color of navigation bar items

### DIFF
--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -21,7 +21,8 @@
  * Color defines
  */
 #define APP_TINT_COLOR [Utilities getGrayColor:0 alpha:0.3]
-#define TINT_COLOR [Utilities getGrayColor:255 alpha:.35]
+#define ICON_TINT_COLOR UIColor.lightGrayColor
+#define ICON_TINT_COLOR_ACTIVE UIColor.systemBlueColor
 #define BAR_TINT_COLOR [Utilities getGrayColor:26 alpha:1]
 #define REMOTE_CONTROL_BAR_TINT_COLOR [Utilities getGrayColor:12 alpha:1]
 #define SLIDER_DEFAULT_COLOR [Utilities getSystemTeal]

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -790,7 +790,7 @@
 
 - (void)setSortButtonImage:(NSString*)sortOrder {
     NSString *imgName = [sortOrder isEqualToString:@"descending"] ? @"st_sort_desc" : @"st_sort_asc";
-    UIImage *image = [Utilities colorizeImage:[UIImage imageNamed:imgName] withColor:UIColor.lightGrayColor];
+    UIImage *image = [Utilities colorizeImage:[UIImage imageNamed:imgName] withColor:ICON_TINT_COLOR];
     [button7 setBackgroundImage:image forState:UIControlStateNormal];
 }
 
@@ -1117,7 +1117,7 @@
         
         [self initSearchController];
         self.searchController.searchBar.backgroundColor = [Utilities getGrayColor:22 alpha:1];
-        self.searchController.searchBar.tintColor = UIColor.lightGrayColor;
+        self.searchController.searchBar.tintColor = ICON_TINT_COLOR;
         imgName = @"st_view_grid";
     }
     else {
@@ -1141,7 +1141,7 @@
     [self buildIndexView];
     [self setIndexViewVisibility];
     
-    UIImage *image = [Utilities colorizeImage:[UIImage imageNamed:imgName] withColor:UIColor.lightGrayColor];
+    UIImage *image = [Utilities colorizeImage:[UIImage imageNamed:imgName] withColor:ICON_TINT_COLOR];
     [button6 setBackgroundImage:image forState:UIControlStateNormal];
     
     if (!isViewDidLoad) {
@@ -5328,7 +5328,7 @@ NSIndexPath *selected;
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputFinished" object:nil userInfo:nil];
-    self.navigationController.navigationBar.tintColor = UIColor.lightGrayColor;
+    self.navigationController.navigationBar.tintColor = ICON_TINT_COLOR;
     [channelListUpdateTimer invalidate];
     channelListUpdateTimer = nil;
 }
@@ -5391,7 +5391,7 @@ NSIndexPath *selected;
         self.navigationController.navigationBar.tintColor = [Utilities lighterColorForColor:albumColor];
     }
     else {
-        self.navigationController.navigationBar.tintColor = UIColor.lightGrayColor;
+        self.navigationController.navigationBar.tintColor = ICON_TINT_COLOR;
     }
     if (isViewDidLoad) {
         [activeLayoutView addSubview:self.searchController.searchBar];
@@ -5445,8 +5445,8 @@ NSIndexPath *selected;
     activeTab = MIN(activeTab, MAX_NORMAL_BUTTONS);
     for (int i = 0; i < count; i++) {
         img = [UIImage imageNamed:buttons[i]];
-        imageOff = [Utilities colorizeImage:img withColor:UIColor.lightGrayColor];
-        imageOn = [Utilities colorizeImage:img withColor:UIColor.systemBlueColor];
+        imageOff = [Utilities colorizeImage:img withColor:ICON_TINT_COLOR];
+        imageOn = [Utilities colorizeImage:img withColor:ICON_TINT_COLOR_ACTIVE];
         [buttonsIB[i] setBackgroundImage:imageOff forState:UIControlStateNormal];
         [buttonsIB[i] setBackgroundImage:imageOn forState:UIControlStateSelected];
         [buttonsIB[i] setBackgroundImage:imageOn forState:UIControlStateHighlighted];
@@ -5477,8 +5477,8 @@ NSIndexPath *selected;
         default:
             // 5 or more buttons/actions require a "more" button
             img = [UIImage imageNamed:@"st_more"];
-            imageOff = [Utilities colorizeImage:img withColor:UIColor.lightGrayColor];
-            imageOn = [Utilities colorizeImage:img withColor:UIColor.systemBlueColor];
+            imageOff = [Utilities colorizeImage:img withColor:ICON_TINT_COLOR];
+            imageOn = [Utilities colorizeImage:img withColor:ICON_TINT_COLOR_ACTIVE];
             [buttonsIB.lastObject setBackgroundImage:imageOff forState:UIControlStateNormal];
             [buttonsIB.lastObject setBackgroundImage:imageOn forState:UIControlStateSelected];
             [buttonsIB.lastObject setBackgroundImage:imageOn forState:UIControlStateHighlighted];

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -577,7 +577,7 @@ static inline BOOL IsEmpty(id obj) {
         backgroundImageView.frame = frame;
         self.view.backgroundColor = UIColor.blackColor;
         self.navigationController.navigationBar.barStyle = UIBarStyleBlack;
-        self.navigationController.navigationBar.tintColor = TINT_COLOR;
+        self.navigationController.navigationBar.tintColor = ICON_TINT_COLOR;
     }
     else {
         int barHeight = 44;

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -36,7 +36,7 @@
     UINavigationBar *newBar = navController.navigationBar;
     newBar.barStyle = UIBarStyleBlackTranslucent;
     [self setNeedsStatusBarAppearanceUpdate];
-    newBar.tintColor = TINT_COLOR;
+    newBar.tintColor = ICON_TINT_COLOR;
     self.view.tintColor = APP_TINT_COLOR;
     [navController hideNavBarBottomLine:YES];
     hostManagementViewController.mainMenu = self.mainMenu;

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -188,7 +188,7 @@
     
     UINavigationBar *newBar = navController.navigationBar;
     newBar.barStyle = UIBarStyleBlack;
-    newBar.tintColor = TINT_COLOR;
+    newBar.tintColor = ICON_TINT_COLOR;
     if (setBarTintColor) {
         newBar.backgroundColor = [Utilities getGrayColor:204 alpha:0.35];
     }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -427,7 +427,7 @@ long currentItemID;
                          iOS7bgEffect.backgroundColor = color;
                          iOS7navBarEffect.backgroundColor = color;
                          if ([color isEqual:UIColor.clearColor]) {
-                             self.navigationController.navigationBar.tintColor = TINT_COLOR;
+                             self.navigationController.navigationBar.tintColor = ICON_TINT_COLOR;
                              [Utilities imageView:backgroundImageView AnimDuration:1.0 Image:[UIImage imageNamed:@"shiny_black_back"]];
                              if (IS_IPAD) {
                                  NSDictionary *params = @{@"startColor": [Utilities getGrayColor:36 alpha:1],
@@ -2487,7 +2487,7 @@ long currentItemID;
     [timer invalidate];
     currentItemID = SELECTED_NONE;
     self.slidingViewController.panGesture.delegate = nil;
-    self.navigationController.navigationBar.tintColor = TINT_COLOR;
+    self.navigationController.navigationBar.tintColor = ICON_TINT_COLOR;
 }
 
 - (void)viewDidDisappear:(BOOL)animated {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -364,7 +364,7 @@ long currentItemID;
     shuffleButton.hidden = YES;
     hiresImage.hidden = YES;
     musicPartyMode = 0;
-    [self setIOS7backgroundEffect:UIColor.clearColor barTintColor:TINT_COLOR];
+    [self setIOS7backgroundEffect:UIColor.clearColor];
     [self hidePlaylistProgressbarWithDeselect:YES];
     [self showPlaylistTable];
     [self toggleSongDetails];
@@ -421,7 +421,7 @@ long currentItemID;
                     completion:NULL];
 }
 
-- (void)IOS7effect:(UIColor*)color barTintColor:(UIColor*)barColor effectDuration:(NSTimeInterval)time {
+- (void)IOS7effect:(UIColor*)color effectDuration:(NSTimeInterval)time {
     [UIView animateWithDuration:time
                      animations:^{
                          iOS7bgEffect.backgroundColor = color;
@@ -456,11 +456,11 @@ long currentItemID;
                      completion:NULL];
 }
 
-- (void)setIOS7backgroundEffect:(UIColor*)color barTintColor:(UIColor*)barColor {
+- (void)setIOS7backgroundEffect:(UIColor*)color {
     foundEffectColor = color;
     if (!nowPlayingView.hidden) {
         [self IOS7colorProgressSlider:color];
-        [self IOS7effect:color barTintColor:barColor effectDuration:1.0];
+        [self IOS7effect:color effectDuration:1.0];
     }
 }
 
@@ -585,7 +585,7 @@ long currentItemID;
                                      if ([thumbnailPath isEqualToString:@""]) {
                                          UIImage *buttonImage = [self resizeToolbarThumb:[UIImage imageNamed:@"coverbox_back"]];
                                          [self setButtonImageAndStartDemo:buttonImage];
-                                         [self setIOS7backgroundEffect:UIColor.clearColor barTintColor:TINT_COLOR];
+                                         [self setIOS7backgroundEffect:UIColor.clearColor];
                                          if (enableJewel) {
                                              thumbnailView.image = [UIImage imageNamed:@"coverbox_back"];
                                          }
@@ -607,7 +607,7 @@ long currentItemID;
                                                  }
                                                  [self setButtonImageAndStartDemo:buttonImage];
                                                  UIColor *effectColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
-                                                 [self setIOS7backgroundEffect:effectColor barTintColor:effectColor];
+                                                 [self setIOS7backgroundEffect:effectColor];
                                              }
                                              else {
                                                  __weak NowPlaying *sf = self;
@@ -621,7 +621,7 @@ long currentItemID;
                                                                                   UIImage *buttonImage = [sf resizeToolbarThumb:[sf imageWithBorderFromImage:image]];
                                                                                   [sf setButtonImageAndStartDemo:buttonImage];
                                                                                   newColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
-                                                                                  [sf setIOS7backgroundEffect:newColor barTintColor:newColor];
+                                                                                  [sf setIOS7backgroundEffect:newColor];
                                                                               }
                                                                           }];
                                                  }
@@ -635,7 +635,7 @@ long currentItemID;
                                                               UIImage *buttonImage = [sf resizeToolbarThumb:jV.image];
                                                               [sf setButtonImageAndStartDemo:buttonImage];
                                                               newColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
-                                                              [sf setIOS7backgroundEffect:newColor barTintColor:newColor];
+                                                              [sf setIOS7backgroundEffect:newColor];
                                                           }
                                                       }];
                                                  }
@@ -1368,7 +1368,6 @@ long currentItemID;
 
 - (void)animViews {
     UIColor *effectColor;
-    UIColor *barColor;
     __block CGRect playlistToolBarOriginY = playlistActionView.frame;
     NSTimeInterval iOS7effectDuration = 1.0;
     if (!nowPlayingView.hidden) {
@@ -1379,9 +1378,8 @@ long currentItemID;
         self.navigationItem.titleView.hidden = YES;
         animationOptionTransition = UIViewAnimationOptionTransitionFlipFromRight;
         effectColor = UIColor.clearColor;
-        barColor = TINT_COLOR;
         playlistToolBarOriginY.origin.y = playlistTableView.frame.size.height - playlistTableView.scrollIndicatorInsets.bottom;
-        [self IOS7effect:effectColor barTintColor:barColor effectDuration:0.2];
+        [self IOS7effect:effectColor effectDuration:0.2];
     }
     else {
         transitionView = playlistView;
@@ -1391,11 +1389,9 @@ long currentItemID;
         animationOptionTransition = UIViewAnimationOptionTransitionFlipFromLeft;
         if (foundEffectColor == nil) {
             effectColor = UIColor.clearColor;
-            barColor = TINT_COLOR;
         }
         else {
             effectColor = foundEffectColor;
-            barColor = foundEffectColor;
         }
         playlistToolBarOriginY.origin.y = playlistTableView.frame.size.height;
     }
@@ -1420,7 +1416,7 @@ long currentItemID;
                                           }
                                           completion:^(BOOL finished) {
                                               if (iOS7effectDuration) {
-                                                  [self IOS7effect:effectColor barTintColor:barColor effectDuration:iOS7effectDuration];
+                                                  [self IOS7effect:effectColor effectDuration:iOS7effectDuration];
                                               }
                                           }];
                      }];

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1392,7 +1392,7 @@ NSInteger buttonAction;
     }
 
     self.edgesForExtendedLayout = 0;
-    self.view.tintColor = TINT_COLOR;
+    self.view.tintColor = APP_TINT_COLOR;
     
     quickHelpImageView.image = [UIImage imageNamed:@"remote_quick_help"];
     [self loadRemoteMode];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -286,7 +286,7 @@
             CustomNavigationController *navController = [[CustomNavigationController alloc] initWithRootViewController:detailViewController];
             UINavigationBar *newBar = navController.navigationBar;
             newBar.barStyle = UIBarStyleBlack;
-            newBar.tintColor = TINT_COLOR;
+            newBar.tintColor = ICON_TINT_COLOR;
             navController.modalPresentationStyle = UIModalPresentationFullScreen;
             [self presentViewController:navController animated:YES completion:NULL];
         }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1758,7 +1758,7 @@ double round(double d) {
             }
         }
         
-        [self setIOS7barTintColor:TINT_COLOR];
+        [self setIOS7barTintColor:ICON_TINT_COLOR];
         viewTitle.textAlignment = NSTextAlignmentCenter;
         bottomShadow.hidden = YES;
     }
@@ -1774,7 +1774,7 @@ double round(double d) {
         [self setIOS7barTintColor:foundTintColor];
     }
     else {
-        [self setIOS7barTintColor:TINT_COLOR];
+        [self setIOS7barTintColor:ICON_TINT_COLOR];
     }
     CGFloat alphaValue = 0.2;
     if (closeButton.alpha == 1) {
@@ -1803,7 +1803,7 @@ double round(double d) {
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     [[NSNotificationCenter defaultCenter] removeObserver: self];
-    [self setIOS7barTintColor:TINT_COLOR];
+    [self setIOS7barTintColor:ICON_TINT_COLOR];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
@@ -1853,7 +1853,7 @@ double round(double d) {
     enableKenBurns = [userDefaults boolForKey:@"ken_preference"];;
     self.kenView = nil;
     logoBackgroundMode = [Utilities getLogoBackgroundMode];
-    foundTintColor = TINT_COLOR;
+    foundTintColor = ICON_TINT_COLOR;
     [self configureView];
     
     xbmcDateFormatter = [NSDateFormatter new];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
As brought up in [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3121198#pid3121198) the navigation bar items have a different gray tone. This PR aligns this to use` UIColor.lightGrayColor` for navigation bar items and toolbar buttons. In addition, the PR removes unused parameters from colorization helper methods inside the `NowPlaying` controller.

Screenshots: https://abload.de/img/bildschirmfoto2022-12gucrv.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Align color of navigation bar items