### PR TITLE
Changes around TCP connection and server status icon

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -378,7 +378,6 @@
 }
 
 - (void)handleWillResignActive:(NSNotification*)sender {
-    [self.tcpJSONRPCconnection stopNetworkCommunication];
 }
 
 - (void)handleDidEnterBackground:(NSNotification*)sender {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -599,7 +599,6 @@
 }
 
 - (void)handleWillResignActive:(NSNotification*)sender {
-    [self.tcpJSONRPCconnection stopNetworkCommunication];
 }
 
 - (void)handleDidEnterBackground:(NSNotification*)sender {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Only stop TCP on `UIApplicationDidEnterBackgroundNotification`. Avoids TCP being switched off on `UIApplicationWillResignActiveNotification` (e.g. when entering the list of active apps). In this case TCP is not enabled again as this is connected to `UIApplicationWillEnterForegroundNotification`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid undesired loss of TCP connect when entering iOS App Switcher or Notification Center