### PR TITLE
Rework iPad background fanart loading and improve scaling quality

### DIFF
--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -92,7 +92,6 @@
     UIColor *foundEffectColor;
     UISegmentedControl *playlistSegmentedControl;
     __weak IBOutlet UILabel *noItemsLabel;
-    UIImageView *tempFanartImageView;
     NSString *storeLiveTVTitle;
     NSString *storeClearlogo;
     NSString *storeClearart;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -452,7 +452,7 @@ long storedItemID;
                 @"startColor": [Utilities getGrayColor:36 alpha:1.0],
                 @"endColor": [Utilities getGrayColor:22 alpha:1.0],
             };
-            [[NSNotificationCenter defaultCenter] postNotificationName:@"UIViewChangeBackgroundImage" object:nil userInfo:params];
+            [[NSNotificationCenter defaultCenter] postNotificationName:@"UIViewChangeBackgroundImage" object:nil userInfo:nil];
         }
         else {
             CGFloat hue, saturation, brightness, alpha;
@@ -615,18 +615,7 @@ long storedItemID;
                                  if (![lastThumbnail isEqualToString:stringURL] || [lastThumbnail isEqualToString:@""]) {
                                      if (IS_IPAD) {
                                          NSString *fanart = (NSNull*)nowPlayingInfo[@"fanart"] == [NSNull null] ? @"" : nowPlayingInfo[@"fanart"];
-                                         if (![fanart isEqualToString:@""]) {
-                                             NSString *fanartURL = [Utilities formatStringURL:fanart serverURL:serverURL];
-                                             __weak NowPlaying *sf = self;
-                                             [tempFanartImageView sd_setImageWithURL:[NSURL URLWithString:fanartURL]
-                                                                           completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
-                                                 UIImage *fanartImage = (error == nil && image != nil) ? image : [UIImage new];
-                                                 [sf notifyChangeForBackgroundImage:fanartImage];
-                                            }];
-                                         }
-                                         else {
-                                             [self notifyChangeForBackgroundImage:[UIImage new]];
-                                         }
+                                         [self notifyChangeForBackgroundImage:fanart];
                                      }
                                      if ([thumbnailPath isEqualToString:@""]) {
                                          UIImage *image = [UIImage imageNamed:@"coverbox_back"];
@@ -835,8 +824,8 @@ long storedItemID;
     }];
 }
 
-- (void)notifyChangeForBackgroundImage:(UIImage*)bgimage {
-    NSDictionary *params = @{@"image": bgimage};
+- (void)notifyChangeForBackgroundImage:(NSString*)bgImagePath {
+    NSDictionary *params = @{@"image": bgImagePath};
     [[NSNotificationCenter defaultCenter] postNotificationName:@"UIViewChangeBackgroundImage" object:nil userInfo:params];
 }
 
@@ -2607,9 +2596,6 @@ long storedItemID;
     songBitRateImage.layer.minificationFilter = kCAFilterTrilinear;
     songSampleRateImage.layer.minificationFilter = kCAFilterTrilinear;
     songNumChanImage.layer.minificationFilter = kCAFilterTrilinear;
-    tempFanartImageView = [UIImageView new];
-    tempFanartImageView.hidden = YES;
-    [self.view addSubview:tempFanartImageView];
     [PartyModeButton setTitle:LOCALIZED_STR(@"Party") forState:UIControlStateNormal];
     [PartyModeButton setTitle:LOCALIZED_STR(@"Party") forState:UIControlStateHighlighted];
     [PartyModeButton setTitle:LOCALIZED_STR(@"Party") forState:UIControlStateSelected];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2596,6 +2596,8 @@ long storedItemID;
     songBitRateImage.layer.minificationFilter = kCAFilterTrilinear;
     songSampleRateImage.layer.minificationFilter = kCAFilterTrilinear;
     songNumChanImage.layer.minificationFilter = kCAFilterTrilinear;
+    thumbnailView.layer.minificationFilter = kCAFilterTrilinear;
+    thumbnailView.layer.magnificationFilter = kCAFilterTrilinear;
     [PartyModeButton setTitle:LOCALIZED_STR(@"Party") forState:UIControlStateNormal];
     [PartyModeButton setTitle:LOCALIZED_STR(@"Party") forState:UIControlStateHighlighted];
     [PartyModeButton setTitle:LOCALIZED_STR(@"Party") forState:UIControlStateSelected];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1685,6 +1685,8 @@ double round(double d) {
     [self.kenView stopAnimation];
     [self.kenView removeFromSuperview];
     self.kenView = [[KenBurnsView alloc] initWithFrame:targetedFrame];
+    self.kenView.layer.minificationFilter = kCAFilterTrilinear;
+    self.kenView.layer.magnificationFilter = kCAFilterTrilinear;
     self.kenView.autoresizingMask = fanartView.autoresizingMask;
     self.kenView.contentMode = fanartView.contentMode;
     self.kenView.delegate = self;
@@ -1843,6 +1845,11 @@ double round(double d) {
     logoBackgroundMode = [Utilities getLogoBackgroundMode];
     foundTintColor = ICON_TINT_COLOR;
     [self configureView];
+    
+    coverView.layer.minificationFilter = kCAFilterTrilinear;
+    coverView.layer.magnificationFilter = kCAFilterTrilinear;
+    fanartView.layer.minificationFilter = kCAFilterTrilinear;
+    fanartView.layer.magnificationFilter = kCAFilterTrilinear;
     
     xbmcDateFormatter = [NSDateFormatter new];
     xbmcDateFormatter.dateFormat = @"yyyy-MM-dd HH:mm:ss";

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -475,6 +475,8 @@
     fanartBackgroundImage.autoresizingMask = rootView.autoresizingMask;
     fanartBackgroundImage.contentMode = UIViewContentModeScaleAspectFill;
     fanartBackgroundImage.alpha = 0.05;
+    fanartBackgroundImage.layer.minificationFilter = kCAFilterTrilinear;
+    fanartBackgroundImage.layer.magnificationFilter = kCAFilterTrilinear;
     [self.view addSubview:fanartBackgroundImage];
 
 	rightSlideView = [[UIView alloc] initWithFrame:CGRectMake(PAD_MENU_TABLE_WIDTH, 0, rootView.frame.size.width - PAD_MENU_TABLE_WIDTH, rootView.frame.size.height - TOOLBAR_HEIGHT)];

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -634,7 +634,19 @@
 }
 
 - (void)handleChangeBackgroundImage:(NSNotification*)sender {
-    [Utilities imageView:fanartBackgroundImage AnimDuration:1.0 Image:[sender.userInfo objectForKey:@"image"]];
+    NSString *fanart = [sender.userInfo objectForKey:@"image"];
+    if (fanart.length) {
+        NSString *serverURL = [Utilities getImageServerURL];
+        NSString *fanartURL = [Utilities formatStringURL:fanart serverURL:serverURL];
+        [fanartBackgroundImage sd_setImageWithURL:[NSURL URLWithString:fanartURL]
+                                        completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
+            UIImage *fanartImage = (error == nil && image != nil) ? image : [UIImage new];
+            [Utilities imageView:fanartBackgroundImage AnimDuration:1.0 Image:fanartImage];
+       }];
+    }
+    else {
+        [Utilities imageView:fanartBackgroundImage AnimDuration:1.0 Image:[UIImage new]];
+    }
 }
 
 - (void)handleChangeBackgroundGradientColor:(NSNotification*)sender {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
NowPlaying does not load the background image anymore, but just sends the path. The image is then loaded in `ViewControllerIPad` which allows to remove an obsolete variable.

Use `kCAFilterTrilinear` for up- and down-scaling for a selected set of views. The views are not part of list or grid view to avoid performance problems while scrolling. This potentially improves the scaling quality.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Rework iPad background fanart loading
Improvement: Use higher quality scaling for several view