### PR TITLE
Bugfix: Use dark background for grid view in TV Shows menu

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -913,7 +913,13 @@
         }
         // Other tabs (e.g. list of episodes) use default layout
         else {
-            cell.backgroundColor = [Utilities getSystemGray6];
+            if (enableCollectionView) {
+                // Gray:28 is similar to systemGray6 in Dark Mode
+                cell.backgroundColor = [Utilities getGrayColor:28 alpha:1.0];
+            }
+            else {
+                cell.backgroundColor = [Utilities getSystemGray6];
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes wrong background color for add-on grid view.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use dark background for grid view in TV Shows menu