### PR TITLE
Bugfix: Stop animating pull down sync on PVR error

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4949,6 +4949,7 @@ NSIndexPath *selected;
 - (void)animateNoResultsFound {
     [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
     [activityIndicatorView stopAnimating];
+    [((UITableView*)activeLayoutView).pullToRefreshView stopAnimating];
 }
 
 - (void)showNoResultsFound:(NSMutableArray*)resultStoreArray refresh:(BOOL)forceRefresh {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue where sync animation continued when attempting to sync recording while not having the PVR running.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Stop animating pull down sync on PVR error