### PR TITLE
Bugfix: Do not sort plugin menus

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3801,7 +3801,8 @@
         @[
             @"Files.GetDirectory", @"method",
         ],
-        @[  @"Files.GetDirectory", @"method",
+        @[
+            @"Files.GetDirectory", @"method",
         ],
         @[],
     ] mutableCopy];

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1497,7 +1497,7 @@
                                   
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
+                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"file_properties": @[
                     @"thumbnail",
                 ],
@@ -2706,7 +2706,7 @@
                                   
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
+                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"file_properties": @[
                     @"thumbnail",
@@ -3874,7 +3874,7 @@
                                     
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
+                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"file_properties": @[
                     @"thumbnail",
@@ -5340,7 +5340,7 @@
                                   
         @[
             @{
-                @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
+                @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"media": @"pictures",
                 @"file_properties": @[
                     @"thumbnail",


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/987.

Do not request Kodi to sort response by "label" when requesting response from addons / plugins.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not sort plugin menus