### PR TITLE
Bugfix: Fixes reported crash in stripRegEx:text

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1199,6 +1199,10 @@
 }
 
 + (NSString*)stripRegEx:(NSString*)regExp text:(NSString*)textIn {
+    // Returns unchanged string, if regExp is nil. Returns nil, if string is nil.
+    if (!textIn || !regExp) {
+        return textIn;
+    }
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regExp options:NSRegularExpressionCaseInsensitive error:NULL];
     NSString *textOut = [regex stringByReplacingMatchesInString:textIn options:0 range:NSMakeRange(0, [textIn length]) withTemplate:@""];
     return textOut;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->


Do not attempt to process regular expression with string or expression `= nil`. Fixes following crash report:

```
Last Exception Backtrace:
0   CoreFoundation                	0x1bec40cb4 __exceptionPreprocess + 164 (NSException.m:202)
1   libobjc.A.dylib               	0x1b7ce03d0 objc_exception_throw + 60 (objc-exception.mm:356)
2   Foundation                    	0x1b8f48a88 -[NSRegularExpression(NSMatching) enumerateMatchesInString:options:range:usingBlock:] + 1724 (NSRegularExpression.m:0)
3   Foundation                    	0x1b8f47c74 -[NSRegularExpression(NSMatching) matchesInString:options:range:] + 180 (NSRegularExpression.m:534)
4   Foundation                    	0x1b8f19e5c -[NSRegularExpression(NSReplacement) stringByReplacingMatchesInString:options:range:withTemplate:] + 140 (NSRegularExpression.m:586)
5   Kodi Remote                   	0x10500c5d8 +[Utilities stripRegEx:text:] + 112 (Utilities.m:1203)
6   Kodi Remote                   	0x10500c630 +[Utilities stripBBandHTML:] + 40 (Utilities.m:1211)
7   Kodi Remote                   	0x104f8d53c -[DetailViewController collectionView:cellForItemAtIndexPath:] + 940 (DetailViewController.m:0)
8   UIKitCore                     	0x1c0def168 -[UICollectionView _createPreparedCellForItemAtIndexPath:withLayoutAttributes:applyAttributes:isFocused:notify:] + 648 (UICollectionView.m:3382)
9   UIKitCore                     	0x1c0deed04 -[UICollectionView _prefetchItemsForPrefetchingContext:] + 384 (UICollectionView.m:3875)
10  UIKitCore                     	0x1c0d255d0 -[UICollectionView _updatePrefetchedCells:] + 140 (UICollectionView.m:4362)
11  UIKitCore                     	0x1c0d25484 -[UICollectionView _updateCycleIdleUntil:] + 492 (UICollectionView.m:4470)
12  UIKitCore                     	0x1c0d25090 ___UIUpdateCycleNotifyIdle_block_invoke + 596 (_UIUpdateCycleIdleScheduler.m:292)
13  libdispatch.dylib             	0x1c6106320 _dispatch_call_block_and_release + 32 (init.c:1518)
14  libdispatch.dylib             	0x1c6107eac _dispatch_client_callout + 20 (object.m:560)
15  libdispatch.dylib             	0x1c61166a4 _dispatch_main_queue_drain + 928 (queue.c:7794)
16  libdispatch.dylib             	0x1c61162f4 _dispatch_main_queue_callback_4CF + 44 (queue.c:7954)
17  CoreFoundation                	0x1beccfc28 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 16 (CFRunLoop.c:1780)
18  CoreFoundation                	0x1becb1560 __CFRunLoopRun + 1992 (CFRunLoop.c:3147)
19  CoreFoundation                	0x1becb63ec CFRunLoopRunSpecific + 612 (CFRunLoop.c:3418)
20  GraphicsServices              	0x1fa1cc35c GSEventRunModal + 164 (GSEvent.c:2196)
21  UIKitCore                     	0x1c1042f58 -[UIApplication _run] + 888 (UIApplication.m:3782)
22  UIKitCore                     	0x1c1042bbc UIApplicationMain + 340 (UIApplication.m:5372)
23  Kodi Remote                   	0x104f54d20 main + 80 (main.m:15)
24  dyld                          	0x1de1e8dec start + 2220 (dyldMain.cpp:1165)

```

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fixes reported crash in stripRegEx:text