### PR TITLE
Improve setting the service discovery preference

### DIFF
--- a/XBMC Remote/HostViewController.h
+++ b/XBMC Remote/HostViewController.h
@@ -43,6 +43,7 @@
     IBOutlet UILabel *howtoLabel;
     IBOutlet UILabel *howtoLaterLabel;
     IBOutlet UIButton *saveButton;
+    IBOutlet UISegmentedControl *segmentServerType;
 }
 
 @property (strong, nonatomic) id detailItem;

--- a/XBMC Remote/HostViewController.h
+++ b/XBMC Remote/HostViewController.h
@@ -37,6 +37,7 @@
     IBOutlet UILabel *hostLabel;
     IBOutlet UILabel *macLabel;
     IBOutlet UILabel *userLabel;
+    IBOutlet UILabel *preferenceLabel;
     IBOutlet UILabel *noInstancesLabel;
     IBOutlet UILabel *findLabel;
     IBOutlet UIView *tipView;

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -558,6 +558,7 @@
     hostLabel.text = LOCALIZED_STR(@"Host : port /\nTCP port");
     macLabel.text = LOCALIZED_STR(@"MAC Address");
     userLabel.text = LOCALIZED_STR(@"Username and Password");
+    preferenceLabel.text = LOCALIZED_STR(@"Preference");
     noInstancesLabel.text = LOCALIZED_STR(@"No XBMC instances were found :(");
     findLabel.text = LOCALIZED_STR(@"\"Find XBMC\" requires XBMC server option\n\"Announce these services to other systems via Zeroconf\" enabled");
     howtoLabel.text = LOCALIZED_STR(@"How-to activate the remote app in Kodi");

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -452,6 +452,7 @@
 }
 
 - (void)stopDiscovery {
+    [timer invalidate];
     [netServiceBrowser stop];
     [activityIndicatorView stopAnimating];
     startDiscover.enabled = YES;
@@ -459,6 +460,7 @@
 
 - (IBAction)startDiscover:(id)sender {
     [self resignKeyboard];
+    [netServiceBrowser stop];
     [activityIndicatorView startAnimating];
     [services removeAllObjects];
     startDiscover.enabled = NO;

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -397,8 +397,9 @@
     }
     if (serverAddresses.count) {
         // Select preferred address type
-        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-        NSString *mode = [userDefaults stringForKey:@"preferred_server_address"];
+        NSArray *segmentModes = @[@"ipv4", @"ipv6", @"hostname"];
+        long index = segmentServerType.selectedSegmentIndex;
+        NSString *mode = index < segmentModes.count ? segmentModes[index] : segmentModes[0];
         NSDictionary *server = serverAddresses[mode];
         
         // Fallback order: ipv4 > ipv6 > hostname
@@ -618,6 +619,14 @@
         frame.origin.y -= bottomPadding;
         tipView.frame = frame;
     }
+    
+    // We use white fonts for the segment control
+    [segmentServerType setTitleTextAttributes:@{NSForegroundColorAttributeName : UIColor.whiteColor} forState:UIControlStateNormal];
+    [segmentServerType setTitleTextAttributes:@{NSForegroundColorAttributeName : UIColor.whiteColor} forState:UIControlStateHighlighted];
+    [segmentServerType setTitleTextAttributes:@{NSForegroundColorAttributeName : UIColor.whiteColor} forState:UIControlStateSelected];
+    
+    // Set segment control text for "host name" mode
+    [segmentServerType setTitle:LOCALIZED_STR(@"Host name") forSegmentAtIndex:2];
 }
 
 - (BOOL)shouldAutorotate {

--- a/XBMC Remote/HostViewController.xib
+++ b/XBMC Remote/HostViewController.xib
@@ -31,6 +31,7 @@
                 <outlet property="noInstancesLabel" destination="43" id="hQf-mn-wP2"/>
                 <outlet property="passwordUI" destination="11" id="24"/>
                 <outlet property="portUI" destination="14" id="22"/>
+                <outlet property="preferenceLabel" destination="dhV-aO-mDJ" id="RZ3-uQ-nUD"/>
                 <outlet property="saveButton" destination="37" id="Ttx-kq-fCl"/>
                 <outlet property="segmentServerType" destination="Y8C-9i-Y7g" id="Ch0-pi-4en"/>
                 <outlet property="startDiscover" destination="39" id="45"/>
@@ -71,7 +72,7 @@
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <string key="text">Host : port /
 TCP port</string>
-                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
                             <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                             <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -123,7 +124,7 @@ TCP port</string>
                             <size key="shadowOffset" width="1" height="1"/>
                         </label>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text=":" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="80">
-                            <rect key="frame" x="233" y="67" width="6" height="20"/>
+                            <rect key="frame" x="232" y="67" width="6" height="20"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -140,10 +141,19 @@ TCP port</string>
                             <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <size key="shadowOffset" width="1" height="1"/>
                         </label>
+                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Preference" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="dhV-aO-mDJ">
+                            <rect key="frame" x="5" y="129" width="80" height="31"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <color key="textColor" red="0.89980614189999997" green="0.89980614189999997" blue="0.89980614189999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <nil key="highlightedColor"/>
+                            <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <size key="shadowOffset" width="1" height="1"/>
+                        </label>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Username and Password" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="16">
                             <rect key="frame" x="5" y="91" width="80" height="31"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
                             <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                             <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -152,7 +162,7 @@ TCP port</string>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="MAC Address" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="76">
                             <rect key="frame" x="5" y="61" width="80" height="31"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
                             <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                             <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -161,7 +171,7 @@ TCP port</string>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Description" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="10">
                             <rect key="frame" x="5" y="7" width="80" height="20"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
                             <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                             <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -212,7 +222,7 @@ TCP port</string>
                             </connections>
                         </textField>
                         <textField clipsSubviews="YES" tag="7" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="00" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="64">
-                            <rect key="frame" x="163" y="64" width="32" height="26"/>
+                            <rect key="frame" x="162" y="64" width="32" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -267,7 +277,7 @@ TCP port</string>
                             </connections>
                         </textField>
                         <textField clipsSubviews="YES" tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="9090" borderStyle="line" placeholder="9090" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="93">
-                            <rect key="frame" x="258" y="34" width="51" height="26"/>
+                            <rect key="frame" x="257" y="34" width="51" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>

--- a/XBMC Remote/HostViewController.xib
+++ b/XBMC Remote/HostViewController.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -31,6 +32,7 @@
                 <outlet property="passwordUI" destination="11" id="24"/>
                 <outlet property="portUI" destination="14" id="22"/>
                 <outlet property="saveButton" destination="37" id="Ttx-kq-fCl"/>
+                <outlet property="segmentServerType" destination="Y8C-9i-Y7g" id="Ch0-pi-4en"/>
                 <outlet property="startDiscover" destination="39" id="45"/>
                 <outlet property="tcpPortUI" destination="93" id="96"/>
                 <outlet property="tipView" destination="z1M-ev-5kX" id="pYU-ca-117"/>
@@ -85,7 +87,7 @@ TCP port</string>
                             <size key="shadowOffset" width="1" height="1"/>
                         </label>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="/" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="98">
-                            <rect key="frame" x="253" y="37" width="6" height="20"/>
+                            <rect key="frame" x="252" y="37" width="6" height="20"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -121,7 +123,7 @@ TCP port</string>
                             <size key="shadowOffset" width="1" height="1"/>
                         </label>
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text=":" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="80">
-                            <rect key="frame" x="234" y="67" width="6" height="20"/>
+                            <rect key="frame" x="233" y="67" width="6" height="20"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <color key="textColor" red="0.89980614185333252" green="0.89980614185333252" blue="0.89980614185333252" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -210,7 +212,7 @@ TCP port</string>
                             </connections>
                         </textField>
                         <textField clipsSubviews="YES" tag="7" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="00" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="64">
-                            <rect key="frame" x="164" y="64" width="32" height="26"/>
+                            <rect key="frame" x="163" y="64" width="32" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -243,7 +245,7 @@ TCP port</string>
                             </connections>
                         </textField>
                         <textField clipsSubviews="YES" tag="10" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="00" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="73">
-                            <rect key="frame" x="278" y="64" width="32" height="26"/>
+                            <rect key="frame" x="277" y="64" width="32" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -265,7 +267,7 @@ TCP port</string>
                             </connections>
                         </textField>
                         <textField clipsSubviews="YES" tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="9090" borderStyle="line" placeholder="9090" textAlignment="center" minimumFontSize="10" translatesAutoresizingMaskIntoConstraints="NO" id="93">
-                            <rect key="frame" x="259" y="34" width="51" height="26"/>
+                            <rect key="frame" x="258" y="34" width="51" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
@@ -301,8 +303,18 @@ TCP port</string>
                             <rect key="frame" x="142" y="200" width="37" height="37"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         </activityIndicatorView>
+                        <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Y8C-9i-Y7g" userLabel="Server Type Segment">
+                            <rect key="frame" x="88" y="128" width="222" height="32"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <segments>
+                                <segment title="IPv4"/>
+                                <segment title="IPv6"/>
+                                <segment title="Host name"/>
+                            </segments>
+                            <color key="selectedSegmentTintColor" systemColor="systemBlueColor"/>
+                        </segmentedControl>
                         <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="37">
-                            <rect key="frame" x="202" y="141" width="108" height="28"/>
+                            <rect key="frame" x="202" y="168" width="108" height="32"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                             <size key="titleShadowOffset" width="1" height="1"/>
@@ -321,7 +333,7 @@ TCP port</string>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="39">
-                            <rect key="frame" x="88" y="141" width="108" height="28"/>
+                            <rect key="frame" x="88" y="168" width="108" height="32"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                             <inset key="titleEdgeInsets" minX="4" minY="0.0" maxX="4" maxY="0.0"/>
@@ -375,7 +387,7 @@ TCP port</string>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                         </view>
                         <view alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="89" userLabel="View - No Instances Found">
-                            <rect key="frame" x="0.0" y="180" width="320" height="85"/>
+                            <rect key="frame" x="0.0" y="208" width="320" height="85"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="No XBMC instances were found :(" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="43">
@@ -428,5 +440,8 @@ TCP port</string>
         <image name="button_find" width="104" height="28"/>
         <image name="shiny_black_back" width="240" height="408"/>
         <image name="tip" width="15" height="15"/>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -12,28 +12,6 @@
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
-			<string>ipv4</string>
-			<key>Key</key>
-			<string>preferred_server_address</string>
-			<key>Title</key>
-			<string>Preferred server address</string>
-			<key>Type</key>
-			<string>PSMultiValueSpecifier</string>
-			<key>Titles</key>
-			<array>
-				<string>IPv4</string>
-				<string>IPv6</string>
-				<string>Host name</string>
-			</array>
-			<key>Values</key>
-			<array>
-				<string>ipv4</string>
-				<string>ipv6</string>
-				<string>hostname</string>
-			</array>
-		</dict>
-		<dict>
-			<key>DefaultValue</key>
 			<true/>
 			<key>Key</key>
 			<string>connection_info_preference</string>

--- a/XBMC Remote/Settings.bundle/de.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/de.lproj/Root.strings
@@ -42,4 +42,3 @@
 "Filemode and Theme changes need app restart" = "Änderungen von Dateimodus oder Thema erfordern einen App-Neustart";
 "Theme (iOS 13+)" = "Thema (iOS 13+)";
 "Episode identifier" = "Episodenkennung";
-"Host name" = "Hostname";

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -42,5 +42,3 @@
 "Global Search" = "Global Search";
 "Main Menu changes needs app restart" = "Main Menu changes needs app restart";
 "Episode identifier" = "Episode identifier";
-"Preferred server address" = "Preferred server address";
-"Host name" = "Host name";

--- a/XBMC Remote/Settings.bundle/es-es.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/es-es.lproj/Root.strings
@@ -42,5 +42,3 @@
 "Filemode and Theme changes need app restart" = "Los cambios de modo de archivo y tema requieren reiniciar la aplicación";
 "Theme (iOS 13+)" = "Tema (iOS 13+)";
 "Episode identifier" = "Identificador de episodio";
-"Host name" = "Nombre de equipo";
-"Preferred server address" = "Dirección del servidor preferido";

--- a/XBMC Remote/Settings.bundle/pl.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/pl.lproj/Root.strings
@@ -42,5 +42,3 @@
 "Filemode and Theme changes need app restart" = "Zmiany trybu plików i motywu wymagają ponownego uruchomienia aplikacji";
 "Theme (iOS 13+)" = "Motyw (iOS 13+)";
 "Episode identifier" = "Identyfikator odcinka";
-"Host name" = "Nazwa hosta";
-"Preferred server address" = "Preferowany adres serwera";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -265,6 +265,8 @@
 "Host : port /\nTCP port" = "Host : port /\nTCP port";
 "MAC Address" = "MAC Address";
 "Username and Password" = "Username and Password";
+"Preference" = "Preference";
+"Host name" = "Host name";
 "Find XBMC" = "Find Kodi";
 "Save" = "Save";
 "No XBMC instances were found :(" = "No Kodi instances were found :(";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
With https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/923 the support to set a preference for the service discovery was added. As changing the preference was a bit awkward (users needed to enter the app settings and then go back to the service discovery screen), this PR adds a UISegmentControl which allows to set the preference for the next 'Find Kodi' button press. This should improve the usability.

Screenshots: https://abload.de/img/bildschirmfoto2023-087sim7.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Set the service discovery preference directly above 'Find Kodi'