### PR TITLE
Bugfix: Support scrolling song details on iPad

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1586,18 +1586,24 @@ long currentItemID;
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
     UITouch *touch = [touches anyObject];
-    CGPoint locationPoint = [touch locationInView:songDetailsView];
-    CGPoint viewPoint1 = [shuffleButton convertPoint:locationPoint fromView:songDetailsView];
-    CGPoint viewPoint2 = [repeatButton convertPoint:locationPoint fromView:songDetailsView];
-    CGPoint viewPoint3 = [itemLogoImage convertPoint:locationPoint fromView:songDetailsView];
-    CGPoint viewPoint4 = [closeButton convertPoint:locationPoint fromView:songDetailsView];
     if (songDetailsView.alpha == 0) {
-        // songDetailsView is not shown, bring it up
-        [self toggleSongDetails];
+        // songDetailsView is not shown
+        CGPoint locationPoint = [touch locationInView:nowPlayingView];
+        CGPoint viewPoint = [jewelView convertPoint:locationPoint fromView:nowPlayingView];
+        BOOL iPadStackActive = AppDelegate.instance.windowController.stackScrollViewController.viewControllersStack.count > 0;
+        if ([jewelView pointInside:viewPoint withEvent:event] && !iPadStackActive) {
+            // We have no iPad stack shown amd jewelView was touched, bring up songDetailsView
+            [self toggleSongDetails];
+        }
     }
     else {
         // songDetailsView is shown, process touches
-        if ([shuffleButton pointInside:viewPoint1 withEvent:event]&& !shuffleButton.hidden) {
+        CGPoint locationPoint = [touch locationInView:songDetailsView];
+        CGPoint viewPoint1 = [shuffleButton convertPoint:locationPoint fromView:songDetailsView];
+        CGPoint viewPoint2 = [repeatButton convertPoint:locationPoint fromView:songDetailsView];
+        CGPoint viewPoint3 = [itemLogoImage convertPoint:locationPoint fromView:songDetailsView];
+        CGPoint viewPoint4 = [closeButton convertPoint:locationPoint fromView:songDetailsView];
+        if ([shuffleButton pointInside:viewPoint1 withEvent:event] && !shuffleButton.hidden) {
             [self changeShuffle:nil];
         }
         else if ([repeatButton pointInside:viewPoint2 withEvent:event] && !repeatButton.hidden) {

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -274,7 +274,7 @@
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                             <subviews>
                                                 <view alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="220" userLabel="View scrubbing message">
-                                                    <rect key="frame" x="20" y="-5" width="280" height="20"/>
+                                                    <rect key="frame" x="20" y="2" width="280" height="20"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                     <subviews>
                                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Scrubbing Message" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="221">

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -464,6 +464,8 @@
     
     menuViewController.tableView.separatorInset = UIEdgeInsetsZero;
     
+    [self.view insertSubview:self.nowPlayingController.songDetailsView aboveSubview:rootView];
+    
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     BOOL clearCache = [userDefaults boolForKey:@"clearcache_preference"];
     if (clearCache) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3121330#pid3121330).

This PR provides following changes:
- Keep `songDetailsView` on top of iiPad's `rootView` to support scrolling of details
- Do not allow to bring up `songDetailsView` while iPad stack is shown
- Move scrubbing message below song details view

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Support scrolling song details on iPad