### PR TITLE
Bugfix: Keep keyboard hidden after dismissing via scroll

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2135,6 +2135,7 @@
 
 - (void)scrollViewDidScroll:(UIScrollView*)theScrollView {
     // Hide keyboard on drag
+    showkeyboard = NO;
     [self.searchController.searchBar resignFirstResponder];
     // Stop an empty search on drag
     NSString *searchString = self.searchController.searchBar.text;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issues reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3122541#pid3122541).

If a search keyboard was dismissed by scrolling, it should keep hidden after selecting an item and coming back to the origin view. This is ensured via setting `showkeyboard = NO;` when dismissing it on dragging the list.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Keep keyboard hidden after dismissing via scroll