### PR TITLE
Bugfix: Fix NowPlaying channel thumb with jewel case

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -340,6 +340,7 @@ long storedItemID;
         thumbnailView.frame = jewelView.frame;
         thumbnailView.contentMode = UIViewContentModeScaleAspectFit;
     }
+    thumbnailView.clipsToBounds = YES;
     songDetailsView.frame = jewelView.frame;
     songDetailsView.center = [jewelView.superview convertPoint:jewelView.center toView:songDetailsView.superview];
     [nowPlayingView bringSubviewToFront:songDetailsView];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -327,10 +327,11 @@ long storedItemID;
         jewelImg = @"jewel_cd.9";
         jeweltype = jewelTypeCD;
     }
+    BOOL forceAspectFit = [type isEqual:@"channel"] || [type isEqual:@"recording"];
     if ([self enableJewelCases]) {
         jewelView.image = [UIImage imageNamed:jewelImg];
         thumbnailView.frame = [Utilities createCoverInsideJewel:jewelView jewelType:jeweltype];
-        thumbnailView.contentMode = UIViewContentModeScaleAspectFill;
+        thumbnailView.contentMode = forceAspectFit ? UIViewContentModeScaleAspectFit : UIViewContentModeScaleAspectFill;
     }
     else {
         jewelView.image = nil;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -319,7 +319,9 @@ long storedItemID;
         jewelImg = @"jewel_dvd.9";
         jeweltype = jewelTypeDVD;
     }
-    else if ([type isEqualToString:@"episode"]) {
+    else if ([type isEqualToString:@"episode"] ||
+             [type isEqualToString:@"channel"] ||
+             [type isEqualToString:@"recording"]) {
         jewelImg = @"jewel_tv.9";
         jeweltype = jewelTypeTV;
     }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -540,6 +540,7 @@ long storedItemID;
                                                 @"episode",
                                                 @"season",
                                                 @"fanart",
+                                                @"channel",
                                                 @"description",
                                                 @"year",
                                                 @"director",
@@ -581,15 +582,16 @@ long storedItemID;
                                  // 2nd: artists
                                  NSString *artist = [Utilities getStringFromItem:nowPlayingInfo[@"artist"]];
                                  NSString *studio = [Utilities getStringFromItem:nowPlayingInfo[@"studio"]];
+                                 NSString *channel = [Utilities getStringFromItem:nowPlayingInfo[@"channel"]];
                                  if (artist.length == 0 && studio.length) {
                                      artist = studio;
+                                 }
+                                 if (artist.length == 0 && channel.length) {
+                                     artist = channel;
                                  }
                                  
                                  // 3rd: album
                                  NSString *album = [Utilities getStringFromItem:nowPlayingInfo[@"album"]];
-                                 if ([nowPlayingInfo[@"type"] isEqualToString:@"channel"]) {
-                                     album = label;
-                                 }
                                  NSString *showtitle = [Utilities getStringFromItem:nowPlayingInfo[@"showtitle"]];
                                  NSString *season = [Utilities getStringFromItem:nowPlayingInfo[@"season"]];
                                  NSString *episode = [Utilities getStringFromItem:nowPlayingInfo[@"episode"]];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/895.

In general `thumbnailView` must use `clipsToBounds` to keep scaled images within the jewel case and the view boundaries. In addition channel logos (when playing TV / Radio or recordings) must use `UIViewContentModeScaleAspectFit` to stay fully visible within the jewel case frame. 
Also changed the channel / recording jewel case to the TV style as it was used for episodes.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2023-05prcl5.png"><img src="https://abload.de/img/bildschirmfoto2023-05prcl5.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix NowPlaying channel thumb with jewel case
Improvement: NowPlaying channel info for recordings