### PR TITLE
Bugfix: Update the mini thumb when stopping playback in playlist view

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -315,14 +315,8 @@ long currentItemID;
 }
 
 - (void)nothingIsPlaying {
-    if (startFlipDemo) {
-        UIImage *image = [UIImage imageNamed:@"st_kodi_window"];
-        [playlistButton setImage:image forState:UIControlStateNormal];
-        [playlistButton setImage:image forState:UIControlStateHighlighted];
-        [playlistButton setImage:image forState:UIControlStateSelected];
-        [NSTimer scheduledTimerWithTimeInterval:FLIP_DEMO_DELAY target:self selector:@selector(startFlipDemo) userInfo:nil repeats:NO];
-        startFlipDemo = NO;
-    }
+    UIImage *image = [UIImage imageNamed:@"st_kodi_window"];
+    [self setButtonImageAndStartDemo:image];
     if (nothingIsPlaying) {
         return;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3122896#pid3122896).

When nothing is playing the method `nothingIsPlaying` handles the screen updates. In this method the mini thumb was not updated to use the default thumb when stopping the playback. To ensure this update happens the condition check needs to be corrected. Luckily, we already have such condition inside `setButtonImageAndStartDemo`. So we just just use this to avoid code duplication.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Update the mini thumb when stopping playback in playlist view