### PR TITLE
Rework layout around status bars, especially iPads

### DIFF
--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -26,6 +26,7 @@
 #define BAR_TINT_COLOR [Utilities getGrayColor:26 alpha:1]
 #define REMOTE_CONTROL_BAR_TINT_COLOR [Utilities getGrayColor:12 alpha:1]
 #define SLIDER_DEFAULT_COLOR [Utilities getSystemTeal]
+#define TOOLBAR_TINT_COLOR [Utilities getGrayColor:38 alpha:0.95]
 
 /*
  * Dimension and layout macros

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5809,7 +5809,12 @@ NSIndexPath *selected;
     [Utilities createTransparentToolbar:buttonsViewBgToolbar];
     
     // Gray background for toolbar
-    buttonsView.backgroundColor = [Utilities getGrayColor:38 alpha:0.95];
+    if (IS_IPHONE) {
+        buttonsView.backgroundColor = [Utilities getGrayColor:38 alpha:0.95];
+    }
+    else {
+        buttonsViewBgToolbar.backgroundColor = [Utilities getGrayColor:38 alpha:0.95];
+    }
     
     if ([methods[@"albumView"] boolValue]) {
         albumView = YES;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5810,10 +5810,10 @@ NSIndexPath *selected;
     
     // Gray background for toolbar
     if (IS_IPHONE) {
-        buttonsView.backgroundColor = [Utilities getGrayColor:38 alpha:0.95];
+        buttonsView.backgroundColor = TOOLBAR_TINT_COLOR;
     }
     else {
-        buttonsViewBgToolbar.backgroundColor = [Utilities getGrayColor:38 alpha:0.95];
+        buttonsViewBgToolbar.backgroundColor = TOOLBAR_TINT_COLOR;
     }
     
     if ([methods[@"albumView"] boolValue]) {

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -479,7 +479,7 @@ static inline BOOL IsEmpty(id obj) {
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    CGFloat deltaY = 44 + UIApplication.sharedApplication.statusBarFrame.size.height;
+    CGFloat deltaY = 44 + [Utilities getTopPadding];
     if (IS_IPAD) {
         deltaY = 0;
     }
@@ -568,7 +568,7 @@ static inline BOOL IsEmpty(id obj) {
     }
     else {
         int barHeight = 44;
-        int statusBarHeight = UIApplication.sharedApplication.statusBarFrame.size.height;
+        int statusBarHeight = [Utilities getTopPadding];
         
         CGRect frame = supportedVersionView.frame;
         frame.origin.y = frame.origin.y + barHeight + statusBarHeight;

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -308,7 +308,7 @@
     [super viewDidLoad];
     
     // The menu list starts at the bottom of the status bar to not overlap with it
-    CGFloat statuBarHeight = CGRectGetHeight(UIApplication.sharedApplication.statusBarFrame);
+    CGFloat statuBarHeight = [Utilities getTopPadding];
     CGRect frame = menuList.frame;
     frame.origin.y = statuBarHeight;
     frame.size.height = frame.size.height - statuBarHeight;

--- a/XBMC Remote/MessagesView.m
+++ b/XBMC Remote/MessagesView.m
@@ -26,7 +26,7 @@
         messageOrigin = frame.origin.y;
         slideHeight = frame.size.height;
         if (IS_IPAD) {
-            slideHeight += 22.0;
+            slideHeight += [Utilities getTopPadding];
         }
         self.frame = CGRectMake(frame.origin.x, messageOrigin - slideHeight, frame.size.width, frame.size.height);
         viewMessage = [[UILabel alloc] initWithFrame:CGRectMake(deltaX, deltaY, frame.size.width - deltaX, frame.size.height - deltaY)];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2200,7 +2200,7 @@ long storedItemID;
     
     // Maximum allowed height excludes status bar, toolbar and safe area
     CGFloat bottomPadding = [Utilities getBottomPadding];
-    CGFloat statusBar = UIApplication.sharedApplication.statusBarFrame.size.height;
+    CGFloat statusBar = [Utilities getTopPadding];
     CGFloat maxheight = height - bottomPadding - statusBar - TOOLBAR_HEIGHT;
     
     nowPlayingView.frame = CGRectMake(PAD_MENU_TABLE_WIDTH + 2,

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2577,7 +2577,7 @@ long storedItemID;
     CGFloat bottomBarHeight = playlistToolbar.frame.size.height + bottomPadding;
     toolbarBackground = [[UIView alloc] initWithFrame:CGRectMake(0, self.view.frame.size.height - bottomBarHeight, self.view.frame.size.width, bottomBarHeight)];
     toolbarBackground.autoresizingMask = playlistToolbar.autoresizingMask;
-    toolbarBackground.backgroundColor = [Utilities getGrayColor:38 alpha:0.95];
+    toolbarBackground.backgroundColor = TOOLBAR_TINT_COLOR;
     [self.view insertSubview:toolbarBackground atIndex:1];
     
     // Set correct size for background image

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -286,7 +286,7 @@
 
 - (CGFloat)getRemoteViewOffsetY {
     // Layout is (top-down): status bar > server info > volume slider > (menu items) > remote view
-    CGFloat statusBarHeight = UIApplication.sharedApplication.statusBarFrame.size.height;
+    CGFloat statusBarHeight = [Utilities getTopPadding];
     CGFloat sliderHeight = volumeSliderView.frame.size.height;
     CGFloat menuItemsHeight = [Utilities hasRemoteToolBar] ? 0 : 3 * RIGHT_MENU_ITEM_HEIGHT;
     return statusBarHeight + SERVER_INFO_HEIGHT + sliderHeight + menuItemsHeight;
@@ -583,7 +583,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    CGFloat deltaY = UIApplication.sharedApplication.statusBarFrame.size.height;
+    CGFloat deltaY = [Utilities getTopPadding];
     self.peekLeftAmount = ANCHOR_RIGHT_PEEK;
     CGRect frame = UIScreen.mainScreen.bounds;
     CGFloat deltaX = ANCHOR_RIGHT_PEEK;

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -145,7 +145,7 @@
             frame.size.width = STACKSCROLL_WIDTH;
         }
         else {
-            deltaY = 44 + CGRectGetHeight(UIApplication.sharedApplication.statusBarFrame);
+            deltaY = 44 + [Utilities getTopPadding];
         }
         
         scrubbingView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, 44)];

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -86,6 +86,7 @@ typedef enum {
 + (BOOL)isTorchOn;
 + (BOOL)hasRemoteToolBar;
 + (CGFloat)getBottomPadding;
++ (CGFloat)getTopPadding;
 + (void)sendXbmcHttp:(NSString*)command;
 + (NSString*)getAppVersionString;
 + (void)checkForReviewRequest;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -887,16 +887,12 @@
 }
 
 + (CGFloat)getBottomPadding {
-    CGFloat bottomPadding = 0;
-    UIWindow *window = UIApplication.sharedApplication.keyWindow;
-    bottomPadding = window.safeAreaInsets.bottom;
+    CGFloat bottomPadding = UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom;
     return bottomPadding;
 }
 
 + (CGFloat)getTopPadding {
-    CGFloat topPadding = 0;
-    UIWindow *window = UIApplication.sharedApplication.keyWindow;
-    topPadding = window.safeAreaInsets.top;
+    CGFloat topPadding = UIApplication.sharedApplication.keyWindow.safeAreaInsets.top;
     return topPadding;
 }
 

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -893,6 +893,13 @@
     return bottomPadding;
 }
 
++ (CGFloat)getTopPadding {
+    CGFloat topPadding = 0;
+    UIWindow *window = UIApplication.sharedApplication.keyWindow;
+    topPadding = window.safeAreaInsets.top;
+    return topPadding;
+}
+
 + (void)sendXbmcHttp:(NSString*)command {
     GlobalData *obj = [GlobalData getInstance];
     NSString *userPassword = [obj.serverPass isEqualToString:@""] ? @"" : [NSString stringWithFormat:@":%@", obj.serverPass];

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -346,7 +346,7 @@
     int tableWidth = PAD_MENU_TABLE_WIDTH;
     int headerHeight = 0;
    
-    rootView = [[UIViewExt alloc] initWithFrame:CGRectMake(0, deltaY, self.view.frame.size.width, self.view.frame.size.height - deltaY - 1)];
+    rootView = [[UIViewExt alloc] initWithFrame:CGRectMake(0, deltaY, self.view.frame.size.width, self.view.frame.size.height - deltaY)];
 	rootView.autoresizingMask = UIViewAutoresizingFlexibleWidth + UIViewAutoresizingFlexibleHeight;
 	rootView.backgroundColor = UIColor.clearColor;
 	

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -332,7 +332,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    int deltaY = [Utilities getTopPadding] + 2; // + 2 used by horizontanLineView
+    int deltaY = [Utilities getTopPadding];
     [self setNeedsStatusBarAppearanceUpdate];
     self.view.tintColor = APP_TINT_COLOR;
     self.tcpJSONRPCconnection = [tcpJSONRPC new];

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -332,7 +332,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    int deltaY = UIApplication.sharedApplication.statusBarFrame.size.height + 2; // + 2 used by horizontanLineView
+    int deltaY = [Utilities getTopPadding] + 2; // + 2 used by horizontanLineView
     [self setNeedsStatusBarAppearanceUpdate];
     self.view.tintColor = APP_TINT_COLOR;
     self.tcpJSONRPCconnection = [tcpJSONRPC new];

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -146,7 +146,7 @@
                 CGRect frame = subview.frame;
                 frame.origin.x = 0 - PAD_MENU_TABLE_WIDTH;
                 if (hideToolbar) {
-                    CGFloat statusbarHeight = UIApplication.sharedApplication.statusBarFrame.size.height;
+                    CGFloat statusbarHeight = [Utilities getTopPadding];
                     frame.origin.y -= statusbarHeight;
                     frame.size.height += statusbarHeight;
                 }
@@ -981,7 +981,7 @@
             frame.size.width += PAD_MENU_TABLE_WIDTH;
             frame.origin.x -= PAD_MENU_TABLE_WIDTH;
             if (hideToolbar) {
-                CGFloat statusbarHeight = UIApplication.sharedApplication.statusBarFrame.size.height;
+                CGFloat statusbarHeight = [Utilities getTopPadding];
                 frame.origin.y -= statusbarHeight;
                 frame.size.height += statusbarHeight;
             }

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -985,6 +985,7 @@
                 frame.origin.y -= statusbarHeight;
                 frame.size.height += statusbarHeight;
             }
+            frame.size.height -= [Utilities getBottomPadding];
             subController.view.frame = frame;
         }
         else if (viewAtRight != nil && [viewAtRight isEqual:subController.view]) {

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -190,7 +190,7 @@
                 CGRect frame = subview.frame;
                 frame.origin.x = 0;
                 frame.origin.y = 0;
-                frame.size.height = self.view.frame.size.height;
+                frame.size.height = self.view.frame.size.height - [Utilities getBottomPadding];
                 frame.size.width = originalFrame.size.width;
                 subview.frame = frame;
                 break;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR reworks some layout related topics:
- Use `safeAreaInsets.top` instead of future deprecated `statusBarFrame.size.height`
- Avoid future deprecated `UIApplication.sharedApplication.keyWindow`
- Fix position `messageView` frame and the height of iPad's `rootView`
- Fix height of iPad stack view after disabling fullscreen (fanart)

Screenshots: 
https://abload.de/img/bildschirmfoto2023-0425dm5.png
https://abload.de/img/bildschirmfoto2023-04grfpj.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix partially visible message view in status bar above iPad stack view
Bugfix: Fix stack view overlapping the bottom toolbar after disabling or rotating fullscreen on iPads with safe bottom area
Bugfix: Fix iPad's toolbar transparency in fullscreen mode
Maintenance: Use safeAreaInsets.top instead of future deprecated statusBarFrame.size.height
Maintenance: Avoid future deprecated UIApplication.sharedApplication.keyWindow
