### PR TITLE
Bugfix: Avoid wrong icon/color to be shown in iPhone main menu

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -126,6 +126,7 @@
         title.text = [Utilities getConnectionStatusServerName];
         line.hidden = YES;
         iconName = [Utilities getConnectionStatusIconName];
+        icon.highlightedImage = nil;
         icon.image = [UIImage imageNamed:iconName];
     }
     else {

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -81,12 +81,6 @@
     return self.mainMenu.count;
 }
 
-- (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
-    if (indexPath.row == 0) {
-        cell.backgroundColor = [Utilities getGrayColor:53 alpha:1];
-    }
-}
-
 - (UITableViewCell*)tableView:(UITableView*)tableView cellForRowAtIndexPath:(NSIndexPath*)indexPath {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"mainMenuCellIdentifier"];
     if (cell == nil) {
@@ -120,7 +114,7 @@
         // Adapt layout for first cell (showing connection status)
         [self setFrameSizes:cell height:PHONE_MENU_INFO_HEIGHT iconsize:CONNECTION_ICON_SIZE];
         
-        // Set icon and text content
+        // Set icon, background color and text content
         title.font = [UIFont fontWithName:@"Roboto-Regular" size:13];
         title.numberOfLines = 2;
         title.text = [Utilities getConnectionStatusServerName];
@@ -128,6 +122,7 @@
         iconName = [Utilities getConnectionStatusIconName];
         icon.highlightedImage = nil;
         icon.image = [UIImage imageNamed:iconName];
+        cell.backgroundColor = [Utilities getGrayColor:53 alpha:1];
     }
     else {
         // Hide kodi logo
@@ -136,13 +131,14 @@
         // Adapt layout for main menu cells
         [self setFrameSizes:cell height:PHONE_MENU_HEIGHT iconsize:MENU_ICON_SIZE];
         
-        // Set icon and text content
+        // Set icon, background color and text content
         title.font = [UIFont fontWithName:@"Roboto-Regular" size:20];
         title.numberOfLines = 1;
         title.text = item.mainLabel;
         line.hidden = NO;
         icon.highlightedImage = [UIImage imageNamed:iconName];
         icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:UIColor.grayColor];
+        cell.backgroundColor = [Utilities getGrayColor:36 alpha:1];
     }
     if (AppDelegate.instance.serverOnLine || indexPath.row == 0) {
         icon.alpha = 1.0;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3168838#pid3168838).

In case of cell re-use the cell background color and the highlighted image were not properly set. This resulted in situations where the brighter background color of the server menu item was used for another menu item after performing sleep. In the same situation the icon shown in the selected server menu item after was falling back to a highlighted image which was set for another menu item before, e.g. the white headphones for the music menu item.

This PR now explicitly sets the `highlightedImage` (`nil` for row 0) and the cell's background color.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid wrong icon/color to be shown in iPhone main menu