### PR TITLE
Improvement: Add "listened" mark for several music library views

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -721,6 +721,7 @@
                         @"year",
                         @"thumbnail",
                         @"artist",
+                        @"playcount",
                 ],
             }, @"parameters",
             @{
@@ -868,6 +869,7 @@
                         @"year",
                         @"thumbnail",
                         @"artist",
+                        @"playcount",
                 ],
             }, @"parameters",
             LOCALIZED_STR(@"Played albums"), @"label",
@@ -1083,6 +1085,7 @@
             @"row4": @"fanart",
             @"row5": @"rating",
             @"row6": @"albumid",
+            @"row7": @"playcount",
             @"playlistid": @PLAYERID_MUSIC,
             @"row8": @"albumid",
             @"row9": @"albumid",
@@ -1108,6 +1111,7 @@
             @"row10": @"file",
             @"row11": @"artist",
             @"row12": @"album",
+            @"row13": @"playcount",
         },
                       
         @{
@@ -1118,6 +1122,7 @@
             @"row4": @"fanart",
             @"row5": @"rating",
             @"row6": @"albumid",
+            @"row7": @"playcount",
             @"playlistid": @PLAYERID_MUSIC,
             @"row8": @"albumid",
             @"row9": @"albumid",
@@ -1125,7 +1130,6 @@
             @"row11": @"genre",
             @"row12": @"description",
             @"row13": @"albumlabel",
-            @"row14": @"playcount",
             @"itemid_extra_info": @"albumdetails",
         },
                       
@@ -1146,6 +1150,7 @@
             @"row12": @"album",
             @"row13": @"duration",
             @"row14": @"rating",
+            @"row15": @"playcount",
         },
                       
         @{
@@ -1365,6 +1370,7 @@
                         @"year",
                         @"thumbnail",
                         @"artist",
+                        @"playcount",
                 ],
             }, @"parameters",
             @{
@@ -1611,6 +1617,7 @@
             @"row4": @"fanart",
             @"row5": @"rating",
             @"row6": @"albumid",
+            @"row7": @"playcount",
             @"playlistid": @PLAYERID_MUSIC,
             @"row8": @"albumid",
             @"row9": @"albumid",
@@ -1903,6 +1910,7 @@
                         @"year",
                         @"thumbnail",
                         @"artist",
+                        @"playcount",
                 ],
             }, @"parameters",
             @{
@@ -1982,6 +1990,7 @@
             @"row4": @"fanart",
             @"row5": @"rating",
             @"row6": @"albumid",
+            @"row7": @"playcount",
             @"playlistid": @PLAYERID_MUSIC,
             @"row8": @"albumid",
             @"row9": @"albumid",


### PR DESCRIPTION


## Description
<!--- Detailed info for reviewers and developers -->
This PR adds the "listened" check mark for several music library items and view:
- Albums reached via Artists
- Albums in Top100 Albums view
- Songs in Top100 Songs view
- Albums in Recently Added Albums view
- Songs in Recently Added Songs view
- Albums reached via Music Roles
- Never display the marks in an album view itself as this visually overloads the view.
- Never display the marks in Recently Played Albums / Song. They were played anyway.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2023-05tmcl3.png"><img src="https://abload.de/img/bildschirmfoto2023-05tmcl3.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Add "listened" mark for several music library views