### PR TITLE
Improvement: Add season/episode info for episode search and episode details

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -518,6 +518,7 @@
                              item[mainFields[@"row16"]], mainFields[@"row16"],
                              item[mainFields[@"row17"]], mainFields[@"row17"],
                              item[mainFields[@"row18"]], mainFields[@"row18"],
+                             item[mainFields[@"row19"]], mainFields[@"row19"],
                              item[mainFields[@"row20"]], mainFields[@"row20"],
                              nil];
     return newItem;
@@ -2506,7 +2507,12 @@
     frame.size.width = frame.size.width - (labelPosition - frame.origin.x);
     frame.origin.x = labelPosition;
     genre.frame = frame;
-    genre.text = [item[@"genre"] stringByReplacingOccurrencesOfString:@"[CR]" withString:@"\n"];
+    if (item[@"episodeid"] && episodesView && [self doesShowSearchResults]) {
+        genre.text = [Utilities formatTVShowStringForSeasonTrailing:item[@"season"] episode:item[@"episode"] title:item[@"genre"]];
+    }
+    else {
+        genre.text = [item[@"genre"] stringByReplacingOccurrencesOfString:@"[CR]" withString:@"\n"];
+    }
 
     frame = runtimeyear.frame;
     frame.origin.x = menuItem.originYearDuration;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1418,6 +1418,7 @@ long storedItemID;
                   itemExtraDict[mainFields[@"row16"]], mainFields[@"row16"],
                   itemExtraDict[mainFields[@"row17"]], mainFields[@"row17"],
                   itemExtraDict[mainFields[@"row18"]], mainFields[@"row18"],
+                  itemExtraDict[mainFields[@"row19"]], mainFields[@"row19"],
                   itemExtraDict[mainFields[@"row20"]], mainFields[@"row20"],
                   nil];
                  [self displayInfoView:newItem];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -659,7 +659,7 @@ double round(double d) {
         label5.text = LOCALIZED_STR(@"SUMMARY");
         label6.text = LOCALIZED_STR(@"CAST");
         parentalRatingLabelUp.text = LOCALIZED_STR(@"PARENTAL RATING");
-        directorLabel.text = [Utilities getStringFromItem:item[@"showtitle"]];
+        directorLabel.text = [Utilities formatTVShowStringForSeasonTrailing:item[@"season"] episode:item[@"episode"] title:item[@"showtitle"]];
         genreLabel.text = [Utilities getDateFromItem:item[@"firstaired"] dateStyle:NSDateFormatterLongStyle];
         runtimeLabel.text = [Utilities getStringFromItem:item[@"director"]];
         studioLabel.text = [Utilities getStringFromItem:item[@"writer"]];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The episode view does not show information on season/episode for each episode as this is given by the section header and the item number. When searching for episodes this information was missing and is now added. The same information is now also added to the episode details view to reflect information on the season and episode number.

Screenshots: https://abload.de/img/bildschirmfoto2023-06kpfa1.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Add season/episode info for episode search and episode details