### PR TITLE
Bugfix: Resolves stutter when scrolling several lists

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -6518,46 +6518,26 @@
     [Utilities archivePath:self.dataFilePath file:@"serverList_saved.dat" data:arrayServerList];
 }
 
+- (void)clearDiskCacheAtPath:(NSString*)cachePath {
+    [[NSFileManager defaultManager] removeItemAtPath:cachePath error:nil];
+    [[NSFileManager defaultManager] createDirectoryAtPath:cachePath
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:NULL];
+}
+
 - (void)clearAppDiskCache {
-    // OLD SDWEBImageCache
-    NSString *fullNamespace = @"ImageCache";
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    NSString *diskCachePath = [paths[0] stringByAppendingPathComponent:fullNamespace];
-    [[NSFileManager defaultManager] removeItemAtPath:diskCachePath error:nil];
-    [[NSFileManager defaultManager] removeItemAtPath:paths[0] error:nil];
+    // Clear SDWebImage image cache
+    [[SDImageCache sharedImageCache] clearDisk];
     
-    // TO BE CHANGED!!!
-    fullNamespace = @"com.hackemist.SDWebImageCache.default";
-    diskCachePath = [paths[0] stringByAppendingPathComponent:fullNamespace];
-    [[NSFileManager defaultManager] removeItemAtPath:diskCachePath error:nil];
-    [[NSFileManager defaultManager] createDirectoryAtPath:diskCachePath
-                              withIntermediateDirectories:YES
-                                               attributes:nil
-                                                    error:NULL];
+    // Clear library cache
+    [self clearDiskCacheAtPath:self.libraryCachePath];
     
-    [[NSFileManager defaultManager] removeItemAtPath:self.libraryCachePath error:nil];
-    [[NSFileManager defaultManager] createDirectoryAtPath:self.libraryCachePath
-                              withIntermediateDirectories:YES
-                                               attributes:nil
-                                                    error:NULL];
+    // Clear EPG cache
+    [self clearDiskCacheAtPath:self.epgCachePath];
     
-    [[NSFileManager defaultManager] removeItemAtPath:self.epgCachePath error:nil];
-    [[NSFileManager defaultManager] createDirectoryAtPath:self.epgCachePath
-                              withIntermediateDirectories:YES
-                                               attributes:nil
-                                                    error:NULL];
-    
-    // Clean NetworkCache
-    NSString *caches = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, TRUE)[0];
-    NSString *appID = [[NSBundle mainBundle] infoDictionary][@"CFBundleIdentifier"];
-    NSString *path = [NSString stringWithFormat:@"%@/%@/Cache.db-wal", caches, appID];
-    [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
-    path = [NSString stringWithFormat:@"%@/%@/Cache.db-shm", caches, appID];
-    [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
-    path = [NSString stringWithFormat:@"%@/%@/Cache.db", caches, appID];
-    [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
-    path = [NSString stringWithFormat:@"%@/%@/fsCachedData", caches, appID];
-    [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+    // Clear network cache
+    [[NSURLCache sharedURLCache] removeAllCachedResponses];
 }
 
 @end

--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -40,5 +40,6 @@
  * Other
  */
 #define LOCALIZED_STR(string) NSLocalizedString(string, nil)
+#define SD_NATIVESIZE_KEY @"nativeSize"
 
 #endif /* ConvenienceMacros_h */

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2849,19 +2849,18 @@
     
         NSString *stringURL = item[@"thumbnail"];
         NSString *displayThumb = @"coverbox_back";
+        [Utilities applyRoundedEdgesView:thumbImageView drawBorder:YES];
         if (![stringURL isEqualToString:@""]) {
             // In few cases stringURL does not hold an URL path but a loadable icon name. In this case
             // ensure setImageWithURL falls back to this icon.
             if ([UIImage imageNamed:stringURL]) {
                 displayThumb = stringURL;
             }
-            __weak UIImageView *weakThumbView = thumbImageView;
             [thumbImageView sd_setImageWithURL:[NSURL URLWithString:stringURL]
                               placeholderImage:[UIImage imageNamed:displayThumb]
                                        options:SDWebImageScaleToNativeSize
                                      completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
                                       if (image != nil) {
-                                          weakThumbView.image = [Utilities applyRoundedEdgesImage:image drawBorder:YES];
                                           [self setViewColor:albumDetailView
                                                        image:image
                                                    isTopMost:YES
@@ -3027,19 +3026,18 @@
                 self.searchController.searchBar.backgroundColor = [Utilities getSystemGray6];
                 self.searchController.searchBar.tintColor = [Utilities get2ndLabelColor];
             }
+            [Utilities applyRoundedEdgesView:thumbImageView drawBorder:YES];
             if (![stringURL isEqualToString:@""]) {
                 // In few cases stringURL does not hold an URL path but a loadable icon name. In this case
                 // ensure setImageWithURL falls back to this icon.
                 if ([UIImage imageNamed:stringURL]) {
                     displayThumb = stringURL;
                 }
-                __weak UIImageView *weakThumbView = thumbImageView;
                 [thumbImageView sd_setImageWithURL:[NSURL URLWithString:stringURL]
                                   placeholderImage:[UIImage imageNamed:displayThumb]
                                            options:SDWebImageScaleToNativeSize
                                       completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
                     if (image != nil) {
-                        weakThumbView.image = [Utilities applyRoundedEdgesImage:image drawBorder:YES];
                         [self setViewColor:albumDetailView
                                      image:image
                                  isTopMost:isFirstListedSeason

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3007,7 +3007,7 @@
         }
         NSInteger seasonIdx = [self indexOfObjectWithSeason:[NSString stringWithFormat:@"%d", [item[@"season"] intValue]] inArray:self.extraSectionRichResults];
         NSInteger firstListedSeason = [self getFirstListedSeason:self.extraSectionRichResults];
-        CGFloat seasonThumbWidth = (albumViewHeight - albumViewPadding * 2) * 0.71;
+        CGFloat seasonThumbWidth = floor((albumViewHeight - albumViewPadding * 2) * 0.71);
         if (seasonIdx != NSNotFound) {
             CGFloat origin_x = seasonThumbWidth + toggleIconSpace + albumViewPadding * 2;
             CGFloat labelwidth = viewWidth - albumViewHeight - albumViewPadding;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3019,6 +3019,7 @@
             UILabel *trackCountLabel = [[UILabel alloc] initWithFrame:CGRectMake(origin_x, bottomMargin, labelwidth - toggleIconSpace, trackCountFontSize + labelPadding)];
             UILabel *releasedLabel = [[UILabel alloc] initWithFrame:CGRectMake(origin_x, bottomMargin - trackCountFontSize - labelPadding / 2, labelwidth - toggleIconSpace, trackCountFontSize + labelPadding)];
             UIImageView *thumbImageView = [[UIImageView alloc] initWithFrame:CGRectMake(albumViewPadding + toggleIconSpace, albumViewPadding, seasonThumbWidth, albumViewHeight - albumViewPadding * 2)];
+            thumbImageView.contentMode = UIViewContentModeScaleAspectFill;
             NSString *stringURL = self.extraSectionRichResults[seasonIdx][@"thumbnail"];
             NSString *displayThumb = @"coverbox_back_section";
             BOOL isFirstListedSeason = [item[@"season"] intValue] == firstListedSeason;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -960,7 +960,7 @@
         __auto_type __weak weakImageView = imgView;
         [imgView sd_setImageWithURL:[NSURL URLWithString:stringURL]
                    placeholderImage:[UIImage imageNamed:displayThumb]
-                            options:0
+                            options:SDWebImageScaleToNativeSize
                            progress:nil
                           completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
             // Only set the logo background, if the attempt to load it was successful (image != nil).
@@ -1799,6 +1799,7 @@
         if (![stringURL isEqualToString:@""]) {
             [cell.posterThumbnail sd_setImageWithURL:[NSURL URLWithString:stringURL]
                                     placeholderImage:[UIImage imageNamed:displayThumb]
+                                             options:SDWebImageScaleToNativeSize
                                            completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
                 UIColor *averageColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
                 CGFloat hue, saturation, brightness, alpha;
@@ -1816,7 +1817,8 @@
 
         if (![fanartURL isEqualToString:@""]) {
             [cell.posterFanart sd_setImageWithURL:[NSURL URLWithString:fanartURL]
-                                 placeholderImage:[UIImage imageNamed:@"blank"]];
+                                 placeholderImage:[UIImage imageNamed:@"blank"]
+                                          options:SDWebImageScaleToNativeSize];
         }
         else {
             [cell.posterFanart sd_setImageWithURL:[NSURL URLWithString:@""]
@@ -2856,6 +2858,7 @@
             __weak UIImageView *weakThumbView = thumbImageView;
             [thumbImageView sd_setImageWithURL:[NSURL URLWithString:stringURL]
                               placeholderImage:[UIImage imageNamed:displayThumb]
+                                       options:SDWebImageScaleToNativeSize
                                      completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
                                       if (image != nil) {
                                           weakThumbView.image = [Utilities applyRoundedEdgesImage:image drawBorder:YES];
@@ -3033,6 +3036,7 @@
                 __weak UIImageView *weakThumbView = thumbImageView;
                 [thumbImageView sd_setImageWithURL:[NSURL URLWithString:stringURL]
                                   placeholderImage:[UIImage imageNamed:displayThumb]
+                                           options:SDWebImageScaleToNativeSize
                                       completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
                     if (image != nil) {
                         weakThumbView.image = [Utilities applyRoundedEdgesImage:image drawBorder:YES];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2058,7 +2058,8 @@ long storedItemID;
     }
     NSString *stringURL = item[@"thumbnail"];
     [thumb sd_setImageWithURL:[NSURL URLWithString:stringURL]
-             placeholderImage:defaultThumb];
+             placeholderImage:defaultThumb
+                      options:SDWebImageScaleToNativeSize];
     thumb = [Utilities applyRoundedEdgesView:thumb drawBorder:YES];
     [self setPlaylistCellProgressBar:cell hidden:YES];
     

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -241,7 +241,8 @@
     }
     if ([tableData[indexPath.row][@"type"] isEqualToString:@"xbmc-exec-addon"]) {
         [icon sd_setImageWithURL:[NSURL URLWithString:tableData[indexPath.row][@"icon"]]
-                placeholderImage:[UIImage imageNamed:@"blank"]];
+                placeholderImage:[UIImage imageNamed:@"blank"]
+                         options:SDWebImageScaleToNativeSize];
         icon.alpha = 1.0;
     }
     else {

--- a/XBMC Remote/SDWebImage/SDImageCache.m
+++ b/XBMC Remote/SDWebImage/SDImageCache.m
@@ -9,6 +9,7 @@
 #import "SDImageCache.h"
 #import "SDWebImageDecoder.h"
 #import "UIImage+MultiFormat.h"
+#import "NSString+MD5.h"
 #import <CommonCrypto/CommonDigest.h>
 
 // See https://github.com/rs/SDWebImage/pull/1141 for discussion
@@ -175,17 +176,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 #pragma mark SDImageCache (private)
 
 - (NSString *)cachedFileNameForKey:(NSString *)key {
-    const char *str = [key UTF8String];
-    if (str == NULL) {
-        str = "";
-    }
-    unsigned char r[CC_MD5_DIGEST_LENGTH];
-    CC_MD5(str, (CC_LONG)strlen(str), r);
-    NSString *filename = [NSString stringWithFormat:@"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%@",
-                          r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10],
-                          r[11], r[12], r[13], r[14], r[15], [[key pathExtension] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@".%@", [key pathExtension]]];
-
-    return filename;
+    return [key SHA256String];
 }
 
 #pragma mark ImageCache
@@ -193,7 +184,9 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 // Init the disk cache
 -(NSString *)makeDiskCachePath:(NSString*)fullNamespace{
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    return [paths[0] stringByAppendingPathComponent:fullNamespace];
+    // Keep path compatible to old SDWebImage path to re-use existing caches after upgrading the App
+    //return [paths[0] stringByAppendingPathComponent:fullNamespace];
+    return paths[0];
 }
 
 - (void)storeImage:(UIImage *)image recalculateFromImage:(BOOL)recalculate imageData:(NSData *)imageData forKey:(NSString *)key toDisk:(BOOL)toDisk {

--- a/XBMC Remote/SDWebImage/SDWebImageDownloader.h
+++ b/XBMC Remote/SDWebImage/SDWebImageDownloader.h
@@ -180,6 +180,7 @@ typedef NSDictionary *(^SDWebImageDownloaderHeadersFilterBlock)(NSURL *url, NSDi
  */
 - (id <SDWebImageOperation>)downloadImageWithURL:(NSURL *)url
                                          options:(SDWebImageDownloaderOptions)options
+                                        userInfo:(NSDictionary *)userInfo
                                         progress:(SDWebImageDownloaderProgressBlock)progressBlock
                                        completed:(SDWebImageDownloaderCompletedBlock)completedBlock;
 

--- a/XBMC Remote/SDWebImage/SDWebImageDownloader.m
+++ b/XBMC Remote/SDWebImage/SDWebImageDownloader.m
@@ -131,7 +131,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
     _operationClass = operationClass ?: [SDWebImageDownloaderOperation class];
 }
 
-- (id <SDWebImageOperation>)downloadImageWithURL:(NSURL *)url options:(SDWebImageDownloaderOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageDownloaderCompletedBlock)completedBlock {
+- (id <SDWebImageOperation>)downloadImageWithURL:(NSURL *)url options:(SDWebImageDownloaderOptions)options userInfo:(NSDictionary *)userInfo progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageDownloaderCompletedBlock)completedBlock {
     __block SDWebImageDownloaderOperation *operation;
     __weak __typeof(self)wself = self;
 
@@ -154,6 +154,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
         operation = [[wself.operationClass alloc] initWithRequest:request
                                                         inSession:self.session
                                                           options:options
+                                                         userInfo:(NSDictionary *)userInfo
                                                          progress:^(NSInteger receivedSize, NSInteger expectedSize) {
                                                              SDWebImageDownloader *sself = wself;
                                                              if (!sself) return;

--- a/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.h
@@ -77,6 +77,7 @@ extern NSString *const SDWebImageDownloadFinishNotification;
 - (id)initWithRequest:(NSURLRequest *)request
             inSession:(NSURLSession *)session
               options:(SDWebImageDownloaderOptions)options
+             userInfo:(NSDictionary *)userInfo
              progress:(SDWebImageDownloaderProgressBlock)progressBlock
             completed:(SDWebImageDownloaderCompletedBlock)completedBlock
             cancelled:(SDWebImageNoParamsBlock)cancelBlock;
@@ -98,6 +99,7 @@ extern NSString *const SDWebImageDownloadFinishNotification;
  */
 - (id)initWithRequest:(NSURLRequest *)request
               options:(SDWebImageDownloaderOptions)options
+             userInfo:(NSDictionary *)userInfo
              progress:(SDWebImageDownloaderProgressBlock)progressBlock
             completed:(SDWebImageDownloaderCompletedBlock)completedBlock
             cancelled:(SDWebImageNoParamsBlock)cancelBlock

--- a/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.m
@@ -348,7 +348,7 @@ didReceiveResponse:(NSURLResponse *)response
 
             if (partialImageRef) {
                 UIImage *image = [UIImage imageWithCGImage:partialImageRef scale:1 orientation:orientation];
-                NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL userInfo:nil];
+                NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                 UIImage *scaledImage = [self scaledImageForKey:key image:image];
                 if (self.shouldDecompressImages) {
                     image = [UIImage decodedImageWithImage:scaledImage];
@@ -422,14 +422,13 @@ didReceiveResponse:(NSURLResponse *)response
                 completionBlock(nil, nil, nil, YES);
             } else if (self.imageData) {
                 UIImage *image = [UIImage sd_imageWithData:self.imageData];
-                NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL userInfo:nil];
+                NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                 image = [self scaledImageForKey:key image:image];
                 
-                if (self.userInfo[@"nativeSize"]) {
-                    CGSize size = CGSizeFromString(self.userInfo[@"nativeSize"]);
+                if (self.userInfo[SD_NATIVESIZE_KEY]) {
+                    CGSize size = CGSizeFromString(self.userInfo[SD_NATIVESIZE_KEY]);
                     image = [image resizedImage:image.CGImage size:size interpolationQuality:kCGInterpolationHigh];
-                    NSData *elabData = UIImagePNGRepresentation(image);
-                    self.imageData = [NSMutableData dataWithData:elabData];
+                    self.imageData = [UIImagePNGRepresentation(image) mutableCopy];
                 }
                 
                 // Do not force decoding animated GIFs

--- a/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.m
@@ -11,6 +11,7 @@
 #import "UIImage+MultiFormat.h"
 #import <ImageIO/ImageIO.h>
 #import "SDWebImageManager.h"
+#import "UIImage+Resize.h"
 
 NSString *const SDWebImageDownloadStartNotification = @"SDWebImageDownloadStartNotification";
 NSString *const SDWebImageDownloadReceiveResponseNotification = @"SDWebImageDownloadReceiveResponseNotification";
@@ -26,6 +27,7 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
 @property (assign, nonatomic, getter = isExecuting) BOOL executing;
 @property (assign, nonatomic, getter = isFinished) BOOL finished;
 @property (strong, nonatomic) NSMutableData *imageData;
+@property (strong, nonatomic) NSDictionary *userInfo;
 
 // This is weak because it is injected by whoever manages this session. If this gets nil-ed out, we won't be able to run
 // the task associated with this operation
@@ -54,6 +56,7 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
 
 - (id)initWithRequest:(NSURLRequest *)request
               options:(SDWebImageDownloaderOptions)options
+             userInfo:(NSDictionary *)userInfo
              progress:(SDWebImageDownloaderProgressBlock)progressBlock
             completed:(SDWebImageDownloaderCompletedBlock)completedBlock
             cancelled:(SDWebImageNoParamsBlock)cancelBlock {
@@ -61,6 +64,7 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
     return [self initWithRequest:request
                        inSession:nil
                          options:options
+                        userInfo:userInfo
                         progress:progressBlock
                        completed:completedBlock
                        cancelled:cancelBlock];
@@ -69,6 +73,7 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
 - (id)initWithRequest:(NSURLRequest *)request
             inSession:(NSURLSession *)session
               options:(SDWebImageDownloaderOptions)options
+             userInfo:(NSDictionary *)userInfo
              progress:(SDWebImageDownloaderProgressBlock)progressBlock
             completed:(SDWebImageDownloaderCompletedBlock)completedBlock
             cancelled:(SDWebImageNoParamsBlock)cancelBlock {
@@ -83,6 +88,7 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
         _finished = NO;
         _expectedSize = 0;
         _unownedSession = session;
+        _userInfo = userInfo;
         responseFromCached = YES; // Initially wrong until `- URLSession:dataTask:willCacheResponse:completionHandler: is called or not called
     }
     return self;
@@ -212,6 +218,7 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
     self.progressBlock = nil;
     self.dataTask = nil;
     self.imageData = nil;
+    self.userInfo = nil;
     self.thread = nil;
     if (self.ownedSession) {
         [self.ownedSession invalidateAndCancel];
@@ -341,7 +348,7 @@ didReceiveResponse:(NSURLResponse *)response
 
             if (partialImageRef) {
                 UIImage *image = [UIImage imageWithCGImage:partialImageRef scale:1 orientation:orientation];
-                NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
+                NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL userInfo:nil];
                 UIImage *scaledImage = [self scaledImageForKey:key image:image];
                 if (self.shouldDecompressImages) {
                     image = [UIImage decodedImageWithImage:scaledImage];
@@ -415,8 +422,15 @@ didReceiveResponse:(NSURLResponse *)response
                 completionBlock(nil, nil, nil, YES);
             } else if (self.imageData) {
                 UIImage *image = [UIImage sd_imageWithData:self.imageData];
-                NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
+                NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL userInfo:nil];
                 image = [self scaledImageForKey:key image:image];
+                
+                if (self.userInfo[@"nativeSize"]) {
+                    CGSize size = CGSizeFromString(self.userInfo[@"nativeSize"]);
+                    image = [image resizedImage:image.CGImage size:size interpolationQuality:kCGInterpolationHigh];
+                    NSData *elabData = UIImagePNGRepresentation(image);
+                    self.imageData = [NSMutableData dataWithData:elabData];
+                }
                 
                 // Do not force decoding animated GIFs
                 if (!image.images) {

--- a/XBMC Remote/SDWebImage/SDWebImageManager.h
+++ b/XBMC Remote/SDWebImage/SDWebImageManager.h
@@ -285,7 +285,8 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 /**
  *Return the cache key for a given URL
  */
-- (NSString *)cacheKeyForURL:(NSURL *)url userInfo:(NSDictionary *)userInfo;;
+- (NSString *)cacheKeyForURL:(NSURL *)url;
+- (NSString *)cacheKeyForURL:(NSURL *)url userInfo:(NSDictionary *)userInfo;
 
 @end
 

--- a/XBMC Remote/SDWebImage/SDWebImageManager.h
+++ b/XBMC Remote/SDWebImage/SDWebImageManager.h
@@ -87,7 +87,13 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * have the hand before setting the image (apply a filter or add it with cross-fade animation for instance)
      * Use this flag if you want to manually set the image in the completion when success
      */
-    SDWebImageAvoidAutoSetImage = 1 << 11
+    SDWebImageAvoidAutoSetImage = 1 << 11,
+    
+    /**
+     * To imperove the app performance we scale some of the images to the desired native size before
+     * caching them. This avoids rescaling to the image native size at runtime.
+     */
+    SDWebImageScaleToNativeSize = 1 << 12
 };
 
 typedef void(^SDWebImageCompletionBlock)(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL);
@@ -211,6 +217,7 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
  */
 - (id <SDWebImageOperation>)downloadImageWithURL:(NSURL *)url
                                          options:(SDWebImageOptions)options
+                                        userInfo:(NSDictionary *)userInfo
                                         progress:(SDWebImageDownloaderProgressBlock)progressBlock
                                        completed:(SDWebImageCompletionWithFinishedBlock)completedBlock;
 
@@ -278,7 +285,7 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 /**
  *Return the cache key for a given URL
  */
-- (NSString *)cacheKeyForURL:(NSURL *)url;
+- (NSString *)cacheKeyForURL:(NSURL *)url userInfo:(NSDictionary *)userInfo;;
 
 @end
 
@@ -298,6 +305,7 @@ typedef void(^SDWebImageCompletedWithFinishedBlock)(UIImage *image, NSError *err
  */
 - (id <SDWebImageOperation>)downloadWithURL:(NSURL *)url
                                     options:(SDWebImageOptions)options
+                                   userInfo:(NSDictionary *)userInfo
                                    progress:(SDWebImageDownloaderProgressBlock)progressBlock
                                   completed:(SDWebImageCompletedWithFinishedBlock)completedBlock __deprecated_msg("Method deprecated. Use `downloadImageWithURL:options:progress:completed:`");
 

--- a/XBMC Remote/SDWebImage/SDWebImageManager.m
+++ b/XBMC Remote/SDWebImage/SDWebImageManager.m
@@ -53,6 +53,10 @@
     return self;
 }
 
+- (NSString *)cacheKeyForURL:(NSURL *)url {
+    return [self cacheKeyForURL:url userInfo:nil];
+}
+
 - (NSString *)cacheKeyForURL:(NSURL *)url userInfo:(NSDictionary *)userInfo {
     if (!url) {
         return @"";
@@ -65,8 +69,8 @@
         cacheKey = [url absoluteString];
     }
     
-    if (userInfo[@"nativeSize"]) {
-        NSString *suffix = userInfo[@"nativeSize"];
+    if (userInfo[SD_NATIVESIZE_KEY]) {
+        NSString *suffix = userInfo[SD_NATIVESIZE_KEY];
         cacheKey = [NSString stringWithFormat:@"%@_resize_%@", cacheKey, suffix];
     }
     
@@ -74,19 +78,19 @@
 }
 
 - (BOOL)cachedImageExistsForURL:(NSURL *)url {
-    NSString *key = [self cacheKeyForURL:url userInfo:nil];
+    NSString *key = [self cacheKeyForURL:url];
     if ([self.imageCache imageFromMemoryCacheForKey:key] != nil) return YES;
     return [self.imageCache diskImageExistsWithKey:key];
 }
 
 - (BOOL)diskImageExistsForURL:(NSURL *)url {
-    NSString *key = [self cacheKeyForURL:url userInfo:nil];
+    NSString *key = [self cacheKeyForURL:url];
     return [self.imageCache diskImageExistsWithKey:key];
 }
 
 - (void)cachedImageExistsForURL:(NSURL *)url
                      completion:(SDWebImageCheckCacheCompletionBlock)completionBlock {
-    NSString *key = [self cacheKeyForURL:url userInfo:nil];
+    NSString *key = [self cacheKeyForURL:url];
     
     BOOL isInMemoryCache = ([self.imageCache imageFromMemoryCacheForKey:key] != nil);
     
@@ -110,7 +114,7 @@
 
 - (void)diskImageExistsForURL:(NSURL *)url
                    completion:(SDWebImageCheckCacheCompletionBlock)completionBlock {
-    NSString *key = [self cacheKeyForURL:url userInfo:nil];
+    NSString *key = [self cacheKeyForURL:url];
     
     [self.imageCache diskImageExistsWithKey:key completion:^(BOOL isInDiskCache) {
         // the completion block of checkDiskCacheForImageWithKey:completion: is always called on the main queue, no need to further dispatch
@@ -333,7 +337,7 @@
 
 - (void)saveImageToCache:(UIImage *)image forURL:(NSURL *)url {
     if (image && url) {
-        NSString *key = [self cacheKeyForURL:url userInfo:nil];
+        NSString *key = [self cacheKeyForURL:url];
         [self.imageCache storeImage:image forKey:key toDisk:YES];
     }
 }

--- a/XBMC Remote/SDWebImage/SDWebImagePrefetcher.m
+++ b/XBMC Remote/SDWebImage/SDWebImagePrefetcher.m
@@ -57,7 +57,7 @@
 - (void)startPrefetchingAtIndex:(NSUInteger)index {
     if (index >= self.prefetchURLs.count) return;
     self.requestedCount++;
-    [self.manager downloadImageWithURL:self.prefetchURLs[index] options:self.options progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+    [self.manager downloadImageWithURL:self.prefetchURLs[index] options:self.options userInfo:nil progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
         if (!finished) return;
         self.finishedCount++;
 

--- a/XBMC Remote/SDWebImage/UIButton+WebCache.m
+++ b/XBMC Remote/SDWebImage/UIButton+WebCache.m
@@ -69,7 +69,7 @@ static char imageURLStorageKey;
     self.imageURLStorage[@(state)] = url;
 
     __weak __typeof(self)wself = self;
-    id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+    id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options userInfo:nil progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
         if (!wself) return;
         dispatch_main_sync_safe(^{
             __strong UIButton *sself = wself;
@@ -117,7 +117,7 @@ static char imageURLStorageKey;
 
     if (url) {
         __weak __typeof(self)wself = self;
-        id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+        id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options userInfo:nil progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             if (!wself) return;
             dispatch_main_sync_safe(^{
                 __strong UIButton *sself = wself;

--- a/XBMC Remote/SDWebImage/UIImageView+HighlightedWebCache.m
+++ b/XBMC Remote/SDWebImage/UIImageView+HighlightedWebCache.m
@@ -34,7 +34,7 @@
 
     if (url) {
         __weak __typeof(self)wself = self;
-        id<SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+        id<SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options userInfo:nil progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             if (!wself) return;
             dispatch_main_sync_safe (^
                                      {

--- a/XBMC Remote/SDWebImage/UIImageView+WebCache.m
+++ b/XBMC Remote/SDWebImage/UIImageView+WebCache.m
@@ -61,7 +61,7 @@ static char TAG_ACTIVITY_SHOW;
         NSDictionary *userInfo = nil;
         if ((options & SDWebImageScaleToNativeSize) && nativeViewSize.width && nativeViewSize.height) {
             userInfo = @{
-                @"nativeSize": NSStringFromCGSize(nativeViewSize),
+                SD_NATIVESIZE_KEY: NSStringFromCGSize(nativeViewSize),
             };
         }
 
@@ -108,7 +108,7 @@ static char TAG_ACTIVITY_SHOW;
 }
 
 - (void)sd_setImageWithPreviousCachedImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock {
-    NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url userInfo:nil];
+    NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
     UIImage *lastPreviousCachedImage = [[SDImageCache sharedImageCache] imageFromDiskCacheForKey:key];
     
     [self sd_setImageWithURL:url placeholderImage:lastPreviousCachedImage ?: placeholder options:options progress:progressBlock completed:completedBlock];    

--- a/XBMC Remote/SDWebImage/UIImageView+WebCache.m
+++ b/XBMC Remote/SDWebImage/UIImageView+WebCache.m
@@ -17,6 +17,10 @@ static char TAG_ACTIVITY_SHOW;
 
 @implementation UIImageView (WebCache)
 
+- (CGSize)doubleSizeRetina:(CGSize)size {
+    return CGSizeMake(size.width * UIScreen.mainScreen.scale, size.height * UIScreen.mainScreen.scale);
+}
+
 - (void)sd_setImageWithURL:(NSURL *)url {
     [self sd_setImageWithURL:url placeholderImage:nil options:0 progress:nil completed:nil];
 }
@@ -52,6 +56,14 @@ static char TAG_ACTIVITY_SHOW;
     }
     
     if (url) {
+        // We want to fill the cache with images the size of the native views to reduce scaling load
+        CGSize nativeViewSize = [self doubleSizeRetina:self.frame.size];
+        NSDictionary *userInfo = nil;
+        if ((options & SDWebImageScaleToNativeSize) && nativeViewSize.width && nativeViewSize.height) {
+            userInfo = @{
+                @"nativeSize": NSStringFromCGSize(nativeViewSize),
+            };
+        }
 
         // check if activityView is enabled or not
         if ([self showActivityIndicatorView]) {
@@ -59,7 +71,7 @@ static char TAG_ACTIVITY_SHOW;
         }
 
         __weak __typeof(self)wself = self;
-        id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+        id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options userInfo:userInfo progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             [wself removeActivityIndicator];
             if (!wself) return;
             dispatch_main_sync_safe(^{
@@ -96,7 +108,7 @@ static char TAG_ACTIVITY_SHOW;
 }
 
 - (void)sd_setImageWithPreviousCachedImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock {
-    NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
+    NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url userInfo:nil];
     UIImage *lastPreviousCachedImage = [[SDImageCache sharedImageCache] imageFromDiskCacheForKey:key];
     
     [self sd_setImageWithURL:url placeholderImage:lastPreviousCachedImage ?: placeholder options:options progress:progressBlock completed:completedBlock];    
@@ -113,7 +125,7 @@ static char TAG_ACTIVITY_SHOW;
     NSMutableArray *operationsArray = [[NSMutableArray alloc] init];
 
     for (NSURL *logoImageURL in arrayOfURLs) {
-        id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:logoImageURL options:0 progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+        id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:logoImageURL options:0 userInfo:nil progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             if (!wself) return;
             dispatch_main_sync_safe(^{
                 __strong UIImageView *sself = wself;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1479,7 +1479,8 @@ double round(double d) {
     NSString *serverURL = [Utilities getImageServerURL];
     NSString *stringURL = [Utilities formatStringURL:cast[indexPath.row][@"thumbnail"] serverURL:serverURL];
     [cell.actorThumbnail sd_setImageWithURL:[NSURL URLWithString:stringURL]
-                           placeholderImage:[UIImage imageNamed:@"person"]];
+                           placeholderImage:[UIImage imageNamed:@"person"]
+                                    options:SDWebImageScaleToNativeSize];
     [Utilities applyRoundedEdgesView:cell.actorThumbnail drawBorder:YES];
     cell.actorName.text = cast[indexPath.row][@"name"] == nil ? self.detailItem[@"label"] : cast[indexPath.row][@"name"];
     if ([cast[indexPath.row][@"role"] length] != 0) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in the forum and which was caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/884.

When the loaded images have a different size as the view they are loaded to re-scaling happens. Before migrating to sdwebimage 3.8.3 there already has been a special treatment for several lists where images were scaled before adding them to the cache. This PR is re-adding this mechanism in a slight different way. Now there is no call parameter but a new option `SDWebImageScaleToNativeSize` introduced. If this is set, the pre-scaling is executed and the targeted size is taken from the view itself. The option is used only for a subset of views, with a focus to views with many images. The improvement is quite visible for episode view and the actor list.

This PR also makes the cache configuration of 3.8.3 compatible to pre-3.8.3 which now allows to keep using an existing image cache when updating from App version 1.12.1 to newer builds. This required to change the cache path from "paths[0]/_default_/namespace" back to "paths[0]/namespace", and to use SHA256 instead of the outdated MD5.

In addition, the method to clear the app cache on user request is reworked. The cleanup of an ancient cache structure (>10 years back) has been removed, and instead of stepwise deleting dedicated paths the cleanup-methods of `SDImageCache` and `NSURLSession.sharedURLCache` are called. For the cleanup of library and EPG cache a helper method is introduced to avoid code duplication.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Resolves stutter when scrolling several lists
Bugfix: Delete image cache at startup on user request
Improvement: Better quality of scaled images
Improvement: Let sdwebimage 3.8.3 support already existing image cache
Improvement: Let clearDiskCache use provided cleanup methods instead of deleting dedicated files