### PR TITLE
Bugfix: Avoid potential crash in trailer preview

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1240,6 +1240,9 @@ double round(double d) {
     embedVideoURL = nil;
     if (trailerString.length > 0) {
         NSURL *trailerURL = [NSURL URLWithString:trailerString];
+        if (!trailerURL) {
+            return;
+        }
         NSURLComponents *trailerComponents = [NSURLComponents componentsWithURL:trailerURL resolvingAgainstBaseURL:YES];
         if ([self isYoutubePluginLink:trailerComponents]) {
             embedVideoURL = [self getEmbeddedYoutubeLink:trailerComponents queryItemName:@"videoid"];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Early return if `URLWithString` returns `nil`. This avoids a crash reported via AppStore for TF build 4196 (1.14).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid potential crash in trailer preview