### PR TITLE
Bugfix: Fix empty cover in NowPlaying

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -55,6 +55,7 @@
 #define TAG_SEEK_FORWARD 7
 #define TAG_ID_EDIT 88
 #define SELECTED_NONE -1
+#define ID_INVALID -2
 #define FLIP_DEMO_DELAY 0.5
 #define FADE_OUT_TIME 0.2
 #define FADE_IN_TIME 0.5
@@ -276,7 +277,6 @@ long lastSelected = SELECTED_NONE;
 int currentPlayerID = PLAYERID_UNKNOWN;
 int storePosSeconds;
 long storedItemID;
-long currentItemID;
 
 - (void)setCoverSize:(NSString*)type {
     NSString *jewelImg = @"";
@@ -522,12 +522,7 @@ long currentItemID;
                              if (methodResult[@"item"] != [NSNull null]) {
                                  nowPlayingInfo = methodResult[@"item"];
                              }
-                             if (nowPlayingInfo[@"id"] == nil) {
-                                 currentItemID = -2;
-                             }
-                             else {
-                                 currentItemID = [nowPlayingInfo[@"id"] longValue];
-                             }
+                             long currentItemID = nowPlayingInfo[@"id"] ? [nowPlayingInfo[@"id"] longValue] : ID_INVALID;
                              if ((nowPlayingInfo.count && currentItemID != storedItemID) || nowPlayingInfo[@"id"] == nil || ([nowPlayingInfo[@"type"] isEqualToString:@"channel"] && ![nowPlayingInfo[@"title"] isEqualToString:storeLiveTVTitle])) {
                                  storedItemID = currentItemID;
                                  [self performSelector:@selector(loadCodecView) withObject:nil afterDelay:.5];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2477,6 +2477,7 @@ long currentItemID;
 }
      
 - (void)startNowPlayingUpdates {
+    storedItemID = SELECTED_NONE;
     [self playbackInfo];
     updateProgressBar = YES;
     [timer invalidate];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2487,7 +2487,7 @@ long currentItemID;
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     [timer invalidate];
-    currentItemID = SELECTED_NONE;
+    storedItemID = SELECTED_NONE;
     self.slidingViewController.panGesture.delegate = nil;
     self.navigationController.navigationBar.tintColor = TINT_COLOR;
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2447,13 +2447,7 @@ long currentItemID;
     if (fromItself) {
         [self handleXBMCPlaylistHasChanged:nil];
     }
-    [self playbackInfo];
-    updateProgressBar = YES;
-    if (timer != nil) {
-        [timer invalidate];
-        timer = nil;
-    }
-    timer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(updateInfo) userInfo:nil repeats:YES];
+    [self startNowPlayingUpdates];
     fromItself = NO;
     if (IS_IPHONE) {
         self.slidingViewController.underRightViewController = nil;
@@ -2480,6 +2474,13 @@ long currentItemID;
 
 - (void)startFlipDemo {
     [self flipAnimButton:playlistButton demo:YES];
+}
+     
+- (void)startNowPlayingUpdates {
+    [self playbackInfo];
+    updateProgressBar = YES;
+    [timer invalidate];
+    timer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(updateInfo) userInfo:nil repeats:YES];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
@@ -2616,13 +2617,7 @@ long currentItemID;
 
 - (void)handleEnterForeground:(NSNotification*)sender {
     [self handleXBMCPlaylistHasChanged:nil];
-    [self playbackInfo];
-    updateProgressBar = YES;
-    if (timer != nil) {
-        [timer invalidate];
-        timer = nil;
-    }
-    timer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(updateInfo) userInfo:nil repeats:YES];
+    [self startNowPlayingUpdates];
 }
 
 - (void)handleXBMCPlaylistHasChanged:(NSNotification*)sender {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3122541#pid3122541).

The issue was generally caused by a race condition when using global variables. In future I would like to get rid of the global variables, but as a quick fix towards the next version is needed, this PR solves the underlying problem.

Background:
The global variable `storedItemID` holds the playlist index of the playing item. In `getActivePlayers` the screen updates are done, triggered by a timer. To reduce load several activities inside `getActivePlayers` are only taking place, if the current playing item `currentItemID` is not the same as `storedItemID`. The error happens, if the new instance of NowPlaying already initialized `storedItemID`, but the old instance still runs the timer for the screen updates and overrides `storedItemID` again. On top, the clean-up of `storedItemID` in the old instance's `ViewDidDisappear` did not happen as the wrong variable was reset. In such case the new instance will not load the thumb properly.

Hotfix:
1. Reinitialize `storedItemID` right before triggering the first screen update for an instance. 
2. Ensure the right variable `storedItemID` is reset in `viewDidDisapper`.

Additional changes:
In Addition to the hot fixes I am removing duplicate code and already make `currentItemID` a local variable.

The global variables need to be removed in a next step.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix empty cover in NowPlaying