### PR TITLE
Improve iPad fullscreen layout

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -63,6 +63,8 @@
 
 #define EPISODE_THUMB_WIDTH 95
 
+#define FULLSCREEN_LABEL_HEIGHT 20
+
 /* Global definition for player id */
 #define PLAYERID_UNKNOWN -1
 #define PLAYERID_MUSIC 0

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -75,7 +75,7 @@
 #define INDICATOR_SIZE 16
 #define FLOWLAYOUT_FULLSCREEN_INSET 8
 #define FLOWLAYOUT_FULLSCREEN_MIN_SPACE 4
-#define FLOWLAYOUT_FULLSCREEN_LABEL 38
+#define FLOWLAYOUT_FULLSCREEN_LABEL (FULLSCREEN_LABEL_HEIGHT * [Utilities getTransformX] + 8)
 
 - (id)initWithFrame:(CGRect)frame {
     if (self = [super init]) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -73,6 +73,9 @@
 #define TINY_PADDING 2
 #define FLAG_SIZE 16
 #define INDICATOR_SIZE 16
+#define FLOWLAYOUT_FULLSCREEN_INSET 8
+#define FLOWLAYOUT_FULLSCREEN_MIN_SPACE 4
+#define FLOWLAYOUT_FULLSCREEN_LABEL 38
 
 - (id)initWithFrame:(CGRect)frame {
     if (self = [super init]) {
@@ -1649,14 +1652,20 @@
 
 - (void)setFlowLayoutParams {
     if (stackscrollFullscreen) {
-        flowLayout.itemSize = CGSizeMake(fullscreenCellGridWidth, fullscreenCellGridHeight);
+        // Calculate the dimensions of the items to match the screen size.
+        CGFloat screenwidth = IS_PORTRAIT ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT;
+        CGFloat numItemsPerRow = screenwidth / fullscreenCellGridWidth;
+        int num = round(numItemsPerRow);
+        CGFloat newWidth = (screenwidth - num * FLOWLAYOUT_FULLSCREEN_MIN_SPACE - 2 * FLOWLAYOUT_FULLSCREEN_INSET) / num;
+        
+        flowLayout.itemSize = CGSizeMake(newWidth, fullscreenCellGridHeight * newWidth / fullscreenCellGridWidth);
         if (!recentlyAddedView && !hiddenLabel) {
-            flowLayout.minimumLineSpacing = 38;
+            flowLayout.minimumLineSpacing = FLOWLAYOUT_FULLSCREEN_LABEL;
         }
         else {
-            flowLayout.minimumLineSpacing = 4;
+            flowLayout.minimumLineSpacing = FLOWLAYOUT_FULLSCREEN_MIN_SPACE;
         }
-        flowLayout.minimumInteritemSpacing = cellMinimumLineSpacing;
+        flowLayout.minimumInteritemSpacing = FLOWLAYOUT_FULLSCREEN_MIN_SPACE;
     }
     else {
         flowLayout.itemSize = CGSizeMake(cellGridWidth, cellGridHeight);

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1650,7 +1650,7 @@
 - (void)setFlowLayoutParams {
     if (stackscrollFullscreen) {
         flowLayout.itemSize = CGSizeMake(fullscreenCellGridWidth, fullscreenCellGridHeight);
-        if (!recentlyAddedView) {
+        if (!recentlyAddedView && !hiddenLabel) {
             flowLayout.minimumLineSpacing = 38;
         }
         else {
@@ -1790,6 +1790,7 @@
         if (hiddenLabel || stackscrollFullscreen) {
             cell.posterLabel.hidden = YES;
             cell.labelImageView.hidden = YES;
+            cell.posterLabelFullscreen.hidden = hiddenLabel;
         }
         else {
             cell.posterLabel.hidden = NO;
@@ -1845,6 +1846,9 @@
         cell.posterYear.font = [UIFont systemFontOfSize:fanartFontSize];
 //        cell.posterYear.text = [NSString stringWithFormat:@"%@%@", item[@"year"], item[@"runtime"] == nil ? @"" : [NSString stringWithFormat:@" - %@", item[@"runtime"]]];
         cell.posterYear.text = item[@"year"];
+        
+        // Set label visibility based on setting
+        cell.posterLabel.hidden = cell.posterGenre.hidden = cell.posterYear.hidden = hiddenLabel;
         if ([playcount intValue]) {
             [cell setOverlayWatched:YES];
         }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5638,7 +5638,11 @@ NSIndexPath *selected;
     sectionNameOverlayView = nil;
     
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-        [self setFlowLayoutParams];
+        if (stackscrollFullscreen) {
+            [self setFlowLayoutParams];
+            [collectionView.collectionViewLayout invalidateLayout];
+            [collectionView reloadData];
+        }
         [activeLayoutView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
     }
                                  completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {}];

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -49,10 +49,10 @@
         [self.contentView addSubview:_labelImageView];
         
         if (IS_IPAD) {
-            _posterLabelFullscreen = [[PosterLabel alloc] initWithFrame:CGRectMake(0, frame.size.height, frame.size.width - borderWidth * 2, labelHeight / 2)];
+            _posterLabelFullscreen = [[PosterLabel alloc] initWithFrame:CGRectMake(0, frame.size.height, frame.size.width - borderWidth * 2, FULLSCREEN_LABEL_HEIGHT)];
             _posterLabelFullscreen.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
             _posterLabelFullscreen.backgroundColor = UIColor.clearColor;
-            _posterLabelFullscreen.textColor = UIColor.grayColor;
+            _posterLabelFullscreen.textColor = UIColor.lightGrayColor;
             _posterLabelFullscreen.textAlignment = NSTextAlignmentCenter;
             _posterLabelFullscreen.numberOfLines = 1;
             _posterLabelFullscreen.adjustsFontSizeToFitWidth = NO;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR was triggered by a discussion in the forum. Following changes are done:
- iPad fullscreen adapts cover size to maintain equal spacing
- iPad fullscreen labels follows "hide label" setting
- Improve readability of labels in fullscreen

Screenshots:
Set 1: https://abload.de/img/bildschirmfoto2023-11qqd6u.png (albums)
Set 2: https://abload.de/img/bildschirmfoto2023-11gcfpt.png (movies)
Set 3: https://abload.de/img/bildschirmfoto2023-11z2dow.png (recently added)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: iPad fullscreen adapts cover size to maintain equal spacing
Improvement: iPad fullscreen labels follows "hide label" setting
Improvement: Better readability of labels in fullscreen