### PR TITLE
Bugfix: All episodes showing "1.01" after clean app install

### DIFF
--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -128,7 +128,7 @@
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
-			<string>1.01</string>
+			<string>%d.%02d</string>
 			<key>Key</key>
 			<string>episode_identifier</string>
 			<key>Title</key>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The default must represent the _value_ not the _name_ of a setting. This fixes an issue where the episode identifier format was set to "1.01" instead of "%d.%02d". The issue shows up after a clean app-install.

Screenshots (left = buggy, right = fixed): https://abload.de/img/bildschirmfoto2023-06g5ejg.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: All episodes showing "1.01" after clean app install