### PR TITLE
Bugfix: Show playlist time to 00:00 when playing new item

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -792,7 +792,6 @@ long storedItemID;
                                      currentTime.hidden = YES;
                                      duration.hidden = YES;
                                  }
-                                 [self updatePlaylistProgressbar:percentage actual:actualTime];
                                  long playlistPosition = [methodResult[@"position"] longValue];
                                  if (playlistPosition > -1) {
                                      playlistPosition += 1;
@@ -818,6 +817,10 @@ long storedItemID;
                                          storeSelection = newSelection;
                                          lastSelected = playlistPosition;
                                      }
+                                     [self updatePlaylistProgressbar:0.0f actual:@"00:00"];
+                                 }
+                                 else {
+                                     [self updatePlaylistProgressbar:percentage actual:actualTime];
                                  }
                              }
                              else {
@@ -2048,6 +2051,7 @@ long storedItemID;
              [queuing stopAnimating];
              UIView *timePlaying = (UIView*)[cell viewWithTag:5];
              [self fadeView:timePlaying hidden:NO];
+             [self updatePlaylistProgressbar:0.0f actual:@"00:00"];
          }
          else {
              UIActivityIndicatorView *queuing = (UIActivityIndicatorView*)[cell viewWithTag:8];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3151058#pid3151058).

The current time showing in the playlist needs to be reset to "00:00" when a new playlist item starts to play or a cell is selected. Otherwise the last valid time for this cell or for the previous played item's time is shown for a second.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show playlist time to 00:00 when playing new item