### PR TITLE
Improvement: Extend the max image cache age to 1 month

### DIFF
--- a/XBMC Remote/SDWebImage/SDImageCache.m
+++ b/XBMC Remote/SDWebImage/SDImageCache.m
@@ -35,7 +35,7 @@
 
 @end
 
-static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
+static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 31; // 1 month
 // PNG signature bytes and data (below)
 static unsigned char kPNGSignatureBytes[8] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
 static NSData *kPNGSignatureData = nil;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
With the migration to SDWebImage 3.8.3 the maximum cache age was reduced from 1 month to 1 week. This PR brings this back to 1 month again.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Extend the max image cache age to 1 month