### PR TITLE
Maintenance: Add LOCALIZED_STR_ARGS convenience macro

### DIFF
--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -41,6 +41,7 @@
  * Other
  */
 #define LOCALIZED_STR(string) NSLocalizedString(string, nil)
+#define LOCALIZED_STR_ARGS(string, ...) [NSString stringWithFormat:LOCALIZED_STR(string), __VA_ARGS__]
 #define SD_NATIVESIZE_KEY @"nativeSize"
 
 #endif /* ConvenienceMacros_h */

--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -57,7 +57,6 @@
     NSTimeInterval startTime;
     NSTimeInterval elapsedTime;
     NSTimer *countExecutionTime;
-    __weak IBOutlet UITextView *debugText;
     int labelPosition;
     int flagX;
     int flagY;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3949,15 +3949,10 @@ NSIndexPath *selected;
                    [self startRetrieveDataWithRefresh:YES];
                }
                else {
-                   NSString *message = @"";
-                   message = [NSString stringWithFormat:LOCALIZED_STR(@"METHOD\n%@\n\nPARAMETERS\n%@\n"), methodToCall, [[[NSString stringWithFormat:@"%@", parameters] stringByReplacingOccurrencesOfString:@" " withString:@""] stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
-                   if (methodError != nil) {
-                       message = [NSString stringWithFormat:@"%@\n\n%@\n", methodError, message];
-                   }
-                   if (error != nil) {
-                       message = [NSString stringWithFormat:@"%@\n\n%@\n", error.localizedDescription, message];
-                       
-                   }
+                   NSString *message = [Utilities formatClipboardMessage:methodToCall
+                                                              parameters:parameters
+                                                                   error:error
+                                                             methodError:methodError];
                    UIAlertController *alertView = [Utilities createAlertCopyClipboard:LOCALIZED_STR(@"ERROR") message:message];
                    [self presentViewController:alertView animated:YES completion:nil];
                }
@@ -4011,15 +4006,10 @@ NSIndexPath *selected;
                    [[NSNotificationCenter defaultCenter] postNotificationName: @"KodiServerRecordTimerStatusChange" object:nil userInfo:params];
                }
                else {
-                   NSString *message = @"";
-                    message = [NSString stringWithFormat:LOCALIZED_STR(@"METHOD\n%@\n\nPARAMETERS\n%@\n"), methodToCall, [[[NSString stringWithFormat:@"%@", parameters] stringByReplacingOccurrencesOfString:@" " withString:@""] stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
-                   if (methodError != nil) {
-                       message = [NSString stringWithFormat:@"%@\n\n%@\n", methodError, message];
-                   }
-                   if (error != nil) {
-                       message = [NSString stringWithFormat:@"%@\n\n%@\n", error.localizedDescription, message];
-                       
-                   }
+                   NSString *message = [Utilities formatClipboardMessage:methodToCall
+                                                              parameters:parameters
+                                                                   error:error
+                                                             methodError:methodError];
                    UIAlertController *alertView = [Utilities createAlertCopyClipboard:LOCALIZED_STR(@"ERROR") message:message];
                    [self presentViewController:alertView animated:YES completion:nil];
                }
@@ -4622,7 +4612,6 @@ NSIndexPath *selected;
 
     [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
 //    NSLog(@"START");
-    debugText.text = [NSString stringWithFormat:LOCALIZED_STR(@"METHOD\n%@\n\nPARAMETERS\n%@\n"), methodToCall, [[[NSString stringWithFormat:@"%@", mutableParameters] stringByReplacingOccurrencesOfString:@" " withString:@""] stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
     elapsedTime = 0;
     startTime = [NSDate timeIntervalSinceReferenceDate];
     countExecutionTime = [NSTimer scheduledTimerWithTimeInterval:WARNING_TIMEOUT target:self selector:@selector(checkExecutionTime) userInfo:nil repeats:YES];
@@ -4669,7 +4658,6 @@ NSIndexPath *selected;
          }
         
          if (error == nil && methodError == nil) {
-//             debugText.text = [NSString stringWithFormat:@"%@\n*DATA: %@", debugText.text, methodResult];
 //             NSLog(@"END JSON");
 //             NSLog(@"DATO RICEVUTO %@", methodResult);
              [resultStoreArray removeAllObjects];
@@ -4793,14 +4781,11 @@ NSIndexPath *selected;
          }
          else {
 //             NSLog(@"ERROR:%@ METHOD:%@", error, methodError);
-             if (methodError != nil) {
-                 debugText.text = [NSString stringWithFormat:@"%@\n\n%@\n", methodError, debugText.text];
-             }
-             if (error != nil) {
-                 debugText.text = [NSString stringWithFormat:@"%@\n\n%@\n", error.localizedDescription, debugText.text];
-                 
-             }
-             UIAlertController *alertView = [Utilities createAlertCopyClipboard:LOCALIZED_STR(@"ERROR") message:debugText.text];
+             NSString *message = [Utilities formatClipboardMessage:methodToCall
+                                                        parameters:mutableParameters
+                                                             error:error
+                                                       methodError:methodError];
+             UIAlertController *alertView = [Utilities createAlertCopyClipboard:LOCALIZED_STR(@"ERROR") message:message];
              [self presentViewController:alertView animated:YES completion:nil];
              
              [self showNoResultsFound:resultStoreArray refresh:forceRefresh];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -704,7 +704,7 @@
     int numResult = (int)self.filteredListContent.count;
     if (numResult) {
         if (numResult != 1) {
-            results = [NSString stringWithFormat:LOCALIZED_STR(@"%d results"), numResult];
+            results = LOCALIZED_STR_ARGS(@"%d results", numResult);
         }
         else {
             results = LOCALIZED_STR(@"1 result");
@@ -1046,7 +1046,7 @@
     }
 
     [Utilities AnimView:moreItemsViewController.view AnimDuration:0.3 Alpha:1.0 XPos:0];
-    NSString *labelText = [NSString stringWithFormat:LOCALIZED_STR(@"More (%d)"), (int)(count - MAX_NORMAL_BUTTONS)];
+    NSString *labelText = LOCALIZED_STR_ARGS(@"More (%d)", (int)(count - MAX_NORMAL_BUTTONS));
     [self setFilternameLabel:labelText runFullscreenButtonCheck:YES forceHide:YES];
     [activityIndicatorView stopAnimating];
 }
@@ -2200,14 +2200,14 @@
 - (NSString*)buildSortInfo:(NSString*)sectionName {
     if ([sortMethodName isEqualToString:@"year"]) {
         if (sectionName.length > 3) {
-            sectionName = [NSString stringWithFormat:LOCALIZED_STR(@"The %@s decade"), sectionName];
+            sectionName = LOCALIZED_STR_ARGS(@"The %@s decade", sectionName);
         }
         else {
             sectionName = LOCALIZED_STR(@"Year not available");
         }
     }
     else if ([sortMethodName isEqualToString:@"dateadded"]) {
-        sectionName = [NSString stringWithFormat:LOCALIZED_STR(@"Year %@"), sectionName];
+        sectionName = LOCALIZED_STR_ARGS(@"Year %@", sectionName);
     }
     else if ([sortMethodName isEqualToString:@"playcount"]) {
         if ([sectionName intValue] == 0) {
@@ -2240,7 +2240,7 @@
         int start = 0;
         int num_stars = [sectionName intValue];
         int stop = numberOfStars;
-        NSString *newName = [NSString stringWithFormat:LOCALIZED_STR(@"Rated %@"), sectionName];
+        NSString *newName = LOCALIZED_STR_ARGS(@"Rated %@", sectionName);
         NSMutableString *stars = [NSMutableString string];
         for (start = 0; start < num_stars; start++) {
             [stars appendString:@"\u2605"];
@@ -2307,7 +2307,7 @@
         }
     }
     else if ([sortMethodName isEqualToString:@"track"]) {
-        sectionName = [NSString stringWithFormat:LOCALIZED_STR(@"Track n.%@"), sectionName];
+        sectionName = LOCALIZED_STR_ARGS(@"Track n.%@", sectionName);
     }
     else if ([sortMethodName isEqualToString:@"itemgroup"]) {
         int index = [sectionName intValue];
@@ -2829,7 +2829,7 @@
         
         // Get year of release
         int year = [item[@"year"] intValue];
-        NSString *releasedText = (year > 0) ? [NSString stringWithFormat:LOCALIZED_STR(@"Released %d"), year] : @"";
+        NSString *releasedText = (year > 0) ? LOCALIZED_STR_ARGS(@"Released %d", year) : @"";
         
         [self layoutSectionView:albumDetailView
                       thumbView:thumbImageView
@@ -2878,11 +2878,11 @@
             NSString *albumText = self.extraSectionRichResults[seasonIdx][@"label"];
             
             // Get amount of episodes
-            NSString *trackCountText = [NSString stringWithFormat:LOCALIZED_STR(@"Episodes: %@"), self.extraSectionRichResults[seasonIdx][@"episode"]];
+            NSString *trackCountText = LOCALIZED_STR_ARGS(@"Episodes: %@", self.extraSectionRichResults[seasonIdx][@"episode"]);
             
             // Get info on when first aired
             NSString *aired = [Utilities getDateFromItem:item[@"year"] dateStyle:NSDateFormatterLongStyle];
-            NSString *releasedText = aired ? [NSString stringWithFormat:LOCALIZED_STR(@"First aired on %@"), aired] : @"";
+            NSString *releasedText = aired ? LOCALIZED_STR_ARGS(@"First aired on %@", aired) : @"";
             
             [self layoutSectionView:albumDetailView
                           thumbView:thumbImageView

--- a/XBMC Remote/DetailViewController.xib
+++ b/XBMC Remote/DetailViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,7 +20,6 @@
                 <outlet property="buttonsView" destination="116" id="134"/>
                 <outlet property="buttonsViewBgToolbar" destination="sPd-OR-uGy" id="DhA-1U-cyk"/>
                 <outlet property="dataList" destination="37" id="93"/>
-                <outlet property="debugText" destination="160" id="162"/>
                 <outlet property="detailView" destination="1" id="158"/>
                 <outlet property="lpgr" destination="97" id="100"/>
                 <outlet property="noFoundView" destination="135" id="140"/>
@@ -201,14 +200,6 @@
                             <rect key="frame" x="398" y="285" width="37" height="37"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         </activityIndicatorView>
-                        <textView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="160">
-                            <rect key="frame" x="0.0" y="190" width="839" height="372"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                            <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                        </textView>
                     </subviews>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>

--- a/XBMC Remote/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/XBMC Remote/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -465,7 +465,7 @@ static char UIScrollViewPullToRefreshView;
 
 - (void)setLastUpdatedDate:(NSDate*)newLastUpdatedDate {
     self.showsDateLabel = YES;
-    self.dateLabel.text = [NSString stringWithFormat:LOCALIZED_STR(@"Last Updated: %@"), newLastUpdatedDate ? [self.dateFormatter stringFromDate:newLastUpdatedDate] : LOCALIZED_STR(@"Never")];
+    self.dateLabel.text = LOCALIZED_STR_ARGS(@"Last Updated: %@", newLastUpdatedDate ? [self.dateFormatter stringFromDate:newLastUpdatedDate] : LOCALIZED_STR(@"Never"));
 }
 
 #pragma mark -

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -75,7 +75,7 @@ double round(double d) {
             float total = [Utilities getFloatValueFromItem:resumePointDict[@"total"]];
             if (position > 0 && total > 0) {
                 resumePointPercentage = (position * 100) / total;
-                [sheetActions addObject:[NSString stringWithFormat:LOCALIZED_STR(@"Resume from %@"), [Utilities convertTimeFromSeconds: @(position)]]];
+                [sheetActions addObject:LOCALIZED_STR_ARGS(@"Resume from %@", [Utilities convertTimeFromSeconds: @(position)])];
             }
         }
         BOOL fromAlbumView = NO;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -502,13 +502,10 @@ double round(double d) {
                    [[NSNotificationCenter defaultCenter] postNotificationName: @"KodiServerRecordTimerStatusChange" object:nil userInfo:params];
                }
                else {
-                   NSString *message = [NSString stringWithFormat:LOCALIZED_STR(@"METHOD\n%@\n\nPARAMETERS\n%@\n"), methodToCall, [[[NSString stringWithFormat:@"%@", parameters] stringByReplacingOccurrencesOfString:@" " withString:@""] stringByReplacingOccurrencesOfString:@"\n" withString:@""]];
-                   if (methodError != nil) {
-                       message = [NSString stringWithFormat:@"%@\n\n%@\n", methodError, message];
-                   }
-                   if (error != nil) {
-                       message = [NSString stringWithFormat:@"%@\n\n%@\n", error.localizedDescription, message];
-                   }
+                   NSString *message = [Utilities formatClipboardMessage:methodToCall
+                                                              parameters:parameters
+                                                                   error:error
+                                                             methodError:methodError];
                    UIAlertController *alertView = [Utilities createAlertCopyClipboard:LOCALIZED_STR(@"ERROR") message:message];
                    [self presentViewController:alertView animated:YES completion:nil];
                }

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -112,6 +112,7 @@ typedef enum {
 + (NSString*)formatTVShowStringForSeasonTrailing:(id)season episode:(id)episode title:(NSString*)title;
 + (NSString*)formatTVShowStringForSeasonLeading:(id)season episode:(id)episode title:(NSString*)title;
 + (NSString*)formatTVShowStringForSeason:(id)season episode:(id)episode;
++ (NSString*)formatClipboardMessage:(NSString*)method parameters:(NSDictionary*)parameters error:(NSError*)error methodError:(DSJSONRPCError*)methodError;
 + (NSString*)stripBBandHTML:(NSString*)text;
 + (BOOL)isValidMacAddress:(NSString*)macAddress;
 + (void)wakeUp:(NSString*)macAddress;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1204,6 +1204,23 @@
     return text;
 }
 
++ (NSString*)formatClipboardMessage:(NSString*)method parameters:(NSDictionary*)parameters error:(NSError*)error methodError:(DSJSONRPCError*)methodError {
+    // Convert dictionary to string and remove spaces and newlines
+    NSString *parameterString = [NSString stringWithFormat:@"%@", parameters];
+    parameterString = [parameterString stringByReplacingOccurrencesOfString:@" " withString:@""];
+    parameterString = [parameterString stringByReplacingOccurrencesOfString:@"\n" withString:@""];
+    
+    // Build and return message
+    NSString *message = [NSString stringWithFormat:@"METHOD\n%@\n\nPARAMETERS\n%@\n", method, parameterString];
+    if (methodError != nil) {
+        message = [NSString stringWithFormat:@"%@\n\n%@\n", methodError, message];
+    }
+    if (error != nil) {
+        message = [NSString stringWithFormat:@"%@\n\n%@\n", error.localizedDescription, message];
+    }
+    return message;
+}
+
 + (NSString*)stripRegEx:(NSString*)regExp text:(NSString*)textIn {
     // Returns unchanged string, if regExp is nil. Returns nil, if string is nil.
     if (!textIn || !regExp) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
During the review of another PR it was suggest to introduce a new convenience macro `LOCALIZED_STR_ARGS` to handle localized strings with arguments/parameters. I felt this improves the code readability and did this.

While working on this I also reworked the copy-clipboard warning popup to use a common method for the creation of the message text.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Add LOCALIZED_STR_ARGS convenience macro