### PR TITLE
Improvement: Do not show jewel case when nothing is playing

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -327,10 +327,8 @@ long storedItemID;
     ProgressSlider.hidden = YES;
     currentTime.text = @"";
     thumbnailView.image = nil;
+    jewelView.image = nil;
     lastThumbnail = @"";
-    if (![self enableJewelCases]) {
-        jewelView.image = nil;
-    }
     duration.text = @"";
     albumName.text = @"";
     songName.text = @"";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The behaviour for "nothing is playing" is inconsistent when the feature option "show jewel case" is enabled: 
1) no jewel case shown when entering the NowPlaying screen while nothing is played
2) jewel case of the last played item is shown when stopping playback or playlist ends. 

With this PR the jewel case is _always_ hidden when nothing is playing.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Do not show jewel case when nothing is playing