### PR TITLE
Maintenance: Reduce use of viewWithTag in iPads StackScrollVC

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2396,7 +2396,8 @@
             trackNumberLabel.adjustsFontSizeToFitWidth = YES;
             trackNumberLabel.minimumScaleFactor = (artistFontSize - 4) / artistFontSize;
             trackNumberLabel.tag = 101;
-            trackNumberLabel.highlightedTextColor = UIColor.whiteColor;
+            trackNumberLabel.highlightedTextColor = [Utilities get1stLabelColor];
+            trackNumberLabel.textColor = [Utilities get1stLabelColor];
             [cell.contentView addSubview:trackNumberLabel];
         }
         else if (channelGuideView) {
@@ -2409,7 +2410,8 @@
             programTimeLabel.minimumScaleFactor = 8.0 / 12.0;
             programTimeLabel.textAlignment = NSTextAlignmentCenter;
             programTimeLabel.tag = 102;
-            programTimeLabel.highlightedTextColor = UIColor.whiteColor;
+            programTimeLabel.highlightedTextColor = [Utilities get2ndLabelColor];
+            programTimeLabel.textColor = [Utilities get2ndLabelColor];
             [cell.contentView addSubview:programTimeLabel];
             ProgressPieView *progressView = [[ProgressPieView alloc] initWithFrame:CGRectMake(4, programTimeLabel.frame.origin.y + programTimeLabel.frame.size.height + 7, epgChannelTimeLabelWidth - 8, epgChannelTimeLabelWidth - 8)];
             progressView.tag = 103;
@@ -2439,20 +2441,24 @@
             isRecordingImageView.backgroundColor = UIColor.clearColor;
             [cell.contentView addSubview:isRecordingImageView];
         }
-        ((UILabel*)[cell viewWithTag:1]).highlightedTextColor = [Utilities get1stLabelColor];
-        ((UILabel*)[cell viewWithTag:2]).highlightedTextColor = [Utilities get2ndLabelColor];
-        ((UILabel*)[cell viewWithTag:3]).highlightedTextColor = [Utilities get2ndLabelColor];
-        ((UILabel*)[cell viewWithTag:4]).highlightedTextColor = [Utilities get2ndLabelColor];
-        ((UILabel*)[cell viewWithTag:5]).highlightedTextColor = [Utilities get2ndLabelColor];
-        ((UILabel*)[cell viewWithTag:101]).highlightedTextColor = [Utilities get1stLabelColor];
-        ((UILabel*)[cell viewWithTag:102]).highlightedTextColor = [Utilities get2ndLabelColor];
-        ((UILabel*)[cell viewWithTag:1]).textColor = [Utilities get1stLabelColor];
-        ((UILabel*)[cell viewWithTag:2]).textColor = [Utilities get2ndLabelColor];
-        ((UILabel*)[cell viewWithTag:3]).textColor = [Utilities get2ndLabelColor];
-        ((UILabel*)[cell viewWithTag:4]).textColor = [Utilities get2ndLabelColor];
-        ((UILabel*)[cell viewWithTag:5]).textColor = [Utilities get2ndLabelColor];
-        ((UILabel*)[cell viewWithTag:101]).textColor = [Utilities get1stLabelColor];
-        ((UILabel*)[cell viewWithTag:102]).textColor = [Utilities get2ndLabelColor];
+        UILabel *title = (UILabel*)[cell viewWithTag:1];
+        UILabel *genre = (UILabel*)[cell viewWithTag:2];
+        UILabel *runtimeyear = (UILabel*)[cell viewWithTag:3];
+        UILabel *runtime = (UILabel*)[cell viewWithTag:4];
+        UILabel *rating = (UILabel*)[cell viewWithTag:5];
+        
+        title.highlightedTextColor = [Utilities get1stLabelColor];
+        genre.highlightedTextColor = [Utilities get2ndLabelColor];
+        runtimeyear.highlightedTextColor = [Utilities get2ndLabelColor];
+        runtime.highlightedTextColor = [Utilities get2ndLabelColor];
+        rating.highlightedTextColor = [Utilities get2ndLabelColor];
+        
+        title.textColor = [Utilities get1stLabelColor];
+        genre.textColor = [Utilities get2ndLabelColor];
+        runtimeyear.textColor = [Utilities get2ndLabelColor];
+        runtime.textColor = [Utilities get2ndLabelColor];
+        rating.textColor = [Utilities get2ndLabelColor];
+        
         cell.backgroundColor = [Utilities getSystemGray6];
     }
     mainMenu *menuItem = self.detailItem;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -87,20 +87,26 @@
     if (cell == nil) {
         NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"serverListCellView" owner:self options:nil];
         cell = nib[0];
-        ((UILabel*)[cell viewWithTag:2]).highlightedTextColor = [Utilities get1stLabelColor];
-        ((UILabel*)[cell viewWithTag:3]).highlightedTextColor = [Utilities get1stLabelColor];
-        ((UILabel*)[cell viewWithTag:2]).textColor = [Utilities getSystemGray1];
-        ((UILabel*)[cell viewWithTag:3]).textColor = [Utilities getSystemGray1];
+        UILabel *cellLabel = (UILabel*)[cell viewWithTag:2];
+        UILabel *cellIP = (UILabel*)[cell viewWithTag:3];
+        
+        cellLabel.highlightedTextColor = [Utilities get1stLabelColor];
+        cellIP.highlightedTextColor = [Utilities get1stLabelColor];
+        
+        cellLabel.textColor = [Utilities getSystemGray1];
+        cellIP.textColor = [Utilities getSystemGray1];
+        
         cell.tintColor = UIColor.lightGrayColor;
         cell.editingAccessoryType = UITableViewCellAccessoryDetailDisclosureButton;
         if (@available(iOS 13.0, *)) {
             cell.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
         }
     }
+    UIImageView *iconView = (UIImageView*)[cell viewWithTag:1];
+    UILabel *cellLabel = (UILabel*)[cell viewWithTag:2];
+    UILabel *cellIP = (UILabel*)[cell viewWithTag:3];
     if (AppDelegate.instance.arrayServerList.count == 0) {
-        ((UIImageView*)[cell viewWithTag:1]).hidden = YES;
-        UILabel *cellLabel = (UILabel*)[cell viewWithTag:2];
-        UILabel *cellIP = (UILabel*)[cell viewWithTag:3];
+        iconView.hidden = YES;
         cellLabel.textAlignment = NSTextAlignmentCenter;
         cellLabel.text = LOCALIZED_STR(@"No saved hosts found");
         cellIP.text = @"";
@@ -109,9 +115,6 @@
         return cell;
     }
     else {
-        UIImageView *iconView = (UIImageView*)[cell viewWithTag:1];
-        UILabel *cellLabel = (UILabel*)[cell viewWithTag:2];
-        UILabel *cellIP = (UILabel*)[cell viewWithTag:3];
         iconView.hidden = NO;
         cellLabel.textAlignment = NSTextAlignmentLeft;
         NSDictionary *item = AppDelegate.instance.arrayServerList[indexPath.row];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2011,13 +2011,17 @@ long storedItemID;
     if (cell == nil) {
         NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"playlistCellView" owner:self options:nil];
         cell = nib[0];
-        ((UILabel*)[cell viewWithTag:1]).highlightedTextColor = [Utilities get1stLabelColor];
-        ((UILabel*)[cell viewWithTag:2]).highlightedTextColor = [Utilities get2ndLabelColor];
-        ((UILabel*)[cell viewWithTag:3]).highlightedTextColor = [Utilities get2ndLabelColor];
+        UILabel *mainLabel = (UILabel*)[cell viewWithTag:1];
+        UILabel *subLabel = (UILabel*)[cell viewWithTag:2];
+        UILabel *cornerLabel = (UILabel*)[cell viewWithTag:3];
         
-        ((UILabel*)[cell viewWithTag:1]).textColor = [Utilities get1stLabelColor];
-        ((UILabel*)[cell viewWithTag:2]).textColor = [Utilities get2ndLabelColor];
-        ((UILabel*)[cell viewWithTag:3]).textColor = [Utilities get2ndLabelColor];
+        mainLabel.highlightedTextColor = [Utilities get1stLabelColor];
+        subLabel.highlightedTextColor = [Utilities get2ndLabelColor];
+        cornerLabel.highlightedTextColor = [Utilities get2ndLabelColor];
+        
+        mainLabel.textColor = [Utilities get1stLabelColor];
+        subLabel.textColor = [Utilities get2ndLabelColor];
+        cornerLabel.textColor = [Utilities get2ndLabelColor];
     }
     NSDictionary *item = (playlistData.count > indexPath.row) ? playlistData[indexPath.row] : nil;
     UIImageView *thumb = (UIImageView*)[cell viewWithTag:4];
@@ -2027,7 +2031,7 @@ long storedItemID;
     UILabel *cornerLabel = (UILabel*)[cell viewWithTag:3];
 
     mainLabel.text = ![item[@"title"] isEqualToString:@""] ? item[@"title"] : item[@"label"];
-    ((UILabel*)[cell viewWithTag:2]).text = @"";
+    subLabel.text = @"";
     if ([item[@"type"] isEqualToString:@"episode"]) {
         mainLabel.text = [NSString stringWithFormat:@"%@", item[@"label"]];
         subLabel.text = [Utilities formatTVShowStringForSeasonTrailing:item[@"season"] episode:item[@"episode"] title:item[@"showtitle"]];

--- a/XBMC Remote/RemoteController.h
+++ b/XBMC Remote/RemoteController.h
@@ -22,6 +22,18 @@ typedef enum {
     IBOutlet UIView *gestureZoneView;
     IBOutlet UIView *buttonZoneView;
     IBOutlet UIImageView *panFallbackImageView;
+    IBOutlet UIButton *buttonSeekBackward;
+    IBOutlet UIButton *buttonPlayPause;
+    IBOutlet UIButton *buttonSeekForward;
+    IBOutlet UIButton *buttonPrevious;
+    IBOutlet UIButton *buttonNext;
+    IBOutlet UIButton *buttonStop;
+    IBOutlet UIButton *buttonMusic;
+    IBOutlet UIButton *buttonMovies;
+    IBOutlet UIButton *buttonTVShows;
+    IBOutlet UIButton *buttonPictures;
+    IBOutlet UIButton *buttonSubtitles;
+    IBOutlet UIButton *buttonAudiostreams;
     int audioVolume;
     CGFloat lastRotation;
     RemotePositionType positionMode;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -142,32 +142,32 @@
     CGRect frame = TransitionalView.frame;
     CGFloat newWidth = GET_MAINSCREEN_WIDTH - ANCHOR_RIGHT_PEEK;
     CGFloat shift;
-    [self hideButton:@[[self.view viewWithTag:TAG_BUTTON_SEEK_BACKWARD],
-                       [self.view viewWithTag:TAG_BUTTON_PLAY_PAUSE],
-                       [self.view viewWithTag:TAG_BUTTON_SEEK_FORWARD],
-                       [self.view viewWithTag:TAG_BUTTON_PREVIOUS],
-                       [self.view viewWithTag:TAG_BUTTON_NEXT]]
+    [self hideButton:@[buttonSeekBackward,
+                       buttonPlayPause,
+                       buttonSeekForward,
+                       buttonPrevious,
+                       buttonNext]
                 hide:YES];
     if ([Utilities hasRemoteToolBar]) {
-        shift = CGRectGetMinY(TransitionalView.frame) - CGRectGetMinY([self.view viewWithTag:TAG_BUTTON_NEXT].frame);
-        [self moveButton:@[[self.view viewWithTag:TAG_BUTTON_MUSIC],
-                           [self.view viewWithTag:TAG_BUTTON_MOVIES],
-                           [self.view viewWithTag:TAG_BUTTON_TVSHOWS],
-                           [self.view viewWithTag:TAG_BUTTON_PICTURES]]
+        shift = CGRectGetMinY(TransitionalView.frame) - CGRectGetMinY(buttonNext.frame);
+        [self moveButton:@[buttonMusic,
+                           buttonMovies,
+                           buttonTVShows,
+                           buttonPictures]
                     ypos: -shift];
     }
     else {
-        shift = CGRectGetMinY(TransitionalView.frame) - CGRectGetMinY([self.view viewWithTag:TAG_BUTTON_STOP].frame);
-        [self hideButton:@[[self.view viewWithTag:TAG_BUTTON_MUSIC],
-                           [self.view viewWithTag:TAG_BUTTON_MOVIES],
-                           [self.view viewWithTag:TAG_BUTTON_TVSHOWS],
-                           [self.view viewWithTag:TAG_BUTTON_PICTURES]]
+        shift = CGRectGetMinY(TransitionalView.frame) - CGRectGetMinY(buttonStop.frame);
+        [self hideButton:@[buttonMusic,
+                           buttonMovies,
+                           buttonTVShows,
+                           buttonPictures]
                     hide: YES];
     }
     
     // Place the transitional view in the middle between the two button rows
-    CGFloat lowerButtonUpperBorder = CGRectGetMinY([self.view viewWithTag:TAG_BUTTON_MUSIC].frame);
-    CGFloat upperButtonLowerBorder = CGRectGetMaxY([self.view viewWithTag:TAG_BUTTON_STOP].frame);
+    CGFloat lowerButtonUpperBorder = CGRectGetMinY(buttonMusic.frame);
+    CGFloat upperButtonLowerBorder = CGRectGetMaxY(buttonStop.frame);
     CGFloat transViewY = (lowerButtonUpperBorder + upperButtonLowerBorder - TransitionalView.frame.size.height) / 2;
     TransitionalView.frame = CGRectMake(frame.origin.x, transViewY, frame.size.width, frame.size.height);
     
@@ -190,7 +190,7 @@
     }
     else {
         // Overload "stop" button with gesture icon in case the toolbar cannot be displayed (e.g. iPhone 4S)
-        UIButton *gestureButton = (UIButton*)[self.view viewWithTag:TAG_BUTTON_STOP];
+        UIButton *gestureButton = buttonStop;
         gestureButton.contentMode = UIViewContentModeScaleAspectFit;
         gestureButton.showsTouchWhenHighlighted = NO;
         [gestureButton setImage:gestureImage forState:UIControlStateNormal];
@@ -687,11 +687,10 @@
         [actionView addAction:action_cancel];
         actionView.modalPresentationStyle = UIModalPresentationPopover;
         
-        UIButton *audioStreamsButton = (UIButton*)[self.view viewWithTag:TAG_BUTTON_AUDIOSTREAMS];
         UIPopoverPresentationController *popPresenter = [actionView popoverPresentationController];
         if (popPresenter != nil) {
             popPresenter.sourceView = remoteControlView;
-            popPresenter.sourceRect = audioStreamsButton.frame;
+            popPresenter.sourceRect = buttonAudiostreams.frame;
         }
         [self presentViewController:actionView animated:YES completion:nil];
     }
@@ -734,11 +733,10 @@
         [actionView addAction:action_cancel];
         actionView.modalPresentationStyle = UIModalPresentationPopover;
         
-        UIButton *subsButton = (UIButton*)[self.view viewWithTag:TAG_BUTTON_SUBTITLES];
         UIPopoverPresentationController *popPresenter = [actionView popoverPresentationController];
         if (popPresenter != nil) {
             popPresenter.sourceView = remoteControlView;
-            popPresenter.sourceRect = subsButton.frame;
+            popPresenter.sourceRect = buttonSubtitles.frame;
         }
         [self presentViewController:actionView animated:YES completion:nil];
     }

--- a/XBMC Remote/RemoteController.xib
+++ b/XBMC Remote/RemoteController.xib
@@ -1,15 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="RemoteController">
             <connections>
                 <outlet property="TransitionalView" destination="178" id="190"/>
+                <outlet property="buttonAudiostreams" destination="120" id="6Ye-3b-UPt"/>
+                <outlet property="buttonMovies" destination="127" id="OEw-R8-8yk"/>
+                <outlet property="buttonMusic" destination="125" id="clG-oU-hXK"/>
+                <outlet property="buttonNext" destination="33" id="LKw-44-hYN"/>
+                <outlet property="buttonPictures" destination="131" id="aJD-b7-meq"/>
+                <outlet property="buttonPlayPause" destination="28" id="oXS-vp-Nb5"/>
+                <outlet property="buttonPrevious" destination="30" id="aRD-8e-mFC"/>
+                <outlet property="buttonSeekBackward" destination="27" id="Nfz-tV-iYf"/>
+                <outlet property="buttonSeekForward" destination="29" id="NMt-iV-Km3"/>
+                <outlet property="buttonStop" destination="31" id="6FX-5c-eyZ"/>
+                <outlet property="buttonSubtitles" destination="118" id="o7b-MH-28e"/>
+                <outlet property="buttonTVShows" destination="129" id="dLN-7J-8Sj"/>
                 <outlet property="buttonZoneView" destination="173" id="177"/>
                 <outlet property="gestureZoneImageView" destination="175" id="191"/>
                 <outlet property="gestureZoneView" destination="174" id="176"/>
@@ -65,7 +77,7 @@
                                 <outletCollection property="gestureRecognizers" destination="Rvl-N6-jCn" appends="YES" id="Fm9-lc-ctc"/>
                             </connections>
                         </button>
-                        <button tag="23" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="129" userLabel="Button - TV">
+                        <button tag="23" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="129" userLabel="Button - TV Shows">
                             <rect key="frame" x="160" y="370" width="75" height="35"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                             <gestureRecognizers/>
@@ -311,7 +323,7 @@
                                 <outletCollection property="gestureRecognizers" destination="197" appends="YES" id="198"/>
                             </connections>
                         </button>
-                        <button tag="20" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="120" userLabel="Button - dvd">
+                        <button tag="20" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="120" userLabel="Button - audiostreams">
                             <rect key="frame" x="160" y="5" width="75" height="35"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -343,7 +355,7 @@
                                 <outletCollection property="gestureRecognizers" destination="194" appends="YES" id="195"/>
                             </connections>
                         </button>
-                        <button tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="30" userLabel="Button - skip backward">
+                        <button tag="5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="30" userLabel="Button - previous">
                             <rect key="frame" x="10" y="44" width="60" height="33"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -407,7 +419,7 @@
                                 <outletCollection property="gestureRecognizers" destination="161" appends="YES" id="162"/>
                             </connections>
                         </button>
-                        <button tag="8" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="33" userLabel="Button - skip forward">
+                        <button tag="8" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="33" userLabel="Button - next">
                             <rect key="frame" x="250" y="44" width="60" height="33"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -774,8 +774,8 @@
     float newValue = newStep * [self.detailItem[@"step"] intValue];
     if (newValue != storeSliderValue) {
         storeSliderValue = newValue;
-        if ([[[slider superview] viewWithTag:102] isKindOfClass:[UILabel class]]) {
-            UILabel *sliderLabel = (UILabel*)[[slider superview] viewWithTag:102];
+        UILabel *sliderLabel = [[slider superview] viewWithTag:102];
+        if (sliderLabel) {
             NSString *stringFormat = @"%i";
             stringFormat = [self getStringFormatFromItem:itemControls defaultFormat:stringFormat];
             sliderLabel.text = [NSString stringWithFormat:stringFormat, (int)storeSliderValue];

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -466,9 +466,6 @@
         textInputField.delegate = self;
         textInputField.tag = 301;
         [cell.contentView addSubview:textInputField];
-        cellLabel.highlightedTextColor = [Utilities get1stLabelColor];
-        descriptionLabel.highlightedTextColor = [Utilities get2ndLabelColor];
-        uiSliderLabel.highlightedTextColor = [Utilities get2ndLabelColor];
 	}
     cell.accessoryType = UITableViewCellAccessoryNone;
 

--- a/XBMC Remote/iPad/StackScrollViewController.h
+++ b/XBMC Remote/iPad/StackScrollViewController.h
@@ -43,6 +43,8 @@
     
     UIView *slideViews;
     UIView *borderViews;
+    UIView *verticalLineView1;
+    UIView *verticalLineView2;
     
     UIView *viewAtLeft;
     UIView *viewAtRight;

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -253,7 +253,6 @@
                                        viewAtLeft.frame.size.width,
                                        viewAtLeft.frame.size.height);
         }
-        [borderViews viewWithTag:3 + VIEW_TAG].hidden = YES;
         [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
         [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
         viewAtLeft2 = nil;
@@ -265,7 +264,6 @@
         for (UIView *subview in slideViews.subviews) {
             [subview removeFromSuperview];
         }
-        [borderViews viewWithTag:3 + VIEW_TAG].hidden = YES;
         [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
         [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
         [viewControllersStack removeAllObjects];
@@ -294,7 +292,6 @@
             [[slideViews viewWithTag:i + VIEW_TAG] removeFromSuperview];
             [viewControllersStack removeLastObject];
         }
-        [borderViews viewWithTag:3 + VIEW_TAG].hidden = YES;
         [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
         [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
     }
@@ -828,7 +825,6 @@
             [subview removeFromSuperview];
         }
         
-        [borderViews viewWithTag:3 + VIEW_TAG].hidden = YES;
         [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
         [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
         [viewControllersStack removeAllObjects];
@@ -867,7 +863,6 @@
         for (UIView *subview in slideViews.subviews) {
             [subview removeFromSuperview];
         }		[viewControllersStack removeAllObjects];
-        [borderViews viewWithTag:3 + VIEW_TAG].hidden = YES;
         [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
         [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
     }

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -62,16 +62,14 @@
         borderViews = [[UIView alloc] initWithFrame:CGRectMake(SLIDE_VIEWS_MINUS_X_POSITION - 2, -2, 2, self.view.frame.size.height + 2)];
         borderViews.backgroundColor = UIColor.clearColor;
         borderViews.autoresizingMask = UIViewAutoresizingFlexibleHeight;
-        UIView *verticalLineView1 = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 1, borderViews.frame.size.height)];
+        verticalLineView1 = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 1, borderViews.frame.size.height)];
         verticalLineView1.backgroundColor = UIColor.whiteColor;
-        verticalLineView1.tag = 1 + VIEW_TAG;
         verticalLineView1.hidden = YES;
         verticalLineView1.autoresizingMask = UIViewAutoresizingFlexibleHeight;
         [borderViews addSubview:verticalLineView1];
         
-        UIView *verticalLineView2 = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 2, borderViews.frame.size.height)];
+        verticalLineView2 = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 2, borderViews.frame.size.height)];
         verticalLineView2.backgroundColor = UIColor.grayColor;
-        verticalLineView2.tag = 2 + VIEW_TAG;
         verticalLineView2.hidden = YES;
         verticalLineView2.autoresizingMask = UIViewAutoresizingFlexibleHeight;
         [borderViews addSubview:verticalLineView2];
@@ -219,8 +217,8 @@
 
 - (void)arrangeVerticalBar {
     if (slideViews.subviews.count > 2) {
-        [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
-        [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
+        verticalLineView2.hidden = YES;
+        verticalLineView1.hidden = YES;
         NSInteger stackCount = 0;
         if (viewAtLeft != nil) {
             stackCount = [slideViews.subviews indexOfObject:viewAtLeft];
@@ -231,11 +229,11 @@
         }
         
         if (stackCount == 2) {
-            [borderViews viewWithTag:2 + VIEW_TAG].hidden = NO;
+            verticalLineView2.hidden = NO;
         }
         if (stackCount >= 3) {
-            [borderViews viewWithTag:2 + VIEW_TAG].hidden = NO;
-            [borderViews viewWithTag:1 + VIEW_TAG].hidden = NO;
+            verticalLineView2.hidden = NO;
+            verticalLineView1.hidden = NO;
         }
     }
 }
@@ -253,8 +251,8 @@
                                        viewAtLeft.frame.size.width,
                                        viewAtLeft.frame.size.height);
         }
-        [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
-        [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
+        verticalLineView2.hidden = YES;
+        verticalLineView1.hidden = YES;
         viewAtLeft2 = nil;
         viewAtRight = nil;
         viewAtLeft = nil;
@@ -264,8 +262,8 @@
         for (UIView *subview in slideViews.subviews) {
             [subview removeFromSuperview];
         }
-        [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
-        [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
+        verticalLineView2.hidden = YES;
+        verticalLineView1.hidden = YES;
         [viewControllersStack removeAllObjects];
         [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollOffScreen" object: nil];
     }];
@@ -292,8 +290,8 @@
             [[slideViews viewWithTag:i + VIEW_TAG] removeFromSuperview];
             [viewControllersStack removeLastObject];
         }
-        [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
-        [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
+        verticalLineView2.hidden = YES;
+        verticalLineView1.hidden = YES;
     }
     // Removes the selection of row for the first slide view
     for (UIView* tableView in slideViews.subviews[0].subviews) {
@@ -779,7 +777,7 @@
     }
     [self arrangeVerticalBar];
     if ([slideViews.subviews indexOfObject:viewAtLeft2] == 1 && isBouncing) {
-        [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
+        verticalLineView2.hidden = YES;
     }
 }
 
@@ -825,8 +823,8 @@
             [subview removeFromSuperview];
         }
         
-        [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
-        [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
+        verticalLineView2.hidden = YES;
+        verticalLineView1.hidden = YES;
         [viewControllersStack removeAllObjects];
     }
     
@@ -863,8 +861,8 @@
         for (UIView *subview in slideViews.subviews) {
             [subview removeFromSuperview];
         }		[viewControllersStack removeAllObjects];
-        [borderViews viewWithTag:2 + VIEW_TAG].hidden = YES;
-        [borderViews viewWithTag:1 + VIEW_TAG].hidden = YES;
+        verticalLineView2.hidden = YES;
+        verticalLineView1.hidden = YES;
     }
     
     if (slideViews.subviews.count != 0) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/546.

This PR reduces the use of `viewWithTag` where it can be replaced by ivars, outlets, xib or refactoring.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Reduce use of viewWithTag