### PR TITLE
Bugfix: Seek via slider fails when displayed playlist and active player do not match

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1767,7 +1767,7 @@ long storedItemID;
 }
 
 - (IBAction)startUpdateProgressBar:(id)sender {
-    [self SimpleAction:@"Player.Seek" params:[Utilities buildPlayerSeekPercentageParams:playerID percentage:ProgressSlider.value] reloadPlaylist:NO startProgressBar:YES];
+    [self SimpleAction:@"Player.Seek" params:[Utilities buildPlayerSeekPercentageParams:currentPlayerID percentage:ProgressSlider.value] reloadPlaylist:NO startProgressBar:YES];
     [Utilities alphaView:scrabbingView AnimDuration:0.3 Alpha:0.0];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3151109#pid3151109).

Caused failing seek if the player ID (e.g. movie) was not the same as current shown playlist (e.g. music).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Seek via slider fails when displayed playlist and active player do not match