### PR TITLE
Bugfix: Not all menu cells updated on connect/disconnect

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -81,6 +81,10 @@
     return self.mainMenu.count;
 }
 
+- (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
+    [Utilities setStyleOfMenuItemCell:cell active:AppDelegate.instance.serverOnLine || indexPath.row == 0];
+}
+
 - (UITableViewCell*)tableView:(UITableView*)tableView cellForRowAtIndexPath:(NSIndexPath*)indexPath {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"mainMenuCellIdentifier"];
     if (cell == nil) {
@@ -140,7 +144,6 @@
         icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:UIColor.grayColor];
         cell.backgroundColor = [Utilities getGrayColor:36 alpha:1];
     }
-    [Utilities setStyleOfMenuItemCell:cell active:AppDelegate.instance.serverOnLine || indexPath.row == 0];
     return cell;
 }
 

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -140,14 +140,7 @@
         icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:UIColor.grayColor];
         cell.backgroundColor = [Utilities getGrayColor:36 alpha:1];
     }
-    if (AppDelegate.instance.serverOnLine || indexPath.row == 0) {
-        icon.alpha = 1.0;
-        title.alpha = 1.0;
-    }
-    else {
-        icon.alpha = 0.3;
-        title.alpha = 0.3;
-    }
+    [Utilities setStyleOfMenuItemCell:cell active:AppDelegate.instance.serverOnLine || indexPath.row == 0];
     return cell;
 }
 

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -96,6 +96,7 @@ typedef enum {
 + (NSString*)getConnectionStatusIconName;
 + (NSString*)getConnectionStatusServerName;
 + (void)addShadowsToView:(UIView*)view viewFrame:(CGRect)frame;
++ (void)setStyleOfMenuItemCell:(UITableViewCell*)cell active:(BOOL)active;
 + (void)setStyleOfMenuItems:(UITableView*)tableView active:(BOOL)active;
 + (void)enableDefaultController:(id<UITableViewDelegate>)viewController tableView:(UITableView*)tableView menuItems:(NSArray*)menuItems;
 + (id)unarchivePath:(NSString*)path file:(NSString*)filename;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1016,8 +1016,15 @@
     }
 }
 
-+ (void)setStyleOfMenuItems:(UITableView*)tableView active:(BOOL)active {
++ (void)setStyleOfMenuItemCell:(UITableViewCell*)cell active:(BOOL)active {
     CGFloat alpha = active ? 1.0 : 0.3;
+    UIImageView *icon = (UIImageView*)[cell viewWithTag:1];
+    UILabel *title = (UILabel*)[cell viewWithTag:3];
+    icon.alpha = alpha;
+    title.alpha = alpha;
+}
+
++ (void)setStyleOfMenuItems:(UITableView*)tableView active:(BOOL)active {
     for (NSIndexPath *indexPath in tableView.indexPathsForVisibleRows) {
         // The iPhone uses the top most cell as connection status. This should not be faded/unfaded.
         if (IS_IPHONE && indexPath.row == 0 && indexPath.section == 0) {
@@ -1026,9 +1033,7 @@
         UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
         [UIView animateWithDuration:0.3
                          animations:^{
-                            ((UIImageView*)[cell viewWithTag:1]).alpha = alpha;
-                            ((UIImageView*)[cell viewWithTag:2]).alpha = alpha;
-                            ((UIImageView*)[cell viewWithTag:3]).alpha = alpha;
+                            [Utilities setStyleOfMenuItemCell:cell active:active];
                          }];
     }
 }

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -136,6 +136,7 @@
 }
 
 - (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
+    [Utilities setStyleOfMenuItemCell:cell active:AppDelegate.instance.serverOnLine];
     cell.backgroundColor = UIColor.clearColor;
 }
 
@@ -159,7 +160,6 @@
     title.text = item.mainLabel;
     icon.highlightedImage = [UIImage imageNamed:iconName];
     icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:UIColor.grayColor];
-    [Utilities setStyleOfMenuItemCell:cell active:AppDelegate.instance.serverOnLine];
     return cell;
 }
 

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -159,14 +159,7 @@
     title.text = item.mainLabel;
     icon.highlightedImage = [UIImage imageNamed:iconName];
     icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:UIColor.grayColor];
-    if (AppDelegate.instance.serverOnLine) {
-        icon.alpha = 1.0;
-        title.alpha = 1.0;
-    }
-    else {
-        icon.alpha = 0.3;
-        title.alpha = 0.3;
-    }
+    [Utilities setStyleOfMenuItemCell:cell active:AppDelegate.instance.serverOnLine];
     return cell;
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes an issue where not all menu cells were updated on connect/disconnect of Kodi server. This happened for menu cells which where scrolled out of the visible area, like on devices with smaller screens or on iPad with a small menu size configuration.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Not all menu cells updated on connect/disconnect