### PR TITLE
Improve service discovery and support IPv6

### DIFF
--- a/XBMC Remote/GlobalData.h
+++ b/XBMC Remote/GlobalData.h
@@ -12,17 +12,19 @@
     NSString *serverDescription;
     NSString *serverUser;
     NSString *serverPass;
-    NSString *serverIP;
+    NSString *serverRawIP; // Holds IP in raw format, e.g. ":::::" for IPv6
+    NSString *serverIP; // Holds IP in URL format, e.g. "[:::::]" for IPv6
     NSString *serverPort;
     int tcpPort;
     NSString *serverHWAddr;
 
-    
+
 }
 
 @property (nonatomic, strong)NSString *serverDescription;
 @property (nonatomic, strong)NSString *serverUser;
 @property (nonatomic, strong)NSString *serverPass;
+@property (nonatomic, strong)NSString *serverRawIP;
 @property (nonatomic, strong)NSString *serverIP;
 @property int tcpPort;
 @property (nonatomic, strong)NSString *serverPort;

--- a/XBMC Remote/GlobalData.m
+++ b/XBMC Remote/GlobalData.m
@@ -13,6 +13,7 @@
 @synthesize serverDescription;
 @synthesize serverUser;
 @synthesize serverPass;
+@synthesize serverRawIP;
 @synthesize serverIP;
 @synthesize serverPort;
 @synthesize tcpPort;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -135,22 +135,14 @@
     return cell;
 }
 
-static inline BOOL IsEmpty(id obj) {
-    return obj == nil
-    || ([obj respondsToSelector:@selector(length)]
-        && [(NSData*)obj length] == 0)
-    || ([obj respondsToSelector:@selector(count)]
-        && [(NSArray*)obj count] == 0);
-}
-
 - (void)selectServerAtIndexPath:(NSIndexPath*)indexPath {
     NSDictionary *item = AppDelegate.instance.arrayServerList[indexPath.row];
-    AppDelegate.instance.obj.serverDescription = IsEmpty(item[@"serverDescription"]) ? @"" : item[@"serverDescription"];
-    AppDelegate.instance.obj.serverUser = IsEmpty(item[@"serverUser"]) ? @"" : item[@"serverUser"];
-    AppDelegate.instance.obj.serverPass = IsEmpty(item[@"serverPass"]) ? @"" : item[@"serverPass"];
-    AppDelegate.instance.obj.serverIP = IsEmpty(item[@"serverIP"]) ? @"" : item[@"serverIP"];
-    AppDelegate.instance.obj.serverPort = IsEmpty(item[@"serverPort"]) ? @"" : item[@"serverPort"];
-    AppDelegate.instance.obj.serverHWAddr = IsEmpty(item[@"serverMacAddress"]) ? @"" : item[@"serverMacAddress"];
+    AppDelegate.instance.obj.serverDescription = item[@"serverDescription"];
+    AppDelegate.instance.obj.serverUser = item[@"serverUser"];
+    AppDelegate.instance.obj.serverPass = item[@"serverPass"];
+    AppDelegate.instance.obj.serverIP = item[@"serverIP"];
+    AppDelegate.instance.obj.serverPort = item[@"serverPort"];
+    AppDelegate.instance.obj.serverHWAddr = item[@"serverMacAddress"];
     AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue];
 }
 

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -52,6 +52,7 @@
         AppDelegate.instance.obj.serverDescription = @"";
         AppDelegate.instance.obj.serverUser = @"";
         AppDelegate.instance.obj.serverPass = @"";
+        AppDelegate.instance.obj.serverRawIP = @"";
         AppDelegate.instance.obj.serverIP = @"";
         AppDelegate.instance.obj.serverPort = @"";
         AppDelegate.instance.obj.serverHWAddr = @"";
@@ -140,7 +141,8 @@
     AppDelegate.instance.obj.serverDescription = item[@"serverDescription"];
     AppDelegate.instance.obj.serverUser = item[@"serverUser"];
     AppDelegate.instance.obj.serverPass = item[@"serverPass"];
-    AppDelegate.instance.obj.serverIP = item[@"serverIP"];
+    AppDelegate.instance.obj.serverRawIP = item[@"serverIP"];
+    AppDelegate.instance.obj.serverIP = [Utilities getUrlStyleAddress:item[@"serverIP"]];
     AppDelegate.instance.obj.serverPort = item[@"serverPort"];
     AppDelegate.instance.obj.serverHWAddr = item[@"serverMacAddress"];
     AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue];
@@ -155,6 +157,7 @@
     AppDelegate.instance.obj.serverDescription = @"";
     AppDelegate.instance.obj.serverUser = @"";
     AppDelegate.instance.obj.serverPass = @"";
+    AppDelegate.instance.obj.serverRawIP = @"";
     AppDelegate.instance.obj.serverIP = @"";
     AppDelegate.instance.obj.serverPort = @"";
     AppDelegate.instance.obj.serverHWAddr = @"";
@@ -222,6 +225,7 @@
                 AppDelegate.instance.obj.serverDescription = @"";
                 AppDelegate.instance.obj.serverUser = @"";
                 AppDelegate.instance.obj.serverPass = @"";
+                AppDelegate.instance.obj.serverRawIP = @"";
                 AppDelegate.instance.obj.serverIP = @"";
                 AppDelegate.instance.obj.serverPort = @"";
                 AppDelegate.instance.obj.serverHWAddr = @"";

--- a/XBMC Remote/HostViewController.h
+++ b/XBMC Remote/HostViewController.h
@@ -26,6 +26,7 @@
     NSMutableArray *services;
     BOOL searching;
     NSNetServiceBrowser *netServiceBrowser;
+    NSNetService *remoteService;
     NSTimer *timer;
     IBOutlet UIActivityIndicatorView *activityIndicatorView;
     IBOutlet UIView *noInstances;

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -53,12 +53,13 @@
     else {
         self.navigationItem.title = LOCALIZED_STR(@"Modify XBMC Server");
         NSIndexPath *idx = self.detailItem;
-        descriptionUI.text = AppDelegate.instance.arrayServerList[idx.row][@"serverDescription"];
-        usernameUI.text = AppDelegate.instance.arrayServerList[idx.row][@"serverUser"];
-        passwordUI.text = AppDelegate.instance.arrayServerList[idx.row][@"serverPass"];
-        ipUI.text = AppDelegate.instance.arrayServerList[idx.row][@"serverIP"];
-        portUI.text = AppDelegate.instance.arrayServerList[idx.row][@"serverPort"];
-        NSString *macAddress = AppDelegate.instance.arrayServerList[idx.row][@"serverMacAddress"];
+        NSDictionary *item = AppDelegate.instance.arrayServerList[idx.row];
+        descriptionUI.text = item[@"serverDescription"];
+        usernameUI.text = item[@"serverUser"];
+        passwordUI.text = item[@"serverPass"];
+        ipUI.text = item[@"serverIP"];
+        portUI.text = item[@"serverPort"];
+        NSString *macAddress = item[@"serverMacAddress"];
         NSArray *mac_octect = [macAddress componentsSeparatedByString:@":"];
         NSInteger num_octects = mac_octect.count;
         if (num_octects > 0) {
@@ -79,7 +80,7 @@
         if (num_octects > 5) {
             mac_5_UI.text = mac_octect[5];
         }
-        tcpPortUI.text = AppDelegate.instance.arrayServerList[idx.row][@"tcpPort"];
+        tcpPortUI.text = item[@"tcpPort"];
     }
 }
 

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -359,8 +359,24 @@
     }
     NSLog(@"Discovery finished: %@", serverAddresses);
     if (serverAddresses.count) {
-        // Select desired type
-        NSDictionary *server = serverAddresses[@"ipv4"];
+        // Select preferred address type
+        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+        NSString *mode = [userDefaults stringForKey:@"preferred_server_address"];
+        NSDictionary *server = serverAddresses[mode];
+        
+        // Fallback order: ipv4 > ipv6 > hostname
+        if (!server) {
+            server = serverAddresses[@"ipv4"];
+        }
+        if (!server) {
+            server = serverAddresses[@"ipv6"];
+        }
+        if (!server) {
+            server = serverAddresses[@"hostname"];
+        }
+        if (!server) {
+            return;
+        }
         
         // Set values for UI and persistency
         descriptionUI.text = service.name;

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -60,25 +60,14 @@
         ipUI.text = item[@"serverIP"];
         portUI.text = item[@"serverPort"];
         NSString *macAddress = item[@"serverMacAddress"];
-        NSArray *mac_octect = [macAddress componentsSeparatedByString:@":"];
-        NSInteger num_octects = mac_octect.count;
-        if (num_octects > 0) {
-            mac_0_UI.text = mac_octect[0];
-        }
-        if (num_octects > 1) {
-            mac_1_UI.text = mac_octect[1];
-        }
-        if (num_octects > 2) {
-            mac_2_UI.text = mac_octect[2];
-        }
-        if (num_octects > 3) {
-            mac_3_UI.text = mac_octect[3];
-        }
-        if (num_octects > 4) {
-            mac_4_UI.text = mac_octect[4];
-        }
-        if (num_octects > 5) {
-            mac_5_UI.text = mac_octect[5];
+        NSArray *macPart = [macAddress componentsSeparatedByString:@":"];
+        if (macPart.count == 6) {
+            mac_0_UI.text = macPart[0];
+            mac_1_UI.text = macPart[1];
+            mac_2_UI.text = macPart[2];
+            mac_3_UI.text = macPart[3];
+            mac_4_UI.text = macPart[4];
+            mac_5_UI.text = macPart[5];
         }
         tcpPortUI.text = item[@"tcpPort"];
     }
@@ -296,19 +285,19 @@
 - (void)fillMacAddressInfo {
     NSString *macAddress = [self resolveMacFromIP:ipUI.text];
     NSArray *macPart = [macAddress componentsSeparatedByString:@":"];
-    if (macPart.count == 6 && ![macAddress isEqualToString:@"02:00:00:00:00:00"]) {
-        mac_0_UI.text = macPart[0];
-        mac_0_UI.textColor = [Utilities getSystemBlue];
-        mac_1_UI.text = macPart[1];
-        mac_1_UI.textColor = [Utilities getSystemBlue];
-        mac_2_UI.text = macPart[2];
-        mac_2_UI.textColor = [Utilities getSystemBlue];
-        mac_3_UI.text = macPart[3];
-        mac_3_UI.textColor = [Utilities getSystemBlue];
-        mac_4_UI.text = macPart[4];
-        mac_4_UI.textColor = [Utilities getSystemBlue];
-        mac_5_UI.text = macPart[5];
-        mac_5_UI.textColor = [Utilities getSystemBlue];
+    if (macPart.count == 6 && ![macAddress isEqualToString:@"00:00:00:00:00:00"]) {
+        NSArray *macLabels = @[
+            mac_0_UI,
+            mac_1_UI,
+            mac_2_UI,
+            mac_3_UI,
+            mac_4_UI,
+            mac_5_UI,
+        ];
+        [macLabels enumerateObjectsUsingBlock:^(UILabel *label, NSUInteger idx, BOOL *stop) {
+            label.text = macPart[idx];
+            label.textColor = [Utilities getSystemBlue];
+        }];
     }
 }
 

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -197,6 +197,8 @@
 - (void)netServiceBrowser:(NSNetServiceBrowser*)browser didNotSearch:(NSDictionary*)errorDict {
     searching = NO;
     [self handleError:errorDict[NSNetServicesErrorCode]];
+    [activityIndicatorView stopAnimating];
+    startDiscover.enabled = YES;
 }
 
 - (void)netServiceBrowser:(NSNetServiceBrowser*)browser

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -53,7 +53,7 @@
                                    nil];
     NSString *notificationName;
     if (status) {
-        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverIP serverPort:AppDelegate.instance.obj.tcpPort];
+        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
         notificationName = @"XBMCServerConnectionSuccess";
     }
     else {
@@ -396,7 +396,7 @@
         if (self.tcpJSONRPCconnection == nil) {
             self.tcpJSONRPCconnection = [tcpJSONRPC new];
         }
-        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverIP serverPort:AppDelegate.instance.obj.tcpPort];
+        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
     }
 }
 

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -475,9 +475,8 @@
         else {
             NSString *command = tableData[indexPath.row][@"action"][@"command"];
             if ([command isEqualToString:@"System.WOL"]) {
-                NSString *serverMAC = AppDelegate.instance.obj.serverHWAddr;
-                if (serverMAC != nil && ![serverMAC isEqualToString:@":::::"]) {
-                    [self wakeUp:AppDelegate.instance.obj.serverHWAddr];
+                if ([Utilities isValidMacAddress:AppDelegate.instance.obj.serverHWAddr]) {
+                    [Utilities wakeUp:AppDelegate.instance.obj.serverHWAddr];
                     [messagesView showMessage:LOCALIZED_STR(@"Command executed") timeout:2.0 color:[Utilities getSystemGreen:0.95]];
                 }
                 else {
@@ -568,10 +567,6 @@
             [sender setUserInteractionEnabled:YES];
         }
     }];
-}
-
-- (void)wakeUp:(NSString*)macAddress {
-    [AppDelegate.instance sendWOL:macAddress withPort:WOL_PORT];
 }
 
 #pragma mark - LifeCycle

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -12,6 +12,28 @@
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
+			<string>ipv4</string>
+			<key>Key</key>
+			<string>preferred_server_address</string>
+			<key>Title</key>
+			<string>Preferred server address</string>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Titles</key>
+			<array>
+				<string>IPv4</string>
+				<string>IPv6</string>
+				<string>Host name</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<string>ipv4</string>
+				<string>ipv6</string>
+				<string>hostname</string>
+			</array>
+		</dict>
+		<dict>
+			<key>DefaultValue</key>
 			<true/>
 			<key>Key</key>
 			<string>connection_info_preference</string>

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -42,3 +42,5 @@
 "Global Search" = "Global Search";
 "Main Menu changes needs app restart" = "Main Menu changes needs app restart";
 "Episode identifier" = "Episode identifier";
+"Preferred server address" = "Preferred server address";
+"Host name" = "Host name";

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -112,5 +112,6 @@ typedef enum {
 + (NSString*)stripBBandHTML:(NSString*)text;
 + (BOOL)isValidMacAddress:(NSString*)macAddress;
 + (void)wakeUp:(NSString*)macAddress;
++ (NSString*)getUrlStyleAddress:(NSString*)address;
 
 @end

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -110,5 +110,7 @@ typedef enum {
 + (NSString*)formatTVShowStringForSeasonLeading:(id)season episode:(id)episode title:(NSString*)title;
 + (NSString*)formatTVShowStringForSeason:(id)season episode:(id)episode;
 + (NSString*)stripBBandHTML:(NSString*)text;
++ (BOOL)isValidMacAddress:(NSString*)macAddress;
++ (void)wakeUp:(NSString*)macAddress;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -8,6 +8,7 @@
 
 #import <AVFoundation/AVFoundation.h>
 #import <StoreKit/StoreKit.h>
+#import <arpa/inet.h>
 #import "Utilities.h"
 #import "AppDelegate.h"
 #import "NSString+MD5.h"
@@ -1212,6 +1213,24 @@
 
 + (void)wakeUp:(NSString*)macAddress {
     [AppDelegate.instance sendWOL:macAddress withPort:WOL_PORT];
+}
+
++ (BOOL)isValidIP6Address:(NSString *)ip {
+    const char *utf8 = [ip UTF8String];
+
+    // Check valid IPv6.
+    struct in6_addr dst6;
+    int success = inet_pton(AF_INET6, utf8, &dst6);
+    
+    return (success == 1);
+}
+
++ (NSString*)getUrlStyleAddress:(NSString*)address {
+    NSString *URLaddress = address;
+    if ([Utilities isValidIP6Address:address]) {
+        URLaddress = [NSString stringWithFormat:@"[%@]", address];
+    }
+    return URLaddress;
 }
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1206,4 +1206,12 @@
     return textOut;
 }
 
++ (BOOL)isValidMacAddress:(NSString*)macAddress {
+    return macAddress && macAddress.length && ![macAddress isEqualToString:@":::::"];
+}
+
++ (void)wakeUp:(NSString*)macAddress {
+    [AppDelegate.instance sendWOL:macAddress withPort:WOL_PORT];
+}
+
 @end

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -103,10 +103,6 @@
     AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue];
 }
 
-- (void)wakeUp:(NSString*)macAddress {
-    [AppDelegate.instance sendWOL:macAddress withPort:WOL_PORT];
-}
-
 - (void)connectionStatus:(NSNotification*)note {
     NSDictionary *theData = note.userInfo;
     NSString *icon_connection = theData[@"icon_connection"];
@@ -217,8 +213,8 @@
     
     if (!AppDelegate.instance.serverOnLine) {
         UIAlertAction *action_wake = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Send Wake-On-LAN") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            if (AppDelegate.instance.obj.serverHWAddr != nil) {
-                [self wakeUp:AppDelegate.instance.obj.serverHWAddr];
+            if ([Utilities isValidMacAddress:AppDelegate.instance.obj.serverHWAddr]) {
+                [Utilities wakeUp:AppDelegate.instance.obj.serverHWAddr];
                 UIAlertController *alertView = [Utilities createAlertOK:LOCALIZED_STR(@"Command executed") message:nil];
                 [self presentViewController:alertView animated:YES completion:nil];
             }

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -98,7 +98,8 @@
     AppDelegate.instance.obj.serverDescription = item[@"serverDescription"];
     AppDelegate.instance.obj.serverUser = item[@"serverUser"];
     AppDelegate.instance.obj.serverPass = item[@"serverPass"];
-    AppDelegate.instance.obj.serverIP = item[@"serverIP"];
+    AppDelegate.instance.obj.serverRawIP = item[@"serverIP"];
+    AppDelegate.instance.obj.serverIP = [Utilities getUrlStyleAddress:item[@"serverIP"]];
     AppDelegate.instance.obj.serverPort = item[@"serverPort"];
     AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue];
 }
@@ -115,7 +116,7 @@
                                    iconName, @"icon_connection",
                                    nil];
     if (status) {
-        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverIP serverPort:AppDelegate.instance.obj.tcpPort];
+        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
         [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCServerConnectionSuccess" object:nil userInfo:params];
         AppDelegate.instance.serverOnLine = YES;
         AppDelegate.instance.serverName = infoText;
@@ -705,7 +706,7 @@
         if (self.tcpJSONRPCconnection == nil) {
             self.tcpJSONRPCconnection = [tcpJSONRPC new];
         }
-        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverIP serverPort:AppDelegate.instance.obj.tcpPort];
+        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
     }
 }
 

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -182,8 +182,8 @@ NSInputStream	*inStream;
         return;
     }
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"wol_preference"] &&
-        AppDelegate.instance.obj.serverHWAddr != nil) {
-        [AppDelegate.instance sendWOL:AppDelegate.instance.obj.serverHWAddr withPort:WOL_PORT];
+        [Utilities isValidMacAddress:AppDelegate.instance.obj.serverHWAddr]) {
+        [Utilities wakeUp:AppDelegate.instance.obj.serverHWAddr];
     }
     inCheck = YES;
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/256.

This PR improves the Remote App's capability during service discovery (when pressing "Find Kodi"):
- Enable support for IPv6 and localhost
- Resolve TCP port automatically
- User setting for preferred address type (IPv4, IPv6 or localhost)
- Bring back "Find Kodi" button on service discovery error

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Support IPv6 and localhost during service discovery
Improvement: Resolve TCP port during service discovery
Improvement: User selectable address type preference
Bugfix: Re-enable "Find Kodi" on service discovery error