### PR TITLE
Bugfix: Fix rounded corners for covers with non-matching aspect ratios

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -919,7 +919,9 @@
 }
 
 - (void)setCellImageView:(UIImageView*)imgView cell:(UIView*)cell dictItem:(NSDictionary*)item url:(NSString*)stringURL size:(CGSize)viewSize defaultImg:(NSString*)displayThumb {
-    if ([item[@"family"] isEqualToString:@"channelid"] || [item[@"family"] isEqualToString:@"type"]) {
+    if ([item[@"family"] isEqualToString:@"channelid"] ||
+        [item[@"family"] isEqualToString:@"recordingid"] ||
+        [item[@"family"] isEqualToString:@"type"]) {
         imgView.contentMode = UIViewContentModeScaleAspectFit;
     }
     BOOL showBorder = !([item[@"family"] isEqualToString:@"channelid"] ||

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1737,7 +1737,7 @@
         cell.posterLabelFullscreen.text = @"";
         cell.posterLabel.font = [UIFont boldSystemFontOfSize:posterFontSize];
         cell.posterLabelFullscreen.font = [UIFont boldSystemFontOfSize:posterFontSize];
-        cell.posterThumbnail.contentMode = UIViewContentModeScaleAspectFit;
+        cell.posterThumbnail.contentMode = UIViewContentModeScaleAspectFill;
         if (stackscrollFullscreen) {
             cell.posterLabelFullscreen.text = item[@"label"];
             cell.labelImageView.hidden = YES;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3151563#pid3151563).

As default for grid view covers `UIViewContentModeScaleAspectFit` was used. This results in a kind of irregular look if some of the downloaded covers are not fully matching the aspect ratio expected by the cover frame. In such case the cover frames are not fully filled and the spaces between the covers are not the same, making the grid look a bit "off".
In addition, this can cause the rounded edges feature to fail. The rounded edges are applied to the cover frame. If the frames are not fully filled the edges do not become visible against the dark background. This is what can be seen in the screenshot provided by the user in the post which is linked above.

Solution is to use `UIViewContentModeScaleAspectFill` which will fully fill the cover frame.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix rounded corners for covers with non-matching aspect ratios