### PR TITLE
Bugfix: Stop connection attempt on authentication error

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -742,6 +742,10 @@
 - (void)authFailed:(NSNotification*)note {
     UIAlertController *alertView = [Utilities createAlertOK:LOCALIZED_STR(@"Authentication Failed") message:LOCALIZED_STR(@"Incorrect Username or Password.\nCheck your settings.")];
     [self presentViewController:alertView animated:YES completion:nil];
+    
+    // Deselect the server which causes the authentication error to allow to correct the credentials
+    NSIndexPath *selection = [serverListTableView indexPathForSelectedRow];
+    [self tableView:serverListTableView didSelectRowAtIndexPath:selection];
 }
 
 - (void)resetDoReveal:(NSNotification*)note {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an error reported via an ASC review.

Stopping the repeated connection attempts is done via deselecting the selected server. This way the loop which attempts to reconnect will be stopped and the user can edit the credentials.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Stop connection attempt on authentication error