### PR TITLE
Rework volume button handling

### DIFF
--- a/XBMC Remote/VolumeSliderView.h
+++ b/XBMC Remote/VolumeSliderView.h
@@ -17,6 +17,7 @@
     IBOutlet UIButton *plusButton;
     IBOutlet UIButton *minusButton;
     BOOL isMuted;
+    BOOL isChangingVolume;
     UIColor *muteIconColor;
 }
 

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -196,10 +196,7 @@
 }
 
 - (void)stopTimer {
-    if (self.timer != nil) {
-        [self.timer invalidate];
-        self.timer = nil;
-    }
+    [self.timer invalidate];
 }
 
 - (void)volumeInfo {
@@ -276,10 +273,7 @@
 
 - (IBAction)stopVolume:(id)timer {
     // Volume change ended (slider or buttons untouched)
-    if (self.holdVolumeTimer != nil) {
-        [self.holdVolumeTimer invalidate];
-        self.holdVolumeTimer = nil;
-    }
+    [self.holdVolumeTimer invalidate];
     [self startTimer];
     isChangingVolume = NO;
 }

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -16,6 +16,12 @@
 #define VOLUMELABEL_PADDING 5 /* space left/right from volume label */
 #define VOLUMESLIDER_HEIGHT 44
 #define SERVER_TIMEOUT 3.0
+#define VOLUME_HOLD_TIMEOUT 0.2
+#define VOLUME_REPEAT_TIMEOUT 0.05
+#define VOLUME_INFO_TIMEOUT 1.0
+#define VOLUME_BUTTON_UP 1
+#define VOLUME_BUTTON_DOWN 2
+#define VOLUME_SLIDER 10
 
 @implementation VolumeSliderView
 
@@ -32,10 +38,9 @@
         [volumeSlider setThumbImage:img forState:UIControlStateNormal];
         [volumeSlider setThumbImage:img forState:UIControlStateHighlighted];
         [self volumeInfo];
-        volumeSlider.tag = 10;
-        [volumeSlider addTarget:self action:@selector(changeServerVolume:) forControlEvents:UIControlEventTouchUpInside];
-        [volumeSlider addTarget:self action:@selector(changeServerVolume:) forControlEvents:UIControlEventTouchUpOutside];
-        [volumeSlider addTarget:self action:@selector(stopTimer) forControlEvents:UIControlEventTouchDown];
+        [volumeSlider addTarget:self action:@selector(changeVolume:) forControlEvents:UIControlEventValueChanged];
+        [volumeSlider addTarget:self action:@selector(stopVolume:) forControlEvents:UIControlEventTouchUpInside];
+        [volumeSlider addTarget:self action:@selector(stopVolume:) forControlEvents:UIControlEventTouchUpOutside];
         CGRect frame_tmp;
         UIColor *volumeIconColor = nil;
         UIImage *muteBackgroundImage = nil;
@@ -158,7 +163,7 @@
 }
 
 - (void)handleApplicationOnVolumeChanged:(NSNotification*)sender {
-    if (holdVolumeTimer == nil) {
+    if (!holdVolumeTimer.valid) {
         NSDictionary *theData = sender.userInfo;
         AppDelegate.instance.serverVolume = [theData[@"params"][@"data"][@"volume"] intValue];
         [self handleServerStatusChanged:nil];
@@ -176,17 +181,18 @@
 - (void)changeServerVolume:(id)sender {
     [[Utilities getJsonRPC]
      callMethod:@"Application.SetVolume" 
-     withParameters:[NSDictionary dictionaryWithObjectsAndKeys: @(volumeSlider.value), @"volume", nil]];
-    if ([sender tag] == 10) {
-        [self startTimer];
-    }
+     withParameters:@{@"volume": @(volumeSlider.value)}];
 }
 
 - (void)startTimer {
     volumeLabel.text = [NSString stringWithFormat:@"%d", AppDelegate.instance.serverVolume];
     volumeSlider.value = AppDelegate.instance.serverVolume;
     [self stopTimer];
-    self.timer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(volumeInfo) userInfo:nil repeats:YES];
+    self.timer = [NSTimer scheduledTimerWithTimeInterval:VOLUME_INFO_TIMEOUT
+                                                  target:self
+                                                selector:@selector(volumeInfo)
+                                                userInfo:nil
+                                                 repeats:YES];
 }
 
 - (void)stopTimer {
@@ -256,39 +262,57 @@
     }];
 }
 
-NSInteger action;
-
 - (IBAction)holdVolume:(id)sender {
+    // Volume up/down button is touched
     [self stopTimer];
-    action = [sender tag];
-    [self changeVolume];
-    self.holdVolumeTimer = [NSTimer scheduledTimerWithTimeInterval:0.2 target:self selector:@selector(changeVolume) userInfo:nil repeats:YES];
+    [self changeVolume:sender];
+    self.holdVolumeTimer = [NSTimer scheduledTimerWithTimeInterval:VOLUME_HOLD_TIMEOUT
+                                                            target:self
+                                                          selector:@selector(longpressVolume:)
+                                                          userInfo:sender
+                                                           repeats:NO];
 }
 
-- (IBAction)stopVolume:(id)sender {
+- (IBAction)stopVolume:(id)timer {
+    // Volume change ended (slider or buttons untouched)
     if (self.holdVolumeTimer != nil) {
         [self.holdVolumeTimer invalidate];
         self.holdVolumeTimer = nil;
     }
-    action = 0;
     [self startTimer];
 }
+- (void)longpressVolume:(id)timer {
+    // Volume up/down was lomgpressed
+    id sender = [timer userInfo];
+    [self.holdVolumeTimer invalidate];
+    self.holdVolumeTimer = [NSTimer scheduledTimerWithTimeInterval:VOLUME_REPEAT_TIMEOUT
+                                                            target:self
+                                                          selector:@selector(autoChangeVolume:)
+                                                          userInfo:sender
+                                                           repeats:YES];
+}
 
-- (void)changeVolume {
-    if (self.holdVolumeTimer.timeInterval == 0.5) {
-        [self.holdVolumeTimer invalidate];
-        self.holdVolumeTimer = [NSTimer scheduledTimerWithTimeInterval:0.05 target:self selector:@selector(changeVolume) userInfo:nil repeats:YES];
-    }
-    if (action == 1 ) { // Volume Raise
-       volumeSlider.value = (int)volumeSlider.value + 2;
-        
-    }
-    else if (action == 2) { // Volume Lower
-        volumeSlider.value = (int)volumeSlider.value - 2;
+- (void)autoChangeVolume:(id)timer {
+    // Volume up/down is automatically changed until holdVolumeTimer is stopped when button is untouched again
+    id sender = [timer userInfo];
+    [self changeVolume:sender];
+}
 
-    }
-    else { // Volume in 2-step resolution
-        volumeSlider.value = ((int)volumeSlider.value / 2) * 2;
+- (void)changeVolume:(id)sender {
+    // Process the volume change
+    NSInteger action = [sender tag];
+    switch (action) {
+        case VOLUME_BUTTON_UP: // Volume Increase
+            volumeSlider.value += 2;
+            break;
+        case VOLUME_BUTTON_DOWN: // Volume Decrease
+            volumeSlider.value -= 2;
+            break;
+        case VOLUME_SLIDER: // Volume slider in 2-step resolution
+            volumeSlider.value = ((int)volumeSlider.value / 2) * 2;
+            break;
+        default:
+            break;
     }
     AppDelegate.instance.serverVolume = volumeSlider.value;
     volumeLabel.text = [NSString stringWithFormat:@"%.0f", volumeSlider.value];

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -163,7 +163,7 @@
 }
 
 - (void)handleApplicationOnVolumeChanged:(NSNotification*)sender {
-    if (!holdVolumeTimer.valid) {
+    if (!isChangingVolume) {
         NSDictionary *theData = sender.userInfo;
         AppDelegate.instance.serverVolume = [theData[@"params"][@"data"][@"volume"] intValue];
         [self handleServerStatusChanged:nil];
@@ -264,6 +264,7 @@
 
 - (IBAction)holdVolume:(id)sender {
     // Volume up/down button is touched
+    isChangingVolume = YES;
     [self stopTimer];
     [self changeVolume:sender];
     self.holdVolumeTimer = [NSTimer scheduledTimerWithTimeInterval:VOLUME_HOLD_TIMEOUT
@@ -280,6 +281,7 @@
         self.holdVolumeTimer = nil;
     }
     [self startTimer];
+    isChangingVolume = NO;
 }
 - (void)longpressVolume:(id)timer {
     // Volume up/down was lomgpressed
@@ -300,6 +302,7 @@
 
 - (void)changeVolume:(id)sender {
     // Process the volume change
+    isChangingVolume = YES;
     NSInteger action = [sender tag];
     switch (action) {
         case VOLUME_BUTTON_UP: // Volume Increase

--- a/XBMC Remote/VolumeSliderView.xib
+++ b/XBMC Remote/VolumeSliderView.xib
@@ -26,16 +26,11 @@
                     <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <size key="shadowOffset" width="1" height="1"/>
                 </label>
-                <slider opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="4">
+                <slider opaque="NO" tag="10" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="4">
                     <rect key="frame" x="97" y="10" width="170" height="29"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <color key="minimumTrackTintColor" red="0.34045934677124023" green="0.62004148960113525" blue="0.72810506820678711" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <color key="maximumTrackTintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <connections>
-                        <action selector="holdVolume:" destination="3" eventType="touchDown" id="fJ1-hh-HjW"/>
-                        <action selector="stopVolume:" destination="3" eventType="touchUpOutside" id="Ww8-5E-s1P"/>
-                        <action selector="stopVolume:" destination="3" eventType="touchUpInside" id="dB6-Nz-aJM"/>
-                    </connections>
                 </slider>
                 <button opaque="NO" tag="2" contentMode="scaleAspectFit" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="15">
                     <rect key="frame" x="66" y="6" width="24" height="36"/>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Rework volume button handling
- Replace magic numbers
- Handle slider via `UIControlEventValueChanged` instead of misusing button press methods
- Dedicated long press handling and timers for volume button press
- Propagate `sender tag` instead of using global variable `action`
- Use `switch-case` instead of `if-else`

Requires to have the volume lock fix (https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/819) merged first. Otherwise the smoother slider handling, which causes more JSON command per second, will cause lock ups as well.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Faster volume change when holding volume buttons
Improvement: Smoother volume change via slider