### PR TITLE
Rename setting to "Find Kodi prefers"

### DIFF
--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -16,7 +16,7 @@
 			<key>Key</key>
 			<string>preferred_server_address</string>
 			<key>Title</key>
-			<string>Preferred server address</string>
+			<string>Find Kodi prefers</string>
 			<key>Type</key>
 			<string>PSMultiValueSpecifier</string>
 			<key>Titles</key>

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -42,5 +42,5 @@
 "Global Search" = "Global Search";
 "Main Menu changes needs app restart" = "Main Menu changes needs app restart";
 "Episode identifier" = "Episode identifier";
-"Preferred server address" = "Preferred server address";
+"Find Kodi prefers" = "'Find Kodi' prefers";
 "Host name" = "Host name";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The setting which allows to select the preference for the address type taken from the service discovery (triggered via pressing "Find Kodi") was not named well. As the setting only influences the service discovery result, and "Service Discovery" is a too technical term, the setting is renamed to "Find Kodi prefers". This directly related to the function / button visible to the user.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Rename setting to "Find Kodi prefers"