### PR TITLE
Bugfix: Fix layout of embedded remote after sleep/resume

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -161,17 +161,13 @@
         title.text = AppDelegate.instance.serverName;
     }
     else if ([tableData[indexPath.row][@"label"] isEqualToString:@"VolumeControl"]) {
-        if (volumeSliderView == nil) {
-            volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectZero leftAnchor:ANCHOR_RIGHT_PEEK isSliderType:YES];
-            [volumeSliderView startTimer];
-        }
+        volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectZero leftAnchor:ANCHOR_RIGHT_PEEK isSliderType:YES];
+        [volumeSliderView startTimer];
         [cell.contentView addSubview:volumeSliderView];
     }
     else if ([tableData[indexPath.row][@"label"] isEqualToString:@"RemoteControl"]) {
-        if (remoteControllerView == nil) {
-            remoteControllerView = [[RemoteController alloc] initWithNibName:@"RemoteController" withEmbedded:YES bundle:nil];
-            remoteControllerView.panFallbackImageView.frame = cell.frame;
-        }
+        remoteControllerView = [[RemoteController alloc] initWithNibName:@"RemoteController" withEmbedded:YES bundle:nil];
+        remoteControllerView.panFallbackImageView.frame = cell.frame;
         [cell.contentView addSubview:remoteControllerView.view];
     }
     else {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR ensures the layout of iPhone's embedded remote is correct after sleep/resume. If not done, the embedded remote's autoresizing moves the toolbar and the remote (when NowPlaying was entered with the remote being placed on bottom) out of the visible area. This potential issue was existing since long, as it happens when after dequeuing not exactly the same cell is being used as the embedded remote initialized with. It now became visible as we disabled dequeueing temporarily for this Controller.

Really needs an overhaul.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix layout of embedded remote after sleep/resume