### PR TITLE
Bugfix: Fix NowPlaying layout with jewel cases in iPad landscape

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2210,9 +2210,9 @@ long storedItemID;
                                       maxheight);
     
     BottomView.frame = CGRectMake(PAD_MENU_TABLE_WIDTH,
-                                  CGRectGetMaxY(thumbnailView.frame) + COVERVIEW_PADDING,
+                                  CGRectGetMaxY(jewelView.frame) + COVERVIEW_PADDING,
                                   width - PAD_MENU_TABLE_WIDTH,
-                                  maxheight - CGRectGetMaxY(thumbnailView.frame));
+                                  maxheight - CGRectGetMaxY(jewelView.frame));
     
     frame = playlistToolbar.frame;
     frame.size.width = width;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Need to use `jewelView` as reference for the `BottomView` position. Fixes an issue where the bottom view was misaligned when activating jewel cases.

Screenshots: https://abload.de/img/bildschirmfoto2023-05i1dfd.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix NowPlaying layout with jewel cases in iPad landscape