### PR TITLE
Maintenance: Rework loading covers in ShowInfoVC

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -31,6 +31,12 @@
 #define ARROW_ALPHA 0.5
 #define IPAD_NAVBAR_PADDING 20
 #define FANART_FULLSCREEN_DISABLE 1
+#define DVD_HEIGHT_IPAD 560
+#define DVD_HEIGHT_IPHONE 376
+#define TV_HEIGHT_IPAD 280
+#define TV_HEIGHT_IPHONE 200
+#define CD_HEIGHT_IPAD 380
+#define CD_HEIGHT_IPHONE 290
 
 @interface ShowInfoViewController ()
 @end
@@ -632,19 +638,14 @@ double round(double d) {
         runtimeLabel.text = [Utilities getStringFromItem:item[@"genre"]];
         studioLabel.text = [Utilities getStringFromItem:item[@"studio"]];
         summaryLabel.text = [Utilities getStringFromItem:item[@"plot"]];
-        
-        if (![Utilities getPreferTvPosterMode] && AppDelegate.instance.serverVersion < 12) {
-            placeHolderImage = @"blank";
-            jewelView.hidden = YES;
-        }
-        else if (IS_IPAD) {
-            int coverHeight = 560;
-            CGRect frame = jewelView.frame;
-            frame.size.height = coverHeight;
-            jewelView.frame = frame;
-        }
+
         jewelImg = @"jewel_dvd.9";
         jeweltype = jewelTypeDVD;
+        int coverHeight = IS_IPAD ? DVD_HEIGHT_IPAD : DVD_HEIGHT_IPHONE;
+        CGRect frame = jewelView.frame;
+        frame.size.height = coverHeight;
+        jewelView.frame = frame;
+        
         coverView.autoresizingMask = UIViewAutoresizingNone;
         coverView.contentMode = UIViewContentModeScaleAspectFill;
     }
@@ -670,7 +671,7 @@ double round(double d) {
         
         jewelImg = @"jewel_tv.9";
         jeweltype = jewelTypeTV;
-        int coverHeight = IS_IPAD ? 280 : 200;
+        int coverHeight = IS_IPAD ? TV_HEIGHT_IPAD : TV_HEIGHT_IPHONE;
         CGRect frame = jewelView.frame;
         frame.size.height = coverHeight;
         jewelView.frame = frame;
@@ -703,7 +704,7 @@ double round(double d) {
         
         jewelImg = @"jewel_cd.9";
         jeweltype = jewelTypeCD;
-        int coverHeight = IS_IPAD ? 380 : 290;
+        int coverHeight = IS_IPAD ? CD_HEIGHT_IPAD : CD_HEIGHT_IPHONE;
         CGRect frame = jewelView.frame;
         frame.size.height = coverHeight;
         jewelView.frame = frame;
@@ -729,7 +730,7 @@ double round(double d) {
         
         jewelImg = @"jewel_cd.9";
         jeweltype = jewelTypeCD;
-        int coverHeight = IS_IPAD ? 380 : 290;
+        int coverHeight = IS_IPAD ? CD_HEIGHT_IPAD : CD_HEIGHT_IPHONE;
         CGRect frame = jewelView.frame;
         frame.size.height = coverHeight;
         jewelView.frame = frame;
@@ -851,12 +852,10 @@ double round(double d) {
         
         jewelImg = @"jewel_dvd.9";
         jeweltype = jewelTypeDVD;
-        if (IS_IPAD) {
-            int coverHeight = 560;
-            CGRect frame = jewelView.frame;
-            frame.size.height = coverHeight;
-            jewelView.frame = frame;
-        }
+        int coverHeight = IS_IPAD ? DVD_HEIGHT_IPAD : DVD_HEIGHT_IPHONE;
+        CGRect frame = jewelView.frame;
+        frame.size.height = coverHeight;
+        jewelView.frame = frame;
         coverView.autoresizingMask = UIViewAutoresizingNone;
         coverView.contentMode = UIViewContentModeScaleToFill;
     }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -583,6 +583,7 @@ double round(double d) {
     isPvrDetail = item[@"recordingid"] != nil || item[@"broadcastid"] != nil;
 //    NSLog(@"ITEM %@", item);
     eJewelType jeweltype = jewelTypeUnknown;
+    NSString *jewelImg = @"";
     lineSpacing = IS_IPAD ? 2 : 0;
     castFontSize = IS_IPAD ? 16 : 14;
     
@@ -595,12 +596,6 @@ double round(double d) {
     clearLogoHeight = ceil(clearLogoWidth * 31.0 / 80.0);
     
     bool enableJewel = [self enableJewelCases];
-    if (!enableJewel) {
-        jewelView.image = nil;
-        CGRect frame = jewelView.frame;
-        frame.origin.x = 0;
-        jewelView.frame = frame;
-    }
     
     CGFloat transform = [Utilities getTransformX];
     NSString *contributorString = @"cast";
@@ -648,10 +643,8 @@ double round(double d) {
             frame.size.height = coverHeight;
             jewelView.frame = frame;
         }
-        if (enableJewel) {
-            jewelView.image = [UIImage imageNamed:@"jewel_dvd.9"];
-            jeweltype = jewelTypeDVD;
-        }
+        jewelImg = @"jewel_dvd.9";
+        jeweltype = jewelTypeDVD;
         coverView.autoresizingMask = UIViewAutoresizingNone;
         coverView.contentMode = UIViewContentModeScaleAspectFill;
     }
@@ -675,10 +668,8 @@ double round(double d) {
         parentalRatingLabel.hidden = YES;
         jewelView.hidden = NO;
         
-        if (enableJewel) {
-            jewelView.image = [UIImage imageNamed:@"jewel_tv.9"];
-            jeweltype = jewelTypeTV;
-        }
+        jewelImg = @"jewel_tv.9";
+        jeweltype = jewelTypeTV;
         int coverHeight = IS_IPAD ? 280 : 200;
         CGRect frame = jewelView.frame;
         frame.size.height = coverHeight;
@@ -710,10 +701,8 @@ double round(double d) {
         parentalRatingLabel.hidden = YES;
         jewelView.hidden = NO;
         
-        if (enableJewel) {
-            jewelView.image = [UIImage imageNamed:@"jewel_cd.9"];
-            jeweltype = jewelTypeCD;
-        }
+        jewelImg = @"jewel_cd.9";
+        jeweltype = jewelTypeCD;
         int coverHeight = IS_IPAD ? 380 : 290;
         CGRect frame = jewelView.frame;
         frame.size.height = coverHeight;
@@ -738,10 +727,8 @@ double round(double d) {
         studioLabel.text = [Utilities getStringFromItem:item[@"studio"]];
         summaryLabel.text = [Utilities getStringFromItem:item[@"plot"]];
         
-        if (enableJewel) {
-            jewelView.image = [UIImage imageNamed:@"jewel_cd.9"];
-            jeweltype = jewelTypeCD;
-        }
+        jewelImg = @"jewel_cd.9";
+        jeweltype = jewelTypeCD;
         int coverHeight = IS_IPAD ? 380 : 290;
         CGRect frame = jewelView.frame;
         frame.size.height = coverHeight;
@@ -774,7 +761,6 @@ double round(double d) {
         numVotesLabel.hidden = YES;
         
         enableJewel = NO;
-        jewelView.image = nil;
     }
     else if ([item[@"family"] isEqualToString:@"recordingid"]) {
         placeHolderImage = @"nocover_channels";
@@ -863,10 +849,8 @@ double round(double d) {
         studioLabel.text = [Utilities getStringFromItem:item[@"studio"]];
         summaryLabel.text = [Utilities getStringFromItem:item[@"plot"]];
         
-        if (enableJewel) {
-            jewelView.image = [UIImage imageNamed:@"jewel_dvd.9"];
-            jeweltype = jewelTypeDVD;
-        }
+        jewelImg = @"jewel_dvd.9";
+        jeweltype = jewelTypeDVD;
         if (IS_IPAD) {
             int coverHeight = 560;
             CGRect frame = jewelView.frame;
@@ -878,10 +862,12 @@ double round(double d) {
     }
 
     if (enableJewel) {
+        jewelView.image = [UIImage imageNamed:jewelImg];
         coverView.frame = [Utilities createCoverInsideJewel:jewelView jewelType:jeweltype];
         coverView.contentMode = UIViewContentModeScaleAspectFill;
     }
     else {
+        jewelView.image = nil;
         coverView.frame = jewelView.frame;
         coverView.contentMode = UIViewContentModeScaleAspectFit;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR simplifies the logic for loading covers in ShowInfoVC with and without jewel case. Always use `coverView` for the cover and `jewelView` for the jewel case. This allows to reduce the complexity of several conditions and makes use of already created helper method `elaborateImage`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Rework loading covers in ShowInfoVC