### PR TITLE
Improvement: Displaying Season/Episode

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2083,14 +2083,9 @@
     else {
         thumbWidth = DEFAULT_THUMB_WIDTH;
     }
-    if (albumView) {
+    if (albumView || episodesView) {
         thumbWidth = 0;
-        labelPosition = thumbWidth + albumViewPadding + trackCountLabelWidth;
-        dataList.separatorInset = UIEdgeInsetsMake(0, 8, 0, 0);
-    }
-    else if (episodesView) {
-        thumbWidth = 0;
-        labelPosition = thumbWidth + albumViewPadding + trackCountLabelWidth;
+        labelPosition = albumViewPadding + trackCountLabelWidth;
     }
     else if (channelGuideView) {
         thumbWidth = 0;
@@ -2099,6 +2094,7 @@
     else {
         labelPosition = thumbWidth + 8;
     }
+    dataList.separatorInset = UIEdgeInsetsMake(0, thumbWidth + 8, 0, 0);
     int newWidthLabel = 0;
     
     // label position for TVShow banner view needs to be tailored to match the default thumb size
@@ -5770,7 +5766,6 @@ NSIndexPath *selected;
     [button7 addTarget:self action:@selector(handleChangeSortLibrary) forControlEvents:UIControlEventTouchUpInside];
     self.edgesForExtendedLayout = UIRectEdgeNone;
     dataList.backgroundView = [[UIView alloc] initWithFrame:CGRectZero];
-    dataList.separatorInset = UIEdgeInsetsMake(0, 53, 0, 0);
     dataList.indicatorStyle = UIScrollViewIndicatorStyleDefault;
     
     CGRect frame = dataList.frame;
@@ -5826,7 +5821,6 @@ NSIndexPath *selected;
     }
     else if ([methods[@"episodesView"] boolValue]) {
         episodesView = YES;
-        dataList.separatorInset = UIEdgeInsetsMake(0, 18, 0, 0);
     }
     else if ([methods[@"tvshowsView"] boolValue]) {
         tvshowsView = AppDelegate.instance.serverVersion > 11 && ![Utilities getPreferTvPosterMode];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2733,6 +2733,12 @@
             hasTimer.hidden = YES;
         }
     }
+    if (!runtimeyear.hidden) {
+        frame = genre.frame;
+        frame.size.width = menuItem.widthLabel - [Utilities getWidthOfLabel:runtimeyear] - 8;
+        genre.frame = frame;
+    }
+    
     NSString *playcount = [NSString stringWithFormat:@"%@", item[@"playcount"]];
     UIImageView *flagView = (UIImageView*)[cell viewWithTag:9];
     frame = flagView.frame;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2090,7 +2090,7 @@
     }
     else if (episodesView) {
         thumbWidth = 0;
-        labelPosition = 18;
+        labelPosition = thumbWidth + albumViewPadding + trackCountLabelWidth;
     }
     else if (channelGuideView) {
         thumbWidth = 0;
@@ -2386,7 +2386,7 @@
     if (cell == nil) {
         NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"jsonDataCell" owner:self options:nil];
         cell = nib[0];
-        if (albumView) {
+        if (albumView || episodesView) {
             UILabel *trackNumberLabel = [[UILabel alloc] initWithFrame:CGRectMake(albumViewPadding, cellHeight / 2 - (artistFontSize + labelPadding) / 2, trackCountLabelWidth - 2, artistFontSize + labelPadding)];
             trackNumberLabel.backgroundColor = UIColor.clearColor;
             trackNumberLabel.font = [UIFont systemFontOfSize:artistFontSize];
@@ -2484,7 +2484,7 @@
     if (channelListView && item[@"channelnumber"]) {
         title.text = [NSString stringWithFormat:@"%@. %@", item[@"channelnumber"], item[@"label"]];
     }
-    else if (item[@"episodeid"]) {
+    else if (item[@"episodeid"] && !episodesView) {
         title.text = [Utilities formatTVShowStringForSeason:item[@"season"] episode:item[@"episode"] title:item[@"label"]];
     }
     else {
@@ -2671,6 +2671,10 @@
     else if (albumView) {
         UILabel *trackNumber = (UILabel*)[cell viewWithTag:101];
         trackNumber.text = item[@"track"];
+    }
+    else if (episodesView) {
+        UILabel *trackNumber = (UILabel*)[cell viewWithTag:101];
+        trackNumber.text = item[@"episode"];
     }
     else if (channelGuideView) {
         runtimeyear.hidden = YES;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2481,7 +2481,7 @@
         title.text = [NSString stringWithFormat:@"%@. %@", item[@"channelnumber"], item[@"label"]];
     }
     else if (item[@"episodeid"] && !episodesView) {
-        title.text = [Utilities formatTVShowStringForSeason:item[@"season"] episode:item[@"episode"] title:item[@"label"]];
+        title.text = [Utilities formatTVShowStringForSeasonLeading:item[@"season"] episode:item[@"episode"] title:item[@"label"]];
     }
     else {
         title.text = item[@"label"];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2567,6 +2567,7 @@
         }
         if ([item[@"filetype"] length] != 0 ||
             [item[@"family"] isEqualToString:@"file"] ||
+            [item[@"family"] isEqualToString:@"type"] ||
             [item[@"family"] isEqualToString:@"genreid"] ||
             [item[@"family"] isEqualToString:@"channelgroupid"] ||
             [item[@"family"] isEqualToString:@"roleid"]) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2393,8 +2393,10 @@
             [cell.contentView addSubview:trackNumberLabel];
         }
         else if (channelGuideView) {
+            UILabel *title = (UILabel*)[cell viewWithTag:1];
             UILabel *programTimeLabel = [[UILabel alloc] initWithFrame:CGRectMake(4, 8, epgChannelTimeLabelWidth - 8, 12 + labelPadding)];
             programTimeLabel.backgroundColor = UIColor.clearColor;
+            programTimeLabel.center = CGPointMake(programTimeLabel.center.x, title.center.y);
             programTimeLabel.font = [UIFont systemFontOfSize:12];
             programTimeLabel.adjustsFontSizeToFitWidth = YES;
             programTimeLabel.minimumScaleFactor = 8.0 / 12.0;
@@ -2530,7 +2532,7 @@
         if (channelListView || recordingListView) {
             CGRect frame;
             frame.origin.x = 4;
-            frame.origin.y = 10;
+            frame.origin.y = 8;
             frame.size.width = ceil(thumbWidth * 0.9);
             frame.size.height = ceil(thumbWidth * 0.7);
             cell.urlImageView.frame = frame;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -591,13 +591,7 @@ long storedItemID;
                                  NSString *season = [Utilities getStringFromItem:nowPlayingInfo[@"season"]];
                                  NSString *episode = [Utilities getStringFromItem:nowPlayingInfo[@"episode"]];
                                  if (album.length == 0 && showtitle.length) {
-                                     if ([season intValue] > 0 && [episode intValue] > 0) {
-                                         NSString *seasonAndEpisode = [Utilities formatTVShowStringForSeason:season episode:episode];
-                                         album = [NSString stringWithFormat:@"%@ - %@", showtitle, seasonAndEpisode];
-                                     }
-                                     else {
-                                         album = showtitle;
-                                     }
+                                     album = [Utilities formatTVShowStringForSeasonTrailing:season episode:episode title:showtitle];
                                  }
                                  NSString *director = [Utilities getStringFromItem:nowPlayingInfo[@"director"]];
                                  if (album.length == 0 && director.length) {
@@ -1725,8 +1719,8 @@ long storedItemID;
                     title = [NSString stringWithFormat:@"%@\n%@\n%@", item[@"label"], item[@"album"], item[@"artist"]];
                 }
                 else if ([item[@"type"] isEqualToString:@"episode"]) {
-                    NSString *tvshowText = [Utilities formatTVShowStringForSeason:item[@"season"] episode:item[@"episode"] title:item[@"label"]];
-                    title = [NSString stringWithFormat:@"%@\n%@", item[@"showtitle"], tvshowText];
+                    NSString *tvshowText = [Utilities formatTVShowStringForSeasonTrailing:item[@"season"] episode:item[@"episode"] title:item[@"showtitle"]];
+                    title = [NSString stringWithFormat:@"%@%@%@", item[@"label"], tvshowText.length ? @"\n" : @"", tvshowText];
                 }
                 [self showActionNowPlaying:sheetActions title:title point:selectedPoint];
             }
@@ -1965,10 +1959,8 @@ long storedItemID;
     mainLabel.text = ![item[@"title"] isEqualToString:@""] ? item[@"title"] : item[@"label"];
     ((UILabel*)[cell viewWithTag:2]).text = @"";
     if ([item[@"type"] isEqualToString:@"episode"]) {
-        if ([item[@"season"] intValue] != 0 || [item[@"episode"] intValue] != 0) {
-            mainLabel.text = [Utilities formatTVShowStringForSeason:item[@"season"] episode:item[@"episode"] title:item[@"label"]];
-        }
-        subLabel.text = [NSString stringWithFormat:@"%@", item[@"showtitle"]];
+        mainLabel.text = [NSString stringWithFormat:@"%@", item[@"label"]];
+        subLabel.text = [Utilities formatTVShowStringForSeasonTrailing:item[@"season"] episode:item[@"episode"] title:item[@"showtitle"]];
     }
     else if ([item[@"type"] isEqualToString:@"song"] ||
              [item[@"type"] isEqualToString:@"musicvideo"]) {

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -128,6 +128,28 @@
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
+			<string>1.01</string>
+			<key>Key</key>
+			<string>episode_identifier</string>
+			<key>Title</key>
+			<string>Episode identifier</string>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Titles</key>
+			<array>
+				<string>1.01</string>
+				<string>1x01</string>
+				<string>S1E01</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<string>%d.%02d</string>
+				<string>%dx%02d</string>
+				<string>S%dE%02d</string>
+			</array>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
 			<true/>
 			<key>Key</key>
 			<string>ken_preference</string>

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -104,7 +104,8 @@ typedef enum {
 + (void)colorLabel:(UILabel*)view AnimDuration:(NSTimeInterval)seconds Color:(UIColor*)color;
 + (float)getPercentElapsed:(NSDate*)startDate EndDate:(NSDate*)endDate;
 + (void)createTransparentToolbar:(UIToolbar*)toolbar;
-+ (NSString*)formatTVShowStringForSeason:(id)season episode:(id)episode title:(NSString*)title;
++ (NSString*)formatTVShowStringForSeasonTrailing:(id)season episode:(id)episode title:(NSString*)title;
++ (NSString*)formatTVShowStringForSeasonLeading:(id)season episode:(id)episode title:(NSString*)title;
 + (NSString*)formatTVShowStringForSeason:(id)season episode:(id)episode;
 
 @end

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -77,6 +77,7 @@ typedef enum {
 + (int)getSec2Min:(BOOL)convert;
 + (NSString*)getImageServerURL;
 + (NSString*)formatStringURL:(NSString*)path serverURL:(NSString*)serverURL;
++ (CGFloat)getWidthOfLabel:(UILabel*)label;
 + (CGFloat)getHeightOfLabel:(UILabel*)label;
 + (UIImage*)roundedCornerImage:(UIImage*)image drawBorder:(BOOL)drawBorder;
 + (UIImageView*)roundedCornerView:(UIImageView*)view drawBorder:(BOOL)drawBorder;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -756,6 +756,14 @@
     return urlString;
 }
 
++ (CGFloat)getWidthOfLabel:(UILabel*)label {
+    CGRect expectedLabelRect = [label.text boundingRectWithSize:CGSizeMake(label.frame.size.width, CGFLOAT_MAX)
+                                                        options:NSStringDrawingUsesLineFragmentOrigin
+                                                     attributes:@{NSFontAttributeName: label.font}
+                                                        context:nil];
+    return ceil(expectedLabelRect.size.width);
+}
+
 + (CGFloat)getHeightOfLabel:(UILabel*)label {
     CGRect expectedLabelRect = [label.text boundingRectWithSize:CGSizeMake(label.frame.size.width, CGFLOAT_MAX)
                                                         options:NSStringDrawingUsesLineFragmentOrigin

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1144,14 +1144,25 @@
          forToolbarPosition:UIBarPositionAny];
 }
 
-+ (NSString*)formatTVShowStringForSeason:(id)season episode:(id)episode title:(NSString*)title {
++ (NSString*)formatTVShowStringForSeasonLeading:(id)season episode:(id)episode title:(NSString*)title {
     NSString *seasonAndEpisode = [Utilities formatTVShowStringForSeason:season episode:episode];
-    NSString *text = [NSString stringWithFormat:@"%@ - %@", seasonAndEpisode, title];
+    NSString *text = [NSString stringWithFormat:@"%@%@%@", seasonAndEpisode, seasonAndEpisode.length ? @" " : @"", title];
+    return text;
+}
+
++ (NSString*)formatTVShowStringForSeasonTrailing:(id)season episode:(id)episode title:(NSString*)title {
+    NSString *seasonAndEpisode = [Utilities formatTVShowStringForSeason:season episode:episode];
+    NSString *text = [NSString stringWithFormat:@"%@%@%@", title, seasonAndEpisode.length ? @" " : @"", seasonAndEpisode];
     return text;
 }
 
 + (NSString*)formatTVShowStringForSeason:(id)season episode:(id)episode {
-    NSString *text = [NSString stringWithFormat:@"S%@E%@", season, episode];
+    NSString *text = @"";
+    if ([season respondsToSelector:@selector(intValue)] && [episode respondsToSelector:@selector(intValue)]) {
+        if ([season intValue] && [episode intValue]) {
+            text = [NSString stringWithFormat:@"%d.%02d", [season intValue], [episode intValue]];
+        }
+    }
     return text;
 }
 

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1158,9 +1158,11 @@
 
 + (NSString*)formatTVShowStringForSeason:(id)season episode:(id)episode {
     NSString *text = @"";
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    NSString *format = [userDefaults stringForKey:@"episode_identifier"];
     if ([season respondsToSelector:@selector(intValue)] && [episode respondsToSelector:@selector(intValue)]) {
         if ([season intValue] && [episode intValue]) {
-            text = [NSString stringWithFormat:@"%d.%02d", [season intValue], [episode intValue]];
+            text = [NSString stringWithFormat:format, [season intValue], [episode intValue]];
         }
     }
     return text;

--- a/XBMC Remote/jsonDataCell.xib
+++ b/XBMC Remote/jsonDataCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -21,37 +21,39 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label clipsSubviews="YES" userInteractionEnabled="NO" tag="1" contentMode="left" fixedFrame="YES" text="La grande bouffe" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="4">
-                        <rect key="frame" x="61" y="0.0" width="222" height="35"/>
+                        <rect key="frame" x="61" y="0.0" width="222" height="30"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
                         <color key="textColor" systemColor="darkTextColor"/>
                         <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <size key="shadowOffset" width="0.0" height="0.0"/>
                     </label>
-                    <label clipsSubviews="YES" userInteractionEnabled="NO" tag="2" contentMode="left" fixedFrame="YES" text="Action / Drama / Crime / Thriller" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="6">
-                        <rect key="frame" x="61" y="33" width="180" height="16"/>
+                    <label clipsSubviews="YES" userInteractionEnabled="NO" tag="2" contentMode="left" fixedFrame="YES" text="Action / Drama / Crime / 1973" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="6">
+                        <rect key="frame" x="61" y="30" width="177" height="16"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <size key="shadowOffset" width="0.0" height="0.0"/>
                     </label>
                     <label clipsSubviews="YES" userInteractionEnabled="NO" tag="4" contentMode="left" fixedFrame="YES" text="130 min" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="7">
                         <rect key="frame" x="61" y="54" width="169" height="14"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <size key="shadowOffset" width="0.0" height="0.0"/>
                     </label>
                     <label clipsSubviews="YES" userInteractionEnabled="NO" tag="3" contentMode="left" fixedFrame="YES" text="1973" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8">
-                        <rect key="frame" x="220" y="33" width="63" height="16"/>
+                        <rect key="frame" x="220" y="30" width="63" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <color key="shadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <size key="shadowOffset" width="0.0" height="0.0"/>
                     </label>
                     <label clipsSubviews="YES" userInteractionEnabled="NO" tag="5" contentMode="left" fixedFrame="YES" text="7.2" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="10">
@@ -61,7 +63,6 @@
                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                         <color key="textColor" red="0.748973548412323" green="0.748973548412323" blue="0.748973548412323" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <color key="shadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <size key="shadowOffset" width="0.0" height="0.0"/>
                     </label>
                     <imageView clipsSubviews="YES" multipleTouchEnabled="YES" tag="6" contentMode="scaleAspectFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="11">

--- a/XBMC Remote/playlistCellView.xib
+++ b/XBMC Remote/playlistCellView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -21,29 +21,28 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     </imageView>
                     <label clipsSubviews="YES" userInteractionEnabled="NO" tag="1" contentMode="left" fixedFrame="YES" text="La grande bouffe" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="7">
-                        <rect key="frame" x="60" y="3" width="253" height="35"/>
+                        <rect key="frame" x="60" y="0.0" width="253" height="30"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
                         <color key="textColor" systemColor="darkTextColor"/>
                         <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </label>
                     <label clipsSubviews="YES" userInteractionEnabled="NO" tag="2" contentMode="left" fixedFrame="YES" text="Action / Drama / Crime / Thriller" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="8">
-                        <rect key="frame" x="60" y="35" width="206" height="16"/>
+                        <rect key="frame" x="60" y="30" width="205" height="16"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <color key="textColor" red="0.3333333432674408" green="0.3333333432674408" blue="0.3333333432674408" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </label>
                     <label clipsSubviews="YES" userInteractionEnabled="NO" tag="3" contentMode="left" fixedFrame="YES" text="1973" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="9">
-                        <rect key="frame" x="271" y="35" width="44" height="16"/>
+                        <rect key="frame" x="271" y="30" width="44" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <color key="textColor" red="0.3333333432674408" green="0.3333333432674408" blue="0.3333333432674408" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <color key="shadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <size key="shadowOffset" width="0.0" height="0.0"/>
                     </label>
                     <view hidden="YES" tag="5" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="14" userLabel="currentTime View">


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Improves display season/episode based on user feedback.

- Add setting "Episode identifier" (options: "1.01", "1x01", "E1S01", "E01S01") 
- Use this identifier consistently in "recently added episodes", playlist, playlist action sheet and NowPlaying
- Show season episodes in same format as album tracks (no "1x01", but simply the episode number "1").
- Adapt formatting to skip displaying season/episode information in case this is not provided.
- Check `season` and `episode` variables for support of `intValue` to improve robustness.
- Improve readability for library view (bigger font for 2nd/3rd row and no shadow for `year` and `rating`)

Screenshots: https://abload.de/img/bildschirmfoto2023-0507c2r.png


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Displaying Season/Episode
Feature: User selectable episode identifier
Improvement: Readability of library list view