### PR TITLE
Feature: Support user resizable left menu on iPad

### DIFF
--- a/XBMC Remote/MoreItemsViewController.h
+++ b/XBMC Remote/MoreItemsViewController.h
@@ -10,11 +10,11 @@
 
 @interface MoreItemsViewController : UIViewController <UITableViewDelegate, UITableViewDataSource> {
 	UITableView *_tableView;
-    NSMutableArray *mainMenuItems;
+    NSArray *mainMenuItems;
     int cellLabelOffset;
 }
 
-- (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu;
+- (id)initWithFrame:(CGRect)frame mainMenu:(NSArray*)menu;
 
 @property (nonatomic, strong) UITableView *tableView;
 

--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -14,7 +14,7 @@
 
 @synthesize tableView = _tableView;
 
-- (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu {
+- (id)initWithFrame:(CGRect)frame mainMenu:(NSArray*)menu {
     if (self = [super init]) {
         cellLabelOffset = 50;
 		self.view.frame = frame;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -43,6 +43,7 @@
 #define PARTYBUTTON_PADDING_LEFT 8
 #define PROGRESSBAR_PADDING_LEFT 20
 #define PROGRESSBAR_PADDING_BOTTOM 80
+#define COVERVIEW_PADDING 10
 #define SEGMENTCONTROL_WIDTH 122
 #define SEGMENTCONTROL_HEIGHT 32
 #define TOOLBAR_HEIGHT 44
@@ -2209,9 +2210,9 @@ long storedItemID;
                                       maxheight);
     
     BottomView.frame = CGRectMake(PAD_MENU_TABLE_WIDTH,
-                                  CGRectGetMaxY(songDetailsView.frame),
+                                  CGRectGetMaxY(thumbnailView.frame) + COVERVIEW_PADDING,
                                   width - PAD_MENU_TABLE_WIDTH,
-                                  maxheight - CGRectGetMaxY(songDetailsView.frame));
+                                  maxheight - CGRectGetMaxY(thumbnailView.frame));
     
     frame = playlistToolbar.frame;
     frame.size.width = width;

--- a/XBMC Remote/ViewControllerIPad.h
+++ b/XBMC Remote/ViewControllerIPad.h
@@ -24,6 +24,7 @@
 	UIViewExt *rootView;
 	UIView *leftMenuView;
 	UIView *rightSlideView;
+    UILabel *playlistHeader;
 	MenuViewController *menuViewController;
     NowPlaying *nowPlayingController;
 	StackScrollViewController *stackScrollViewController;

--- a/XBMC Remote/ViewControllerIPad.h
+++ b/XBMC Remote/ViewControllerIPad.h
@@ -21,13 +21,13 @@
 
 
 @interface ViewControllerIPad : UIViewController {
-	UIViewExt *rootView;
-	UIView *leftMenuView;
-	UIView *rightSlideView;
+    UIViewExt *rootView;
+    UIView *leftMenuView;
+    UIView *rightSlideView;
     UILabel *playlistHeader;
-	MenuViewController *menuViewController;
+    MenuViewController *menuViewController;
     NowPlaying *nowPlayingController;
-	StackScrollViewController *stackScrollViewController;
+    StackScrollViewController *stackScrollViewController;
     NSIndexPath *storeServerSelection;
     int YPOS;
     UIButton *remoteButton;

--- a/XBMC Remote/ViewControllerIPad.h
+++ b/XBMC Remote/ViewControllerIPad.h
@@ -37,6 +37,7 @@
     UIImageView *connectionStatus;
     VolumeSliderView *volumeSliderView;
     BOOL firstRun;
+    BOOL didTouchLeftMenu;
     NSTimer *extraTimer;
     HostManagementViewController *_hostPickerViewController;
     BOOL serverPicker;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -338,6 +338,9 @@
     NSInteger maxMenuItems = round(CGRectGetMinY(playlistHeader.frame) / PAD_MENU_HEIGHT);
     CGFloat tableHeight = MIN([(NSMutableArray*)mainMenu count], maxMenuItems) * PAD_MENU_HEIGHT;
     [self changeLeftMenu:tableHeight];
+    
+    // Save configuration
+    [self saveLeftMenuSplit:maxMenuItems];
 }
 
 #pragma mark - App clear disk cache methods
@@ -359,6 +362,28 @@
                          NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
                          [userDefaults removeObjectForKey:@"clearcache_preference"];
                      }];
+}
+
+#pragma mark - Persistence
+
+- (void)saveLeftMenuSplit:(NSInteger)numberOfMenuItems {
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    [userDefaults setInteger:numberOfMenuItems forKey:@"numberOfMenuItemsShownInLeftMenu"];
+    return;
+}
+
+- (NSInteger)loadLeftMenuSplit {
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    NSNumber *maxMenuItemSaved = [userDefaults objectForKey:@"numberOfMenuItemsShownInLeftMenu"];
+    NSInteger maxMenuItems;
+    if (maxMenuItemSaved) {
+        maxMenuItems = [maxMenuItemSaved intValue];
+    }
+    else {
+        // At least keep 1 playlist item visible
+        maxMenuItems = floor((GET_MAINSCREEN_WIDTH - [Utilities getTopPadding] - PLAYLIST_HEADER_HEIGHT - TOOLBAR_HEIGHT - PLAYLIST_ACTION_HEIGHT - [Utilities getBottomPadding] - PLAYLIST_CELL_HEIGHT) / PAD_MENU_HEIGHT);
+    }
+    return maxMenuItems;
 }
 
 #pragma mark - Lifecycle
@@ -437,7 +462,7 @@
     AppDelegate.instance.obj = [GlobalData getInstance];
     
     // Create the left menu
-    NSInteger maxMenuItems = floor((GET_MAINSCREEN_WIDTH - deltaY - PLAYLIST_HEADER_HEIGHT - TOOLBAR_HEIGHT - PLAYLIST_ACTION_HEIGHT - [Utilities getBottomPadding] - PLAYLIST_CELL_HEIGHT) / PAD_MENU_HEIGHT);
+    NSInteger maxMenuItems = [self loadLeftMenuSplit];
     [self createLeftMenu:maxMenuItems];
     
     rootView = [[UIViewExt alloc] initWithFrame:CGRectMake(0, deltaY, self.view.frame.size.width, self.view.frame.size.height - deltaY)];

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -32,6 +32,8 @@
 #define CONNECTION_PADDING 20
 #define REMOTE_PADDING_LEFT 45
 #define PLAYLIST_HEADER_HEIGHT 24
+#define PLAYLIST_ACTION_HEIGHT 44
+#define PLAYLIST_CELL_HEIGHT 53
 
 @interface ViewControllerIPad () {
     NSMutableArray *mainMenu;
@@ -435,7 +437,8 @@
     AppDelegate.instance.obj = [GlobalData getInstance];
     
     // Create the left menu
-    [self createLeftMenu:[(NSMutableArray*)mainMenu count]];
+    NSInteger maxMenuItems = floor((GET_MAINSCREEN_WIDTH - deltaY - PLAYLIST_HEADER_HEIGHT - TOOLBAR_HEIGHT - PLAYLIST_ACTION_HEIGHT - [Utilities getBottomPadding] - PLAYLIST_CELL_HEIGHT) / PAD_MENU_HEIGHT);
+    [self createLeftMenu:maxMenuItems];
     
     rootView = [[UIViewExt alloc] initWithFrame:CGRectMake(0, deltaY, self.view.frame.size.width, self.view.frame.size.height - deltaY)];
 	rootView.autoresizingMask = UIViewAutoresizingFlexibleWidth + UIViewAutoresizingFlexibleHeight;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -311,6 +311,7 @@
     if ([playlistHeader pointInside:locationPoint withEvent:event]) {
         playlistHeader.backgroundColor = UIColor.systemBlueColor;
         playlistHeader.textColor = UIColor.whiteColor;
+        didTouchLeftMenu = YES;
     }
 }
 
@@ -330,17 +331,20 @@
     // Hand over to nowPlayingController
     [self.nowPlayingController touchesEnded:touches withEvent:event];
     
-    // Untouching restores default color of playlist header and lets header snap into desired position
-    playlistHeader.backgroundColor = UIColor.clearColor;
-    playlistHeader.textColor = UIColor.lightGrayColor;
-    
-    // Finalize the left menu layout
-    NSInteger maxMenuItems = round(CGRectGetMinY(playlistHeader.frame) / PAD_MENU_HEIGHT);
-    CGFloat tableHeight = MIN([(NSMutableArray*)mainMenu count], maxMenuItems) * PAD_MENU_HEIGHT;
-    [self changeLeftMenu:tableHeight];
-    
-    // Save configuration
-    [self saveLeftMenuSplit:maxMenuItems];
+    if (didTouchLeftMenu) {
+        // Untouching restores default color of playlist header and lets header snap into desired position
+        playlistHeader.backgroundColor = UIColor.clearColor;
+        playlistHeader.textColor = UIColor.lightGrayColor;
+        
+        // Finalize the left menu layout
+        NSInteger maxMenuItems = round(CGRectGetMinY(playlistHeader.frame) / PAD_MENU_HEIGHT);
+        CGFloat tableHeight = MIN([(NSMutableArray*)mainMenu count], maxMenuItems) * PAD_MENU_HEIGHT;
+        [self changeLeftMenu:tableHeight];
+        
+        // Save configuration
+        [self saveLeftMenuSplit:maxMenuItems];
+        didTouchLeftMenu = NO;
+    }
 }
 
 #pragma mark - App clear disk cache methods

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -392,6 +392,16 @@
 
 #pragma mark - Lifecycle
 
+- (void)layoutPlaylistNowplayingForTableHeight:(CGFloat)tableHeight {
+    CGRect frame = self.nowPlayingController.view.frame;
+    YPOS = (int)(tableHeight + PLAYLIST_HEADER_HEIGHT);
+    frame.origin.y = YPOS;
+    frame.size.width = PAD_MENU_TABLE_WIDTH;
+    frame.size.height = self.view.frame.size.height - YPOS - [Utilities getTopPadding];
+    self.nowPlayingController.view.autoresizingMask = UIViewAutoresizingFlexibleHeight;
+    self.nowPlayingController.view.frame = frame;
+}
+
 - (void)changeLeftMenu:(CGFloat)tableHeight {
     // Main menu
     [menuViewController setMenuHeight:tableHeight];
@@ -402,13 +412,7 @@
     playlistHeader.frame = frame;
     
     // Playlist and NowPlaying
-    frame = self.nowPlayingController.view.frame;
-    YPOS = (int)(tableHeight + PLAYLIST_HEADER_HEIGHT);
-    frame.origin.y = YPOS;
-    frame.size.width = PAD_MENU_TABLE_WIDTH;
-    frame.size.height = self.view.frame.size.height - YPOS - [Utilities getTopPadding];
-    self.nowPlayingController.view.autoresizingMask = UIViewAutoresizingFlexibleHeight;
-    self.nowPlayingController.view.frame = frame;
+    [self layoutPlaylistNowplayingForTableHeight:tableHeight];
     
     [self.nowPlayingController setNowPlayingDimension:[self screenSizeOrientationIndependent].width
                                                height:[self screenSizeOrientationIndependent].height
@@ -439,13 +443,7 @@
     
     // Playlist and NowPlaying
     self.nowPlayingController = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
-    CGRect frame = self.nowPlayingController.view.frame;
-    YPOS = (int)(tableHeight + PLAYLIST_HEADER_HEIGHT);
-    frame.origin.y = YPOS;
-    frame.size.width = PAD_MENU_TABLE_WIDTH;
-    frame.size.height = self.view.frame.size.height - YPOS - [Utilities getTopPadding];
-    self.nowPlayingController.view.autoresizingMask = UIViewAutoresizingFlexibleHeight;
-    self.nowPlayingController.view.frame = frame;
+    [self layoutPlaylistNowplayingForTableHeight:tableHeight];
     
     [self.nowPlayingController setNowPlayingDimension:[self screenSizeOrientationIndependent].width
                                                height:[self screenSizeOrientationIndependent].height

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -32,7 +32,6 @@
 #define CONNECTION_PADDING 20
 #define REMOTE_PADDING_LEFT 45
 #define PLAYLIST_HEADER_HEIGHT 24
-#define LINE_HEIGHT 1
 
 @interface ViewControllerIPad () {
     NSMutableArray *mainMenu;
@@ -303,8 +302,40 @@
 
 #pragma mark - Touch Events
 
+- (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
+    UITouch *touch = [touches anyObject];
+    // Touching the playlist header marks it in blue and brings it on top.
+    CGPoint locationPoint = [touch locationInView:playlistHeader];
+    if ([playlistHeader pointInside:locationPoint withEvent:event]) {
+        playlistHeader.backgroundColor = UIColor.systemBlueColor;
+        playlistHeader.textColor = UIColor.whiteColor;
+    }
+}
+
+- (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
+    UITouch *touch = [touches anyObject];
+    // Moving the playlist header
+    CGPoint locationPoint = [touch locationInView:leftMenuView];
+    if ([leftMenuView pointInside:locationPoint withEvent:event]) {
+        // Change the left menu layout
+        CGFloat maxMenuItems = locationPoint.y / PAD_MENU_HEIGHT;
+        CGFloat tableHeight = MIN([(NSMutableArray*)mainMenu count], maxMenuItems) * PAD_MENU_HEIGHT;
+        [self changeLeftMenu:tableHeight];
+    }
+}
+
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
+    // Hand over to nowPlayingController
     [self.nowPlayingController touchesEnded:touches withEvent:event];
+    
+    // Untouching restores default color of playlist header and lets header snap into desired position
+    playlistHeader.backgroundColor = UIColor.clearColor;
+    playlistHeader.textColor = UIColor.lightGrayColor;
+    
+    // Finalize the left menu layout
+    NSInteger maxMenuItems = round(CGRectGetMinY(playlistHeader.frame) / PAD_MENU_HEIGHT);
+    CGFloat tableHeight = MIN([(NSMutableArray*)mainMenu count], maxMenuItems) * PAD_MENU_HEIGHT;
+    [self changeLeftMenu:tableHeight];
 }
 
 #pragma mark - App clear disk cache methods
@@ -330,6 +361,68 @@
 
 #pragma mark - Lifecycle
 
+- (void)changeLeftMenu:(CGFloat)tableHeight {
+    // Main menu
+    [menuViewController setMenuHeight:tableHeight];
+    
+    // Seperator
+    CGRect frame = playlistHeader.frame;
+    frame.origin.y = tableHeight;
+    playlistHeader.frame = frame;
+    
+    // Playlist and NowPlaying
+    frame = self.nowPlayingController.view.frame;
+    YPOS = (int)(tableHeight + PLAYLIST_HEADER_HEIGHT);
+    frame.origin.y = YPOS;
+    frame.size.width = PAD_MENU_TABLE_WIDTH;
+    frame.size.height = self.view.frame.size.height - YPOS - [Utilities getTopPadding];
+    self.nowPlayingController.view.autoresizingMask = UIViewAutoresizingFlexibleHeight;
+    self.nowPlayingController.view.frame = frame;
+    
+    [self.nowPlayingController setNowPlayingDimension:[self screenSizeOrientationIndependent].width
+                                               height:[self screenSizeOrientationIndependent].height
+                                                 YPOS:-YPOS];
+}
+
+- (void)createLeftMenu:(NSInteger)maxMenuItems {
+    NSInteger tableHeight = MIN([(NSMutableArray*)mainMenu count], maxMenuItems) * PAD_MENU_HEIGHT;
+    
+    // Create left menu
+    leftMenuView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, PAD_MENU_TABLE_WIDTH, self.view.frame.size.height)];
+    leftMenuView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
+    
+    // Main menu
+    menuViewController = [[MenuViewController alloc] initWithFrame:CGRectMake(0, 0, leftMenuView.frame.size.width, leftMenuView.frame.size.height) mainMenu:mainMenu menuHeight:tableHeight];
+    menuViewController.view.backgroundColor = UIColor.clearColor;
+    [leftMenuView addSubview:menuViewController.view];
+    
+    // Seperator
+    playlistHeader = [[UILabel alloc] initWithFrame:CGRectMake(0, tableHeight, PAD_MENU_TABLE_WIDTH, PLAYLIST_HEADER_HEIGHT)];
+    playlistHeader.backgroundColor = UIColor.clearColor;
+    playlistHeader.textColor = UIColor.lightGrayColor;
+    playlistHeader.text = LOCALIZED_STR(@"Playlist");
+    playlistHeader.textAlignment = NSTextAlignmentCenter;
+    playlistHeader.layer.borderColor = [Utilities getGrayColor:77 alpha:0.6].CGColor;
+    playlistHeader.layer.borderWidth = 1.0;
+    [leftMenuView addSubview:playlistHeader];
+    
+    // Playlist and NowPlaying
+    self.nowPlayingController = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
+    CGRect frame = self.nowPlayingController.view.frame;
+    YPOS = (int)(tableHeight + PLAYLIST_HEADER_HEIGHT);
+    frame.origin.y = YPOS;
+    frame.size.width = PAD_MENU_TABLE_WIDTH;
+    frame.size.height = self.view.frame.size.height - YPOS - [Utilities getTopPadding];
+    self.nowPlayingController.view.autoresizingMask = UIViewAutoresizingFlexibleHeight;
+    self.nowPlayingController.view.frame = frame;
+    
+    [self.nowPlayingController setNowPlayingDimension:[self screenSizeOrientationIndependent].width
+                                               height:[self screenSizeOrientationIndependent].height
+                                                 YPOS:-YPOS];
+    
+    [leftMenuView addSubview:self.nowPlayingController.view];
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     int deltaY = [Utilities getTopPadding];
@@ -340,12 +433,10 @@
     [self.view addSubview:virtualKeyboard];
     firstRun = YES;
     AppDelegate.instance.obj = [GlobalData getInstance];
-
-    int cellHeight = PAD_MENU_HEIGHT;
-    NSInteger tableHeight = [(NSMutableArray*)mainMenu count] * cellHeight;
-    int tableWidth = PAD_MENU_TABLE_WIDTH;
-    int headerHeight = 0;
-   
+    
+    // Create the left menu
+    [self createLeftMenu:[(NSMutableArray*)mainMenu count]];
+    
     rootView = [[UIViewExt alloc] initWithFrame:CGRectMake(0, deltaY, self.view.frame.size.width, self.view.frame.size.height - deltaY)];
 	rootView.autoresizingMask = UIViewAutoresizingFlexibleWidth + UIViewAutoresizingFlexibleHeight;
 	rootView.backgroundColor = UIColor.clearColor;
@@ -355,41 +446,8 @@
     fanartBackgroundImage.contentMode = UIViewContentModeScaleAspectFill;
     fanartBackgroundImage.alpha = 0.05;
     [self.view addSubview:fanartBackgroundImage];
-    
-	leftMenuView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, tableWidth, self.view.frame.size.height)];
-	leftMenuView.autoresizingMask = UIViewAutoresizingFlexibleHeight;	
-    
-	menuViewController = [[MenuViewController alloc] initWithFrame:CGRectMake(0, headerHeight, leftMenuView.frame.size.width, leftMenuView.frame.size.height) mainMenu:mainMenu];
-	menuViewController.view.backgroundColor = UIColor.clearColor;
-	[menuViewController viewWillAppear:NO];
-	[menuViewController viewDidAppear:NO];
-	[leftMenuView addSubview:menuViewController.view];
-    
-    UIView *horizontalLineView1 = [[UIView alloc] initWithFrame:CGRectMake(0, tableHeight, tableWidth, LINE_HEIGHT)];
-    horizontalLineView1.backgroundColor = [Utilities getGrayColor:77 alpha:0.6];
-    [leftMenuView addSubview:horizontalLineView1];
-    
-    UILabel *header = [[UILabel alloc] initWithFrame:CGRectMake(0, tableHeight, PAD_MENU_TABLE_WIDTH, PLAYLIST_HEADER_HEIGHT)];
-    header.backgroundColor = UIColor.clearColor;
-    header.textColor = UIColor.lightGrayColor;
-    header.text = LOCALIZED_STR(@"Playlist");
-    header.textAlignment = NSTextAlignmentCenter;
-    [leftMenuView addSubview:header];
 
-    self.nowPlayingController = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
-    CGRect frame = self.nowPlayingController.view.frame;
-    YPOS = (int)(tableHeight + LINE_HEIGHT + headerHeight + PLAYLIST_HEADER_HEIGHT);
-    frame.origin.y = YPOS;
-    frame.size.width = tableWidth;
-    frame.size.height = self.view.frame.size.height - YPOS - deltaY;
-    self.nowPlayingController.view.autoresizingMask = UIViewAutoresizingFlexibleHeight;
-    self.nowPlayingController.view.frame = frame;
-    
-    [self.nowPlayingController setNowPlayingDimension:[self screenSizeOrientationIndependent].width height:[self screenSizeOrientationIndependent].height YPOS:-YPOS];
-    
-    [leftMenuView addSubview:self.nowPlayingController.view];
-
-	rightSlideView = [[UIView alloc] initWithFrame:CGRectMake(leftMenuView.frame.size.width, 0, rootView.frame.size.width - leftMenuView.frame.size.width, rootView.frame.size.height - TOOLBAR_HEIGHT)];
+	rightSlideView = [[UIView alloc] initWithFrame:CGRectMake(PAD_MENU_TABLE_WIDTH, 0, rootView.frame.size.width - PAD_MENU_TABLE_WIDTH, rootView.frame.size.height - TOOLBAR_HEIGHT)];
 	rightSlideView.autoresizingMask = UIViewAutoresizingFlexibleWidth + UIViewAutoresizingFlexibleHeight;
     
 	stackScrollViewController = [StackScrollViewController new];
@@ -477,7 +535,7 @@
     int bottomPadding = [Utilities getBottomPadding];
     
     if (bottomPadding > 0) {
-        frame = volumeSliderView.frame;
+        CGRect frame = volumeSliderView.frame;
         frame.origin.y -= bottomPadding;
         volumeSliderView.frame = frame;
         

--- a/XBMC Remote/iPad/MenuViewController.h
+++ b/XBMC Remote/iPad/MenuViewController.h
@@ -45,7 +45,8 @@
     int lastSelected;
 }
 
-- (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu;
+- (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu menuHeight:(CGFloat)tableHeight;
+- (void)setMenuHeight:(CGFloat)tableHeight;
 - (void)setLastSelected:(int)selection;
 
 @property (nonatomic, strong) UITableView *tableView;

--- a/XBMC Remote/iPad/MenuViewController.h
+++ b/XBMC Remote/iPad/MenuViewController.h
@@ -41,11 +41,11 @@
 
 @interface MenuViewController : UIViewController <UITableViewDelegate, UITableViewDataSource> {
 	UITableView *_tableView;
-    NSMutableArray *mainMenuItems;
+    NSArray *mainMenuItems;
     int lastSelected;
 }
 
-- (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu menuHeight:(CGFloat)tableHeight;
+- (id)initWithFrame:(CGRect)frame mainMenu:(NSArray*)menu menuHeight:(CGFloat)tableHeight;
 - (void)setMenuHeight:(CGFloat)tableHeight;
 - (void)setLastSelected:(int)selection;
 

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -51,10 +51,9 @@
 #pragma mark -
 #pragma mark View lifecycle
 
-- (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu {
+- (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu menuHeight:(CGFloat)tableHeight {
     if (self = [super init]) {
         self.view.frame = frame;
-        CGFloat tableHeight = menu.count * PAD_MENU_HEIGHT;
         _tableView = [[UITableView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, tableHeight) style:UITableViewStylePlain];
         _tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
         _tableView.delegate = self;
@@ -91,6 +90,12 @@
                                              selector: @selector(handleEnablingDefaultController)
                                                  name: @"KodiStartDefaultController"
                                                object: nil];
+}
+
+- (void)setMenuHeight:(CGFloat)tableHeight {
+    CGRect frame = _tableView.frame;
+    frame.size.height = tableHeight;
+    _tableView.frame = frame;
 }
 
 - (void)handleDeselectSection {

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -51,7 +51,7 @@
 #pragma mark -
 #pragma mark View lifecycle
 
-- (id)initWithFrame:(CGRect)frame mainMenu:(NSMutableArray*)menu menuHeight:(CGFloat)tableHeight {
+- (id)initWithFrame:(CGRect)frame mainMenu:(NSArray*)menu menuHeight:(CGFloat)tableHeight {
     if (self = [super init]) {
         self.view.frame = frame;
         _tableView = [[UITableView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, tableHeight) style:UITableViewStylePlain];

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -59,6 +59,7 @@
         _tableView.delegate = self;
         _tableView.dataSource = self;
         _tableView.backgroundColor = UIColor.clearColor;
+        _tableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
         mainMenuItems = menu;
         UIView *footerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 1)];
         _tableView.tableFooterView = footerView;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR implements a user resizable left menu for iPad's. The user can now vertically move the playlist header via touch and by this tailor the split between main menu and playlist. The limits are from showing no main menu at all to at least show a single playlist item. The user selected layout persists.

Screenshot: https://abload.de/img/bildschirmfoto2023-04mddrm.png 

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Support user resizable left menu on iPad