### PR TITLE
Bugfix: Fix layout issue for iPhone 14 Pro

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -479,7 +479,7 @@ static inline BOOL IsEmpty(id obj) {
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    CGFloat deltaY = 44 + [Utilities getTopPadding];
+    CGFloat deltaY = self.navigationController.navigationBar.frame.size.height + [Utilities getTopPadding];
     if (IS_IPAD) {
         deltaY = 0;
     }
@@ -512,7 +512,8 @@ static inline BOOL IsEmpty(id obj) {
     messagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     [self.view addSubview:messagesView];
     
-    serverInfoView = [[UITextView alloc] initWithFrame:CGRectMake(MARGIN, deltaY + MARGIN, self.view.frame.size.width - 2 * MARGIN, self.view.frame.size.height - bottomPadding - deltaY - 44 - 2 * MARGIN)];
+    CGFloat toolbarHeight = bottomToolbar.frame.size.height;
+    serverInfoView = [[UITextView alloc] initWithFrame:CGRectMake(MARGIN, deltaY + MARGIN, self.view.frame.size.width - 2 * MARGIN, self.view.frame.size.height - deltaY - toolbarHeight - 2 * MARGIN)];
     serverInfoView.autoresizingMask = UIViewAutoresizingFlexibleWidth |
                                       UIViewAutoresizingFlexibleHeight |
                                       UIViewAutoresizingFlexibleLeftMargin |
@@ -567,7 +568,7 @@ static inline BOOL IsEmpty(id obj) {
         self.navigationController.navigationBar.tintColor = ICON_TINT_COLOR;
     }
     else {
-        int barHeight = 44;
+        int barHeight = self.navigationController.navigationBar.frame.size.height;
         int statusBarHeight = [Utilities getTopPadding];
         
         CGRect frame = supportedVersionView.frame;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -892,7 +892,7 @@
 }
 
 + (CGFloat)getTopPadding {
-    CGFloat topPadding = UIApplication.sharedApplication.keyWindow.safeAreaInsets.top;
+    CGFloat topPadding = UIApplication.sharedApplication.statusBarFrame.size.height;
     return topPadding;
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
On iPhone 14 Pro the status bar and top safe area have different sizes ([link](https://useyourloaf.com/blog/iphone-14-screen-sizes/#:~:text=The%20iPhone%2014%20Pro%20screen,area%20inset%20is%2059%20points.)). The App layout needs the status bar height.

In addition, some magic numbers in HostManagementViewController are replaced with the proper frame sizes.

Screenshots (iPhone 14 Pro):
<a href="https://abload.de/image.php?img=bildschirmfoto2023-05qjehy.png"><img src="https://abload.de/img/bildschirmfoto2023-05qjehy.png" /></a>


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix layout issue for iPhone 14 Pro