### PR TITLE
Bugfix: Use correct position for iPad's playlist toolbar

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2292,7 +2292,7 @@ long storedItemID;
     playlistLeftShadow.hidden = NO;
     
     frame = playlistActionView.frame;
-    frame.origin.y = playlistToolbar.frame.origin.y - playlistToolbar.frame.size.height;
+    frame.origin.y = playlistTableView.frame.size.height - playlistActionView.frame.size.height;
     playlistActionView.frame = frame;
     playlistActionView.alpha = 1.0;
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The iPad's playlist toolbar position was wrongly calculated and now became visible after the latest changes.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use correct position for iPad's playlist toolbar