### PR TITLE
Improved robustness against mal-formatted JSON API responses

### DIFF
--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -184,6 +184,20 @@
                 completionHandler(methodName, aID, nil, nil, aError);
             }
         }
+        // Deserialized object is not a dictionary
+        else if (![jsonResult isKindOfClass:[NSDictionary class]]) {
+            // Pass the error to completion handler
+            if (completionHandler) {
+                NSError *aError = [NSError errorWithDomain:RPC_DOMAIN code:DSJSONRPCParseError userInfo:@{NSLocalizedDescriptionKey: LOCALIZED_STR(@"Received unexpected JSON object.")}];
+                NSDictionary *jsonErrorDict = @{
+                    @"code": @(JSONRPCInvalidObject),
+                    @"message": LOCALIZED_STR(@"Received unexpected JSON object."),
+                    @"data": [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding],
+                };
+                DSJSONRPCError *jsonRPCError = [DSJSONRPCError errorWithData:jsonErrorDict];
+                completionHandler(methodName, aID, nil, jsonRPCError, aError);
+            }
+        }
         // The JSON server passed back an error for the response
         else if (!jsonError && jsonResult[@"error"] != nil && [jsonResult[@"error"] isKindOfClass:[NSDictionary class]]) {
             // Pass the error to completion handler

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPCError.h
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPCError.h
@@ -43,7 +43,8 @@ typedef enum {
     JSONRPCInvalidRequest = -32600,
     JSONRPCMethodNotFound = -32601,
     JSONRPCInvalidParams = -32602,
-    JSONRPCInternalError = -32603
+    JSONRPCInternalError = -32603,
+    JSONRPCInvalidObject = -32604,
 } JSONRPCErrorType;
 
 

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -362,3 +362,5 @@
 "Metering mode" = "Metering mode";
 "Focal length" = "Focal length";
 "Camera model" = "Camera model";
+
+"Received unexpected JSON object." = "Received unexpected JSON object.";


### PR DESCRIPTION
Improves robustness against mal-formatted JSON API responses.

## Description
<!--- Detailed info for reviewers and developers -->
Check for expected JSON object (`NSDictionary`) after deserialization. This avoids potential crashes reported via AppStore:

```
Last Exception Backtrace:
0   CoreFoundation                	0x1ce588cb4 __exceptionPreprocess + 164 (NSException.m:202)
1   libobjc.A.dylib               	0x1c76283d0 objc_exception_throw + 60 (objc-exception.mm:356)
2   CoreFoundation                	0x1ce6fdab8 -[NSObject(NSObject) doesNotRecognizeSelector:] + 136 (NSObject.m:140)
3   CoreFoundation                	0x1ce59f0e8 ___forwarding___ + 1592 (NSForwarding.m:3578)
4   CoreFoundation                	0x1ce605900 _CF_forwarding_prep_0 + 96 (:-1)
5   Kodi Remote                   	0x1043901b8 -[DSJSONRPC URLSession:task:didCompleteWithError:] + 804 (DSJSONRPC.m:180)
6   CFNetwork                     	0x1cf5aad0c __79-[__NSCFURLSessionDelegateWrapper task:didCompleteWithError:completionHandler:]_block_invoke + 36 (SessionDelegateWrapper.mm:450)
7   libdispatch.dylib             	0x1d5a4e320 _dispatch_call_block_and_release + 32 (init.c:1518)
8   libdispatch.dylib             	0x1d5a4feac _dispatch_client_callout + 20 (object.m:560)
9   libdispatch.dylib             	0x1d5a5e6a4 _dispatch_main_queue_drain + 928 (queue.c:7794)
10  libdispatch.dylib             	0x1d5a5e2f4 _dispatch_main_queue_callback_4CF + 44 (queue.c:7954)
11  CoreFoundation                	0x1ce617c28 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 16 (CFRunLoop.c:1780)
12  CoreFoundation                	0x1ce5f9560 __CFRunLoopRun + 1992 (CFRunLoop.c:3147)
13  CoreFoundation                	0x1ce5fe3ec CFRunLoopRunSpecific + 612 (CFRunLoop.c:3418)
14  GraphicsServices              	0x209b1435c GSEventRunModal + 164 (GSEvent.c:2196)
15  UIKitCore                     	0x1d098af58 -[UIApplication _run] + 888 (UIApplication.m:3782)
16  UIKitCore                     	0x1d098abbc UIApplicationMain + 340 (UIApplication.m:5372)
17  Kodi Remote                   	0x10430d3b8 main + 88 (main.m:15)
18  dyld                          	0x1edb30dec start + 2220 (dyldMain.cpp:1165)

```

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improved robustness against mal-formatted JSON API responses