### PR TITLE
Rework NowPlaying

### DIFF
--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -17,6 +17,7 @@
 @class DetailViewController;
 
 @interface NowPlaying : UIViewController <UITableViewDataSource, UITableViewDelegate, SDWebImageManagerDelegate, UIGestureRecognizerDelegate> {
+    IBOutlet UIView *transitionView;
     IBOutlet UITableView *playlistTableView;
     IBOutlet UILabel *albumName;
     IBOutlet UILabel *songName;

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -26,7 +26,6 @@
     IBOutlet UIImageView *jewelView;
     IBOutlet UIImageView *thumbnailView;
     IBOutlet UIView *BottomView;
-    IBOutlet UIView *TopView;
     UIView *transitionView;
     UIView *transitionedView;
     IBOutlet UIView *nowPlayingView;

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -26,8 +26,8 @@
     IBOutlet UIImageView *jewelView;
     IBOutlet UIImageView *thumbnailView;
     IBOutlet UIView *BottomView;
-    UIView *transitionView;
-    UIView *transitionedView;
+    UIView *transitionFromView;
+    UIView *transitionToView;
     IBOutlet UIView *nowPlayingView;
     IBOutlet UIView *playlistView;
     IBOutlet UIView *songDetailsView;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -57,8 +57,7 @@
 #define SELECTED_NONE -1
 #define ID_INVALID -2
 #define FLIP_DEMO_DELAY 0.5
-#define FADE_OUT_TIME 0.2
-#define FADE_IN_TIME 0.5
+#define TRANSITION_TIME 0.7
 
 - (void)setDetailItem:(id)newDetailItem {
     if (_detailItem != newDetailItem) {
@@ -1391,7 +1390,7 @@ long storedItemID;
         startFlipDemo = NO;
     }
     UIImage *buttonImage;
-    if (!nowPlayingView.hidden && !demo) {
+    if (nowPlayingView.hidden && !demo) {
         if (thumbnailView.image.size.width) {
             UIImage *image = [self enableJewelCases] ? [self imageWithBorderFromImage:thumbnailView.image] : thumbnailView.image;
             buttonImage = [self resizeToolbarThumb:image];
@@ -1404,26 +1403,15 @@ long storedItemID;
         buttonImage = [UIImage imageNamed:@"now_playing_playlist"];
     }
     [UIView transitionWithView:button
-                      duration:FADE_OUT_TIME
-                       options:UIViewAnimationOptionCurveEaseIn | animationOptionTransition
+                      duration:TRANSITION_TIME
+                       options:UIViewAnimationOptionCurveEaseOut | animationOptionTransition
                     animations:^{
-                         // fade out current button image
-                         button.alpha = 0.0;
-                     }
-                     completion:^(BOOL finished) {
-                        [UIView transitionWithView:button
-                                          duration:FADE_IN_TIME
-                                           options:UIViewAnimationOptionCurveEaseOut | animationOptionTransition
-                                        animations:^{
-                                            // fade in new button image
-                                            button.alpha = 1.0;
-                                            [button setImage:buttonImage forState:UIControlStateNormal];
-                                            [button setImage:buttonImage forState:UIControlStateHighlighted];
-                                            [button setImage:buttonImage forState:UIControlStateSelected];
-                                        }
-                                        completion:^(BOOL finished) {}
-                        ];
-                     }
+        // Animate transition to new button image
+        [button setImage:buttonImage forState:UIControlStateNormal];
+        [button setImage:buttonImage forState:UIControlStateHighlighted];
+        [button setImage:buttonImage forState:UIControlStateSelected];
+                     } 
+                     completion:^(BOOL finished) {}
     ];
 }
 
@@ -1456,27 +1444,18 @@ long storedItemID;
     }
     [self animateToColors:effectColor];
     
-    [UIView transitionWithView:transitionFromView
-                      duration:FADE_OUT_TIME
-                       options:UIViewAnimationOptionCurveEaseIn | animationOptionTransition
+    [UIView transitionWithView:transitionView
+                      duration:TRANSITION_TIME
+                       options:UIViewAnimationOptionCurveEaseOut | animationOptionTransition
                     animations:^{
-                          transitionFromView.alpha = 0.0;
+        transitionFromView.hidden = YES;
+        transitionToView.hidden = NO;
+        playlistActionView.alpha = playtoolbarAlpha;
+        self.navigationItem.titleView.hidden = NO;
                      }
                      completion:^(BOOL finished) {
-                        [UIView transitionWithView:transitionToView
-                                          duration:FADE_IN_TIME
-                                           options:UIViewAnimationOptionCurveEaseOut | animationOptionTransition
-                                        animations:^{
-                                              transitionFromView.hidden = YES;
-                                              transitionToView.hidden = NO;
-                                              transitionToView.alpha = 1.0;
-                                              playlistActionView.alpha = playtoolbarAlpha;
-                                              self.navigationItem.titleView.hidden = NO;
-                                          }
-                                        completion:^(BOOL finished) {
-                                              [self setIPadBackgroundColor:effectColor effectDuration:1.0];
-                                      }];
-                     }];
+        [self setIPadBackgroundColor:effectColor effectDuration:1.0];
+    }];
     [self flipAnimButton:playlistButton demo:NO];
 }
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -588,8 +588,13 @@ long storedItemID;
                                  NSString *showtitle = [Utilities getStringFromItem:nowPlayingInfo[@"showtitle"]];
                                  NSString *season = [Utilities getStringFromItem:nowPlayingInfo[@"season"]];
                                  NSString *episode = [Utilities getStringFromItem:nowPlayingInfo[@"episode"]];
-                                 if (album.length == 0 && showtitle.length && [season intValue] > 0) {
-                                     album = showtitle.length ? [NSString stringWithFormat:@"%@ - S%@E%@", showtitle, season, episode] : @"";
+                                 if (album.length == 0 && showtitle.length) {
+                                     if ([season intValue] > 0 && [episode intValue] > 0) {
+                                         album = [NSString stringWithFormat:@"%@ - S%@E%@", showtitle, season, episode];
+                                     }
+                                     else {
+                                         album = showtitle;
+                                     }
                                  }
                                  NSString *director = [Utilities getStringFromItem:nowPlayingInfo[@"director"]];
                                  if (album.length == 0 && director.length) {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -564,36 +564,43 @@ long storedItemID;
                                  [itemDescription scrollRangeToVisible:NSMakeRange(0, 0)];
                                  
                                  // Set NowPlaying text fields
-                                 NSString *album = [Utilities getStringFromItem:nowPlayingInfo[@"album"]];
+                                 // 1st: title
                                  NSString *label = [Utilities getStringFromItem:nowPlayingInfo[@"label"]];
+                                 NSString *title = [Utilities getStringFromItem:nowPlayingInfo[@"title"]];
+                                 storeLiveTVTitle = title;
+                                 if (title.length == 0) {
+                                     title = label;
+                                 }
+                                 
+                                 // 2nd: artists
+                                 NSString *artist = [Utilities getStringFromItem:nowPlayingInfo[@"artist"]];
+                                 NSString *studio = [Utilities getStringFromItem:nowPlayingInfo[@"studio"]];
+                                 if (artist.length == 0 && studio.length) {
+                                     artist = studio;
+                                 }
+                                 
+                                 // 3rd: album
+                                 NSString *album = [Utilities getStringFromItem:nowPlayingInfo[@"album"]];
                                  if ([nowPlayingInfo[@"type"] isEqualToString:@"channel"]) {
                                      album = label;
                                  }
-                                 NSString *title = [Utilities getStringFromItem:nowPlayingInfo[@"title"]];
-                                 storeLiveTVTitle = title;
-                                 NSString *artist = [Utilities getStringFromItem:nowPlayingInfo[@"artist"]];
                                  NSString *showtitle = [Utilities getStringFromItem:nowPlayingInfo[@"showtitle"]];
                                  NSString *season = [Utilities getStringFromItem:nowPlayingInfo[@"season"]];
                                  NSString *episode = [Utilities getStringFromItem:nowPlayingInfo[@"episode"]];
                                  if (album.length == 0 && showtitle.length && [season intValue] > 0) {
                                      album = showtitle.length ? [NSString stringWithFormat:@"%@ - S%@E%@", showtitle, season, episode] : @"";
                                  }
-                                 if (title.length == 0) {
-                                     title = label;
-                                 }
                                  NSString *director = [Utilities getStringFromItem:nowPlayingInfo[@"director"]];
                                  if (album.length == 0 && director.length) {
                                      album = director;
                                  }
-                                 NSString *studio = [Utilities getStringFromItem:nowPlayingInfo[@"studio"]];
-                                 if (artist.length == 0 && studio.length) {
-                                     artist = studio;
-                                 }
+                                 
                                  // top to bottom: songName, artistName, albumName
                                  songName.text = title;
                                  artistName.text = artist;
                                  albumName.text = album;
                                  
+                                 // Set cover size and load covers
                                  NSString *type = [Utilities getStringFromItem:nowPlayingInfo[@"type"]];
                                  currentType = type;
                                  [self setCoverSize:currentType];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -411,9 +411,9 @@ long storedItemID;
                                 [ProgressSlider setThumbImage:image forState:UIControlStateNormal];
                                 [ProgressSlider setThumbImage:image forState:UIControlStateHighlighted];
                             }
-                            [Utilities colorLabel:albumName AnimDuration:1.0 Color:UIColor.whiteColor];
-                            [Utilities colorLabel:songName AnimDuration:1.0 Color:[Utilities getGrayColor:230 alpha:1]];
-                            [Utilities colorLabel:artistName AnimDuration:1.0 Color:UIColor.lightGrayColor];
+                            [Utilities colorLabel:albumName AnimDuration:1.0 Color:UIColor.lightGrayColor];
+                            [Utilities colorLabel:songName AnimDuration:1.0 Color:UIColor.whiteColor];
+                            [Utilities colorLabel:artistName AnimDuration:1.0 Color:UIColor.whiteColor];
                             [Utilities colorLabel:currentTime AnimDuration:1.0 Color:UIColor.lightGrayColor];
                             [Utilities colorLabel:duration AnimDuration:1.0 Color:UIColor.lightGrayColor];
                         }
@@ -429,11 +429,11 @@ long storedItemID;
                                 [ProgressSlider setThumbImage:thumbImage forState:UIControlStateNormal];
                                 [ProgressSlider setThumbImage:thumbImage forState:UIControlStateHighlighted];
                             }
-                            [Utilities colorLabel:albumName AnimDuration:1.0 Color:pgThumbColor];
-                            [Utilities colorLabel:songName AnimDuration:1.0 Color:pgThumbColor];
-                            [Utilities colorLabel:artistName AnimDuration:1.0 Color:progressColor];
-                            [Utilities colorLabel:currentTime AnimDuration:1.0 Color:progressColor];
-                            [Utilities colorLabel:duration AnimDuration:1.0 Color:progressColor];
+                            [Utilities colorLabel:albumName AnimDuration:1.0 Color:slightLighterColor];
+                            [Utilities colorLabel:songName AnimDuration:1.0 Color:lighterColor];
+                            [Utilities colorLabel:artistName AnimDuration:1.0 Color:lighterColor];
+                            [Utilities colorLabel:currentTime AnimDuration:1.0 Color:slightLighterColor];
+                            [Utilities colorLabel:duration AnimDuration:1.0 Color:slightLighterColor];
                         }
                     }
                     completion:NULL];
@@ -2243,10 +2243,6 @@ long storedItemID;
     frame.size.width = width;
     toolbarBackground.frame = frame;
     
-    frame = TopView.frame;
-    frame.size.height = CGRectGetMinY(songDetailsView.frame);
-    TopView.frame = frame;
-    
     [self setCoverSize:currentType];
 }
 
@@ -2262,9 +2258,9 @@ long storedItemID;
     CGFloat width = IS_IPHONE ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_WIDTH - PAD_MENU_TABLE_WIDTH;
     CGFloat scale = MIN(height / IPHONE_SCREEN_DESIGN_HEIGHT, width / IPHONE_SCREEN_DESIGN_WIDTH);
     
-    albumName.font        = [UIFont systemFontOfSize:floor(18 * scale)];
-    songName.font         = [UIFont systemFontOfSize:floor(16 * scale)];
-    artistName.font       = [UIFont systemFontOfSize:floor(14 * scale)];
+    albumName.font        = [UIFont systemFontOfSize:floor(16 * scale)];
+    songName.font         = [UIFont boldSystemFontOfSize:floor(20 * scale)];
+    artistName.font       = [UIFont systemFontOfSize:floor(16 * scale)];
     currentTime.font      = [UIFont systemFontOfSize:floor(12 * scale)];
     duration.font         = [UIFont systemFontOfSize:floor(12 * scale)];
     scrabbingMessage.font = [UIFont systemFontOfSize:floor(10 * scale)];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -536,6 +536,7 @@ long storedItemID;
                                                 @"season",
                                                 @"fanart",
                                                 @"description",
+                                                @"director",
                                                 @"plot"] mutableCopy];
                 if (AppDelegate.instance.serverVersion > 11) {
                     [properties addObject:@"art"];
@@ -579,6 +580,10 @@ long storedItemID;
                                  }
                                  if (title.length == 0) {
                                      title = label;
+                                 }
+                                 NSString *director = [Utilities getStringFromItem:nowPlayingInfo[@"director"]];
+                                 if (album.length == 0 && director.length) {
+                                     album = director;
                                  }
                                  NSString *studio = [Utilities getStringFromItem:nowPlayingInfo[@"studio"]];
                                  if (artist.length == 0 && studio.length) {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2287,7 +2287,7 @@ long storedItemID;
     playlistToolbar.items = iPhoneItems;
     
     CGRect frame = playlistActionView.frame;
-    frame.origin.y = CGRectGetMinY(playlistToolbar.frame) - playlistActionView.frame.size.height;
+    frame.origin.y = playlistTableView.frame.size.height - playlistActionView.frame.size.height;
     playlistActionView.frame = frame;
     playlistActionView.alpha = 0.0;
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -622,22 +622,15 @@ long storedItemID;
                                          NSString *fanart = (NSNull*)nowPlayingInfo[@"fanart"] == [NSNull null] ? @"" : nowPlayingInfo[@"fanart"];
                                          if (![fanart isEqualToString:@""]) {
                                              NSString *fanartURL = [Utilities formatStringURL:fanart serverURL:serverURL];
+                                             __weak NowPlaying *sf = self;
                                              [tempFanartImageView setImageWithURL:[NSURL URLWithString:fanartURL]
                                                                         completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
-                                                                            if (error == nil && image != nil) {
-                                                                                NSDictionary *params = @{@"image": image};
-                                                                                [[NSNotificationCenter defaultCenter] postNotificationName:@"UIViewChangeBackgroundImage" object:nil userInfo:params];
-                                                                            }
-                                                                            else {
-                                                                                NSDictionary *params = @{@"image": [UIImage new]};
-                                                                                [[NSNotificationCenter defaultCenter] postNotificationName:@"UIViewChangeBackgroundImage" object:nil userInfo:params];
-                                                                            }
-                                                                            
-                                                                        }];
+                                                 UIImage *fanartImage = (error == nil && image != nil) ? image : [UIImage new];
+                                                 [sf notifyChangeForBackgroundImage:fanartImage];
+                                            }];
                                          }
                                          else {
-                                             NSDictionary *params = @{@"image": [UIImage new]};
-                                             [[NSNotificationCenter defaultCenter] postNotificationName:@"UIViewChangeBackgroundImage" object:nil userInfo:params];
+                                             [self notifyChangeForBackgroundImage:[UIImage new]];
                                          }
                                      }
                                      if ([thumbnailPath isEqualToString:@""]) {
@@ -846,6 +839,11 @@ long storedItemID;
             [self nothingIsPlaying];
         }
     }];
+}
+
+- (void)notifyChangeForBackgroundImage:(UIImage*)bgimage {
+    NSDictionary *params = @{@"image": bgimage};
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"UIViewChangeBackgroundImage" object:nil userInfo:params];
 }
 
 - (void)processLoadedThumbImage:(NowPlaying*)sf thumb:(UIImageView*)thumb image:(UIImage*)image enableJewel:(BOOL)enableJewel {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -536,6 +536,7 @@ long storedItemID;
                                                 @"season",
                                                 @"fanart",
                                                 @"description",
+                                                @"year",
                                                 @"director",
                                                 @"plot"] mutableCopy];
                 if (AppDelegate.instance.serverVersion > 11) {
@@ -594,6 +595,10 @@ long storedItemID;
                                  if (album.length == 0 && director.length) {
                                      album = director;
                                  }
+                                 
+                                 // Add year to artist string, if available
+                                 NSString *year = [Utilities getYearFromItem:nowPlayingInfo[@"year"]];
+                                 artist = [self formatArtistYear:artist year:year];
                                  
                                  // top to bottom: songName, artistName, albumName
                                  songName.text = title;
@@ -877,6 +882,20 @@ long storedItemID;
             [self nothingIsPlaying];
         }
     }];
+}
+
+- (NSString*)formatArtistYear:(NSString*)artist year:(NSString*)year {
+    NSString *text = @"";
+    if (artist.length && year.length) {
+        text = [NSString stringWithFormat:@"%@ (%@)", artist, year];
+    }
+    else if (year.length) {
+        text = year;
+    }
+    else if (artist.length) {
+        text = artist;
+    }
+    return text;
 }
 
 - (void)loadCodecView {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -641,47 +641,22 @@ long storedItemID;
                                          }
                                      }
                                      if ([thumbnailPath isEqualToString:@""]) {
-                                         UIImage *buttonImage = [self resizeToolbarThumb:[UIImage imageNamed:@"coverbox_back"]];
-                                         [self setButtonImageAndStartDemo:buttonImage];
-                                         [self setColorEffect:UIColor.clearColor];
-                                         if (enableJewel) {
-                                             thumbnailView.image = [UIImage imageNamed:@"coverbox_back"];
-                                         }
-                                         else {
-                                             [self changeImage:thumbnailView image:[UIImage imageNamed:@"coverbox_back"]];
-                                         }
+                                         UIImage *image = [UIImage imageNamed:@"coverbox_back"];
+                                         [self processLoadedThumbImage:self thumb:thumbnailView image:image enableJewel:enableJewel];
                                      }
                                      else {
                                          [[SDImageCache sharedImageCache] queryDiskCacheForKey:stringURL done:^(UIImage *image, SDImageCacheType cacheType) {
                                              if (image != nil) {
-                                                 UIImage *processedImage = [self imageWithBorderFromImage:image];
-                                                 UIImage *buttonImage = [self resizeToolbarThumb:processedImage];
-                                                 if (enableJewel) {
-                                                     thumbnailView.image = image;
-                                                 }
-                                                 else {
-                                                     [self changeImage:thumbnailView image:processedImage];
-                                                 }
-                                                 [self setButtonImageAndStartDemo:buttonImage];
-                                                 UIColor *effectColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
-                                                 [self setColorEffect:effectColor];
+                                                 [self processLoadedThumbImage:self thumb:thumbnailView image:image enableJewel:enableJewel];
                                              }
                                              else {
                                                  __weak UIImageView *thumb = thumbnailView;
                                                  __weak NowPlaying *sf = self;
-                                                 __block UIColor *newColor = nil;
                                                  [thumbnailView setImageWithURL:[NSURL URLWithString:stringURL]
                                                            placeholderImage:[UIImage imageNamed:@"coverbox_back"]
                                                                   completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType) {
                                                       if (error == nil) {
-                                                          UIImage *processedImage = [sf imageWithBorderFromImage:image];
-                                                          UIImage *buttonImage = [sf resizeToolbarThumb:processedImage];
-                                                          if (!enableJewel) {
-                                                              [sf changeImage:thumb image:processedImage];
-                                                          }
-                                                          [sf setButtonImageAndStartDemo:buttonImage];
-                                                          newColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
-                                                          [sf setColorEffect:newColor];
+                                                          [sf processLoadedThumbImage:sf thumb:thumb image:image enableJewel:enableJewel];
                                                       }
                                                   }];
                                              }
@@ -708,17 +683,7 @@ long storedItemID;
                              lastThumbnail = @"";
                              [self setCoverSize:@"song"];
                              UIImage *image = [UIImage imageNamed:@"coverbox_back"];
-                             UIImage *processedImage = [self imageWithBorderFromImage:image];
-                             UIImage *buttonImage = [self resizeToolbarThumb:processedImage];
-                             if (enableJewel) {
-                                 thumbnailView.image = image;
-                             }
-                             else {
-                                 [self changeImage:thumbnailView image:processedImage];
-                             }
-                             [self setButtonImageAndStartDemo:buttonImage];
-                             UIColor *effectColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
-                             [self setColorEffect:effectColor];
+                             [self processLoadedThumbImage:self thumb:thumbnailView image:image enableJewel:enableJewel];
                          }
                      }
                      else {
@@ -881,6 +846,20 @@ long storedItemID;
             [self nothingIsPlaying];
         }
     }];
+}
+
+- (void)processLoadedThumbImage:(NowPlaying*)sf thumb:(UIImageView*)thumb image:(UIImage*)image enableJewel:(BOOL)enableJewel {
+    UIImage *processedImage = [sf imageWithBorderFromImage:image];
+    UIImage *buttonImage = [sf resizeToolbarThumb:processedImage];
+    if (enableJewel) {
+        thumb.image = image;
+    }
+    else {
+        [sf changeImage:thumb image:processedImage];
+    }
+    [sf setButtonImageAndStartDemo:buttonImage];
+    UIColor *newColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
+    [sf setColorEffect:newColor];
 }
 
 - (NSString*)formatArtistYear:(NSString*)artist year:(NSString*)year {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1431,8 +1431,8 @@ long storedItemID;
     UIColor *effectColor;
     __block CGFloat playtoolbarAlpha = 1.0;
     if (!nowPlayingView.hidden) {
-        transitionView = nowPlayingView;
-        transitionedView = playlistView;
+        transitionFromView = nowPlayingView;
+        transitionToView = playlistView;
         self.navigationItem.title = LOCALIZED_STR(@"Playlist");
         self.navigationItem.titleView.hidden = YES;
         animationOptionTransition = UIViewAnimationOptionTransitionFlipFromRight;
@@ -1441,8 +1441,8 @@ long storedItemID;
         playtoolbarAlpha = 1.0;
     }
     else {
-        transitionView = playlistView;
-        transitionedView = nowPlayingView;
+        transitionFromView = playlistView;
+        transitionToView = nowPlayingView;
         self.navigationItem.title = LOCALIZED_STR(@"Now Playing");
         self.navigationItem.titleView.hidden = YES;
         animationOptionTransition = UIViewAnimationOptionTransitionFlipFromLeft;
@@ -1456,20 +1456,20 @@ long storedItemID;
     }
     [self animateToColors:effectColor];
     
-    [UIView transitionWithView:transitionView
+    [UIView transitionWithView:transitionFromView
                       duration:FADE_OUT_TIME
                        options:UIViewAnimationOptionCurveEaseIn | animationOptionTransition
                     animations:^{
-                          transitionView.alpha = 0.0;
+                          transitionFromView.alpha = 0.0;
                      }
                      completion:^(BOOL finished) {
-                        [UIView transitionWithView:transitionedView
+                        [UIView transitionWithView:transitionToView
                                           duration:FADE_IN_TIME
                                            options:UIViewAnimationOptionCurveEaseOut | animationOptionTransition
                                         animations:^{
-                                              transitionView.hidden = YES;
-                                              transitionedView.hidden = NO;
-                                              transitionedView.alpha = 1.0;
+                                              transitionFromView.hidden = YES;
+                                              transitionToView.hidden = NO;
+                                              transitionToView.alpha = 1.0;
                                               playlistActionView.alpha = playtoolbarAlpha;
                                               self.navigationItem.titleView.hidden = NO;
                                           }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -102,6 +102,11 @@
 
 #pragma mark - utility
 
+- (NSString*)formatTVShowStringForSeason:(id)season episode:(id)episode title:(NSString*)title {
+    NSString *text = [NSString stringWithFormat:@"S%@E%@ - %@", season, episode, title];
+    return text;
+}
+
 - (NSString*)getNowPlayingThumbnailPath:(NSDictionary*)item {
     // If a recording is played, we can use the iocn (typically the station logo)
     BOOL useIcon = [item[@"type"] isEqualToString:@"recording"] || [item[@"recordingid"] longValue] > 0;
@@ -560,7 +565,7 @@ long storedItemID;
                                  storeLiveTVTitle = title;
                                  NSString *artist = [Utilities getStringFromItem:nowPlayingInfo[@"artist"]];
                                  if (album.length == 0 && ((NSNull*)nowPlayingInfo[@"showtitle"] != [NSNull null]) && nowPlayingInfo[@"season"] > 0) {
-                                     album = [nowPlayingInfo[@"showtitle"] length] != 0 ? [NSString stringWithFormat:@"%@ - %@x%@", nowPlayingInfo[@"showtitle"], nowPlayingInfo[@"season"], nowPlayingInfo[@"episode"]] : @"";
+                                     album = [nowPlayingInfo[@"showtitle"] length] != 0 ? [NSString stringWithFormat:@"%@ - S%@E%@", nowPlayingInfo[@"showtitle"], nowPlayingInfo[@"season"], nowPlayingInfo[@"episode"]] : @"";
                                  }
                                  if (title.length == 0) {
                                      title = [Utilities getStringFromItem:nowPlayingInfo[@"label"]];
@@ -1736,7 +1741,8 @@ long storedItemID;
                     title = [NSString stringWithFormat:@"%@\n%@\n%@", item[@"label"], item[@"album"], item[@"artist"]];
                 }
                 else if ([item[@"type"] isEqualToString:@"episode"]) {
-                    title = [NSString stringWithFormat:@"%@\n%@x%@. %@", item[@"showtitle"], item[@"season"], item[@"episode"], item[@"label"]];
+                    NSString *tvshowText = [self formatTVShowStringForSeason:item[@"season"] episode:item[@"episode"] title:item[@"label"]];
+                    title = [NSString stringWithFormat:@"%@\n%@", item[@"showtitle"], tvshowText];
                 }
                 [self showActionNowPlaying:sheetActions title:title point:selectedPoint];
             }
@@ -1976,7 +1982,7 @@ long storedItemID;
     ((UILabel*)[cell viewWithTag:2]).text = @"";
     if ([item[@"type"] isEqualToString:@"episode"]) {
         if ([item[@"season"] intValue] != 0 || [item[@"episode"] intValue] != 0) {
-            mainLabel.text = [NSString stringWithFormat:@"%@x%02i. %@", item[@"season"], [item[@"episode"] intValue], item[@"title"]];
+            mainLabel.text = [self formatTVShowStringForSeason:item[@"season"] episode:item[@"episode"] title:item[@"title"]];
         }
         subLabel.text = [NSString stringWithFormat:@"%@", item[@"showtitle"]];
     }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -555,28 +555,40 @@ long storedItemID;
                              long currentItemID = nowPlayingInfo[@"id"] ? [nowPlayingInfo[@"id"] longValue] : ID_INVALID;
                              if ((nowPlayingInfo.count && currentItemID != storedItemID) || nowPlayingInfo[@"id"] == nil || ([nowPlayingInfo[@"type"] isEqualToString:@"channel"] && ![nowPlayingInfo[@"title"] isEqualToString:storeLiveTVTitle])) {
                                  storedItemID = currentItemID;
-                                 itemDescription.text = [nowPlayingInfo[@"description"] length] != 0 ? [NSString stringWithFormat:@"%@", nowPlayingInfo[@"description"]] : [nowPlayingInfo[@"plot"] length] != 0 ? [NSString stringWithFormat:@"%@", nowPlayingInfo[@"plot"]] : @"";
+
+                                 // Set song details description text
+                                 NSString *description = [Utilities getStringFromItem:nowPlayingInfo[@"description"]];
+                                 NSString *plot = [Utilities getStringFromItem:nowPlayingInfo[@"plot"]];
+                                 itemDescription.text = description.length ? description : (plot.length ? plot : @"");
                                  [itemDescription scrollRangeToVisible:NSMakeRange(0, 0)];
+                                 
+                                 // Set NowPlaying text fields
                                  NSString *album = [Utilities getStringFromItem:nowPlayingInfo[@"album"]];
+                                 NSString *label = [Utilities getStringFromItem:nowPlayingInfo[@"label"]];
                                  if ([nowPlayingInfo[@"type"] isEqualToString:@"channel"]) {
-                                     album = nowPlayingInfo[@"label"];
+                                     album = label;
                                  }
                                  NSString *title = [Utilities getStringFromItem:nowPlayingInfo[@"title"]];
                                  storeLiveTVTitle = title;
                                  NSString *artist = [Utilities getStringFromItem:nowPlayingInfo[@"artist"]];
-                                 if (album.length == 0 && ((NSNull*)nowPlayingInfo[@"showtitle"] != [NSNull null]) && nowPlayingInfo[@"season"] > 0) {
-                                     album = [nowPlayingInfo[@"showtitle"] length] != 0 ? [NSString stringWithFormat:@"%@ - S%@E%@", nowPlayingInfo[@"showtitle"], nowPlayingInfo[@"season"], nowPlayingInfo[@"episode"]] : @"";
+                                 NSString *showtitle = [Utilities getStringFromItem:nowPlayingInfo[@"showtitle"]];
+                                 NSString *season = [Utilities getStringFromItem:nowPlayingInfo[@"season"]];
+                                 NSString *episode = [Utilities getStringFromItem:nowPlayingInfo[@"episode"]];
+                                 if (album.length == 0 && showtitle.length && [season intValue] > 0) {
+                                     album = showtitle.length ? [NSString stringWithFormat:@"%@ - S%@E%@", showtitle, season, episode] : @"";
                                  }
                                  if (title.length == 0) {
-                                     title = [Utilities getStringFromItem:nowPlayingInfo[@"label"]];
+                                     title = label;
                                  }
-
-                                 if (artist.length == 0 && ((NSNull*)nowPlayingInfo[@"studio"] != [NSNull null])) {
-                                     artist = [Utilities getStringFromItem:nowPlayingInfo[@"studio"]];
+                                 NSString *studio = [Utilities getStringFromItem:nowPlayingInfo[@"studio"]];
+                                 if (artist.length == 0 && studio.length) {
+                                     artist = studio;
                                  }
-                                 albumName.text = album;
+                                 // top to bottom: songName, artistName, albumName
                                  songName.text = title;
                                  artistName.text = artist;
+                                 albumName.text = album;
+                                 
                                  NSString *type = [Utilities getStringFromItem:nowPlayingInfo[@"type"]];
                                  currentType = type;
                                  [self setCoverSize:currentType];

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -60,14 +60,14 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="416"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
+                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" fixedFrame="YES" image="shiny_black_back" translatesAutoresizingMaskIntoConstraints="NO" id="94">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="416"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                </imageView>
                 <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="98" userLabel="Transition View">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="416"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" fixedFrame="YES" image="shiny_black_back" translatesAutoresizingMaskIntoConstraints="NO" id="94">
-                            <rect key="frame" x="0.0" y="0.0" width="320" height="372"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        </imageView>
                         <imageView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" fixedFrame="YES" image="xbmc_overlay" translatesAutoresizingMaskIntoConstraints="NO" id="156" userLabel="Image View - xbmc_overlay_iphone">
                             <rect key="frame" x="20" y="120" width="280" height="73"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -49,6 +49,7 @@
                 <outlet property="songSampleRate" destination="112" id="115"/>
                 <outlet property="songSampleRateImage" destination="b3u-Km-zml" id="mcn-U2-3U2"/>
                 <outlet property="thumbnailView" destination="52" id="53"/>
+                <outlet property="transitionView" destination="98" id="Hxy-bA-FyS"/>
                 <outlet property="view" destination="1" id="3"/>
                 <outlet property="xbmcOverlayImage" destination="154" id="155"/>
                 <outlet property="xbmcOverlayImage_iphone" destination="156" id="157"/>

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,7 +12,6 @@
                 <outlet property="BottomView" destination="J3u-n4-WAH" id="Fo6-uW-nQe"/>
                 <outlet property="PartyModeButton" destination="141" id="143"/>
                 <outlet property="ProgressSlider" destination="171" id="172"/>
-                <outlet property="TopView" destination="gLk-KE-7Rq" id="HtV-L6-UIF"/>
                 <outlet property="activityIndicatorView" destination="139" id="140"/>
                 <outlet property="albumName" destination="5" id="45"/>
                 <outlet property="artistName" destination="9" id="48"/>
@@ -123,36 +122,20 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <imageView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" fixedFrame="YES" image="xbmc_overlay" translatesAutoresizingMaskIntoConstraints="NO" id="154" userLabel="Image View - xbmc_overlay_ipad">
-                                    <rect key="frame" x="20" y="121" width="280" height="72"/>
+                                    <rect key="frame" x="20" y="91" width="280" height="72"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                 </imageView>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="52" userLabel="Image View - thumbnail">
-                                    <rect key="frame" x="40" y="43" width="240" height="240"/>
+                                    <rect key="frame" x="40" y="12" width="240" height="240"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 </imageView>
                                 <imageView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4" userLabel="Image View - jewel case or thumb">
-                                    <rect key="frame" x="10" y="31" width="300" height="266"/>
+                                    <rect key="frame" x="10" y="1" width="300" height="266"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                 </imageView>
-                                <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gLk-KE-7Rq" userLabel="Top View">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="42"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" flexibleMaxY="YES"/>
-                                    <subviews>
-                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="5" userLabel="Label Album">
-                                            <rect key="frame" x="5" y="0.0" width="310" height="42"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <nil key="highlightedColor"/>
-                                            <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.75" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <size key="shadowOffset" width="1" height="1"/>
-                                        </label>
-                                    </subviews>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </view>
                                 <view alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="104" userLabel="Song Details View">
-                                    <rect key="frame" x="40" y="42" width="240" height="240"/>
+                                    <rect key="frame" x="40" y="12" width="240" height="240"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gWQ-ZF-P81" userLabel="Item Logo Image">
@@ -266,19 +249,19 @@
                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.75" colorSpace="custom" customColorSpace="sRGB"/>
                                 </view>
                                 <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="J3u-n4-WAH" userLabel="Bottom View">
-                                    <rect key="frame" x="0.0" y="282" width="320" height="90"/>
+                                    <rect key="frame" x="0.0" y="266" width="320" height="106"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WnT-sg-K6N" userLabel="Time View">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                             <subviews>
                                                 <view alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="220" userLabel="View scrubbing message">
-                                                    <rect key="frame" x="20" y="2" width="280" height="20"/>
-                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
+                                                    <rect key="frame" x="20" y="-30" width="280" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                     <subviews>
                                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Scrubbing Message" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="221">
-                                                            <rect key="frame" x="5" y="0.0" width="270" height="10"/>
+                                                            <rect key="frame" x="5" y="0.0" width="270" height="15"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -287,7 +270,7 @@
                                                             <size key="shadowOffset" width="0.0" height="1"/>
                                                         </label>
                                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Scrubbing rate" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="222">
-                                                            <rect key="frame" x="5" y="10" width="270" height="10"/>
+                                                            <rect key="frame" x="5" y="15" width="270" height="15"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES"/>
                                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                                                             <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -299,7 +282,7 @@
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </view>
                                                 <slider opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="171" userLabel="Horizontal progress bar" customClass="OBSlider">
-                                                    <rect key="frame" x="20" y="15" width="280" height="29"/>
+                                                    <rect key="frame" x="20" y="5" width="280" height="29"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                     <color key="minimumTrackTintColor" red="0.34045934677124023" green="0.62004142999649048" blue="0.72810506820678711" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="maximumTrackTintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -313,7 +296,7 @@
                                                     </connections>
                                                 </slider>
                                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="30" userLabel="Label Current Time">
-                                                    <rect key="frame" x="5" y="40" width="90" height="10"/>
+                                                    <rect key="frame" x="5" y="26" width="90" height="12"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -322,7 +305,7 @@
                                                     <size key="shadowOffset" width="1" height="1"/>
                                                 </label>
                                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="31" userLabel="Label Total Time">
-                                                    <rect key="frame" x="224" y="40" width="91" height="10"/>
+                                                    <rect key="frame" x="225" y="26" width="90" height="12"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -334,7 +317,7 @@
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </view>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="6" userLabel="Label Title">
-                                            <rect key="frame" x="5" y="49" width="310" height="20"/>
+                                            <rect key="frame" x="5" y="40" width="310" height="24"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <color key="textColor" red="0.90011978149414062" green="0.90011978149414062" blue="0.90011978149414062" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -343,10 +326,19 @@
                                             <size key="shadowOffset" width="1" height="1"/>
                                         </label>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="9" userLabel="Label Artist">
-                                            <rect key="frame" x="5" y="70" width="310" height="15"/>
+                                            <rect key="frame" x="5" y="64" width="310" height="18"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <nil key="highlightedColor"/>
+                                            <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.75" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <size key="shadowOffset" width="1" height="1"/>
+                                        </label>
+                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="5" userLabel="Label Album">
+                                            <rect key="frame" x="5" y="82" width="310" height="18"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                             <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.75" colorSpace="custom" customColorSpace="sRGB"/>
                                             <size key="shadowOffset" width="1" height="1"/>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/719.

**Layout:**
The layout is updated by moving the cover up and having all text elements below. The text font (bold/normal, size, color) is changed to highlight the most important information.

**Content:**
`"year"` and `"director"` is shown as well as enrichment to the already available information.

**Refactoring:**
The code is refactored to ease up updating cover with and without having jewel case enabled: `thubmnailView` now always represents the cover and `jewelView` always the jewel case image. This allows to reduce code duplication and complexity.

**Animation:**
The flip animation when toggling between playlist and NowPlaying views is reworked to a single staged animation which looks a lot smoother than the former 2-staged implementation. The toggle-button animation on the right side of the toolbar is updated accordingly,



#727 must be merged first.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Refactor handling of cover and jewel case views to reduce code duplication
Improvement: Easier to read NowPlaying key information
Improvement: Smoother animation when toggling playlist and NowPlaying
Improvement: Added year and director where applicable