### PR TITLE
Rework use of activity indicator

### DIFF
--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -136,7 +136,6 @@
 
 @property (nonatomic, strong) NSMutableArray *filteredListContent;
 @property (strong, nonatomic) id detailItem;
-@property (nonatomic, readonly) UIActivityIndicatorView *activityIndicatorView;
 @property (strong, nonatomic) BDKCollectionIndexView *indexView;
 @property (nonatomic, strong) NSMutableDictionary *sections;
 @property (nonatomic, strong) NSMutableArray *richResults;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2006,7 +2006,15 @@
     self.indexView.alpha = 1.0;
 }
 
-#pragma mark - Cell Formatting 
+#pragma mark - Cell Formatting
+
+- (UIActivityIndicatorView*)getCellActivityIndicator:(NSIndexPath*)indexPath {
+    // Get the indicator view and place it in the middle of the thumb (if no thumb keep it at least fully visible)
+    id cell = [self getCell:indexPath];
+    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    cellActivityIndicator.center = CGPointMake(MAX(thumbWidth / 2, cellActivityIndicator.frame.size.width / 2), cellHeight / 2);
+    return cellActivityIndicator;
+}
 
 - (void)setTVshowThumbSize {
     mainMenu *Menuitem = self.detailItem;
@@ -3314,8 +3322,7 @@ NSIndexPath *selected;
 }
 
 - (void)markVideo:(NSMutableDictionary*)item indexPath:(NSIndexPath*)indexPath watched:(int)watched {
-    id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    UIActivityIndicatorView *cellActivityIndicator = [self getCellActivityIndicator:indexPath];
     [cellActivityIndicator startAnimating];
 
     NSString *methodToCall = @"";
@@ -3972,8 +3979,7 @@ NSIndexPath *selected;
     if ([itemid longValue] == 0) {
         return;
     }
-    id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    UIActivityIndicatorView *cellActivityIndicator = [self getCellActivityIndicator:indexPath];
     NSString *methodToCall = @"PVR.DeleteTimer";
     NSDictionary *parameters = @{@"timerid": itemid};
 
@@ -4027,8 +4033,7 @@ NSIndexPath *selected;
             parameterName = @"broadcastid";
         }
     }
-    id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    UIActivityIndicatorView *cellActivityIndicator = [self getCellActivityIndicator:indexPath];
     [cellActivityIndicator startAnimating];
     NSDictionary *parameters = @{parameterName: itemid};
     [[Utilities getJsonRPC] callMethod:methodToCall
@@ -4037,6 +4042,7 @@ NSIndexPath *selected;
                [cellActivityIndicator stopAnimating];
                [self deselectAtIndexPath:indexPath];
                if (error == nil && methodError == nil) {
+                   id cell = [self getCell:indexPath];
                    UIImageView *isRecordingImageView = (UIImageView*)[cell viewWithTag:104];
                    isRecordingImageView.hidden = !isRecordingImageView.hidden;
                    NSNumber *status = @(![item[@"isrecording"] boolValue]);
@@ -4071,8 +4077,7 @@ NSIndexPath *selected;
 }
 
 - (void)addQueue:(NSDictionary*)item indexPath:(NSIndexPath*)indexPath afterCurrentItem:(BOOL)afterCurrent {
-    id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    UIActivityIndicatorView *cellActivityIndicator = [self getCellActivityIndicator:indexPath];
     [cellActivityIndicator startAnimating];
     mainMenu *menuItem = [self getMainMenu:item];
     NSDictionary *mainFields = menuItem.mainFields[choosedTab];
@@ -4150,8 +4155,7 @@ NSIndexPath *selected;
 }
 
 - (void)playerOpen:(NSDictionary*)params index:(NSIndexPath*)indexPath {
-    id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    UIActivityIndicatorView *cellActivityIndicator = [self getCellActivityIndicator:indexPath];
     [self playerOpen:params index:indexPath indicator:cellActivityIndicator];
 }
 
@@ -4180,8 +4184,7 @@ NSIndexPath *selected;
     if (mainFields.count == 0) {
         return;
     }
-    id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    UIActivityIndicatorView *cellActivityIndicator = [self getCellActivityIndicator:indexPath];
     [cellActivityIndicator startAnimating];
     int playlistid = [mainFields[@"playlistid"] intValue];
     if ([mainFields[@"row8"] isEqualToString:@"channelid"] ||
@@ -4435,8 +4438,7 @@ NSIndexPath *selected;
         return; // something goes wrong
     }
     
-    id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    UIActivityIndicatorView *cellActivityIndicator = [self getCellActivityIndicator:indexPath];
     [cellActivityIndicator startAnimating];
     
     NSMutableArray *newProperties = [parameters[@"properties"] mutableCopy];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4118,24 +4118,24 @@ NSIndexPath *selected;
                          }];
                      }
                      else {
-                         [self addToPlaylist:playlistid currentItem:value currentKey:key currentActivityIndicator:queuing];
+                         [self addToPlaylist:playlistid currentItem:value currentKey:key indicator:queuing];
                      }
                  }
                  else {
-                     [self addToPlaylist:playlistid currentItem:value currentKey:key currentActivityIndicator:queuing];
+                     [self addToPlaylist:playlistid currentItem:value currentKey:key indicator:queuing];
                  }
              }
              else {
-                [self addToPlaylist:playlistid currentItem:value currentKey:key currentActivityIndicator:queuing];
+                [self addToPlaylist:playlistid currentItem:value currentKey:key indicator:queuing];
              }
          }];
     }
     else {
-        [self addToPlaylist:playlistid currentItem:value currentKey:key currentActivityIndicator:queuing];
+        [self addToPlaylist:playlistid currentItem:value currentKey:key indicator:queuing];
     }
 }
 
-- (void)addToPlaylist:(NSInteger)playlistid currentItem:(id)value currentKey:(NSString*)key currentActivityIndicator:(UIActivityIndicatorView*)queuing {
+- (void)addToPlaylist:(NSInteger)playlistid currentItem:(id)value currentKey:(NSString*)key indicator:(UIActivityIndicatorView*)queuing {
     NSDictionary *params = @{
         @"playlistid": @(playlistid),
         @"item": [NSDictionary dictionaryWithObjectsAndKeys: value, key, nil],

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -37,7 +37,6 @@
 @implementation DetailViewController
 
 @synthesize detailItem = _detailItem;
-@synthesize activityIndicatorView;
 @synthesize sections;
 @synthesize filteredListContent;
 @synthesize richResults;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4152,6 +4152,10 @@ NSIndexPath *selected;
 - (void)playerOpen:(NSDictionary*)params index:(NSIndexPath*)indexPath {
     id cell = [self getCell:indexPath];
     UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    [self playerOpen:params index:indexPath indicator:queuing];
+}
+
+- (void)playerOpen:(NSDictionary*)params index:(NSIndexPath*)indexPath indicator:(UIActivityIndicatorView*)queuing {
     [queuing startAnimating];
     [[Utilities getJsonRPC] callMethod:@"Player.Open" withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         [queuing stopAnimating];
@@ -4189,13 +4193,13 @@ NSIndexPath *selected;
         NSDictionary *itemParams = @{
             @"item": [NSDictionary dictionaryWithObjectsAndKeys: channelid, @"channelid", nil],
         };
-        [self playerOpen:itemParams index:indexPath];
+        [self playerOpen:itemParams index:indexPath indicator:queuing];
     }
     else if ([mainFields[@"row7"] isEqualToString:@"plugin"]) {
         NSDictionary *itemParams = @{
             @"item": [NSDictionary dictionaryWithObjectsAndKeys: item[@"file"], @"file", nil],
         };
-        [self playerOpen:itemParams index:indexPath];
+        [self playerOpen:itemParams index:indexPath indicator:queuing];
     }
     else {
         id optionsParam = nil;
@@ -4231,13 +4235,15 @@ NSIndexPath *selected;
                      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *internalError) {
                          [self playlistAndPlay:playlistParams
                                 playbackParams:playbackParams
-                                     indexPath:indexPath];
+                                     indexPath:indexPath
+                                     indicator:queuing];
                      }];
                 }
                 else {
                     [self playlistAndPlay:playlistParams
                            playbackParams:playbackParams
-                                indexPath:indexPath];
+                                indexPath:indexPath
+                                indicator:queuing];
                 }
             }
             else {
@@ -4247,15 +4253,13 @@ NSIndexPath *selected;
     }
 }
 
-- (void)playlistAndPlay:(NSDictionary*)playlistParams playbackParams:(NSDictionary*)playbackParams indexPath:(NSIndexPath*)indexPath {
+- (void)playlistAndPlay:(NSDictionary*)playlistParams playbackParams:(NSDictionary*)playbackParams indexPath:(NSIndexPath*)indexPath indicator:(UIActivityIndicatorView*)queuing {
     [[Utilities getJsonRPC] callMethod:@"Playlist.Add" withParameters:playlistParams onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (error == nil && methodError == nil) {
             [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCPlaylistHasChanged" object: nil];
-            [self playerOpen:playbackParams index:indexPath];
+            [self playerOpen:playbackParams index:indexPath indicator:queuing];
         }
         else {
-            id cell = [self getCell:indexPath];
-            UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
             [queuing stopAnimating];
         }
     }];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3315,8 +3315,8 @@ NSIndexPath *selected;
 
 - (void)markVideo:(NSMutableDictionary*)item indexPath:(NSIndexPath*)indexPath watched:(int)watched {
     id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
-    [queuing startAnimating];
+    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    [cellActivityIndicator startAnimating];
 
     NSString *methodToCall = @"";
     NSString *family = item[@"family"];
@@ -3341,7 +3341,7 @@ NSIndexPath *selected;
                 }
                 [self updateCellAndSaveRichData:indexPath watched:watched item:item];
             }
-            [queuing stopAnimating];
+            [cellActivityIndicator stopAnimating];
          }];
         return;
     }
@@ -3355,7 +3355,7 @@ NSIndexPath *selected;
         methodToCall = @"VideoLibrary.SetMusicVideoDetails";
     }
     else {
-        [queuing stopAnimating];
+        [cellActivityIndicator stopAnimating];
         return;
     }
     NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
@@ -3369,7 +3369,7 @@ NSIndexPath *selected;
          if (error == nil && methodError == nil) {
              [self updateCellAndSaveRichData:indexPath watched:watched item:item];
          }
-        [queuing stopAnimating];
+        [cellActivityIndicator stopAnimating];
      }];
 }
 
@@ -3973,15 +3973,15 @@ NSIndexPath *selected;
         return;
     }
     id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
     NSString *methodToCall = @"PVR.DeleteTimer";
     NSDictionary *parameters = @{@"timerid": itemid};
 
-    [queuing startAnimating];
+    [cellActivityIndicator startAnimating];
     [[Utilities getJsonRPC] callMethod:methodToCall
          withParameters:parameters
            onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-               [queuing stopAnimating];
+               [cellActivityIndicator stopAnimating];
                [self deselectAtIndexPath:indexPath];
                if (error == nil && methodError == nil) {
                    [self.searchController setActive:NO];
@@ -4028,13 +4028,13 @@ NSIndexPath *selected;
         }
     }
     id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
-    [queuing startAnimating];
+    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    [cellActivityIndicator startAnimating];
     NSDictionary *parameters = @{parameterName: itemid};
     [[Utilities getJsonRPC] callMethod:methodToCall
          withParameters:parameters
            onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-               [queuing stopAnimating];
+               [cellActivityIndicator stopAnimating];
                [self deselectAtIndexPath:indexPath];
                if (error == nil && methodError == nil) {
                    UIImageView *isRecordingImageView = (UIImageView*)[cell viewWithTag:104];
@@ -4072,8 +4072,8 @@ NSIndexPath *selected;
 
 - (void)addQueue:(NSDictionary*)item indexPath:(NSIndexPath*)indexPath afterCurrentItem:(BOOL)afterCurrent {
     id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
-    [queuing startAnimating];
+    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    [cellActivityIndicator startAnimating];
     mainMenu *menuItem = [self getMainMenu:item];
     NSDictionary *mainFields = menuItem.mainFields[choosedTab];
     if (forceMusicAlbumMode) {
@@ -4103,7 +4103,7 @@ NSIndexPath *selected;
              if (error == nil && methodError == nil) {
                  if ([NSJSONSerialization isValidJSONObject:methodResult]) {
                      if ([methodResult count]) {
-                         [queuing stopAnimating];
+                         [cellActivityIndicator stopAnimating];
                          int newPos = [methodResult[@"position"] intValue] + 1;
                          NSString *action2 = @"Playlist.Insert";
                          NSDictionary *params2 = @{
@@ -4118,30 +4118,30 @@ NSIndexPath *selected;
                          }];
                      }
                      else {
-                         [self addToPlaylist:playlistid currentItem:value currentKey:key indicator:queuing];
+                         [self addToPlaylist:playlistid currentItem:value currentKey:key indicator:cellActivityIndicator];
                      }
                  }
                  else {
-                     [self addToPlaylist:playlistid currentItem:value currentKey:key indicator:queuing];
+                     [self addToPlaylist:playlistid currentItem:value currentKey:key indicator:cellActivityIndicator];
                  }
              }
              else {
-                [self addToPlaylist:playlistid currentItem:value currentKey:key indicator:queuing];
+                [self addToPlaylist:playlistid currentItem:value currentKey:key indicator:cellActivityIndicator];
              }
          }];
     }
     else {
-        [self addToPlaylist:playlistid currentItem:value currentKey:key indicator:queuing];
+        [self addToPlaylist:playlistid currentItem:value currentKey:key indicator:cellActivityIndicator];
     }
 }
 
-- (void)addToPlaylist:(NSInteger)playlistid currentItem:(id)value currentKey:(NSString*)key indicator:(UIActivityIndicatorView*)queuing {
+- (void)addToPlaylist:(NSInteger)playlistid currentItem:(id)value currentKey:(NSString*)key indicator:(UIActivityIndicatorView*)cellActivityIndicator {
     NSDictionary *params = @{
         @"playlistid": @(playlistid),
         @"item": [NSDictionary dictionaryWithObjectsAndKeys: value, key, nil],
     };
     [[Utilities getJsonRPC] callMethod:@"Playlist.Add" withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-        [queuing stopAnimating];
+        [cellActivityIndicator stopAnimating];
         if (error == nil && methodError == nil) {
             [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCPlaylistHasChanged" object: nil];
         }
@@ -4151,14 +4151,14 @@ NSIndexPath *selected;
 
 - (void)playerOpen:(NSDictionary*)params index:(NSIndexPath*)indexPath {
     id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
-    [self playerOpen:params index:indexPath indicator:queuing];
+    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    [self playerOpen:params index:indexPath indicator:cellActivityIndicator];
 }
 
-- (void)playerOpen:(NSDictionary*)params index:(NSIndexPath*)indexPath indicator:(UIActivityIndicatorView*)queuing {
-    [queuing startAnimating];
+- (void)playerOpen:(NSDictionary*)params index:(NSIndexPath*)indexPath indicator:(UIActivityIndicatorView*)cellActivityIndicator {
+    [cellActivityIndicator startAnimating];
     [[Utilities getJsonRPC] callMethod:@"Player.Open" withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-        [queuing stopAnimating];
+        [cellActivityIndicator stopAnimating];
         if (error == nil && methodError == nil) {
             [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCPlaylistHasChanged" object: nil];
             [self showNowPlaying];
@@ -4181,8 +4181,8 @@ NSIndexPath *selected;
         return;
     }
     id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
-    [queuing startAnimating];
+    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    [cellActivityIndicator startAnimating];
     int playlistid = [mainFields[@"playlistid"] intValue];
     if ([mainFields[@"row8"] isEqualToString:@"channelid"] ||
         [mainFields[@"row8"] isEqualToString:@"broadcastid"]) {
@@ -4193,13 +4193,13 @@ NSIndexPath *selected;
         NSDictionary *itemParams = @{
             @"item": [NSDictionary dictionaryWithObjectsAndKeys: channelid, @"channelid", nil],
         };
-        [self playerOpen:itemParams index:indexPath indicator:queuing];
+        [self playerOpen:itemParams index:indexPath indicator:cellActivityIndicator];
     }
     else if ([mainFields[@"row7"] isEqualToString:@"plugin"]) {
         NSDictionary *itemParams = @{
             @"item": [NSDictionary dictionaryWithObjectsAndKeys: item[@"file"], @"file", nil],
         };
-        [self playerOpen:itemParams index:indexPath indicator:queuing];
+        [self playerOpen:itemParams index:indexPath indicator:cellActivityIndicator];
     }
     else {
         id optionsParam = nil;
@@ -4236,31 +4236,31 @@ NSIndexPath *selected;
                          [self playlistAndPlay:playlistParams
                                 playbackParams:playbackParams
                                      indexPath:indexPath
-                                     indicator:queuing];
+                                     indicator:cellActivityIndicator];
                      }];
                 }
                 else {
                     [self playlistAndPlay:playlistParams
                            playbackParams:playbackParams
                                 indexPath:indexPath
-                                indicator:queuing];
+                                indicator:cellActivityIndicator];
                 }
             }
             else {
-                [queuing stopAnimating];
+                [cellActivityIndicator stopAnimating];
             }
         }];
     }
 }
 
-- (void)playlistAndPlay:(NSDictionary*)playlistParams playbackParams:(NSDictionary*)playbackParams indexPath:(NSIndexPath*)indexPath indicator:(UIActivityIndicatorView*)queuing {
+- (void)playlistAndPlay:(NSDictionary*)playlistParams playbackParams:(NSDictionary*)playbackParams indexPath:(NSIndexPath*)indexPath indicator:(UIActivityIndicatorView*)cellActivityIndicator {
     [[Utilities getJsonRPC] callMethod:@"Playlist.Add" withParameters:playlistParams onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (error == nil && methodError == nil) {
             [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCPlaylistHasChanged" object: nil];
-            [self playerOpen:playbackParams index:indexPath indicator:queuing];
+            [self playerOpen:playbackParams index:indexPath indicator:cellActivityIndicator];
         }
         else {
-            [queuing stopAnimating];
+            [cellActivityIndicator stopAnimating];
         }
     }];
 }
@@ -4434,10 +4434,10 @@ NSIndexPath *selected;
     else {
         return; // something goes wrong
     }
-
+    
     id cell = [self getCell:indexPath];
-    UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
-    [queuing startAnimating];
+    UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    [cellActivityIndicator startAnimating];
     
     NSMutableArray *newProperties = [parameters[@"properties"] mutableCopy];
     if (parameters[@"kodiExtrasPropertiesMinimumVersion"] != nil) {
@@ -4457,9 +4457,8 @@ NSIndexPath *selected;
     [[Utilities getJsonRPC]
      callMethod:methodToCall
      withParameters:newParameters
-
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-         [queuing stopAnimating];
+         [cellActivityIndicator stopAnimating];
          if (error == nil && methodError == nil) {
              if ([NSJSONSerialization isValidJSONObject:methodResult]) {
                  NSString *itemid_extra_info = @"";

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1286,8 +1286,8 @@ long storedItemID;
      callMethod:methodToCall
      withParameters:newParameters
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+         [queuing stopAnimating];
          if (error == nil && methodError == nil) {
-             [queuing stopAnimating];
              if ([NSJSONSerialization isValidJSONObject:methodResult]) {
                  NSString *itemid_extra_info = @"";
                  if ((NSNull*)mainFields[@"itemid_extra_info"] != [NSNull null]) {
@@ -1366,13 +1366,9 @@ long storedItemID;
                   nil];
                  [self displayInfoView:newItem];
              }
-             else {
-                 [queuing stopAnimating];
-             }
          }
          else {
              [self somethingGoesWrong:LOCALIZED_STR(@"Details not found")];
-             [queuing stopAnimating];
          }
      }];
 }
@@ -2050,16 +2046,11 @@ long storedItemID;
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
          if (error == nil && methodError == nil) {
              storedItemID = SELECTED_NONE;
-             UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
-             [queuing stopAnimating];
              UIView *timePlaying = (UIView*)[cell viewWithTag:5];
              [self fadeView:timePlaying hidden:NO];
              [self updatePlaylistProgressbar:0.0f actual:@"00:00"];
          }
-         else {
-             UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
-             [queuing stopAnimating];
-         }
+         [queuing stopAnimating];
      }
      ];
     

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1259,8 +1259,8 @@ long storedItemID;
         return; // something goes wrong
     }
     UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:indexPath];
-    UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
-    [queuing startAnimating];
+    UIActivityIndicatorView *activityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    [activityIndicator startAnimating];
     id object = @([item[itemid] intValue]);
     if (AppDelegate.instance.serverVersion > 11 && [methodToCall isEqualToString:@"AudioLibrary.GetArtistDetails"]) {// WORKAROUND due the lack of the artistid with Playlist.GetItems
         methodToCall = @"AudioLibrary.GetArtists";
@@ -1286,7 +1286,7 @@ long storedItemID;
      callMethod:methodToCall
      withParameters:newParameters
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-         [queuing stopAnimating];
+         [activityIndicator stopAnimating];
          if (error == nil && methodError == nil) {
              if ([NSJSONSerialization isValidJSONObject:methodResult]) {
                  NSString *itemid_extra_info = @"";
@@ -2037,9 +2037,9 @@ long storedItemID;
 
 - (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath {
     UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:indexPath];
-    UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];
+    UIActivityIndicatorView *activityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:8];
     storeSelection = nil;
-    [queuing startAnimating];
+    [activityIndicator startAnimating];
     [[Utilities getJsonRPC]
      callMethod:@"Player.Open" 
      withParameters:@{@"item": @{@"position": @(indexPath.row), @"playlistid": @(playerID)}}
@@ -2050,7 +2050,7 @@ long storedItemID;
              [self fadeView:timePlaying hidden:NO];
              [self updatePlaylistProgressbar:0.0f actual:@"00:00"];
          }
-         [queuing stopAnimating];
+         [activityIndicator stopAnimating];
      }
      ];
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR reworks the use of `UIActivityIndicatorView`. The code will now simply hand over the pointer to the `UIActivityIndicatorView` object instead of reading it via `viewWithTag`.  In addition, the variable names and the position of the activity indicator are improved.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Rework use of activity indicator