### PR TITLE
Rework remote messages

### DIFF
--- a/XBMC Remote/MessagesView.h
+++ b/XBMC Remote/MessagesView.h
@@ -13,6 +13,7 @@
 @interface MessagesView : UIView {
     NSTimer *fadeoutTimer;
     CGFloat slideHeight;
+    CGFloat messageOrigin;
 }
 
 - (id)initWithFrame:(CGRect)frame deltaY:(CGFloat)deltaY deltaX:(CGFloat)deltaX;

--- a/XBMC Remote/MessagesView.m
+++ b/XBMC Remote/MessagesView.m
@@ -23,11 +23,12 @@
         bottomBorder.backgroundColor = [Utilities getGrayColor:0 alpha:0.35].CGColor;
         [self.layer addSublayer:bottomBorder];
         self.backgroundColor = [Utilities getGrayColor:0 alpha:0.9];
+        messageOrigin = frame.origin.y;
         slideHeight = frame.size.height;
         if (IS_IPAD) {
             slideHeight += 22.0;
         }
-        self.frame = CGRectMake(frame.origin.x, -slideHeight, frame.size.width, frame.size.height);
+        self.frame = CGRectMake(frame.origin.x, messageOrigin - slideHeight, frame.size.width, frame.size.height);
         viewMessage = [[UILabel alloc] initWithFrame:CGRectMake(deltaX, deltaY, frame.size.width - deltaX, frame.size.height - deltaY)];
         viewMessage.backgroundColor = UIColor.clearColor;
         viewMessage.font = [UIFont boldSystemFontOfSize:16];
@@ -51,7 +52,7 @@
                           delay:0.0
                         options:UIViewAnimationOptionCurveEaseInOut
                      animations:^{
-        self.frame = CGRectMake(frame.origin.x, -slideHeight, frame.size.width, frame.size.height);
+        self.frame = CGRectMake(frame.origin.x, messageOrigin - slideHeight, frame.size.width, frame.size.height);
         self.alpha = 0.0;
                      }
                      completion:^(BOOL finished) {}];
@@ -62,7 +63,7 @@
                           delay:0.0
                         options:UIViewAnimationOptionCurveEaseInOut
                      animations:^{
-        self.frame = CGRectMake(frame.origin.x, 0, frame.size.width, frame.size.height);
+        self.frame = CGRectMake(frame.origin.x, messageOrigin, frame.size.width, frame.size.height);
         self.alpha = 1.0;
                      }
                      completion:^(BOOL finished) {}];
@@ -77,7 +78,7 @@
                           delay:0.0
                         options:UIViewAnimationOptionCurveEaseInOut
                      animations:^{
-        self.frame = CGRectMake(frame.origin.x, -slideHeight, frame.size.width, frame.size.height);
+        self.frame = CGRectMake(frame.origin.x, messageOrigin - slideHeight, frame.size.width, frame.size.height);
         self.alpha = 0.0;
                      }
                      completion:^(BOOL finished) {}];

--- a/XBMC Remote/MessagesView.m
+++ b/XBMC Remote/MessagesView.m
@@ -52,6 +52,7 @@
                         options:UIViewAnimationOptionCurveEaseInOut
                      animations:^{
         self.frame = CGRectMake(frame.origin.x, -slideHeight, frame.size.width, frame.size.height);
+        self.alpha = 0.0;
                      }
                      completion:^(BOOL finished) {}];
     viewMessage.text = message;

--- a/XBMC Remote/MessagesView.m
+++ b/XBMC Remote/MessagesView.m
@@ -37,6 +37,7 @@
         viewMessage.textAlignment = NSTextAlignmentCenter;
         viewMessage.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
         [self addSubview:viewMessage];
+        self.alpha = 0.0;
     }
     return self;
 }

--- a/XBMC Remote/RemoteController.h
+++ b/XBMC Remote/RemoteController.h
@@ -17,7 +17,6 @@ typedef enum {
 
 @interface RemoteController : UIViewController <UIGestureRecognizerDelegate> {
     IBOutlet UIView *remoteControlView;
-    IBOutlet UILabel *subsInfoLabel;
     IBOutlet UIView *quickHelpView;
     IBOutlet UIImageView *quickHelpImageView;
     IBOutlet UIView *gestureZoneView;

--- a/XBMC Remote/RemoteController.h
+++ b/XBMC Remote/RemoteController.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import "DSJSONRPC.h"
+#import "MessagesView.h"
 
 typedef enum {
     remoteTop,
@@ -37,6 +38,7 @@ typedef enum {
     BOOL isGestureViewActive;
     NSDictionary *subsDictionary;
     NSDictionary *audiostreamsDictionary;
+    MessagesView *messagesView;
 }
 
 - (IBAction)startVibrate:(id)sender;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -184,11 +184,6 @@
     frame.size.height -= shift;
     quickHelpView.frame = frame;
     
-    frame = subsInfoLabel.frame;
-    frame.origin.x = 0;
-    frame.size.width = newWidth;
-    subsInfoLabel.frame = frame;
-    
     [self setupGestureView];
     if ([Utilities hasRemoteToolBar]) {
         [self createRemoteToolbar:gestureImage width:newWidth xMin:ANCHOR_RIGHT_PEEK yMax:TOOLBAR_PARENT_HEIGHT isEmbedded:YES];
@@ -235,11 +230,6 @@
         
         frame.origin.y = 0;
         quickHelpView.frame = frame;
-        
-        frame = subsInfoLabel.frame;
-        frame.size.width = UIScreen.mainScreen.bounds.size.width;
-        frame.origin.x = (remoteControlView.frame.size.width - UIScreen.mainScreen.bounds.size.width) / 2;
-        subsInfoLabel.frame = frame;
     }
     else {
         VolumeSliderView *volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectZero leftAnchor:0.0 isSliderType:YES];
@@ -266,11 +256,6 @@
         
         frame.origin = CGPointZero;
         quickHelpView.frame = frame;
-        
-        frame = subsInfoLabel.frame;
-        frame.size.width = remoteControlView.frame.size.width;
-        frame.origin.x = 0;
-        subsInfoLabel.frame = frame;
         
         frame = remoteControlView.frame;
         frame.size.height += TOOLBAR_HEIGHT + CGRectGetMaxY(volumeSliderView.frame);

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1376,6 +1376,19 @@ NSInteger buttonAction;
                                                 deltaX:0];
     messagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     [rootView addSubview:messagesView];
+    
+    if (isEmbeddedMode) {
+        // Shadow on right side of movable screen
+        CGRect shadowRect = CGRectMake(0,
+                                       0,
+                                       PANEL_SHADOW_SIZE,
+                                       messagesView.frame.size.height);
+        UIImageView *shadowRight = [[UIImageView alloc] initWithFrame:shadowRect];
+        shadowRight.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleLeftMargin;
+        shadowRight.image = [UIImage imageNamed:@"tableRight"];
+        shadowRight.opaque = YES;
+        [messagesView addSubview:shadowRight];
+    }
 }
 
 - (void)handleSettingsButton:(id)sender {

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1365,9 +1365,17 @@ NSInteger buttonAction;
     gestureZoneImageView.layer.minificationFilter = kCAFilterTrilinear;
     self.view.backgroundColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"backgroundImage_repeat"]];
     
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, TransitionalView.frame.size.height / 2 - DEFAULT_MSG_HEIGHT / 2, TransitionalView.frame.size.width, DEFAULT_MSG_HEIGHT) deltaY:0 deltaX:0];
+    UIView *rootView = IS_IPHONE ? UIApplication.sharedApplication.keyWindow.rootViewController.view : self.view;
+    CGFloat deltaY = IS_IPHONE ? UIApplication.sharedApplication.statusBarFrame.size.height : 0;
+    CGFloat originX = isEmbeddedMode ? ANCHOR_RIGHT_PEEK : 0;
+    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(originX,
+                                                                  0,
+                                                                  TransitionalView.frame.size.width,
+                                                                  DEFAULT_MSG_HEIGHT + deltaY)
+                                                deltaY:deltaY
+                                                deltaX:0];
     messagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
-    [TransitionalView addSubview:messagesView];
+    [rootView addSubview:messagesView];
 }
 
 - (void)handleSettingsButton:(id)sender {

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -393,25 +393,7 @@
 # pragma mark - view Effects
 
 - (void)showSubInfo:(NSString*)message timeout:(NSTimeInterval)timeout color:(UIColor*)color {
-    // first fade in
-    [UIView animateWithDuration:0.1
-                          delay:0.0
-                        options:UIViewAnimationOptionCurveEaseInOut
-                     animations:^{
-        subsInfoLabel.alpha = 0.8;
-        subsInfoLabel.text = message;
-        subsInfoLabel.textColor = color;
-    }
-                     completion:^(BOOL finished) {
-        // then fade out
-        [UIView animateWithDuration:0.2
-                              delay:timeout
-                            options:UIViewAnimationOptionCurveEaseInOut
-                         animations:^{
-            subsInfoLabel.alpha = 0.0;
-        }
-                         completion:^(BOOL finished) {}];
-    }];
+    [messagesView showMessage:message timeout:timeout color:color];
 }
 
 # pragma mark - ToolBar
@@ -709,7 +691,7 @@
                             id audiostreamIndex = audiostreamsDictionary[@"audiostreams"][i][@"index"];
                             if (audiostreamIndex) {
                                 [self playbackAction:@"Player.SetAudioStream" params:@{@"stream": audiostreamIndex}];
-                                [self showSubInfo:actiontitle timeout:2.0 color:UIColor.whiteColor];
+                                [self showSubInfo:actiontitle timeout:2.0 color:[Utilities getSystemGreen:1.0]];
                             }
                         }
                     }
@@ -756,7 +738,7 @@
                             if (subsIndex) {
                                 [self playbackAction:@"Player.SetSubtitle" params:@{@"subtitle": subsIndex}];
                                 [self playbackAction:@"Player.SetSubtitle" params:@{@"subtitle": @"on"}];
-                                [self showSubInfo:actiontitle timeout:2.0 color:UIColor.whiteColor];
+                                [self showSubInfo:actiontitle timeout:2.0 color:[Utilities getSystemGreen:1.0]];
                             }
                         }
                     }
@@ -1397,6 +1379,10 @@ NSInteger buttonAction;
     [[SDImageCache sharedImageCache] clearMemory];
     gestureZoneImageView.layer.minificationFilter = kCAFilterTrilinear;
     self.view.backgroundColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"backgroundImage_repeat"]];
+    
+    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, TransitionalView.frame.size.height / 2 - DEFAULT_MSG_HEIGHT / 2, TransitionalView.frame.size.width, DEFAULT_MSG_HEIGHT) deltaY:0 deltaX:0];
+    messagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
+    [TransitionalView addSubview:messagesView];
 }
 
 - (void)handleSettingsButton:(id)sender {

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -509,7 +509,7 @@
                                      [self showActionSubtitles:actionSheetTitles];
                                  }
                                  else {
-                                     [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") timeout:2.0 color:[Utilities getSystemRed:1.0]];
+                                     [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") timeout:2.0 color:[Utilities getSystemRed:0.95]];
                                  }
                              }
                          }
@@ -517,7 +517,7 @@
                  }];
             }
             else {
-                [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") timeout:2.0 color:[Utilities getSystemRed:1.0]];
+                [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") timeout:2.0 color:[Utilities getSystemRed:0.95]];
             }
         }
     }];
@@ -576,7 +576,7 @@
                                      [self showActionAudiostreams:actionSheetTitles];
                                  }
                                  else {
-                                     [self showSubInfo:LOCALIZED_STR(@"Audiostreams not available") timeout:2.0 color:[Utilities getSystemRed:1.0]];
+                                     [self showSubInfo:LOCALIZED_STR(@"Audiostreams not available") timeout:2.0 color:[Utilities getSystemRed:0.95]];
                                  }
                              }
                         }
@@ -584,7 +584,7 @@
                  }];
             }
             else {
-                [self showSubInfo:LOCALIZED_STR(@"Audiostream not available") timeout:2.0 color:[Utilities getSystemRed:1.0]];
+                [self showSubInfo:LOCALIZED_STR(@"Audiostream not available") timeout:2.0 color:[Utilities getSystemRed:0.95]];
             }
         }
     }];
@@ -676,7 +676,7 @@
                             id audiostreamIndex = audiostreamsDictionary[@"audiostreams"][i][@"index"];
                             if (audiostreamIndex) {
                                 [self playbackAction:@"Player.SetAudioStream" params:@{@"stream": audiostreamIndex}];
-                                [self showSubInfo:actiontitle timeout:2.0 color:[Utilities getSystemGreen:1.0]];
+                                [self showSubInfo:actiontitle timeout:2.0 color:[Utilities getSystemGreen:0.95]];
                             }
                         }
                     }
@@ -703,9 +703,9 @@
         UIAlertController *actionView = [UIAlertController alertControllerWithTitle:LOCALIZED_STR(@"Subtitles") message:nil preferredStyle:UIAlertControllerStyleActionSheet];
         
         UIAlertAction *action_cancel = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {}];
-        
+
         UIAlertAction *action_disable = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Disable subtitles") style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
-            [self showSubInfo:LOCALIZED_STR(@"Subtitles disabled") timeout:2.0 color:[Utilities getSystemRed:1.0]];
+            [self showSubInfo:LOCALIZED_STR(@"Subtitles disabled") timeout:2.0 color:[Utilities getSystemGreen:0.95]];
             [self playbackAction:@"Player.SetSubtitle" params:@{@"subtitle": @"off"}];
         }];
         if ([subsDictionary[@"subtitleenabled"] boolValue]) {
@@ -723,7 +723,7 @@
                             if (subsIndex) {
                                 [self playbackAction:@"Player.SetSubtitle" params:@{@"subtitle": subsIndex}];
                                 [self playbackAction:@"Player.SetSubtitle" params:@{@"subtitle": @"on"}];
-                                [self showSubInfo:actiontitle timeout:2.0 color:[Utilities getSystemGreen:1.0]];
+                                [self showSubInfo:actiontitle timeout:2.0 color:[Utilities getSystemGreen:0.95]];
                             }
                         }
                     }

--- a/XBMC Remote/RemoteController.xib
+++ b/XBMC Remote/RemoteController.xib
@@ -17,7 +17,6 @@
                 <outlet property="quickHelpImageView" destination="168" id="172"/>
                 <outlet property="quickHelpView" destination="167" id="171"/>
                 <outlet property="remoteControlView" destination="1" id="135"/>
-                <outlet property="subsInfoLabel" destination="136" id="137"/>
                 <outlet property="view" destination="133" id="134"/>
             </connections>
         </placeholder>
@@ -423,16 +422,6 @@
                                 <action selector="startVibrate:" destination="-1" eventType="touchUpInside" id="68"/>
                             </connections>
                         </button>
-                        <label clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.0" contentMode="left" fixedFrame="YES" text="subtitles info" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="136" userLabel="Label - subs info">
-                            <rect key="frame" x="0.0" y="270" width="320" height="50"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
-                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
-                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <nil key="highlightedColor"/>
-                            <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <size key="shadowOffset" width="1" height="1"/>
-                        </label>
                         <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="167" userLabel="Quick Help - View">
                             <rect key="frame" x="0.0" y="0.0" width="320" height="460"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -24,6 +24,8 @@ typedef enum {
     bgTrans
 } LogoBackgroundType;
 
+#define PANEL_SHADOW_SIZE 16
+
 @interface Utilities : NSObject
 
 + (UIColor*)averageColor:(UIImage*)image inverse:(BOOL)inverse autoColorCheck:(BOOL)autoColorCheck;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -18,7 +18,6 @@
 #define XBMC_LOGO_PADDING 10
 #define PERSISTENCE_KEY_VERSION @"VersionUnderReview"
 #define PERSISTENCE_KEY_PLAYBACK_ATTEMPTS @"PlaybackAttempts"
-#define PANEL_SHADOW_SIZE 16
 
 @implementation Utilities
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR updates the remote's messages for subtitle and audio stream configuration changes. Now, the same message style as for the rest of the app is used. The messages are always placed in the vertical middle of the touch area / 4-button remote field, use the full remote width and have centralized text.

To be able to implement this, the app-wide used class`MessagesView` needs some updates:
- Messages are invisible right from the start and only become visible while animating them
- Messages can be placed at non-0 vertical positions

Screenshots (top = new, bottom = old):
https://abload.de/img/bildschirmfoto2023-010qeck.png 

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Improve readability of subtitle and audio stream messages