### PR TITLE
Fix filebrowser

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -2352,6 +2352,7 @@
 
         @[
             @{
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
             }, @"parameters",
             LOCALIZED_STR(@"Files"), @"label",
@@ -3120,6 +3121,7 @@
         
         @[
             @{
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
             }, @"parameters",
             LOCALIZED_STR(@"Files"), @"label",

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1514,7 +1514,7 @@
                                   
         @[
             @{
-                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"file_properties": @[
                     @"thumbnail",
                 ],
@@ -2718,7 +2718,7 @@
                                   
         @[
             @{
-                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"file_properties": @[
                     @"thumbnail",
@@ -3881,7 +3881,7 @@
                                     
         @[
             @{
-                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"file_properties": @[
                     @"thumbnail",
@@ -5343,7 +5343,7 @@
                                   
         @[
             @{
-                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
+                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"pictures",
                 @"file_properties": @[
                     @"thumbnail",

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5033,8 +5033,10 @@ NSIndexPath *selected;
 - (void)indexAndDisplayData {
     mainMenu *menuItem = self.detailItem;
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
     NSArray *copyRichResults = [self.richResults copy];
     BOOL addUITableViewIndexSearch = NO;
+    BOOL isFileBrowsing = [methods[@"method"] isEqualToString:@"Files.GetDirectory"];
     self.sectionArray = nil;
     autoScrollTable = nil;
     if (copyRichResults.count == 0) {
@@ -5062,7 +5064,7 @@ NSIndexPath *selected;
     // Sort tokens need to be processed outside of other conditions to ensure they are applied
     // also for default sorting coming from Kodi server.
     NSString *sortbymethod = sortMethodName;
-    if (sortMethodName != nil) {
+    if (sortMethodName != nil && !isFileBrowsing) {
         if ([self isEligibleForSorttokenSort]) {
             copyRichResults = [self applySortTokens:copyRichResults sortmethod:sortbymethod];
             sortbymethod = @"sortby";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://www.kodinerds.net/index.php/Thread/73696-Titel-Sortierung-Kodi-Remote-V1-8-1-App-auf-IPad/).

When in file browser mode the remote app requests Kodi to report the result sorted by label. This result list will start with directories, followed by files -- each block sorted by label. The remote app must not sort this again.

In addition, this PR will also configure sort-by-label when requesting the Movie and Video sources (was already done for TV Shows).

Screenshots: https://abload.de/img/bildschirmfoto2023-02lvijd.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Keep directories on top while in file browsing mode
Bugfix: Sort Movie and Video sources by name