### PR TITLE
Improvement: Reformat non-embedded to embedded youtube video link

### DIFF
--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -80,7 +80,7 @@
     int thumbWidth;
     int tvshowHeight;
     UITableView *actorsTable;
-    NSString *embedVideoURL;
+    NSURL *embedVideoURL;
     UIColor *foundTintColor;
     UILabel *viewTitle;
     __weak IBOutlet UIImageView *bottomShadow;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The implemented solution will identify multiple variants of youtube.com and youtu.be links (http, https, www or not), extract the video id and create a fresh FullHD embedded youtube link from this. This allows to show all such links with in-app preview.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Reformat non-embedded to embedded youtube video link