### PR TITLE
Improve section handling when expand/collapse seasons in episodes view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -858,8 +858,9 @@
         [indexPaths addObject:[NSIndexPath indexPathForRow:i inSection:section]];
     }
     // Add/remove the section content
+    BOOL expandSection = [self.sectionArrayOpen[section] boolValue];
     UIButton *toggleButton = (UIButton*)[sender.view viewWithTag:99];
-    if ([self.sectionArrayOpen[section] boolValue]) {
+    if (expandSection) {
         [dataList beginUpdates];
         [dataList insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationMiddle];
         [dataList endUpdates];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -861,14 +861,14 @@
     UIButton *toggleButton = (UIButton*)[sender.view viewWithTag:99];
     if ([self.sectionArrayOpen[section] boolValue]) {
         [dataList beginUpdates];
-        [dataList insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationTop];
+        [dataList insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationMiddle];
         [dataList endUpdates];
         toggleButton.selected = YES;
     }
     else {
         toggleButton.selected = NO;
         [dataList beginUpdates];
-        [dataList deleteRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationTop];
+        [dataList deleteRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationMiddle];
         [dataList endUpdates];
     }
     // Refresh leyout

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -849,29 +849,31 @@
     [self.searchController.searchBar resignFirstResponder];
     [self.searchController setActive:NO];
     NSInteger section = [sender.view tag];
+    
     // Toggle the section's state (open/close)
-    [self.sectionArrayOpen replaceObjectAtIndex:section withObject:@(![self.sectionArrayOpen[section] boolValue])];
+    BOOL expandSection = ![self.sectionArrayOpen[section] boolValue];
+    self.sectionArrayOpen[section] = @(expandSection);
+    
     // Build the section content
-    NSInteger countEpisodes = [[self.sections objectForKey:self.sectionArray[section]] count];
+    NSInteger countEpisodes = [self.sections[self.sectionArray[section]] count];
     NSMutableArray *indexPaths = [NSMutableArray new];
     for (NSInteger i = 0; i < countEpisodes; i++) {
         [indexPaths addObject:[NSIndexPath indexPathForRow:i inSection:section]];
     }
+    
     // Add/remove the section content
-    BOOL expandSection = [self.sectionArrayOpen[section] boolValue];
     UIButton *toggleButton = (UIButton*)[sender.view viewWithTag:99];
     if (expandSection) {
         [dataList beginUpdates];
         [dataList insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationMiddle];
         [dataList endUpdates];
-        toggleButton.selected = YES;
     }
     else {
-        toggleButton.selected = NO;
         [dataList beginUpdates];
         [dataList deleteRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationMiddle];
         [dataList endUpdates];
     }
+    toggleButton.selected = expandSection;
     dataList.tableHeaderView = self.searchController.searchBar;
     
     // Refresh layout (moves section header to top when expanding any season or when toggling the first season)

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -872,13 +872,18 @@
         [dataList deleteRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationMiddle];
         [dataList endUpdates];
     }
-    // Refresh leyout
     dataList.tableHeaderView = self.searchController.searchBar;
-    [dataList setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
-    // Scroll to first item in section (first episode in season)
-    NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:section];
-    CGRect sectionRect = [dataList rectForRowAtIndexPath:indexPath];
-    [dataList scrollRectToVisible:sectionRect animated:YES];
+    
+    // Refresh layout (moves section header to top when expanding any season or when toggling the first season)
+    int visibleRows = 0;
+    for (int i = 0; i < section; i++) {
+        visibleRows += [dataList numberOfRowsInSection:i];
+    }
+    int insetToMoveSectionToTop = iOSYDelta + section * albumViewHeight + visibleRows * cellHeight;
+    if (expandSection || section == 0) {
+        // Moves inset to show current section on top
+        [dataList setContentOffset:CGPointMake(0, insetToMoveSectionToTop) animated:YES];
+    }
 }
 
 - (void)goBack:(id)sender {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Expanded sections now always move their section header to top, which allows to show all available episodes. Collapsed sections will stay at their position -- except the first section which needs to have the inset set explicitly to deal with scrolled episodes.

Use `UITableViewRowAnimationMiddle` when showing/hiding episodes. This resolves a glitch where unfolding a season animated the newly shown episode from above the section header. Now the animation fades in each newly shown episode from its middle which gives a smoother user experience.

In addition, some refactoring is done to use literals and use local variables where is makes sense.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Smoother section expand/collapse animation in episodes view
Improvement: Always move section header to top when expanding a season
Improvement: Keep section header's position when collapsing a season