### PR TITLE
Bugfix: Show Hi-Res logo again

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -834,7 +834,8 @@ long storedItemID;
              hiresImage.hidden = YES;
              if (playerID == PLAYERID_MUSIC && currentPlayerID == playerID) {
                  NSString *codec = [Utilities getStringFromItem:methodResult[@"MusicPlayer.Codec"]];
-                 [self setSongDetails:songCodec image:songCodecImage item:[self processSongCodecName:codec]];
+                 codec = [self processSongCodecName:codec];
+                 [self setSongDetails:songCodec image:songCodecImage item:codec];
                  [self setSongDetails:songBitRate image:songBitRateImage item:methodResult[@"MusicPlayer.Channels"]];
                  
                  BOOL isLossless = [self isLosslessFormat:codec];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes the Hi-Res logo not being shown (regression of app version 1.10). Simply process the codec name right after reading it. This ensures code names like "pcm_..." are recognized as lossless codecs.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show Hi-Res logo again