### PR TITLE
Improvement: Smoother animation when expanding/collapsing season's episodes

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -860,14 +860,14 @@
     UIButton *toggleButton = (UIButton*)[sender.view viewWithTag:99];
     if ([self.sectionArrayOpen[section] boolValue]) {
         [dataList beginUpdates];
-        [dataList insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationTop];
+        [dataList insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationMiddle];
         [dataList endUpdates];
         toggleButton.selected = YES;
     }
     else {
         toggleButton.selected = NO;
         [dataList beginUpdates];
-        [dataList deleteRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationTop];
+        [dataList deleteRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationMiddle];
         [dataList endUpdates];
     }
     // Refresh leyout


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Use `UITableViewRowAnimationMiddle` when showing/hiding episodes. This resolves a glitch where unfolding a season animated the newly shown episode from above the section header. Now the animation fades in each newly shown episode from its middle which gives a smoother user experience.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Smoother animation when expanding/collapsing season's episodes