### PR TITLE
Improvement: Keep minimum space for playlist item in iPad landscape

### DIFF
--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -342,7 +342,8 @@
     AppDelegate.instance.obj = [GlobalData getInstance];
 
     int cellHeight = PAD_MENU_HEIGHT;
-    NSInteger tableHeight = [(NSMutableArray*)mainMenu count] * cellHeight;
+    NSInteger maxMenuItems = floor((GET_MAINSCREEN_WIDTH - deltaY - PLAYLIST_HEADER_HEIGHT - TOOLBAR_HEIGHT) / 2.0 / PAD_MENU_HEIGHT);
+    NSInteger tableHeight = MIN([(NSMutableArray*)mainMenu count], maxMenuItems) * cellHeight;
     int tableWidth = PAD_MENU_TABLE_WIDTH;
     int headerHeight = 0;
    
@@ -359,7 +360,7 @@
 	leftMenuView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, tableWidth, self.view.frame.size.height)];
 	leftMenuView.autoresizingMask = UIViewAutoresizingFlexibleHeight;	
     
-	menuViewController = [[MenuViewController alloc] initWithFrame:CGRectMake(0, headerHeight, leftMenuView.frame.size.width, leftMenuView.frame.size.height) mainMenu:mainMenu];
+	menuViewController = [[MenuViewController alloc] initWithFrame:CGRectMake(0, headerHeight, leftMenuView.frame.size.width, leftMenuView.frame.size.height) mainMenu:mainMenu menuHeight:tableHeight];
 	menuViewController.view.backgroundColor = UIColor.clearColor;
 	[menuViewController viewWillAppear:NO];
 	[menuViewController viewDidAppear:NO];

--- a/XBMC Remote/iPad/MenuViewController.h
+++ b/XBMC Remote/iPad/MenuViewController.h
@@ -45,7 +45,7 @@
     int lastSelected;
 }
 
-- (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu;
+- (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu menuHeight:(CGFloat)tableHeight;
 - (void)setLastSelected:(int)selection;
 
 @property (nonatomic, strong) UITableView *tableView;

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -51,10 +51,9 @@
 #pragma mark -
 #pragma mark View lifecycle
 
-- (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu {
+- (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu menuHeight:(CGFloat)tableHeight {
     if (self = [super init]) {
         self.view.frame = frame;
-        CGFloat tableHeight = menu.count * PAD_MENU_HEIGHT;
         _tableView = [[UITableView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, tableHeight) style:UITableViewStylePlain];
         _tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
         _tableView.delegate = self;


### PR DESCRIPTION
Leaves more free space for playlist. The menu items are scrollable.

## Description
<!--- Detailed info for reviewers and developers -->
As also mentioned by a user the increased amount of main menu items had a negative effect on the space left for the playlist items on iPad. This PR limits the main menu height to maximum 50% of landscape height, which leaves about 40% for the playlist items and improves the usability. The main menu items are scrollable, each main item can still be entered.

Based on this change the app can be further enhanced with more main menu entries like "Folder browsing" or "Settings".

Screenshots: https://abload.de/img/bildschirmfoto2023-011wf8f.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Keep minimum space for playlist item in iPad landscape