### PR TITLE
Bugfix: Do not mark program active if not started yet

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2691,7 +2691,7 @@
         programStartTime.text = [localHourMinuteFormatter stringFromDate:starttime];
         float percent_elapsed = [Utilities getPercentElapsed:starttime EndDate:endtime];
 
-        if (percent_elapsed >= 0 && percent_elapsed < 100) {
+        if (percent_elapsed > 0 && percent_elapsed < 100) {
             title.textColor = [Utilities getSystemBlue];
             genre.textColor = [Utilities getSystemBlue];
             programStartTime.textColor = [Utilities getSystemBlue];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
0% elapsed can occur when both `starttime` and `endtime` are empty strings or `nil`. In this case do not mark the program as active.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not mark program active if not started yet