### PR TITLE
Improvement: End editing playlist when clearing it

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -929,6 +929,7 @@ long currentItemID;
 - (void)clearPlaylist:(int)playlistID {
     [[Utilities getJsonRPC] callMethod:@"Playlist.Clear" withParameters:@{@"playlistid": @(playlistID)} onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError* error) {
         if (error == nil && methodError == nil) {
+            [playlistTableView setEditing:NO animated:NO];
             [self createPlaylist:NO animTableView:NO];
         }
     }];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3122361#pid3122361).

The playlist editing shall be ended after clearing the playlist (done via shaking when "Shake to clear playlist" is enabled).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: End editing playlist when clearing it