### PR TITLE
Bugfixes for iPhone main menu's server status

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -97,21 +97,25 @@
         UIView *backgroundView = [[UIView alloc] initWithFrame:cell.frame];
         backgroundView.backgroundColor = [Utilities getGrayColor:22 alpha:1];
         cell.selectedBackgroundView = backgroundView;
+        
+        // Load Kodi background logo
+        UIImage *logo = [UIImage imageNamed:@"xbmc_logo"];
+        UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:PHONE_MENU_INFO_HEIGHT width:self.view.bounds.size.width]];
+        xbmc_logo.alpha = 0.25;
+        xbmc_logo.image = logo;
+        xbmc_logo.highlightedImage = [UIImage imageNamed:@"xbmc_logo_selected"];
+        xbmc_logo.tag = 6;
+        [cell insertSubview:xbmc_logo atIndex:0];
     }
     mainMenu *item = self.mainMenu[indexPath.row];
     NSString *iconName = item.icon;
     UIImageView *icon = (UIImageView*)[cell viewWithTag:1];
     UILabel *title = (UILabel*)[cell viewWithTag:3];
     UIImageView *line = (UIImageView*)[cell viewWithTag:4];
+    UIImageView *xbmc_logo = (UIImageView*)[cell viewWithTag:6];
     if (indexPath.row == 0) {
-        // Load Kodi background logo
-        UIImage *logo = [UIImage imageNamed:@"xbmc_logo"];
-        UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:PHONE_MENU_INFO_HEIGHT width:self.view.bounds.size.width]];
-        xbmc_logo.alpha = 0.25;
-        xbmc_logo.image = logo;
+        // Show kodi logo
         xbmc_logo.hidden = NO;
-        xbmc_logo.highlightedImage = [UIImage imageNamed:@"xbmc_logo_selected"];
-        [cell insertSubview:xbmc_logo atIndex:0];
         
         // Adapt layout for first cell (showing connection status)
         [self setFrameSizes:cell height:PHONE_MENU_INFO_HEIGHT iconsize:CONNECTION_ICON_SIZE];
@@ -125,6 +129,9 @@
         icon.image = [UIImage imageNamed:iconName];
     }
     else {
+        // Hide kodi logo
+        xbmc_logo.hidden = YES;
+        
         // Adapt layout for main menu cells
         [self setFrameSizes:cell height:PHONE_MENU_HEIGHT iconsize:MENU_ICON_SIZE];
         

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -119,7 +119,7 @@
         // Set icon and text content
         title.font = [UIFont fontWithName:@"Roboto-Regular" size:13];
         title.numberOfLines = 2;
-        title.text = LOCALIZED_STR(@"No connection");
+        title.text = [Utilities getConnectionStatusServerName];
         line.hidden = YES;
         iconName = [Utilities getConnectionStatusIconName];
         icon.image = [UIImage imageNamed:iconName];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -101,6 +101,15 @@
     UIView *backView = [[UIView alloc] initWithFrame:cell.frame];
     backView.backgroundColor = [Utilities getGrayColor:22 alpha:1];
     cell.selectedBackgroundView = backView;
+    
+    // Load Kodi background logo
+    UIImage *logo = [UIImage imageNamed:@"xbmc_logo"];
+    UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:PHONE_MENU_INFO_HEIGHT width:self.view.bounds.size.width]];
+    xbmc_logo.alpha = 0.25;
+    xbmc_logo.image = logo;
+    xbmc_logo.highlightedImage = [UIImage imageNamed:@"xbmc_logo_selected"];
+    xbmc_logo.hidden = YES;
+    [cell insertSubview:xbmc_logo atIndex:0];
     // WROKAROUND END
     
     // Reset to default for each cell to allow dequeuing
@@ -134,13 +143,8 @@
     
     // Tailor cell layout for content type
     if ([tableData[indexPath.row][@"label"] isEqualToString:@"ServerInfo"]) {
-        // Load Kodi background logo
-        UIImage *logo = [UIImage imageNamed:@"xbmc_logo"];
-        UIImageView *xbmc_logo = [[UIImageView alloc] initWithFrame:[Utilities createXBMCInfoframe:logo height:SERVER_INFO_HEIGHT width:self.view.bounds.size.width]];
-        xbmc_logo.alpha = 0.25;
-        xbmc_logo.image = logo;
+        // Show kodi logo
         xbmc_logo.hidden = NO;
-        [cell.contentView insertSubview:xbmc_logo atIndex:0];
         
         // Enable connection status icon and place it
         status.frame = CGRectMake(STATUS_SPACING,

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -88,6 +88,7 @@ typedef enum {
 + (NSString*)getAppVersionString;
 + (void)checkForReviewRequest;
 + (NSString*)getConnectionStatusIconName;
++ (NSString*)getConnectionStatusServerName;
 + (void)addShadowsToView:(UIView*)view viewFrame:(CGRect)frame;
 + (void)setStyleOfMenuItems:(UITableView*)tableView active:(BOOL)active;
 + (void)enableDefaultController:(id<UITableViewDelegate>)viewController tableView:(UITableView*)tableView menuItems:(NSArray*)menuItems;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -944,6 +944,14 @@
     return iconName;
 }
 
++ (NSString*)getConnectionStatusServerName {
+    NSString *serverName = @"No connection";
+    if (AppDelegate.instance.serverOnLine) {
+        serverName = AppDelegate.instance.serverName;
+    }
+    return serverName;
+}
+
 + (void)addShadowsToView:(UIView*)view viewFrame:(CGRect)frame {
     view.clipsToBounds = NO;
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
After dequeuing iPhone  main menu cells, the server info (top most row) was reinitialized with "No connection". Instead, the current server name must be used.

In addition, only add the Kodi logo at cell creation, and control visibility afterwards. This fixes an issues with multiple instances of Kodi logo added on top of each other when the server status uses a dequeued cell.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show correct server name / layout after moving iPhone server status out of visible area