### PR TITLE
Improvement: Use same message layout for embedded and fullscreen remote

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1361,28 +1361,15 @@ NSInteger buttonAction;
     
     UIView *rootView = IS_IPHONE ? UIApplication.sharedApplication.keyWindow.rootViewController.view : self.view;
     CGFloat deltaY = IS_IPHONE ? UIApplication.sharedApplication.statusBarFrame.size.height : 0;
-    CGFloat originX = isEmbeddedMode ? ANCHOR_RIGHT_PEEK : 0;
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(originX,
+    CGFloat messageWidth = IS_IPHONE ? UIApplication.sharedApplication.statusBarFrame.size.width : TransitionalView.frame.size.width;
+    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0,
                                                                   0,
-                                                                  TransitionalView.frame.size.width,
+                                                                  messageWidth,
                                                                   DEFAULT_MSG_HEIGHT + deltaY)
                                                 deltaY:deltaY
                                                 deltaX:0];
     messagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     [rootView addSubview:messagesView];
-    
-    if (isEmbeddedMode) {
-        // Shadow on right side of movable screen
-        CGRect shadowRect = CGRectMake(0,
-                                       0,
-                                       PANEL_SHADOW_SIZE,
-                                       messagesView.frame.size.height);
-        UIImageView *shadowRight = [[UIImageView alloc] initWithFrame:shadowRect];
-        shadowRight.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleLeftMargin;
-        shadowRight.image = [UIImage imageNamed:@"tableRight"];
-        shadowRight.opaque = YES;
-        [messagesView addSubview:shadowRight];
-    }
 }
 
 - (void)handleSettingsButton:(id)sender {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR addresses an issue raised in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3165521#pid3165521).

On iPhone the remote messages shall always cover the same area (full width and down to bottom of navigation bar). This avoids visual glitches when swiping the embedded remote and keeps the behaviour consistent for both embedded and fullscreen remote on iPhones. There is no change for iPad.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Use same message layout for embedded and fullscreen remote