### PR TITLE
Bugfix: TVShow episodes do not show with Kodi 17 and older

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3883,7 +3883,6 @@
                         @"playcount",
                         @"episode",
                         @"art",
-                        @"title",
                 ],
             }, @"extra_section_parameters",
             LOCALIZED_STR(@"Episodes"), @"label",

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4782,7 +4782,7 @@ NSIndexPath *selected;
              [activeLayoutView reloadData];
              if ([NSJSONSerialization isValidJSONObject:methodResult]) {
                  NSString *itemid = @"";
-                 NSDictionary *mainFields = [self.detailItem mainFields][choosedTab];
+                 NSMutableDictionary *mainFields = [[self.detailItem mainFields][choosedTab] mutableCopy];
                  if ((NSNull*)mainFields[@"itemid"] != [NSNull null]) {
                      itemid = mainFields[@"itemid"];
                  }
@@ -4793,6 +4793,10 @@ NSIndexPath *selected;
                      else {
                          return;
                      }
+                 }
+                 // "VideoLibrary.GetSeasons" does not support "title" for API < 9.7.0. Instead, we look for "label" which is always provided.
+                 if ([methodName isEqualToString:@"VideoLibrary.GetSeasons"]) {
+                     mainFields[@"row1"] = @"label";
                  }
                  if (methodResult[@"recordings"] != nil) {
                      recordingListView = YES;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/901.

The parameter `"title"` is not support for `"GetSeasons"` with API < 10. `"GetSeasons"` is used to request additional data for section header for the episode view. As the same mapping configuration (`mainFields`) is used, the easiest approach to resolve this is to change the mapping to use `"label"` in only this case. With this the problematic `"title"` parameter can be removed from the JSON request.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Entering TVShow episodes fails with Kodi 17 and older