### PR TITLE
Fix and improve unfolding TV Show season

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -872,7 +872,7 @@
         [dataList endUpdates];
     }
     // Refresh leyout
-    [self configureLibraryView];
+    dataList.tableHeaderView = self.searchController.searchBar;
     [dataList setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
     // Scroll to first item in section (first episode in season)
     NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:section];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -846,6 +846,8 @@
 }
 
 - (void)toggleOpen:(UITapGestureRecognizer*)sender {
+    [self.searchController.searchBar resignFirstResponder];
+    [self.searchController setActive:NO];
     NSInteger section = [sender.view tag];
     // Toggle the section's state (open/close)
     [self.sectionArrayOpen replaceObjectAtIndex:section withObject:@(![self.sectionArrayOpen[section] boolValue])];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -872,8 +872,9 @@
     // Refresh leyout
     [self configureLibraryView];
     [dataList setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
-    // Scroll to section
-    CGRect sectionRect = [dataList rectForSection:section];
+    // Scroll to first item in section (first episode in season)
+    NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:section];
+    CGRect sectionRect = [dataList rectForRowAtIndexPath:indexPath];
     [dataList scrollRectToVisible:sectionRect animated:YES];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Handles issues reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3123435#pid3123435).

With this PR only the first episode of an unfolded season is moved into the visible area. This feels smoother than scrolling the whole season into view.
Also change the interaction of search and unfolding a season. Explicitly dismiss keyboard and end search. Also only restore the `dataList.tableHeaderView` after updating `dataList`, instead of reinitializing the whole library view. This resolves some glitches (e.g. unfolding a season while active search does not end search properly).

Test cases:
- Enter TV Show > enter search > scroll > shall dismiss search and keyboard -> OK
- Enter TV Show > enter search > unfold season > shall dismiss search and keyboard -> OK
- Enter TV Show > unfold season > enter search > shall bring up keyboard -> OK
- Enter TV Show > unfold season > enter search > scroll > shall dismiss search and keyboard -> OK
- Enter TV Show > unfold season > enter search > unfold season > shall dismiss search and keyboard -> OK

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Scroll first episode of unfolded season into visible area
Bugfix: Proper interaction of unfolding season and search