### PR TITLE
Maintenance: Improve code readability by introducing version check helper methods

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4679,7 +4679,7 @@ NSIndexPath *selected;
     if (filterModeType == ViewModeAlbumArtists ||
         filterModeType == ViewModeSongArtists ||
         filterModeType == ViewModeDefaultArtists) {
-        if (AppDelegate.instance.APImajorVersion >= 4) {
+        if ([VersionCheck hasAlbumArtistOnlySupport]) {
             switch (filterModeType) {
                 case ViewModeAlbumArtists:
                     mutableParameters[@"albumartistsonly"] = @YES;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4709,8 +4709,7 @@ NSIndexPath *selected;
     BOOL useCommonPvrRecordingsTimers = NO;
     if ([methodToCall containsString:@"PVR."]) {
         // PVR methods do not support "sort" before JSON API 12.1
-        if ((AppDelegate.instance.APImajorVersion < 12) ||
-            ((AppDelegate.instance.APImajorVersion == 12) && (AppDelegate.instance.APIminorVersion < 1))) {
+        if (![VersionCheck hasPvrSortSupport]) {
             // remove "sort" from setup
             [mutableParameters removeObjectForKey:@"sort"];
         }

--- a/XBMC Remote/VersionCheck.h
+++ b/XBMC Remote/VersionCheck.h
@@ -12,5 +12,6 @@
 @interface VersionCheck : NSObject
 
 + (BOOL)hasRecordingIdPlaylistSupport;
++ (BOOL)hasGroupSingleItemSetsSupport;
 
 @end

--- a/XBMC Remote/VersionCheck.h
+++ b/XBMC Remote/VersionCheck.h
@@ -15,5 +15,6 @@
 + (BOOL)hasGroupSingleItemSetsSupport;
 + (BOOL)hasSortTokenReadSupport;
 + (BOOL)hasPvrSortSupport;
++ (BOOL)hasAlbumArtistOnlySupport;
 
 @end

--- a/XBMC Remote/VersionCheck.h
+++ b/XBMC Remote/VersionCheck.h
@@ -14,5 +14,6 @@
 + (BOOL)hasRecordingIdPlaylistSupport;
 + (BOOL)hasGroupSingleItemSetsSupport;
 + (BOOL)hasSortTokenReadSupport;
++ (BOOL)hasPvrSortSupport;
 
 @end

--- a/XBMC Remote/VersionCheck.h
+++ b/XBMC Remote/VersionCheck.h
@@ -13,5 +13,6 @@
 
 + (BOOL)hasRecordingIdPlaylistSupport;
 + (BOOL)hasGroupSingleItemSetsSupport;
++ (BOOL)hasSortTokenReadSupport;
 
 @end

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -30,4 +30,9 @@
             AppDelegate.instance.APImajorVersion >= 10;
 }
 
++ (BOOL)hasPvrSortSupport {
+    // PVR methods support "sort" from JSON API 12.1 on
+    return (AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 1) || AppDelegate.instance.APImajorVersion > 12;
+}
+
 @end

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -35,4 +35,9 @@
     return (AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 1) || AppDelegate.instance.APImajorVersion > 12;
 }
 
++ (BOOL)hasAlbumArtistOnlySupport {
+    // "albumartistonly" parameter is supported from API 4.0.0 on
+    return AppDelegate.instance.APImajorVersion >= 4;
+}
+
 @end

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -17,4 +17,11 @@
     return (AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 7) || AppDelegate.instance.APImajorVersion > 12;
 }
 
++ (BOOL)hasGroupSingleItemSetsSupport {
+    // GroupSingleItemSets is enabled (supported from API 6.32.4 on)
+    return (AppDelegate.instance.APImajorVersion >= 7) ||
+           (AppDelegate.instance.APImajorVersion == 6 && AppDelegate.instance.APIminorVersion >= 33) ||
+           (AppDelegate.instance.APImajorVersion == 6 && AppDelegate.instance.APIminorVersion == 32 && AppDelegate.instance.APIpatchVersion >= 4);
+}
+
 @end

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -24,4 +24,10 @@
            (AppDelegate.instance.APImajorVersion == 6 && AppDelegate.instance.APIminorVersion == 32 && AppDelegate.instance.APIpatchVersion >= 4);
 }
 
++ (BOOL)hasSortTokenReadSupport {
+    // Sort token can be read from API 9.5.0 on
+    return (AppDelegate.instance.APImajorVersion == 9 && AppDelegate.instance.APIminorVersion >= 5) ||
+            AppDelegate.instance.APImajorVersion >= 10;
+}
+
 @end

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -312,9 +312,8 @@ NSOutputStream	*outStream;
 
 - (void)readSorttokens {
     NSArray *defaultTokens = @[@"The ", @"The.", @"The_"];
-    // Sort token can be read from API 9.5.0 on
-    if ((AppDelegate.instance.APImajorVersion >= 10) ||
-        (AppDelegate.instance.APImajorVersion == 9 && AppDelegate.instance.APIminorVersion >= 5)) {
+    // Read sort token from properties
+    if ([VersionCheck hasSortTokenReadSupport]) {
         [[Utilities getJsonRPC]
          callMethod:@"Application.GetProperties"
          withParameters:@{@"properties":@[@"sorttokens"]}

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -9,6 +9,7 @@
 #import "tcpJSONRPC.h"
 #import "AppDelegate.h"
 #import "Utilities.h"
+#import "VersionCheck.h"
 
 #define SERVER_TIMEOUT 3.0
 #define MRMC_TIMEWARP 14.0
@@ -289,10 +290,8 @@ NSOutputStream	*outStream;
 }
 
 - (void)readGroupSingleItemSets {
-    // Check if groupsingleitemsets is enabled (supported from API 6.32.4 on)
-    if ((AppDelegate.instance.APImajorVersion >= 7) ||
-        (AppDelegate.instance.APImajorVersion == 6 && AppDelegate.instance.APIminorVersion >= 33) ||
-        (AppDelegate.instance.APImajorVersion == 6 && AppDelegate.instance.APIminorVersion == 32 && AppDelegate.instance.APIpatchVersion >= 4)) {
+    // Check if GroupSingleItemSets is enabled
+    if ([VersionCheck hasGroupSingleItemSetsSupport]) {
         [[Utilities getJsonRPC]
          callMethod:@"Settings.GetSettingValue"
          withParameters:@{@"setting": @"videolibrary.groupsingleitemsets"}


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
To improve code readability several version checks for major/minor/patch versions of the API are moved to dedicated helper methods of the class `VersionCheck`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Introduce dedicated check methods instead of checking API major/minor/patch version