### PR TITLE
Bugfix: playlist empty after calling Safari from App on iPad

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2555,9 +2555,6 @@
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
-    [Utilities AnimView:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:slideFrom];
-    songDetailsView.alpha = 0;
-    [playlistTableView setEditing:NO animated:YES];
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes and issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3169970#pid3169970).

NowPlaying's `viewDidDisAppear` does not need to end editing or make elements invisible. On iPhone the view is anyway deallocated after reaching `viewDidDisappear`. On iPad we want to keep the status as this only happens when calling Safari from the App (e.g. following the help link or entering Wikipedia). This fixes an issue where the playlist was empty, the editing got stopped and the NowPlaying overlay was closed on iPad after opening Safari from the App.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: playlist empty after calling Safari from App on iPad