### PR TITLE
Maintenance: Refactor player commands

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4371,32 +4371,6 @@ NSIndexPath *selected;
     [self showActionSheet:nil sheetActions:sheetActions item:item rectOriginX:rectOrigin + albumViewPadding rectOriginY:rectOrigin];
 }
 
-//- (void)playbackAction:(NSString*)action params:(NSArray*)parameters {
-//    [[Utilities getJsonRPC] callMethod:@"Playlist.GetPlaylists" withParameters:@{} onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-//        if (error == nil && methodError == nil) {
-////            NSLog(@"RISPOSRA %@", methodResult);
-//            if (methodResult.count > 0) {
-//                NSNumber *response = methodResult[0][@"playerid"];
-////                NSMutableArray *commonParams = [NSMutableArray arrayWithObjects:response, @"playerid", nil];
-////                if (parameters != nil) {
-////                    [commonParams addObjectsFromArray:parameters];
-////                }
-////                [[Utilities getJsonRPC] callMethod:action withParameters:nil onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-////                    if (error == nil && methodError == nil) {
-////                        //                        NSLog(@"comando %@ eseguito ", action);
-////                    }
-////                    else {
-////                        NSLog(@"ci deve essere un secondo problema %@", methodError);
-////                    }
-////                }];
-//            }
-//        }
-//        else {
-//            NSLog(@"ci deve essere un primo problema %@", methodError);
-//        }
-//    }];
-//}
-
 # pragma mark - JSON DATA Management
 
 - (void)checkExecutionTime {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -996,21 +996,12 @@ long storedItemID;
 }
 
 - (void)playbackAction:(NSString*)action params:(NSDictionary*)parameters checkPartyMode:(BOOL)checkPartyMode {
-    [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:[NSDictionary dictionary] onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+    NSMutableDictionary *commonParams = [NSMutableDictionary dictionaryWithDictionary:parameters];
+    commonParams[@"playerid"] = @(currentPlayerID);
+    [[Utilities getJsonRPC] callMethod:action withParameters:commonParams onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (error == nil && methodError == nil) {
-            if ([methodResult count] > 0) {
-                NSMutableDictionary *commonParams = [NSMutableDictionary dictionaryWithDictionary:parameters];
-                NSNumber *response = methodResult[0][@"playerid"];
-                if (response != nil) {
-                    commonParams[@"playerid"] = response;
-                }
-                [[Utilities getJsonRPC] callMethod:action withParameters:commonParams onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-                    if (error == nil && methodError == nil) {
-                        if (musicPartyMode && checkPartyMode) {
-                            [self checkPartyMode];
-                        }
-                    }
-                }];
+            if (musicPartyMode && checkPartyMode) {
+                [self checkPartyMode];
             }
         }
     }];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -995,16 +995,16 @@ long storedItemID;
     }];
 }
 
-- (void)playbackAction:(NSString*)action params:(NSArray*)parameters checkPartyMode:(BOOL)checkPartyMode {
+- (void)playbackAction:(NSString*)action params:(NSDictionary*)parameters checkPartyMode:(BOOL)checkPartyMode {
     [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:[NSDictionary dictionary] onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (error == nil && methodError == nil) {
             if ([methodResult count] > 0) {
+                NSMutableDictionary *commonParams = [NSMutableDictionary dictionaryWithDictionary:parameters];
                 NSNumber *response = methodResult[0][@"playerid"];
-                NSMutableArray *commonParams = [NSMutableArray arrayWithObjects:response, @"playerid", nil];
-                if (parameters != nil) {
-                    [commonParams addObjectsFromArray:parameters];
+                if (response != nil) {
+                    commonParams[@"playerid"] = response;
                 }
-                [[Utilities getJsonRPC] callMethod:action withParameters:[Utilities indexKeyedDictionaryFromArray:commonParams] onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+                [[Utilities getJsonRPC] callMethod:action withParameters:commonParams onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
                     if (error == nil && methodError == nil) {
                         if (musicPartyMode && checkPartyMode) {
                             [self checkPartyMode];
@@ -1463,12 +1463,12 @@ long storedItemID;
 
 - (IBAction)startVibrate:(id)sender {
     NSString *action;
-    NSArray *params;
+    NSDictionary *params;
     switch ([sender tag]) {
         case TAG_ID_PREVIOUS:
             if (AppDelegate.instance.serverVersion > 11) {
                 action = @"Player.GoTo";
-                params = @[@"previous", @"to"];
+                params = @{@"to": @"previous"};
                 [self playbackAction:action params:params checkPartyMode:YES];
             }
             else {
@@ -1495,7 +1495,7 @@ long storedItemID;
         case TAG_ID_NEXT:
             if (AppDelegate.instance.serverVersion > 11) {
                 action = @"Player.GoTo";
-                params = @[@"next", @"to"];
+                params = @{@"to": @"next"};
                 [self playbackAction:action params:params checkPartyMode:YES];
             }
             else {
@@ -1750,11 +1750,11 @@ long storedItemID;
     if (gestureRecognizer.state == UIGestureRecognizerStateBegan) {
         switch (gestureRecognizer.view.tag) {
             case TAG_SEEK_BACKWARD:// BACKWARD BUTTON - DECREASE PLAYBACK SPEED
-                [self playbackAction:@"Player.SetSpeed" params:@[@"decrement", @"speed"] checkPartyMode:NO];
+                [self playbackAction:@"Player.SetSpeed" params:@{@"speed": @"decrement"} checkPartyMode:NO];
                 break;
                 
             case TAG_SEEK_FORWARD:// FORWARD BUTTON - INCREASE PLAYBACK SPEED
-                [self playbackAction:@"Player.SetSpeed" params:@[@"increment", @"speed"] checkPartyMode:NO];
+                [self playbackAction:@"Player.SetSpeed" params:@{@"speed": @"increment"} checkPartyMode:NO];
                 break;
                 
             case TAG_ID_EDIT:// EDIT TABLE

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -38,7 +38,7 @@ typedef enum {
 + (BOOL)getPreferTvPosterMode;
 + (LogoBackgroundType)getLogoBackgroundMode;
 + (NSDictionary*)buildPlayerSeekPercentageParams:(int)playerID percentage:(float)percentage;
-+ (NSArray*)buildPlayerSeekStepParams:(NSString*)stepmode;
++ (NSDictionary*)buildPlayerSeekStepParams:(NSString*)stepmode;
 + (CGFloat)getTransformX;
 + (UIColor*)getSystemRed:(CGFloat)alpha;
 + (UIColor*)getSystemGreen:(CGFloat)alpha;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -313,13 +313,13 @@
     return params;
 }
 
-+ (NSArray*)buildPlayerSeekStepParams:(NSString*)stepmode {
-    NSArray *params = nil;
++ (NSDictionary*)buildPlayerSeekStepParams:(NSString*)stepmode {
+    NSDictionary *params = nil;
     if (AppDelegate.instance.serverVersion < 15) {
-        params = @[stepmode, @"value"];
+        params = @{@"value": stepmode};
     }
     else {
-        params = @[@{@"step": stepmode}, @"value"];
+        params = @{@"value": @{@"step": stepmode}};
     }
     return params;
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR refactors the player commands (e.g. play, pause, seek) to use `NSDictionary` directly, which allows to reduce overhead by converting from array to dictionary.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Refactor player commands