### PR TITLE
Improve handling of race condition in NowPlaying view

### DIFF
--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -99,6 +99,11 @@
     CGFloat bottomPadding;
     BOOL waitForInfoLabelsToSettle;
     CGFloat descriptionFontSize;
+    int lastPlayerID;
+    long lastSelected;
+    int currentPlayerID;
+    int storePosSeconds;
+    long storedItemID;
 }
 
 - (void)setNowPlayingDimension:(int)width height:(int)height YPOS:(int)YPOS;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -488,6 +488,10 @@ long storedItemID;
 
 - (void)getActivePlayers {
     [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:[NSDictionary dictionary] withTimeout:2.0 onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+        // Do not process further, if the view is already off the view hierarchy.
+        if (!self.viewIfLoaded.window) {
+            return;
+        }
         if (error == nil && methodError == nil) {
             if ([methodResult isKindOfClass:[NSArray class]] && [methodResult count] > 0) {
                 nothingIsPlaying = NO;
@@ -541,6 +545,10 @@ long storedItemID;
                  withParameters:@{@"playerid": @(currentPlayerID),
                                   @"properties": properties}
                  onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+                     // Do not process further, if the view is already off the view hierarchy.
+                     if (!self.viewIfLoaded.window) {
+                         return;
+                     }
                      if (error == nil && methodError == nil) {
                          bool enableJewel = [self enableJewelCases];
                          if ([methodResult isKindOfClass:[NSDictionary class]]) {
@@ -679,6 +687,10 @@ long storedItemID;
                                                    @"shuffled",
                                                    @"canseek"]}
                  onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+                     // Do not process further, if the view is already off the view hierarchy.
+                     if (!self.viewIfLoaded.window) {
+                         return;
+                     }
                      if (error == nil && methodError == nil) {
                          if ([methodResult isKindOfClass:[NSDictionary class]]) {
                              if ([methodResult count]) {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -90,6 +90,9 @@
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
         // Custom initialization
+        lastPlayerID = PLAYERID_UNKNOWN;
+        lastSelected = SELECTED_NONE;
+        currentPlayerID = PLAYERID_UNKNOWN;
     }
     return self;
 }
@@ -296,12 +299,6 @@
 }
 
 #pragma mark - JSON management
-
-int lastPlayerID = PLAYERID_UNKNOWN;
-long lastSelected = SELECTED_NONE;
-int currentPlayerID = PLAYERID_UNKNOWN;
-int storePosSeconds;
-long storedItemID;
 
 - (void)setCoverSize:(NSString*)type {
     NSString *jewelImg = @"";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3160623#pid3160623).

JSON API responses can arrive after the NowPlaying view was already removed from the view hierarchy. Adding a check for this resolves a runtime warning when calling `cellForRowAtIndexPath` on a view which is not in the view hierarchy anymore. In addition, such check fixes a problem where `storedItemID` was set for an old instance of NowPlaying, causing the new instance to not load thumbs and metadata for the current running item anymore.

Use ivar instead of global variable in NowPlaying to avoid potential problems with race conditions where outdated instances of NowPlaying would set global variables like storedItemID` which influence the behaviour of the current instance. Now each instance starts with a clean slate by design.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid potential empty NowPlaying screen on iPhones
Improvement: Avoid runtime warning in NowPlaying on iPhone