### PR TITLE
Bugfix: LiveTV issues using 12h time format on App device and 24h format by Kodi server

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5730,6 +5730,7 @@ NSIndexPath *selected;
     xbmcDateFormatter = [NSDateFormatter new];
     xbmcDateFormatter.dateFormat = @"yyyy-MM-dd HH:mm:ss";
     xbmcDateFormatter.timeZone = [NSTimeZone timeZoneWithName:@"UTC"]; // all times in Kodi PVR are UTC
+    xbmcDateFormatter.locale = [NSLocale systemLocale]; // Needed to work with 12h system setting in combination with "UTC"
     localHourMinuteFormatter = [NSDateFormatter new];
     localHourMinuteFormatter.dateFormat = @"HH:mm";
     localHourMinuteFormatter.timeZone = [NSTimeZone systemTimeZone];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -252,14 +252,10 @@
     UITableView *tableView = parameters[@"tableView"];
     NSMutableDictionary *item = parameters[@"item"];
     NSMutableArray *retrievedEPG = [NSMutableArray new];
-    NSDateFormatter *dateFormatter = [NSDateFormatter new];
-    dateFormatter.dateFormat = @"yyyy-MM-dd HH:mm:ss";
-    dateFormatter.timeZone = [NSTimeZone timeZoneWithName:@"UTC"]; // all times in Kodi PVR are UTC
-
     for (id EPGobject in broadcasts) {
         if ([EPGobject isKindOfClass:[NSDictionary class]]) {
-            NSDate *starttime = [dateFormatter dateFromString:EPGobject[@"starttime"]];
-            NSDate *endtime = [dateFormatter dateFromString:EPGobject[@"endtime"]];
+            NSDate *starttime = [xbmcDateFormatter dateFromString:EPGobject[@"starttime"]];
+            NSDate *endtime = [xbmcDateFormatter dateFromString:EPGobject[@"endtime"]];
             [retrievedEPG addObject:[NSDictionary dictionaryWithObjectsAndKeys:
                                      starttime, @"starttime",
                                      endtime, @"endtime",

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1857,6 +1857,7 @@ double round(double d) {
     xbmcDateFormatter = [NSDateFormatter new];
     xbmcDateFormatter.dateFormat = @"yyyy-MM-dd HH:mm:ss";
     xbmcDateFormatter.timeZone = [NSTimeZone timeZoneWithName:@"UTC"]; // all times in Kodi PVR are UTC
+    xbmcDateFormatter.locale = [NSLocale systemLocale]; // Needed to work with 12h system setting in combination with "UTC"
     
     localStartDateFormatter = [NSDateFormatter new];
     localStartDateFormatter.timeZone = [NSTimeZone systemTimeZone];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Issue was reported in the forum and details were already shared [in this post](https://forum.kodi.tv/showthread.php?tid=373911&pid=3162311#pid3162311).

Explicitly set locale to `systemLocale` for `NSDateFormatter` using "UTC" timezone. This resolves an issue where `NSDateFormatter` returns `nil` on `dateFromString` when the user selects a 12h format on his iOS device and Kodi sends 24h format. This resulted in issues in the channel list, the channel guide view (EPG) and the recording details.

In addition, this PR improves performance in the channel list by using an ivar instead of a local instance of `NSDateFormatter`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: LiveTV issues using 12h time format on App device and 24h format by Kodi server