### PR TITLE
Bugfixes for TV Show banner layout

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -921,6 +921,9 @@
                 cell.backgroundColor = [Utilities getSystemGray6];
             }
         }
+        if ([cell isKindOfClass:[UITableViewCell class]]) {
+            [(UITableViewCell*)cell contentView].backgroundColor = cell.backgroundColor;
+        }
     }
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3129,9 +3129,6 @@
     else if (section != 0 || [self doesShowSearchResults]) {
         return sectionHeight;
     }
-    if ([self.sections allKeys].count == 1) {
-        return 1;
-    }
     return 0;
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Use same background for `contenView` and `cell` for TV Show banners.
Set `heightForHeaderInSection` to 0 when there is only 1 section.

Screenshots:
<a href="https://abload.de/image.php?img=bildschirmfoto2023-05xlizs.png"><img src="https://abload.de/img/bildschirmfoto2023-05xlizs.png" /></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Remove white line on top of TV Show banners
Bugfix: Remove white frame around selected TV Show banner