### PR TITLE
Improvement: Show "-" in case no EXIF data is reported for the given tag

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -994,6 +994,9 @@
 }
 
 - (NSAttributedString*)formatInfo:(NSString*)name text:(NSString*)text {
+    if (!text.length) {
+        text = @"-";
+    }
     int fontSize = descriptionFontSize;
     // Bold and gray for label
     name = [NSString stringWithFormat:@"%@: ", name];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Show "-" in case no EXIF data is reported for the given tag. This is easier to read than just leaving empty strings.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Show "-" in case no EXIF data is reported for the given tag