### PR TITLE
Bugfix: Fix regression when updating detailItem

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -36,6 +36,7 @@
 
 @implementation DetailViewController
 
+@synthesize detailItem = _detailItem;
 @synthesize activityIndicatorView;
 @synthesize sections;
 @synthesize filteredListContent;
@@ -3707,6 +3708,14 @@ NSIndexPath *selected;
 }
 
 #pragma mark - View Configuration
+
+- (void)setDetailItem:(id)newDetailItem {
+    if (_detailItem != newDetailItem) {
+        _detailItem = newDetailItem;
+        // Update the view.
+        [self configureView];
+    }
+}
 
 - (void)configureView {
     mainMenu *menuItem = self.detailItem;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -27,6 +27,7 @@
 
 @implementation NowPlaying
 
+@synthesize detailItem = _detailItem;
 @synthesize remoteController;
 @synthesize jewelView;
 @synthesize shuffleButton;
@@ -65,6 +66,14 @@ typedef enum {
     PLAYERID_VIDEO = 1,
     PLAYERID_PICTURES = 2
 } PlayerIDs;
+
+- (void)setDetailItem:(id)newDetailItem {
+    if (_detailItem != newDetailItem) {
+        _detailItem = newDetailItem;
+        // Update the view.
+        [self configureView];
+    }
+}
 
 - (void)configureView {
     // Update the user interface for the detail item.


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/864.

Fixes a regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/699/commits/59d83881b963e2a5fa646a8e44fbc69a1c2adc6b.

By fault active code was removed, causing the shortcut icons to enter Remote and NowPlaying not being displayed anymore in iPhone navigation bar.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix regression of not showing remote/NowPlaying shortcuts on iPhones