### PR TITLE
Maintenance: Use standard notation when declaring weak self

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -626,12 +626,12 @@
                                      }
                                      else {
                                          __weak UIImageView *thumb = thumbnailView;
-                                         __weak NowPlaying *sf = self;
+                                         __typeof__(self) __weak weakSelf = self;
                                          [thumbnailView sd_setImageWithURL:[NSURL URLWithString:stringURL]
                                                           placeholderImage:[UIImage imageNamed:@"coverbox_back"]
                                                                  completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
                                               if (error == nil) {
-                                                  [sf processLoadedThumbImage:sf thumb:thumb image:image enableJewel:enableJewel];
+                                                  [weakSelf processLoadedThumbImage:weakSelf thumb:thumb image:image enableJewel:enableJewel];
                                               }
                                           }];
                                      }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1264,11 +1264,11 @@ double round(double d) {
     if (thumbnailPath.length) {
         coverView.alpha = 0.0;
     }
-    __weak ShowInfoViewController *sf = self;
+    __typeof__(self) __weak weakSelf = self;
     [coverView sd_setImageWithURL:[NSURL URLWithString:thumbnailPath]
                  placeholderImage:[UIImage imageNamed:placeHolderImage]
                         completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
-                        __auto_type strongSelf = sf;
+                        __auto_type strongSelf = weakSelf;
                         if (!strongSelf) {
                             return;
                         }
@@ -1282,11 +1282,11 @@ double round(double d) {
 }
 
 - (void)loadFanart:(NSString*)fanartPath {
-    __weak ShowInfoViewController *sf = self;
+    __typeof__(self) __weak weakSelf = self;
     [fanartView sd_setImageWithURL:[NSURL URLWithString:fanartPath]
                   placeholderImage:[UIImage imageNamed:@"blank"]
                          completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
-                          __auto_type strongSelf = sf;
+                          __auto_type strongSelf = weakSelf;
                           if (strongSelf != nil && strongSelf->enableKenBurns) {
                               [strongSelf elabKenBurns:image];
                               [Utilities alphaView:strongSelf.kenView AnimDuration:1.5 Alpha:0.2];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
As suggested in https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/949#discussion_r1440715340 this PR changes the declaration of a weak self to the standard notation:

`__weak __typeof(self) weakSelf = self;`

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Use standard notation when declaring weak self