### PR TITLE
Bugfix: Hide the iPad background image if nothing is playing

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -447,6 +447,7 @@ long storedItemID;
                 @"startColor": [Utilities getGrayColor:36 alpha:1.0],
                 @"endColor": [Utilities getGrayColor:22 alpha:1.0],
             };
+            [[NSNotificationCenter defaultCenter] postNotificationName:@"UIViewChangeBackgroundImage" object:nil userInfo:params];
         }
         else {
             CGFloat hue, saturation, brightness, alpha;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3150902#pid3150902).

When migrating to new XCode and reworking the color effect in NowPlaying screen, there was a regression caused which does not hide a fanart background when entering the "nothing is playing" state (e.g. stopping playback or losing the connection). This PR fixes this regression.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Hide the iPad background image if nothing is playing