### PR TITLE
Fix iOS device service discovery

### DIFF
--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -299,7 +299,10 @@
 - (void)fillMacAddressInfo {
     NSString *macAddress = [self resolveMacFromIP:ipUI.text];
     NSArray *macPart = [macAddress componentsSeparatedByString:@":"];
-    if (macPart.count == 6 && ![macAddress isEqualToString:@"00:00:00:00:00:00"]) {
+    // Both 02:... and 00:... are invalid addresses (first seen on target, second on simulator)
+    if (macPart.count == 6 &&
+        ![macAddress isEqualToString:@"02:00:00:00:00:00"] &&
+        ![macAddress isEqualToString:@"00:00:00:00:00:00"]) {
         NSArray *macLabels = @[
             mac_0_UI,
             mac_1_UI,

--- a/XBMC Remote/Kodi Remote-Info.plist
+++ b/XBMC Remote/Kodi Remote-Info.plist
@@ -47,6 +47,7 @@
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_xbmc-jsonrpc-h._tcp</string>
+		<string>_xbmc-jsonrpc._tcp</string>
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Kodi Remote App uses local network to find and communicate to Kodi instances in the network.</string>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes resolving the TCP IP on iOS devices (hardware). The new code also ignore invalid MAC addresses on iOS devices ("02:00:00:...").

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Resolve TCP IP on iOS devices
Bugfix: Ignore invalid MAC address on iOS devices