### PR TITLE
Bugfix: Current time frozen after editing a single playlist item

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2123,6 +2123,10 @@ long currentItemID;
     return UITableViewCellEditingStyleDelete;
 }
 
+- (void)tableView:(UITableView*)tableView didEndEditingRowAtIndexPath:(NSIndexPath*)indexPath {
+    [self createPlaylist:NO animTableView:YES];
+}
+
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer*)gestureRecognizer {
     if (playlistTableView.editing) {
         return NO;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves and issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3122896#pid3122896).

Reset the playlist after editing a row. Ensures the list view is properly initialized again after editing a single row. This resolves a problem where the current playback time was not properly updated after entering edit mode for a playlist item.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Current time frozen after editing a single playlist item