### PR TITLE
Improvement: Blue color for selected item in grid / recently added

### DIFF
--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -68,7 +68,7 @@
 
         UIView *bgView = [[UIView alloc] initWithFrame:frame];
         bgView.layer.borderWidth = borderWidth;
-        bgView.layer.borderColor = [Utilities getSystemGreen:1.0].CGColor;
+        bgView.layer.borderColor = [Utilities getSystemBlue].CGColor;
         self.selectedBackgroundView = bgView;
     }
     return self;

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -93,7 +93,7 @@
         
         UIView *bgView = [[UIView alloc] initWithFrame:frame];
         bgView.layer.borderWidth = borderWidth;
-        bgView.layer.borderColor = [Utilities getSystemGreen:1.0].CGColor;
+        bgView.layer.borderColor = [Utilities getSystemBlue].CGColor;
         self.selectedBackgroundView = bgView;
     }
     return self;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Use `systemBlue` instead of `systemGreen` when highlighting selected items in grid view and "recently added" views. This aligns better with the color scheme of the Apps's UI. `systemBlue` is commonly used to visualize active views and elements.

Screenshots: <a href="https://abload.de/image.php?img=bildschirmfoto2023-05i8fry.png"><img src="https://abload.de/img/bildschirmfoto2023-05i8fry.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Blue color for selected item in grid / recently added