### PR TITLE
Bugfix: Remove unwanted empty space and horizontal bar above settings

### DIFF
--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -126,6 +126,9 @@
 		_tableView.delegate = self;
 		_tableView.dataSource = self;
         _tableView.backgroundColor = UIColor.clearColor;
+        if (@available(iOS 15.0, *)) {
+            _tableView.sectionHeaderTopPadding = 0;
+        }
         UIView *footerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 1)];
 		_tableView.tableFooterView = footerView;
         self.view.backgroundColor = UIColor.clearColor;
@@ -674,7 +677,7 @@
 }
 
 - (CGFloat)tableView:(UITableView*)tableView heightForHeaderInSection:(NSInteger)section {
-    return 1;
+    return 0;
 }
 
 - (UIView*)tableView:(UITableView*)tableView viewForFooterInSection:(NSInteger)section {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Since XCode 13 and iOS 15 `sectionHeaderTopPadding` must be set to zero explicitly. This was not yet done in the Kodi settings controller. In addition the PR sets the section header height to zero as well. Both changes avoid and unwanted empty space and horizontal bar above the settings.

Screenshot:
<a href="https://abload.de/image.php?img=bildschirmfoto2023-0303fn2.png"><img src="https://abload.de/img/bildschirmfoto2023-0303fn2.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Remove unwanted empty space and horizontal bar above settings