### PR TITLE
Fixes for custom buttons

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -80,6 +80,7 @@
 }
 
 - (UITableViewCell*)tableView:(UITableView*)tableView cellForRowAtIndexPath:(NSIndexPath*)indexPath {
+    /*
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"rightMenuCellIdentifier"];
     if (cell == nil) {
         NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"rightCellView" owner:self options:nil];
@@ -90,6 +91,17 @@
         backView.backgroundColor = [Utilities getGrayColor:22 alpha:1];
         cell.selectedBackgroundView = backView;
     }
+    */
+    // WORKAROUND BEGIN
+    // Load nib each time as otherwise the layout of the cells is not properly handled after sleep / resume.
+    NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"rightCellView" owner:self options:nil];
+    UITableViewCell *cell = nib[0];
+    
+    // Set background view
+    UIView *backView = [[UIView alloc] initWithFrame:cell.frame];
+    backView.backgroundColor = [Utilities getGrayColor:22 alpha:1];
+    cell.selectedBackgroundView = backView;
+    // WROKAROUND END
     
     // Reset to default for each cell to allow dequeuing
     UIImageView *icon = (UIImageView*)[cell viewWithTag:1];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -117,6 +117,7 @@
     if (@available(iOS 13.0, *)) {
         cell.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
     }
+    cell.tintColor = UIColor.lightGrayColor;
     NSString *iconName = @"blank";
     
     // Tailor cell layout for content type


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
As mentioned in https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/836 there is still a problem with the layout after sleep / resume cell in `RightMenuViewController`. The former code also was not using dequeueing but loaded the cell fresh each time. To unblock the release 1.12 I propose a workaround which again loads the custom button rows each time when entering `cellForRowAtIndexPath`.

This needs another rework in future.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Improve readability of button rename icon in light mode
Bugfix: Fix custom button layout problems after sleep / resume