### PR TITLE
Rework configuration of SDWebImage

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -75,6 +75,9 @@
 #define ITEM_MOVIE_PAD_WIDTH_RECENTLY_FULLSCREEN 502.0
 #define ITEM_MOVIE_PAD_HEIGHT_RECENTLY_FULLSCREEN 206.0
 
+// Amount of bytes per pixel for images cached in memory (32 bit png)
+#define BYTES_PER_PIXEL 4
+
 #pragma mark helper
 
 - (NSDictionary*)itemSizes_Musicfullscreen {
@@ -398,6 +401,11 @@
         else {
             arrayServerList = [NSMutableArray new];
         }
+        
+        // Set the image in-memory cache to 25% of physical memory (but max to 512 MB). maxCost reflects the amount of pixels.
+        NSInteger memorySize = [[NSProcessInfo processInfo] physicalMemory];
+        NSInteger maxCost = MIN(memorySize / 4, 512 * 1024 * 1024) / BYTES_PER_PIXEL;
+        [[SDImageCache sharedImageCache] setMaxMemoryCost:maxCost];
         
         NSFileManager *fileManager = [NSFileManager defaultManager];
         NSArray *cachePaths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5386,8 +5386,6 @@ NSIndexPath *selected;
 
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
-//    [SDWebImageManager.sharedManager cancelAll];
-//    [[SDImageCache sharedImageCache] clearMemory];
 }
 
 - (void)revealMenu:(id)sender {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5714,11 +5714,6 @@ NSIndexPath *selected;
     serverMinorVersion = AppDelegate.instance.serverMinorVersion;
     libraryCachePath = AppDelegate.instance.libraryCachePath;
     epgCachePath = AppDelegate.instance.epgCachePath;
-    SDWebImageDownloader *manager = [SDWebImageManager sharedManager].imageDownloader;
-    NSDictionary *httpHeaders = AppDelegate.instance.getServerHTTPHeaders;
-    if (httpHeaders[@"Authorization"] != nil) {
-        [manager setValue:httpHeaders[@"Authorization"] forHTTPHeaderField:@"Authorization"];
-    }
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     hiddenLabel = [userDefaults boolForKey:@"hidden_label_preference"];
     noItemsLabel.text = LOCALIZED_STR(@"No items found.");

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -368,6 +368,9 @@
     icon.image = [UIImage imageNamed:icon_connection];
     UILabel *title = (UILabel*)[cell viewWithTag:3];
     title.text = infoText;
+    
+    // We are connected to server, we now need to share credentials with SDWebImageManager
+    [Utilities setWebImageAuthorizationOnSuccessNotification:note];
 }
 
 - (void)handleTcpJSONRPCChangeServerStatus:(NSNotification*)sender {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2580,11 +2580,6 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    SDWebImageDownloader *manager = [SDWebImageManager sharedManager].imageDownloader;
-    NSDictionary *httpHeaders = AppDelegate.instance.getServerHTTPHeaders;
-    if (httpHeaders[@"Authorization"] != nil) {
-        [manager setValue:httpHeaders[@"Authorization"] forHTTPHeaderField:@"Authorization"];
-    }
     itemDescription.selectable = NO;
     itemLogoImage.layer.minificationFilter = kCAFilterTrilinear;
     songCodecImage.layer.minificationFilter = kCAFilterTrilinear;
@@ -2669,11 +2664,6 @@
 }
 
 - (void)connectionSuccess:(NSNotification*)note {
-    SDWebImageDownloader *manager = [SDWebImageManager sharedManager].imageDownloader;
-    NSDictionary *httpHeaders = AppDelegate.instance.getServerHTTPHeaders;
-    if (httpHeaders[@"Authorization"] != nil) {
-        [manager setValue:httpHeaders[@"Authorization"] forHTTPHeaderField:@"Authorization"];
-    }
 }
 
 - (void)handleShakeNotification {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -625,22 +625,15 @@
                                          [self processLoadedThumbImage:self thumb:thumbnailView image:image enableJewel:enableJewel];
                                      }
                                      else {
-                                         [[SDImageCache sharedImageCache] queryDiskCacheForKey:stringURL done:^(UIImage *image, SDImageCacheType cacheType) {
-                                             if (image != nil) {
-                                                 [self processLoadedThumbImage:self thumb:thumbnailView image:image enableJewel:enableJewel];
-                                             }
-                                             else {
-                                                 __weak UIImageView *thumb = thumbnailView;
-                                                 __weak NowPlaying *sf = self;
-                                                 [thumbnailView sd_setImageWithURL:[NSURL URLWithString:stringURL]
-                                                                  placeholderImage:[UIImage imageNamed:@"coverbox_back"]
-                                                                         completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
-                                                      if (error == nil) {
-                                                          [sf processLoadedThumbImage:sf thumb:thumb image:image enableJewel:enableJewel];
-                                                      }
-                                                  }];
-                                             }
-                                         }];
+                                         __weak UIImageView *thumb = thumbnailView;
+                                         __weak NowPlaying *sf = self;
+                                         [thumbnailView sd_setImageWithURL:[NSURL URLWithString:stringURL]
+                                                          placeholderImage:[UIImage imageNamed:@"coverbox_back"]
+                                                                 completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
+                                              if (error == nil) {
+                                                  [sf processLoadedThumbImage:sf thumb:thumb image:image enableJewel:enableJewel];
+                                              }
+                                          }];
                                      }
                                  }
                                  lastThumbnail = stringURL;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1356,7 +1356,6 @@ NSInteger buttonAction;
         [self setEmbeddedView];
     }
     
-    [[SDImageCache sharedImageCache] clearMemory];
     gestureZoneImageView.layer.minificationFilter = kCAFilterTrilinear;
     self.view.backgroundColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"backgroundImage_repeat"]];
     

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1338,11 +1338,6 @@ NSInteger buttonAction;
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    SDWebImageDownloader *manager = [SDWebImageManager sharedManager].imageDownloader;
-    NSDictionary *httpHeaders = AppDelegate.instance.getServerHTTPHeaders;
-    if (httpHeaders[@"Authorization"] != nil) {
-        [manager setValue:httpHeaders[@"Authorization"] forHTTPHeaderField:@"Authorization"];
-    }
 
     self.edgesForExtendedLayout = 0;
     self.view.tintColor = APP_TINT_COLOR;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1248,54 +1248,35 @@ double round(double d) {
     if (thumbnailPath.length) {
         coverView.alpha = 0.0;
     }
-    [[SDImageCache sharedImageCache] queryDiskCacheForKey:thumbnailPath done:^(UIImage *image, SDImageCacheType cacheType) {
-        if (image != nil) {
-            foundTintColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO autoColorCheck:YES]];
-            [self setIOS7barTintColor:foundTintColor];
-            [self elaborateImage:image fallbackImage:[UIImage imageNamed:placeHolderImage]];
-        }
-        else {
-            __weak ShowInfoViewController *sf = self;
-            __block UIColor *newColor = nil;
-            [coverView sd_setImageWithURL:[NSURL URLWithString:thumbnailPath]
-                         placeholderImage:[UIImage imageNamed:placeHolderImage]
-                                completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
-                                if (image != nil) {
-                                    newColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO autoColorCheck:YES]];
-                                    [sf setIOS7barTintColor:newColor];
-                                    foundTintColor = newColor;
-                                }
-                                [sf elaborateImage:image fallbackImage:[UIImage imageNamed:placeHolderImage]];
-            }];
-        }
+    __weak ShowInfoViewController *sf = self;
+    [coverView sd_setImageWithURL:[NSURL URLWithString:thumbnailPath]
+                 placeholderImage:[UIImage imageNamed:placeHolderImage]
+                        completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
+                        __auto_type strongSelf = sf;
+                        if (!strongSelf) {
+                            return;
+                        }
+                        if (image != nil) {
+                            UIColor *newColor = [Utilities lighterColorForColor:[Utilities averageColor:image inverse:NO autoColorCheck:YES]];
+                            [strongSelf setIOS7barTintColor:newColor];
+                            foundTintColor = newColor;
+                        }
+                        [strongSelf elaborateImage:image fallbackImage:[UIImage imageNamed:placeHolderImage]];
     }];
 }
 
 - (void)loadFanart:(NSString*)fanartPath {
     __weak ShowInfoViewController *sf = self;
-    [[SDImageCache sharedImageCache] queryDiskCacheForKey:fanartPath done:^(UIImage *image, SDImageCacheType cacheType) {
-        __auto_type strongSelf = sf;
-        if (image != nil) {
-            fanartView.image = image;
-            if (strongSelf != nil && strongSelf->enableKenBurns) {
-                fanartView.alpha = 0;
-                [sf elabKenBurns:image];
-                [Utilities alphaView:sf.kenView AnimDuration:1.5 Alpha:0.2];
-            }
-        }
-        else {
-            [fanartView sd_setImageWithURL:[NSURL URLWithString:fanartPath]
-                          placeholderImage:[UIImage imageNamed:@"blank"]
-                                 completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
-                                  __auto_type strongSelf = sf;
-                                  if (strongSelf != nil && strongSelf->enableKenBurns) {
-                                      [sf elabKenBurns:image];
-                                      [Utilities alphaView:sf.kenView AnimDuration:1.5 Alpha:0.2];
-                                  }
-                              }
-             ];
-        }
-    }];
+    [fanartView sd_setImageWithURL:[NSURL URLWithString:fanartPath]
+                  placeholderImage:[UIImage imageNamed:@"blank"]
+                         completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
+                          __auto_type strongSelf = sf;
+                          if (strongSelf != nil && strongSelf->enableKenBurns) {
+                              [strongSelf elabKenBurns:image];
+                              [Utilities alphaView:strongSelf.kenView AnimDuration:1.5 Alpha:0.2];
+                          }
+                      }
+     ];
     fanartView.clipsToBounds = YES;
 }
 

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1807,11 +1807,6 @@ double round(double d) {
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    SDWebImageDownloader *manager = [SDWebImageManager sharedManager].imageDownloader;
-    NSDictionary *httpHeaders = AppDelegate.instance.getServerHTTPHeaders;
-    if (httpHeaders[@"Authorization"] != nil) {
-        [manager setValue:httpHeaders[@"Authorization"] forHTTPHeaderField:@"Authorization"];
-    }
     isViewDidLoad = YES;
     fanartView.tag = 1;
     fanartView.userInteractionEnabled = YES;

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -64,6 +64,7 @@ typedef enum {
 + (UIAlertController*)createAlertCopyClipboard:(NSString*)title message:(NSString*)msg;
 + (void)SFloadURL:(NSString*)url fromctrl:(UIViewController<SFSafariViewControllerDelegate>*)fromctrl;
 + (DSJSONRPC*)getJsonRPC;
++ (void)setWebImageAuthorizationOnSuccessNotification:(NSNotification*)note;
 + (NSDictionary*)indexKeyedDictionaryFromArray:(NSArray*)array;
 + (NSMutableDictionary*)indexKeyedMutableDictionaryFromArray:(NSArray*)array;
 + (NSString*)convertTimeFromSeconds:(NSNumber*)seconds;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -12,6 +12,7 @@
 #import "Utilities.h"
 #import "AppDelegate.h"
 #import "NSString+MD5.h"
+#import "SDWebImageManager.h"
 
 #define GET_ROUNDED_EDGES_RADIUS(size) MAX(MIN(size.width, size.height) * 0.03, 6.0)
 #define GET_ROUNDED_EDGES_PATH(rect, radius) [UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:radius];
@@ -553,6 +554,16 @@
         checkRPC = checksum;
     }
     return jsonRPC;
+}
+
++ (void)setWebImageAuthorizationOnSuccessNotification:(NSNotification*)note {
+    if ([note.name isEqualToString:@"XBMCServerConnectionSuccess"]) {
+        SDWebImageDownloader *manager = [SDWebImageManager sharedManager].imageDownloader;
+        NSDictionary *httpHeaders = AppDelegate.instance.getServerHTTPHeaders;
+        if (httpHeaders[@"Authorization"] != nil) {
+            [manager setValue:httpHeaders[@"Authorization"] forHTTPHeaderField:@"Authorization"];
+        }
+    }
 }
 
 + (NSDictionary*)indexKeyedDictionaryFromArray:(NSArray*)array {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -108,6 +108,9 @@
     NSDictionary *theData = note.userInfo;
     NSString *icon_connection = theData[@"icon_connection"];
     connectionStatus.image = [UIImage imageNamed:icon_connection];
+    
+    // We are connected to server, we now need to share credentials with SDWebImageManager
+    [Utilities setWebImageAuthorizationOnSuccessNotification:note];
 }
 
 - (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
1. Limit in-memory cache size (1/4 of physical memory, but 256 MB max)
2. Only call `clearMemory` (= cleaning in-memory cache) in `applicationDidReceiveMemoryWarning`
3. Use `sd_setImageWithURL` instead of `queryDiskCacheForKey` which aligns this with all other places where images are loaded.
4. Set authorization for SWWebImage on connection success only.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Rework configuration of SDWebImage
