### PR TITLE
Bugfix: Ensure correct server status icons (red/yellow/green)

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -56,10 +56,8 @@
         AppDelegate.instance.obj.serverPort = @"";
         AppDelegate.instance.obj.serverHWAddr = @"";
         [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCServerHasChanged" object: nil];
-        NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
-        if (standardUserDefaults) {
-            [standardUserDefaults setObject: @(-1) forKey:@"lastServer"];
-        }
+        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+        [userDefaults setObject: @(-1) forKey:@"lastServer"];
         [connectingActivityIndicator stopAnimating];
     }
     HostViewController *hostController = [[HostViewController alloc] initWithNibName:@"HostViewController" bundle:nil];
@@ -167,10 +165,8 @@ static inline BOOL IsEmpty(id obj) {
     AppDelegate.instance.obj.serverHWAddr = @"";
     AppDelegate.instance.serverOnLine = NO;
     AppDelegate.instance.obj.tcpPort = 0;
-    NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
-    if (standardUserDefaults) {
-        [standardUserDefaults setObject: @(-1) forKey:@"lastServer"];
-    }
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    [userDefaults setObject: @(-1) forKey:@"lastServer"];
     ((UIImageView*)[cell viewWithTag:1]).image = [UIImage imageNamed:@"connection_off"];
 }
 
@@ -190,10 +186,8 @@ static inline BOOL IsEmpty(id obj) {
             UITableViewCell *cell = [serverListTableView cellForRowAtIndexPath:indexPath];
             cell.accessoryType = UITableViewCellAccessoryCheckmark;
             [self selectServerAtIndexPath:indexPath];
-            NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
-            if (standardUserDefaults) {
-                [standardUserDefaults setObject: @(indexPath.row) forKey:@"lastServer"];
-            }
+            NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+            [userDefaults setObject: @(indexPath.row) forKey:@"lastServer"];
             // Trigger Local Network Privacy Alert (if not already done for the App)
             [AppDelegate.instance triggerLocalNetworkPrivacyAlert];
         }
@@ -223,12 +217,10 @@ static inline BOOL IsEmpty(id obj) {
         [AppDelegate.instance.arrayServerList removeObjectAtIndex:indexPath.row];
         [AppDelegate.instance saveServerList];
         if (storeServerSelection) {
-            NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
+            NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
             if (indexPath.row < storeServerSelection.row) {
                 storeServerSelection = [NSIndexPath indexPathForRow:storeServerSelection.row - 1 inSection:storeServerSelection.section];
-                if (standardUserDefaults) {
-                    [standardUserDefaults setObject: @(storeServerSelection.row) forKey:@"lastServer"];
-                }
+                [userDefaults setObject: @(storeServerSelection.row) forKey:@"lastServer"];
             }
             else if (storeServerSelection.row == indexPath.row) {
                 storeServerSelection = nil;
@@ -240,7 +232,7 @@ static inline BOOL IsEmpty(id obj) {
                 AppDelegate.instance.obj.serverHWAddr = @"";
                 AppDelegate.instance.obj.tcpPort = 0;
                 [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCServerHasChanged" object: nil];
-                [standardUserDefaults setObject: @(-1) forKey:@"lastServer"];
+                [userDefaults setObject: @(-1) forKey:@"lastServer"];
             }
         }
         if (indexPath.row < [tableView numberOfRowsInSection:indexPath.section]) {

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -37,7 +37,6 @@ NSInputStream	*inStream;
                                                  selector: @selector(handleDidEnterBackground:)
                                                      name: @"UIApplicationDidEnterBackgroundNotification"
                                                    object: nil];
-
     }
     return self;
 }
@@ -62,15 +61,15 @@ NSInputStream	*inStream;
         return;
     }
     CFReadStreamRef readStream;
-	CFStreamCreatePairWithSocketToHost(NULL, (CFStringRef)CFBridgingRetain(server), port, &readStream, NULL);
-	inStream = (__bridge NSInputStream*)readStream;
-//	outStream = (__bridge NSOutputStream*)writeStream;
-	inStream.delegate = self;
-//	outStream.delegate = self;
-	[inStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
-//	[outStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
-	[inStream open];
-//	[outStream open];
+    CFStreamCreatePairWithSocketToHost(NULL, (CFStringRef)CFBridgingRetain(server), port, &readStream, NULL);
+    inStream = (__bridge NSInputStream*)readStream;
+    //	outStream = (__bridge NSOutputStream*)writeStream;
+    inStream.delegate = self;
+    //	outStream.delegate = self;
+    [inStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    //	[outStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    [inStream open];
+    //	[outStream open];
     CFRelease((__bridge CFTypeRef)server);
 }
 
@@ -91,22 +90,22 @@ NSInputStream	*inStream;
 
 - (void)stream:(NSStream*)theStream handleEvent:(NSStreamEvent)streamEvent {
 
-	switch (streamEvent) {
-    
+    switch (streamEvent) {
+
         case NSStreamEventOpenCompleted:
             AppDelegate.instance.serverTCPConnectionOpen = YES;
             [self tcpConnectionNotifications:YES];
-			break;
+            break;
             
-		case NSStreamEventHasBytesAvailable:
-			if (theStream == inStream) {
-				uint8_t buffer[1024];
-				int len;
-				while ([inStream hasBytesAvailable]) {
-					len = (int)[inStream read:buffer maxLength:sizeof(buffer)];
-					if (len > 0) {
-						NSData *output = [[NSData alloc] initWithBytes:buffer length:len];
-						if (nil != output) {
+        case NSStreamEventHasBytesAvailable:
+            if (theStream == inStream) {
+                uint8_t buffer[1024];
+                int len;
+                while ([inStream hasBytesAvailable]) {
+                    len = (int)[inStream read:buffer maxLength:sizeof(buffer)];
+                    if (len > 0) {
+                        NSData *output = [[NSData alloc] initWithBytes:buffer length:len];
+                        if (nil != output) {
                             NSError *parseError = nil;
                             NSDictionary *notification = [NSJSONSerialization JSONObjectWithData:output options:kNilOptions error:&parseError];
                             if (parseError == nil) {
@@ -119,19 +118,19 @@ NSInputStream	*inStream;
                                     [[NSNotificationCenter defaultCenter] postNotificationName:method object:nil userInfo:params];
                                 }
                             }
-						}
-					}
-				}
-			}
-			break;
+                        }
+                    }
+                }
+            }
+            break;
             
-		case NSStreamEventErrorOccurred:
+        case NSStreamEventErrorOccurred:
             AppDelegate.instance.serverTCPConnectionOpen = NO;
             inCheck = NO;
             [[NSNotificationCenter defaultCenter] postNotificationName:@"tcpJSONRPCConnectionError" object:nil userInfo:nil];
-			break;
-			
-		case NSStreamEventEndEncountered:
+            break;
+
+        case NSStreamEventEndEncountered:
             AppDelegate.instance.serverTCPConnectionOpen = NO;
             inCheck = NO;
             [theStream close];
@@ -140,9 +139,9 @@ NSInputStream	*inStream;
             [[NSNotificationCenter defaultCenter] postNotificationName:@"tcpJSONRPCConnectionClosed" object:nil userInfo:nil];
             [self tcpConnectionNotifications:NO];
             break;
-		default:
+        default:
             break;
-	}
+    }
 }
 
 - (void)tcpConnectionNotifications:(BOOL)hasTcpConnection {
@@ -194,54 +193,54 @@ NSInputStream	*inStream;
      withParameters:checkServerParams
      withTimeout: SERVER_TIMEOUT
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-         inCheck = NO;
-         if (error == nil && methodError == nil) {
-             if (AppDelegate.instance.serverOnLine) {
-                 return;
-             }
-             // Read JSON RPC API version
-             [self readJSONRPCAPIVersion];
-             
-             // Read if ignorearticles is enabled
-             [self readIgnoreArticlesEnabled];
-             
-             AppDelegate.instance.serverVolume = [methodResult[@"volume"] intValue];
-             if (!AppDelegate.instance.serverOnLine) {
-                 if ([NSJSONSerialization isValidJSONObject:methodResult]) {
-                     NSDictionary *serverInfo = methodResult[@"version"];
-                     AppDelegate.instance.serverVersion = [serverInfo[@"major"] intValue];
-                     AppDelegate.instance.serverMinorVersion = [serverInfo[@"minor"] intValue];
-                     NSString *realServerName = methodResult[@"name"];
-                     if ([realServerName isEqualToString:@"MrMC"]) {
-                         AppDelegate.instance.serverVersion += MRMC_TIMEWARP;
-                     }
-                     infoTitle = [NSString stringWithFormat:@"%@ v%@.%@ %@",
-                                          AppDelegate.instance.obj.serverDescription,
-                                          serverInfo[@"major"],
-                                          serverInfo[@"minor"],
-                                          serverInfo[@"tag"]];//, serverInfo[@"revision"]
-                     [self jsonConnectionNotifications:YES];
-                     [self showSetupNotifications:NO];
-                 }
-                 else {
-                     if (AppDelegate.instance.serverOnLine) {
-                         [self jsonConnectionNotifications:NO];
-                     }
-                     [self showSetupNotifications:YES];
-                 }
-             }
-         }
-         else {
-             if (error != nil) {
-                 [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerConnectionError" object:nil userInfo:@{@"error_message": [error localizedDescription]}];
-             }
-             AppDelegate.instance.serverVolume = -1;
-             if (AppDelegate.instance.serverOnLine) {
-                 [self jsonConnectionNotifications:NO];
-             }
-             [self showSetupNotifications:YES];
-         }
-     }];
+        inCheck = NO;
+        if (error == nil && methodError == nil) {
+            if (AppDelegate.instance.serverOnLine) {
+                return;
+            }
+            // Read JSON RPC API version
+            [self readJSONRPCAPIVersion];
+
+            // Read if ignorearticles is enabled
+            [self readIgnoreArticlesEnabled];
+
+            AppDelegate.instance.serverVolume = [methodResult[@"volume"] intValue];
+            if (!AppDelegate.instance.serverOnLine) {
+                if ([NSJSONSerialization isValidJSONObject:methodResult]) {
+                    NSDictionary *serverInfo = methodResult[@"version"];
+                    AppDelegate.instance.serverVersion = [serverInfo[@"major"] intValue];
+                    AppDelegate.instance.serverMinorVersion = [serverInfo[@"minor"] intValue];
+                    NSString *realServerName = methodResult[@"name"];
+                    if ([realServerName isEqualToString:@"MrMC"]) {
+                        AppDelegate.instance.serverVersion += MRMC_TIMEWARP;
+                    }
+                    infoTitle = [NSString stringWithFormat:@"%@ v%@.%@ %@",
+                                 AppDelegate.instance.obj.serverDescription,
+                                 serverInfo[@"major"],
+                                 serverInfo[@"minor"],
+                                 serverInfo[@"tag"]];//, serverInfo[@"revision"]
+                    [self jsonConnectionNotifications:YES];
+                    [self showSetupNotifications:NO];
+                }
+                else {
+                    if (AppDelegate.instance.serverOnLine) {
+                        [self jsonConnectionNotifications:NO];
+                    }
+                    [self showSetupNotifications:YES];
+                }
+            }
+        }
+        else {
+            if (error != nil) {
+                [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerConnectionError" object:nil userInfo:@{@"error_message": [error localizedDescription]}];
+            }
+            AppDelegate.instance.serverVolume = -1;
+            if (AppDelegate.instance.serverOnLine) {
+                [self jsonConnectionNotifications:NO];
+            }
+            [self showSetupNotifications:YES];
+        }
+    }];
 }
 
 - (void)readIgnoreArticlesEnabled {
@@ -251,12 +250,12 @@ NSInputStream	*inStream;
      withParameters:@{@"setting": @"filelists.ignorethewhensorting"}
      withTimeout: SERVER_TIMEOUT
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-         if (!error && !methodError) {
-             AppDelegate.instance.isIgnoreArticlesEnabled = [methodResult[@"value"] boolValue];
-         }
-         else {
-             AppDelegate.instance.isIgnoreArticlesEnabled = NO;
-         }
+        if (!error && !methodError) {
+            AppDelegate.instance.isIgnoreArticlesEnabled = [methodResult[@"value"] boolValue];
+        }
+        else {
+            AppDelegate.instance.isIgnoreArticlesEnabled = NO;
+        }
     }];
 }
 
@@ -267,23 +266,23 @@ NSInputStream	*inStream;
      withParameters:nil
      withTimeout: SERVER_TIMEOUT
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-         if (!error && !methodError) {
-             // Kodi 11 and earlier do not support "major"/"minor"/"patch" and reply with "version" only
-             if (![methodResult[@"version"] isKindOfClass:[NSNumber class]]) {
-                 AppDelegate.instance.APImajorVersion = [methodResult[@"version"][@"major"] intValue];
-                 AppDelegate.instance.APIminorVersion = [methodResult[@"version"][@"minor"] intValue];
-                 AppDelegate.instance.APIpatchVersion = [methodResult[@"version"][@"patch"] intValue];
-             }
-             else {
-                 AppDelegate.instance.APImajorVersion = [methodResult[@"version"] intValue];
-                 AppDelegate.instance.APIminorVersion = 0;
-                 AppDelegate.instance.APIpatchVersion = 0;
-             }
-         }
-         // Read the sorttokens
-         [self readSorttokens];
-         // Read 1-movie-set setting
-         [self readGroupSingleItemSets];
+        if (!error && !methodError) {
+            // Kodi 11 and earlier do not support "major"/"minor"/"patch" and reply with "version" only
+            if (![methodResult[@"version"] isKindOfClass:[NSNumber class]]) {
+                AppDelegate.instance.APImajorVersion = [methodResult[@"version"][@"major"] intValue];
+                AppDelegate.instance.APIminorVersion = [methodResult[@"version"][@"minor"] intValue];
+                AppDelegate.instance.APIpatchVersion = [methodResult[@"version"][@"patch"] intValue];
+            }
+            else {
+                AppDelegate.instance.APImajorVersion = [methodResult[@"version"] intValue];
+                AppDelegate.instance.APIminorVersion = 0;
+                AppDelegate.instance.APIpatchVersion = 0;
+            }
+        }
+        // Read the sorttokens
+        [self readSorttokens];
+        // Read 1-movie-set setting
+        [self readGroupSingleItemSets];
     }];
 }
 
@@ -295,12 +294,12 @@ NSInputStream	*inStream;
          withParameters:@{@"setting": @"videolibrary.groupsingleitemsets"}
          withTimeout: SERVER_TIMEOUT
          onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-             if (!error && !methodError) {
-                 AppDelegate.instance.isGroupSingleItemSetsEnabled = [methodResult[@"value"] boolValue];
-             }
-             else {
-                 AppDelegate.instance.isGroupSingleItemSetsEnabled = YES;
-             }
+            if (!error && !methodError) {
+                AppDelegate.instance.isGroupSingleItemSetsEnabled = [methodResult[@"value"] boolValue];
+            }
+            else {
+                AppDelegate.instance.isGroupSingleItemSetsEnabled = YES;
+            }
         }];
     }
     else {
@@ -317,12 +316,12 @@ NSInputStream	*inStream;
          withParameters:@{@"properties":@[@"sorttokens"]}
          withTimeout: SERVER_TIMEOUT
          onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-             if (!error && !methodError) {
-                 AppDelegate.instance.KodiSorttokens = methodResult[@"sorttokens"];
-             }
-             else {
-                 AppDelegate.instance.KodiSorttokens = defaultTokens;
-             }
+            if (!error && !methodError) {
+                AppDelegate.instance.KodiSorttokens = methodResult[@"sorttokens"];
+            }
+            else {
+                AppDelegate.instance.KodiSorttokens = defaultTokens;
+            }
         }];
     }
     else {

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -93,14 +93,9 @@ NSInputStream	*inStream;
 
 	switch (streamEvent) {
     
-        case NSStreamEventOpenCompleted:{
+        case NSStreamEventOpenCompleted:
             AppDelegate.instance.serverTCPConnectionOpen = YES;
-            NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
-                                    infoTitle, @"message",
-                                    @"connection_on", @"icon_connection",
-                                    nil];
-            [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerConnectionSuccess" object:nil userInfo:params];
-        }
+            [self tcpConnectionNotifications:YES];
 			break;
             
 		case NSStreamEventHasBytesAvailable:
@@ -151,6 +146,14 @@ NSInputStream	*inStream;
 	}
 }
 
+- (void)tcpConnectionNotifications:(BOOL)hasTcpConnection {
+    NSString *connectionIcon = hasTcpConnection ? @"connection_on" : @"connection_on_notcp";
+    NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
+                            infoTitle, @"message",
+                            connectionIcon, @"icon_connection",
+                            nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerConnectionSuccess" object:nil userInfo:params];
+}
 
 - (void)noConnectionNotifications {
     NSDictionary *params = @{

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -173,9 +173,6 @@ NSInputStream	*inStream;
         }
         return;
     }
-    if (AppDelegate.instance.serverTCPConnectionOpen) {
-        return;
-    }
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"wol_preference"] &&
         AppDelegate.instance.obj.serverHWAddr != nil) {
         [AppDelegate.instance sendWOL:AppDelegate.instance.obj.serverHWAddr withPort:WOL_PORT];
@@ -190,6 +187,9 @@ NSInputStream	*inStream;
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
          inCheck = NO;
          if (error == nil && methodError == nil) {
+             if (AppDelegate.instance.serverOnLine) {
+                 return;
+             }
              // Read JSON RPC API version
              [self readJSONRPCAPIVersion];
              

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -166,13 +166,17 @@ NSInputStream	*inStream;
     [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCChangeServerStatus" object:nil userInfo:params];
 }
 
+- (void)showSetupNotifications:(BOOL)showSetup {
+    NSDictionary *params = @{@"showSetup": @(showSetup)};
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
+}
+
 - (void)checkServer {
     if (inCheck) {
         return;
     }
     if (AppDelegate.instance.obj.serverIP.length == 0) {
-        NSDictionary *params = @{@"showSetup": @YES};
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
+        [self showSetupNotifications:YES];
         if (AppDelegate.instance.serverOnLine) {
             [self jsonConnectionNotifications:NO];
         }
@@ -217,15 +221,13 @@ NSInputStream	*inStream;
                                           serverInfo[@"minor"],
                                           serverInfo[@"tag"]];//, serverInfo[@"revision"]
                      [self jsonConnectionNotifications:YES];
-                     NSDictionary *params = @{@"showSetup": @NO};
-                     [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
+                     [self showSetupNotifications:NO];
                  }
                  else {
                      if (AppDelegate.instance.serverOnLine) {
                          [self jsonConnectionNotifications:NO];
                      }
-                     NSDictionary *params = @{@"showSetup": @YES};
-                     [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
+                     [self showSetupNotifications:YES];
                  }
              }
          }
@@ -237,8 +239,7 @@ NSInputStream	*inStream;
              if (AppDelegate.instance.serverOnLine) {
                  [self jsonConnectionNotifications:NO];
              }
-             NSDictionary *params = @{@"showSetup": @YES};
-             [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
+             [self showSetupNotifications:YES];
          }
      }];
 }

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -110,14 +110,13 @@ NSInputStream	*inStream;
                             NSError *parseError = nil;
                             NSDictionary *notification = [NSJSONSerialization JSONObjectWithData:output options:kNilOptions error:&parseError];
                             if (parseError == nil) {
-                                NSString *method = @"";
-                                NSDictionary *paramsDict;
-                                if ((NSNull*)notification[@"method"] != [NSNull null]) {
-                                        method = notification[@"method"];
-                                    if ((NSNull*)notification[@"params"] != [NSNull null]) {
-                                        paramsDict = [NSDictionary dictionaryWithObject:notification[@"params"] forKey:@"params"];
+                                if (notification[@"method"] != [NSNull null]) {
+                                    NSString *method = notification[@"method"];
+                                    NSDictionary *params;
+                                    if (notification[@"params"] != [NSNull null]) {
+                                        params = @{@"params": notification[@"params"]};
                                     }
-                                    [[NSNotificationCenter defaultCenter] postNotificationName:method object:nil userInfo:paramsDict];
+                                    [[NSNotificationCenter defaultCenter] postNotificationName:method object:nil userInfo:params];
                                 }
                             }
 						}

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -148,10 +148,11 @@ NSInputStream	*inStream;
 
 - (void)tcpConnectionNotifications:(BOOL)hasTcpConnection {
     NSString *connectionIcon = hasTcpConnection ? @"connection_on" : @"connection_on_notcp";
-    NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
-                            infoTitle, @"message",
-                            connectionIcon, @"icon_connection",
-                            nil];
+    NSString *connectionName = infoTitle ?: @"";
+    NSDictionary *params = @{
+        @"message": connectionName,
+        @"icon_connection": connectionIcon,
+    };
     [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerConnectionSuccess" object:nil userInfo:params];
 }
 
@@ -220,7 +221,7 @@ NSInputStream	*inStream;
                          @"icon_connection": @"connection_on_notcp",
                      };
                      [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCChangeServerStatus" object:nil userInfo:params];
-                     params = @{@"showSetup": @(NO)};
+                     params = @{@"showSetup": @NO};
                      [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
                  }
                  else {

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -155,11 +155,13 @@ NSInputStream	*inStream;
     [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerConnectionSuccess" object:nil userInfo:params];
 }
 
-- (void)noConnectionNotifications {
+- (void)jsonConnectionNotifications:(BOOL)hasJsonConnection {
+    NSString *connectionIcon = hasJsonConnection ? @"connection_on_notcp" : @"connection_off";
+    NSString *connectionName = hasJsonConnection ? (infoTitle ?: @"") : LOCALIZED_STR(@"No connection");
     NSDictionary *params = @{
-        @"status": @NO,
-        @"message": LOCALIZED_STR(@"No connection"),
-        @"icon_connection": @"connection_off",
+        @"status": @(hasJsonConnection),
+        @"message": connectionName,
+        @"icon_connection": connectionIcon,
     };
     [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCChangeServerStatus" object:nil userInfo:params];
 }
@@ -172,7 +174,7 @@ NSInputStream	*inStream;
         NSDictionary *params = @{@"showSetup": @YES};
         [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
         if (AppDelegate.instance.serverOnLine) {
-            [self noConnectionNotifications];
+            [self jsonConnectionNotifications:NO];
         }
         return;
     }
@@ -214,18 +216,13 @@ NSInputStream	*inStream;
                                           serverInfo[@"major"],
                                           serverInfo[@"minor"],
                                           serverInfo[@"tag"]];//, serverInfo[@"revision"]
-                     NSDictionary *params = @{
-                         @"status": @YES,
-                         @"message": infoTitle,
-                         @"icon_connection": @"connection_on_notcp",
-                     };
-                     [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCChangeServerStatus" object:nil userInfo:params];
-                     params = @{@"showSetup": @NO};
+                     [self jsonConnectionNotifications:YES];
+                     NSDictionary *params = @{@"showSetup": @NO};
                      [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
                  }
                  else {
                      if (AppDelegate.instance.serverOnLine) {
-                         [self noConnectionNotifications];
+                         [self jsonConnectionNotifications:NO];
                      }
                      NSDictionary *params = @{@"showSetup": @YES};
                      [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
@@ -238,7 +235,7 @@ NSInputStream	*inStream;
              }
              AppDelegate.instance.serverVolume = -1;
              if (AppDelegate.instance.serverOnLine) {
-                 [self noConnectionNotifications];
+                 [self jsonConnectionNotifications:NO];
              }
              NSDictionary *params = @{@"showSetup": @YES};
              [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -139,7 +139,7 @@ NSInputStream	*inStream;
             [theStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
             theStream.delegate = nil;
             [[NSNotificationCenter defaultCenter] postNotificationName:@"tcpJSONRPCConnectionClosed" object:nil userInfo:nil];
-
+            [self tcpConnectionNotifications:NO];
             break;
 		default:
             break;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/553.

This PR reworks signaling TCP/JSON connection status to reduce code duplication. It also fixes possibly misaligned server status icons and ensures the loss of JSON connection (now falls back to red status) or TCP connection (now falls back to yellow connection) is properly recognized and signaled to user. 

#843 must be merged first.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Ensure correct server status icons (red/yellow/green)
Maintenance: Refactor signaling of TCP/JSON connection status