### PR TITLE
Maintenance: Refactor applying rounded edges to UIViews

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2060,7 +2060,7 @@
     [thumb sd_setImageWithURL:[NSURL URLWithString:stringURL]
              placeholderImage:defaultThumb
                       options:SDWebImageScaleToNativeSize];
-    thumb = [Utilities applyRoundedEdgesView:thumb drawBorder:YES];
+    [Utilities applyRoundedEdgesView:thumb drawBorder:YES];
     [self setPlaylistCellProgressBar:cell hidden:YES];
     
     return cell;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -563,7 +563,7 @@ double round(double d) {
         
         // Ensure we draw the rounded edges around TV station logo view
         coverView.image = imageToShow;
-        coverView = [Utilities applyRoundedEdgesView:coverView drawBorder:YES];
+        [Utilities applyRoundedEdgesView:coverView drawBorder:YES];
         
         // Choose correct background color for station logos
         if (image != nil) {

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -82,9 +82,9 @@ typedef enum {
 + (CGFloat)getWidthOfLabel:(UILabel*)label;
 + (CGFloat)getHeightOfLabel:(UILabel*)label;
 + (UIImage*)roundedCornerImage:(UIImage*)image drawBorder:(BOOL)drawBorder;
-+ (UIImageView*)roundedCornerView:(UIImageView*)view drawBorder:(BOOL)drawBorder;
++ (void)roundedCornerView:(UIView*)view drawBorder:(BOOL)drawBorder;
 + (UIImage*)applyRoundedEdgesImage:(UIImage*)image drawBorder:(BOOL)drawBorder;
-+ (UIImageView*)applyRoundedEdgesView:(UIImageView*)imageView drawBorder:(BOOL)drawBorder;
++ (void)applyRoundedEdgesView:(UIView*)view drawBorder:(BOOL)drawBorder;
 + (void)turnTorchOn:(id)sender on:(BOOL)torchOn;
 + (BOOL)isTorchOn;
 + (BOOL)hasRemoteToolBar;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -816,7 +816,7 @@
     return roundedCornerImage;
 }
 
-+ (UIImageView*)roundedCornerView:(UIImageView*)view drawBorder:(BOOL)drawBorder {
++ (void)roundedCornerView:(UIView*)view drawBorder:(BOOL)drawBorder {
     CALayer *imageLayer = view.layer;
     
     // Set radius for corners
@@ -842,8 +842,6 @@
     else {
         imageLayer.borderWidth = 0;
     }
-    
-    return view;
 }
 
 + (UIImage*)applyRoundedEdgesImage:(UIImage*)image drawBorder:(BOOL)drawBorder {
@@ -855,13 +853,12 @@
     return image;
 }
 
-+ (UIImageView*)applyRoundedEdgesView:(UIImageView*)imageView drawBorder:(BOOL)drawBorder {
++ (void)applyRoundedEdgesView:(UIView*)view drawBorder:(BOOL)drawBorder {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     BOOL corner_preference = [userDefaults boolForKey:@"rounded_corner_preference"];
     if (corner_preference) {
-        imageView = [Utilities roundedCornerView:imageView drawBorder:drawBorder];
+        [Utilities roundedCornerView:view drawBorder:drawBorder];
     }
-    return imageView;
 }
 
 + (void)turnTorchOn:(id)sender on:(BOOL)torchOn {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Rounded edges are applied to `UIView` and not only to the subclass `UIImageView`. This allows to ease up the implementation and to unify calling it.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Refactor applying rounded edges to UIViews