### PR TITLE
Improvement: Sort settings array before displaying

### DIFF
--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -567,7 +567,10 @@
                     else {
                         delimiter = [NSString stringWithFormat:@"%@ ", delimiter];
                     }
-                    cellText = [self.detailItem[@"value"] componentsJoinedByString:delimiter];
+                    NSArray *settingsArray = self.detailItem[@"value"];
+                    NSSortDescriptor *descriptor = [[NSSortDescriptor alloc] initWithKey:nil ascending:YES];
+                    settingsArray = [settingsArray sortedArrayUsingDescriptors:@[descriptor]];
+                    cellText = [settingsArray componentsJoinedByString:delimiter];
                 }
                 else {
                     cellText = [NSString stringWithFormat:@"%@", self.detailItem[@"value"]];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
partially solves https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/981.

Sort the array of values before displaying it in the settings UI.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Sort settings array before displaying