### PR TITLE
Improvement: Ignore BB and HTML code for menu entries and descriptions

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -444,7 +444,7 @@
 }
 
 - (void)setFilternameLabel:(NSString*)labelText runFullscreenButtonCheck:(BOOL)check forceHide:(BOOL)forceHide {
-    self.navigationItem.title = labelText;
+    self.navigationItem.title = [Utilities stripBBandHTML:labelText];
     if (IS_IPHONE) {
         return;
     }
@@ -1751,12 +1751,12 @@
         cell.posterLabelFullscreen.font = [UIFont boldSystemFontOfSize:posterFontSize];
         cell.posterThumbnail.contentMode = UIViewContentModeScaleAspectFill;
         if (stackscrollFullscreen) {
-            cell.posterLabelFullscreen.text = item[@"label"];
+            cell.posterLabelFullscreen.text = [Utilities stripBBandHTML:item[@"label"]];
             cell.labelImageView.hidden = YES;
             cell.posterLabelFullscreen.hidden = NO;
         }
         else {
-            cell.posterLabel.text = item[@"label"];
+            cell.posterLabel.text = [Utilities stripBBandHTML:item[@"label"]];
             cell.posterLabelFullscreen.hidden = YES;
         }
         
@@ -2500,7 +2500,7 @@
         title.text = [Utilities formatTVShowStringForSeasonLeading:item[@"season"] episode:item[@"episode"] title:item[@"label"]];
     }
     else {
-        title.text = item[@"label"];
+        title.text = [Utilities stripBBandHTML:item[@"label"]];
     }
 
     frame = genre.frame;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -560,6 +560,7 @@ long storedItemID;
                                      NSString *description = [Utilities getStringFromItem:nowPlayingInfo[@"description"]];
                                      NSString *plot = [Utilities getStringFromItem:nowPlayingInfo[@"plot"]];
                                      itemDescription.text = description.length ? description : (plot.length ? plot : @"");
+                                     itemDescription.text = [Utilities stripBBandHTML:itemDescription.text];
                                      [itemDescription scrollRangeToVisible:NSMakeRange(0, 0)];
                                  }
                                  

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -883,6 +883,8 @@ double round(double d) {
 
     parentalRatingLabel.text = [Utilities getStringFromItem:item[@"mpaa"]];
     
+    summaryLabel.text = [Utilities stripBBandHTML:summaryLabel.text];
+    
     if ([item[@"trailer"] isKindOfClass:[NSString class]]) {
         [self processTrailerFromString:item[@"trailer"]];
     }

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -108,5 +108,6 @@ typedef enum {
 + (NSString*)formatTVShowStringForSeasonTrailing:(id)season episode:(id)episode title:(NSString*)title;
 + (NSString*)formatTVShowStringForSeasonLeading:(id)season episode:(id)episode title:(NSString*)title;
 + (NSString*)formatTVShowStringForSeason:(id)season episode:(id)episode;
++ (NSString*)stripBBandHTML:(NSString*)text;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1176,4 +1176,25 @@
     return text;
 }
 
++ (NSString*)stripRegEx:(NSString*)regExp text:(NSString*)textIn {
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regExp options:NSRegularExpressionCaseInsensitive error:NULL];
+    NSString *textOut = [regex stringByReplacingMatchesInString:textIn options:0 range:NSMakeRange(0, [textIn length]) withTemplate:@""];
+    return textOut;
+}
+
++ (NSString*)stripBBandHTML:(NSString*)text {
+    NSString *textOut = text;
+    
+    // Strip html, <x>, whereas x is not ""
+    textOut = [Utilities stripRegEx:@"<[^>]+>" text:textOut];
+    
+    // Strip BB code, [x] [/x], whereas x = b,u,i,s,center,left,right,url,img and spaces
+    textOut = [Utilities stripRegEx:@"\\[/?(b|u|i|s|center|left|right|url|img)\\]" text:textOut];
+    
+    // Strip BB code, [x=anything] [/x], whereas x = font,size,color,url and spaces
+    textOut = [Utilities stripRegEx:@"\\[/?(font|size|color|url)(=[^]]+)?\\]" text:textOut];
+    
+    return textOut;
+}
+
 @end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/369.

This PR will improve displaying content with BB or HTML code. It was reported by users that some plugins (e.g. youtube) and  most likely also the metadata of some service providers use BB or HTML code. As it is not reasonable to let the BB or HTML code control the layout (e.g. the text must keep readable in its context and for dark/light mode), the related code is stripped off and not used. For BB code most of the key words are stripped (`b, u, i, s, center, left, right, url, img, font, size, color`), for HTML simply all non-empty `<>`-brackets are stripped. The latter is _a lot_ faster than using the iOS internal solution via `NSHTMLTextDocumentType`.

Screenshots (youtube plugin main menu):
<a href="https://abload.de/image.php?img=bildschirmfoto2023-028jdjc.png"><img src="https://abload.de/img/bildschirmfoto2023-028jdjc.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Ingnore BB and HTLM code for menu entries and descriptions