### PR TITLE
disable bitcode in fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,7 +31,7 @@ lane :tf do |options|
     clean: true,
     output_directory: 'build',
     include_symbols: true,
-    include_bitcode: true,
+    include_bitcode: false,
     export_method: 'app-store',
     xcargs: "CURRENT_PROJECT_VERSION=#{number_of_commits}",
   )


### PR DESCRIPTION
Xcode 14 no longer needs bitcode