### PR TITLE
Bugfix: Do not end up in debug messages when searching in add ons

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5208,7 +5208,7 @@ NSIndexPath *selected;
 
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputFinished" object:nil userInfo:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputCanceled" object:nil userInfo:nil];
     self.navigationController.navigationBar.tintColor = ICON_TINT_COLOR;
     [channelListUpdateTimer invalidate];
 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5462,12 +5462,12 @@ NSIndexPath *selected;
             }
             
             if (arr_properties == nil) {
-                arr_properties = [NSArray array];
+                arr_properties = @[];
             }
             
             NSArray *arr_sort = parameters[@"parameters"][@"sort"];
             if (arr_sort == nil) {
-                arr_sort = [NSArray array];
+                arr_sort = @[];
             }
             tempDict[@"properties"] = arr_properties;
             tempDict[@"sort"] = arr_sort;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4639,7 +4639,7 @@ NSIndexPath *selected;
          // methodError "-32100" combined with "PVR." method calls. Other errors are still
          // shown via debug message.
          if (error == nil && methodError != nil && [methodToCall containsString:@"PVR."]) {
-             if (methodError.code == -32100) {
+             if (methodError.code == JSONRPCMethodExecutionFailure) {
                  [self animateNoResultsFound];
                  return;
              }
@@ -4647,7 +4647,7 @@ NSIndexPath *selected;
          // Ignore error when aborting a search or sending an empty search string within an addon. Just show "no results".
          NSString *directory = mutableParameters[@"directory"];
          if (error == nil && methodError != nil && [directory hasPrefix:@"plugin://"] && [directory containsString:@"search"]) {
-             if (methodError.code == -32602) {
+             if (methodError.code == JSONRPCInvalidParams) {
                  [self animateNoResultsFound];
                  return;
              }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4644,6 +4644,14 @@ NSIndexPath *selected;
                  return;
              }
          }
+         // Ignore error when aborting a search or sending an empty search string within an addon. Just show "no results".
+         NSString *directory = mutableParameters[@"directory"];
+         if (error == nil && methodError != nil && [directory hasPrefix:@"plugin://"] && [directory containsString:@"search"]) {
+             if (methodError.code == -32602) {
+                 [self animateNoResultsFound];
+                 return;
+             }
+         }
          // If the feature to also show movies sets with only 1 movie is disabled and the current results
          // are movie sets, enable the postprocessing to ignore movies sets with only 1 movie.
          BOOL ignoreSingleMovieSets = !AppDelegate.instance.isGroupSingleItemSetsEnabled && [methodToCall isEqualToString:@"VideoLibrary.GetMovieSets"];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -493,7 +493,7 @@
 }
 
 - (void)getActivePlayers {
-    [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:[NSDictionary dictionary] withTimeout:2.0 onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+    [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:@{} withTimeout:2.0 onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         // Do not process further, if the view is already off the view hierarchy.
         if (!self.viewIfLoaded.window) {
             return;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -305,7 +305,7 @@
 }
 
 - (void)twoFingersTap {
-    [self GUIAction:@"Input.Home" params:[NSDictionary dictionary] httpAPIcallback:nil];
+    [self GUIAction:@"Input.Home" params:@{} httpAPIcallback:nil];
 }
 
 - (void)handleTouchpadLongPress:(UILongPressGestureRecognizer*)gestureRecognizer {
@@ -336,11 +336,11 @@
                      [self sendActionNoRepeat];
                  }
                  else {
-                     [self GUIAction:@"Input.ContextMenu" params:[NSDictionary dictionary] httpAPIcallback:@"SendKey(0xF043)"];
+                     [self GUIAction:@"Input.ContextMenu" params:@{} httpAPIcallback:@"SendKey(0xF043)"];
                  }
              }
              else {
-                 [self GUIAction:@"Input.ContextMenu" params:[NSDictionary dictionary] httpAPIcallback:@"SendKey(0xF043)"];
+                 [self GUIAction:@"Input.ContextMenu" params:@{} httpAPIcallback:@"SendKey(0xF043)"];
              }
          }];
     }
@@ -484,7 +484,7 @@
 }
 
 - (void)subtitlesActionSheet {
-    [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:[NSDictionary dictionary] onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+    [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:@{} onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (error == nil && methodError == nil && [methodResult isKindOfClass:[NSArray class]]) {
             if ([methodResult count] > 0) {
                 NSNumber *response = methodResult[0][@"playerid"] != [NSNull null] ? methodResult[0][@"playerid"] : nil;
@@ -529,7 +529,7 @@
 }
 
 - (void)audioStreamActionSheet {
-    [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:[NSDictionary dictionary] onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+    [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:@{} onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (error == nil && methodError == nil && [methodResult isKindOfClass:[NSArray class]]) {
             if ([methodResult count] > 0) {
                 NSNumber *response = methodResult[0][@"playerid"] != [NSNull null] ? methodResult[0][@"playerid"] : nil;
@@ -572,7 +572,7 @@
 }
 
 - (void)playbackAction:(NSString*)action params:(NSDictionary*)parameters {
-    [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:[NSDictionary dictionary] onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+    [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:@{} onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (error == nil && methodError == nil && [methodResult isKindOfClass:[NSArray class]]) {
             if ([methodResult count] > 0) {
                 NSMutableDictionary *commonParams = [NSMutableDictionary dictionaryWithDictionary:parameters];
@@ -750,7 +750,7 @@ NSInteger buttonAction;
 //    NSString *action;
     switch (buttonAction) {
         case TAG_BUTTON_MENU: // MENU OSD
-            [self GUIAction:@"Input.ShowOSD" params:[NSDictionary dictionary] httpAPIcallback:@"SendKey(0xF04D)"];
+            [self GUIAction:@"Input.ShowOSD" params:@{} httpAPIcallback:@"SendKey(0xF04D)"];
             break;
         default:
             break;
@@ -825,37 +825,37 @@ NSInteger buttonAction;
     switch (buttonAction) {
         case TAG_BUTTON_ARROW_UP:
             action = @"Input.Up";
-            [self GUIAction:action params:[NSDictionary dictionary] httpAPIcallback:nil];
+            [self GUIAction:action params:@{} httpAPIcallback:nil];
             [self playerStep:@"bigforward" musicPlayerGo:nil musicPlayerAction:@"increaserating"];
             break;
             
         case TAG_BUTTON_ARROW_LEFT:
             action = @"Input.Left";
-            [self GUIAction:action params:[NSDictionary dictionary] httpAPIcallback:nil];
+            [self GUIAction:action params:@{} httpAPIcallback:nil];
             [self playerStep:@"smallbackward" musicPlayerGo:@"previous" musicPlayerAction:nil];
             break;
 
         case TAG_BUTTON_SELECT:
             action = @"Input.Select";
-            [self GUIAction:action params:[NSDictionary dictionary] httpAPIcallback:nil];
+            [self GUIAction:action params:@{} httpAPIcallback:nil];
             [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputFinished" object:nil userInfo:nil];
             break;
 
         case TAG_BUTTON_ARROW_RIGHT:
             action = @"Input.Right";
-            [self GUIAction:action params:[NSDictionary dictionary] httpAPIcallback:nil];
+            [self GUIAction:action params:@{} httpAPIcallback:nil];
             [self playerStep:@"smallforward" musicPlayerGo:@"next" musicPlayerAction:nil];
             break;
             
         case TAG_BUTTON_ARROW_DOWN:
             action = @"Input.Down";
-            [self GUIAction:action params:[NSDictionary dictionary] httpAPIcallback:nil];
+            [self GUIAction:action params:@{} httpAPIcallback:nil];
             [self playerStep:@"bigbackward" musicPlayerGo:nil musicPlayerAction:@"decreaserating"];
             break;
             
         case TAG_BUTTON_BACK:
             action = @"Input.Back";
-            [self GUIAction:action params:[NSDictionary dictionary] httpAPIcallback:nil];
+            [self GUIAction:action params:@{} httpAPIcallback:nil];
             break;
             
         default:
@@ -925,23 +925,23 @@ NSInteger buttonAction;
         
         case TAG_BUTTON_HOME: // HOME
             action = @"Input.Home";
-            [self GUIAction:action params:[NSDictionary dictionary] httpAPIcallback:nil];
+            [self GUIAction:action params:@{} httpAPIcallback:nil];
             break;
             
         case TAG_BUTTON_INFO: // INFO
             action = @"Input.Info";
-            [self GUIAction:action params:[NSDictionary dictionary] httpAPIcallback:@"SendKey(0xF049)"];
+            [self GUIAction:action params:@{} httpAPIcallback:@"SendKey(0xF049)"];
             break;
             
         case TAG_BUTTON_SELECT:
             action = @"Input.Select";
-            [self GUIAction:action params:[NSDictionary dictionary] httpAPIcallback:nil];
+            [self GUIAction:action params:@{} httpAPIcallback:nil];
             [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputFinished" object:nil userInfo:nil];
             break;
             
         case TAG_BUTTON_MENU: // MENU OSD
             action = @"Input.ShowOSD";
-            [self GUIAction:action params:[NSDictionary dictionary] httpAPIcallback:@"SendKey(0xF04D)"];
+            [self GUIAction:action params:@{} httpAPIcallback:@"SendKey(0xF04D)"];
             break;
         
         case TAG_BUTTON_SUBTITLES:
@@ -1023,13 +1023,13 @@ NSInteger buttonAction;
                     [self GUIAction:@"Input.ExecuteAction" params:@{@"action": @"playerdebug"} httpAPIcallback:nil];
                 }
                 else {
-                    [self GUIAction:@"Input.ShowCodec" params:[NSDictionary dictionary] httpAPIcallback:@"SendKey(0xF04F)"];
+                    [self GUIAction:@"Input.ShowCodec" params:@{} httpAPIcallback:@"SendKey(0xF04F)"];
                 }
                 break;
 
             case TAG_BUTTON_SELECT: // CONTEXT MENU
             case TAG_BUTTON_MENU:
-                [self GUIAction:@"Input.ContextMenu" params:[NSDictionary dictionary] httpAPIcallback:@"SendKey(0xF043)"];
+                [self GUIAction:@"Input.ContextMenu" params:@{} httpAPIcallback:@"SendKey(0xF043)"];
                 break;
 
             case TAG_BUTTON_SUBTITLES: // SUBTITLES BUTTON

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -470,7 +470,7 @@
                 NSIndexPath *commandIdx = [self getIndexPathForKey:@"ok_button" withValue:ok_button inArray:[tableData valueForKey:@"action"]];
                 NSString *command = [tableData valueForKey:@"action"][commandIdx.row][@"command"];
                 if (command != nil) {
-                    [self xbmcAction:command params:[NSDictionary dictionary] uiControl:nil];
+                    [self xbmcAction:command params:@{} uiControl:nil];
                 }
             }];
             [alertView addAction:cancelButton];

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -231,47 +231,47 @@
     }
     else {
         UIAlertAction *action_pwr_off_system = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Power off System") style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
-            [self powerAction:@"System.Shutdown" params:[NSDictionary dictionary]];
+            [self powerAction:@"System.Shutdown" params:@{}];
         }];
         [actionView addAction:action_pwr_off_system];
         
         UIAlertAction *action_quit_kodi = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Quit XBMC application") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"Application.Quit" params:[NSDictionary dictionary]];
+            [self powerAction:@"Application.Quit" params:@{}];
         }];
         [actionView addAction:action_quit_kodi];
         
         UIAlertAction *action_hibernate = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Hibernate") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"System.Hibernate" params:[NSDictionary dictionary]];
+            [self powerAction:@"System.Hibernate" params:@{}];
         }];
         [actionView addAction:action_hibernate];
         
         UIAlertAction *action_suspend = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Suspend") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"System.Suspend" params:[NSDictionary dictionary]];
+            [self powerAction:@"System.Suspend" params:@{}];
         }];
         [actionView addAction:action_suspend];
         
         UIAlertAction *action_reboot = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Reboot") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"System.Reboot" params:[NSDictionary dictionary]];
+            [self powerAction:@"System.Reboot" params:@{}];
         }];
         [actionView addAction:action_reboot];
         
         UIAlertAction *action_scan_audio_lib = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Update Audio Library") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"AudioLibrary.Scan" params:[NSDictionary dictionary]];
+            [self powerAction:@"AudioLibrary.Scan" params:@{}];
         }];
         [actionView addAction:action_scan_audio_lib];
         
         UIAlertAction *action_clean_audio_lib = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Clean Audio Library") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"AudioLibrary.Clean" params:[NSDictionary dictionary]];
+            [self powerAction:@"AudioLibrary.Clean" params:@{}];
         }];
         [actionView addAction:action_clean_audio_lib];
         
         UIAlertAction *action_scan_video_lib = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Update Video Library") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"VideoLibrary.Scan" params:[NSDictionary dictionary]];
+            [self powerAction:@"VideoLibrary.Scan" params:@{}];
         }];
         [actionView addAction:action_scan_video_lib];
         
         UIAlertAction *action_clean_video_lib = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Clean Video Library") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"VideoLibrary.Clean" params:[NSDictionary dictionary]];
+            [self powerAction:@"VideoLibrary.Clean" params:@{}];
         }];
         [actionView addAction:action_clean_video_lib];
     }

--- a/XBMC Remote/XBMCVirtualKeyboard.h
+++ b/XBMC Remote/XBMCVirtualKeyboard.h
@@ -14,12 +14,11 @@
     UIView *inputAccView;
     UILabel *keyboardTitle;
     UITextField *backgroundTextField;
-    int accessoryHeight;
-    int padding;
-    int verboseHeight;
-    int textSize;
-    int background_padding;
-    int alignBottom;
+    int paddingLeftRight;
+    int paddingTopBottom;
+    int textFieldHeight;
+    int textFontSize;
+    int keyboardTitleHeight;
     CGFloat screenWidth;
 }
 

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -76,15 +76,15 @@
                                                      name: @"Input.OnInputRequested"
                                                    object: nil];
         [[NSNotificationCenter defaultCenter] addObserver: self
-                                                 selector: @selector(hideKeyboard:)
+                                                 selector: @selector(hideKeyboard)
                                                      name: @"Input.OnInputFinished"
                                                    object: nil];
         [[NSNotificationCenter defaultCenter] addObserver: self
-                                                 selector: @selector(cancelKeyboard:)
+                                                 selector: @selector(cancelKeyboard)
                                                      name: @"Input.OnInputCanceled"
                                                    object: nil];
         [[NSNotificationCenter defaultCenter] addObserver: self
-                                                 selector: @selector(toggleVirtualKeyboard:)
+                                                 selector: @selector(toggleVirtualKeyboard)
                                                      name: @"toggleVirtualKeyboard"
                                                    object: nil];
     }
@@ -97,14 +97,14 @@
     return NO;
 }
 
-- (void)cancelKeyboard:(id)sender {
+- (void)cancelKeyboard {
     if ([backgroundTextField isEditing]) {
         [self GUIAction:@"Input.Back" params:[NSDictionary dictionary] httpAPIcallback:nil];
     }
-    [self hideKeyboard:nil];
+    [self hideKeyboard];
 }
 
-- (void)hideKeyboard:(id)sender {
+- (void)hideKeyboard {
     [backgroundTextField resignFirstResponder];
     backgroundTextField.text = @"";
     [xbmcVirtualKeyboard resignFirstResponder];
@@ -142,9 +142,9 @@
     [backgroundTextField becomeFirstResponder];
 }
 
-- (void)toggleVirtualKeyboard:(id)sender {
+- (void)toggleVirtualKeyboard {
     if ([xbmcVirtualKeyboard isFirstResponder] || [backgroundTextField isFirstResponder]) {
-        [self hideKeyboard:nil];
+        [self hideKeyboard];
     }
     else {
         [self showKeyboard:nil];
@@ -217,7 +217,7 @@
 
 - (void)textFieldDidEndEditing:(UITextField*)textField {
     if (textField.tag == VIRTUAL_KEYBOARD_TEXTFIELD) {
-        [self performSelectorOnMainThread:@selector(hideKeyboard:) withObject:nil waitUntilDone:NO];
+        [self performSelectorOnMainThread:@selector(hideKeyboard) withObject:nil waitUntilDone:NO];
     }
 }
 

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -107,7 +107,7 @@
              if (error == nil && methodError == nil && [methodResult isKindOfClass: [NSDictionary class]]) {
                  if (methodResult[@"currentwindow"] != [NSNull null]) {
                      if ([methodResult[@"currentwindow"][@"id"] longValue] == WINDOW_VIRTUAL_KEYBOARD) {
-                         [self GUIAction:@"Input.Back" params:[NSDictionary dictionary] httpAPIcallback:nil];
+                         [self GUIAction:@"Input.Back" params:@{} httpAPIcallback:nil];
                      }
                  }
              }
@@ -198,7 +198,7 @@
         else { // CHARACTER
             unichar x = [string characterAtIndex:0];
             if (x == '\n') {
-                [self GUIAction:@"Input.Select" params:[NSDictionary dictionary] httpAPIcallback:nil];
+                [self GUIAction:@"Input.Select" params:@{} httpAPIcallback:nil];
                 [backgroundTextField resignFirstResponder];
                 [xbmcVirtualKeyboard resignFirstResponder];
             }

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -173,8 +173,8 @@
             [Utilities sendXbmcHttp:@"SendKey(0xf108)"];
         }
         else { // CHARACTER
-            int x = (unichar) [string characterAtIndex: 0];
-            if (x == 10) {
+            unichar x = [string characterAtIndex:0];
+            if (x == '\n') {
                 [self GUIAction:@"Input.Select" params:[NSDictionary dictionary] httpAPIcallback:nil];
                 [backgroundTextField resignFirstResponder];
                 [xbmcVirtualKeyboard resignFirstResponder];
@@ -186,18 +186,20 @@
         return NO;
     }
     else {
+        BOOL inputFinished = NO;
         NSString *stringToSend = [theTextField.text stringByReplacingCharactersInRange:range withString:string];
         if (string.length != 0) {
-            int x = (unichar) [string characterAtIndex: 0];
-            if (x == 10) {
-                [self GUIAction:@"Input.SendText" params:[NSDictionary dictionaryWithObjectsAndKeys:[stringToSend substringToIndex:stringToSend.length - 1], @"text", @YES, @"done", nil] httpAPIcallback:nil];
+            unichar x = [string characterAtIndex:0];
+            if (x == '\n') {
+                stringToSend = [stringToSend substringToIndex:stringToSend.length - 1];
                 [backgroundTextField resignFirstResponder];
                 [xbmcVirtualKeyboard resignFirstResponder];
                 theTextField.text = @"";
-                return YES;
+                inputFinished = YES;
             }
         }
-        [self GUIAction:@"Input.SendText" params:[NSDictionary dictionaryWithObjectsAndKeys:stringToSend, @"text", @NO, @"done", nil] httpAPIcallback:nil];
+        stringToSend = stringToSend ?: @"";
+        [self GUIAction:@"Input.SendText" params:@{@"text": stringToSend, @"done": @(inputFinished)} httpAPIcallback:nil];
         return YES;
     }
 }

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -11,6 +11,7 @@
 #import "Utilities.h"
 
 #define VIRTUAL_KEYBOARD_TEXTFIELD 10
+#define WINDOW_VIRTUAL_KEYBOARD 10103
 
 @implementation XBMCVirtualKeyboard
 
@@ -99,7 +100,18 @@
 
 - (void)cancelKeyboard {
     if ([backgroundTextField isEditing]) {
-        [self GUIAction:@"Input.Back" params:[NSDictionary dictionary] httpAPIcallback:nil];
+        [[Utilities getJsonRPC]
+         callMethod:@"GUI.GetProperties"
+         withParameters:@{@"properties": @[@"currentwindow"]}
+         onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+             if (error == nil && methodError == nil && [methodResult isKindOfClass: [NSDictionary class]]) {
+                 if (methodResult[@"currentwindow"] != [NSNull null]) {
+                     if ([methodResult[@"currentwindow"][@"id"] longValue] == WINDOW_VIRTUAL_KEYBOARD) {
+                         [self GUIAction:@"Input.Back" params:[NSDictionary dictionary] httpAPIcallback:nil];
+                     }
+                 }
+             }
+         }];
     }
     [self hideKeyboard];
 }

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -12,28 +12,24 @@
 
 #define VIRTUAL_KEYBOARD_TEXTFIELD 10
 #define WINDOW_VIRTUAL_KEYBOARD 10103
+#define INPUT_PADDING_LEFT_RIGHT 18
+#define INPUT_PADDING_BOTTOM 10
+#define TEXT_FONT_SIZE 14
+#define TEXT_HEIGHT 24
+#define TITLE_PADDING 6
 
 @implementation XBMCVirtualKeyboard
 
 - (id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        CGFloat keyboardTitlePadding = 6;
-        accessoryHeight = 52;
-        padding = 25;
-        verboseHeight = 24;
-        textSize = 14;
-        background_padding = 6;
-        alignBottom = 10;
-        UIColor *accessoryBackgroundColor = [Utilities getSystemGray4];
-        if (IS_IPAD) {
-            accessoryHeight = 74;
-            verboseHeight = 34;
-            padding = 50;
-            textSize = 20;
-            alignBottom = 12;
-        }
-
+        CGFloat scale = IS_IPAD ? 1.4 : 1.0;
+        paddingLeftRight = floor(INPUT_PADDING_LEFT_RIGHT * scale);
+        paddingTopBottom = floor(INPUT_PADDING_BOTTOM * scale);
+        keyboardTitleHeight = floor(TEXT_HEIGHT * scale);
+        textFieldHeight = floor(TEXT_HEIGHT * scale);
+        textFontSize = floor(TEXT_FONT_SIZE * scale);
+        
         xbmcVirtualKeyboard = [[UITextField alloc] initWithFrame:frame];
         xbmcVirtualKeyboard.hidden = YES;
         xbmcVirtualKeyboard.delegate = self;
@@ -41,25 +37,23 @@
         xbmcVirtualKeyboard.autocapitalizationType = UITextAutocapitalizationTypeNone;
         [self addSubview:xbmcVirtualKeyboard];
         
-        CGRect screenBound = UIScreen.mainScreen.bounds;
-        CGSize screenSize = screenBound.size;
-        screenWidth = screenSize.width;
+        screenWidth = UIScreen.mainScreen.bounds.size.width;
         
-        keyboardTitle = [[UILabel alloc] initWithFrame:CGRectMake(keyboardTitlePadding, 0, screenWidth - keyboardTitlePadding * 2, (int)(accessoryHeight / 2) - (int)(verboseHeight / 2) + alignBottom + 1)];
+        keyboardTitle = [[UILabel alloc] initWithFrame:CGRectMake(TITLE_PADDING, 0, screenWidth - TITLE_PADDING * 2, keyboardTitleHeight)];
         keyboardTitle.contentMode = UIViewContentModeScaleToFill;
         keyboardTitle.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleLeftMargin;
         keyboardTitle.textAlignment = NSTextAlignmentCenter;
         keyboardTitle.backgroundColor = UIColor.clearColor;
-        keyboardTitle.font = [UIFont boldSystemFontOfSize:textSize];
+        keyboardTitle.font = [UIFont boldSystemFontOfSize:textFontSize];
         keyboardTitle.adjustsFontSizeToFitWidth = YES;
         keyboardTitle.minimumScaleFactor = 0.6;
         keyboardTitle.textColor = [Utilities get1stLabelColor];
 
-        backgroundTextField = [[UITextField alloc] initWithFrame:CGRectMake(padding - background_padding, (int)(accessoryHeight / 2) - (int)(verboseHeight / 2) + alignBottom, screenWidth - (padding - background_padding) * 2, verboseHeight)];
+        backgroundTextField = [[UITextField alloc] initWithFrame:CGRectMake(paddingLeftRight, keyboardTitleHeight, screenWidth - paddingLeftRight * 2, textFieldHeight)];
         backgroundTextField.userInteractionEnabled = YES;
         backgroundTextField.borderStyle = UITextBorderStyleRoundedRect;
         backgroundTextField.backgroundColor = [Utilities getSystemGray6];
-        backgroundTextField.font = [UIFont systemFontOfSize:textSize];
+        backgroundTextField.font = [UIFont systemFontOfSize:textFontSize];
         backgroundTextField.textColor = [Utilities get1stLabelColor];
         backgroundTextField.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleLeftMargin;
         backgroundTextField.autocorrectionType = UITextAutocorrectionTypeNo;
@@ -68,8 +62,8 @@
         backgroundTextField.delegate = self;
         backgroundTextField.tag = VIRTUAL_KEYBOARD_TEXTFIELD;
         
-        inputAccView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, screenWidth, accessoryHeight)];
-        inputAccView.backgroundColor = accessoryBackgroundColor;
+        inputAccView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, screenWidth, keyboardTitleHeight + textFieldHeight + paddingTopBottom)];
+        inputAccView.backgroundColor = [Utilities getSystemGray4];
         [inputAccView addSubview:keyboardTitle];
         [inputAccView addSubview:backgroundTextField];
         [[NSNotificationCenter defaultCenter] addObserver: self
@@ -166,28 +160,11 @@
 #pragma mark - UITextFieldDelegate Methods
 
 - (void)textFieldDidBeginEditing:(UITextField*)textField {
-    CGFloat finalHeight = accessoryHeight - alignBottom;
-    CGRect screenBound = UIScreen.mainScreen.bounds;
-    CGSize screenSize = screenBound.size;
-    screenWidth = screenSize.width;
-    CGRect frame = inputAccView.frame;
-    frame.size.width = screenWidth;
-    inputAccView.frame = frame;
-    
-    if ([keyboardTitle.text isEqualToString:@""]) {
-        inputAccView.frame = CGRectMake(0, 0, screenWidth, finalHeight);
-        backgroundTextField.frame = CGRectMake(padding - background_padding, (int)(accessoryHeight / 2) - (int)(verboseHeight / 2) - (int)(alignBottom / 2), screenWidth - (padding - background_padding) * 2, verboseHeight);
-    }
-    else {
-        finalHeight = accessoryHeight;
-        inputAccView.frame = CGRectMake(0, 0, screenWidth, finalHeight);
-        backgroundTextField.frame = CGRectMake(padding - background_padding, (int)(accessoryHeight / 2) - (int)(verboseHeight / 2) + alignBottom, screenWidth - (padding - background_padding) * 2, verboseHeight);
-    }
+    int titleHeight = keyboardTitle.text.length ? keyboardTitleHeight : paddingTopBottom;
+    screenWidth = UIScreen.mainScreen.bounds.size.width;
+    inputAccView.frame = CGRectMake(0, 0, screenWidth, titleHeight + textFieldHeight + paddingTopBottom);
+    backgroundTextField.frame = CGRectMake(paddingLeftRight, titleHeight, screenWidth - paddingLeftRight * 2, textFieldHeight);
     textField.inputAccessoryView = inputAccView;
-    if (textField.inputAccessoryView.constraints.count > 0) {
-            NSLayoutConstraint *constraint = textField.inputAccessoryView.constraints[0];
-        constraint.constant = finalHeight;
-    }
 }
 
 - (BOOL)textField:(UITextField*)theTextField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString*)string {

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -80,6 +80,10 @@
                                                      name: @"Input.OnInputFinished"
                                                    object: nil];
         [[NSNotificationCenter defaultCenter] addObserver: self
+                                                 selector: @selector(cancelKeyboard:)
+                                                     name: @"Input.OnInputCanceled"
+                                                   object: nil];
+        [[NSNotificationCenter defaultCenter] addObserver: self
                                                  selector: @selector(toggleVirtualKeyboard:)
                                                      name: @"toggleVirtualKeyboard"
                                                    object: nil];
@@ -91,6 +95,13 @@
 
 - (BOOL)canBecomeFirstResponder {
     return NO;
+}
+
+- (void)cancelKeyboard:(id)sender {
+    if ([backgroundTextField isEditing]) {
+        [self GUIAction:@"Input.Back" params:[NSDictionary dictionary] httpAPIcallback:nil];
+    }
+    [self hideKeyboard:nil];
 }
 
 - (void)hideKeyboard:(id)sender {

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPCError.h
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPCError.h
@@ -39,6 +39,7 @@
 #import <Foundation/Foundation.h>
 
 typedef enum {
+    JSONRPCMethodExecutionFailure = -32100,
     JSONRPCParseError = -32700,
     JSONRPCInvalidRequest = -32600,
     JSONRPCMethodNotFound = -32601,


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/986.

Virtual keyboard might have been closed on App, but not on Kodi, which resulted in unexpected debug errors on the App. This is now resolved by canceling the Kodi keyboard by sending "Input.Back" in case of an active keyboard being canceled in the App. In addition, the App does now not show a debug message, when `""` was sent to the Addon search. Instead, only the "no items found" message is seen.
On top, this PR does some refactoring and hygiene changes like indentation and white spaces corrections, removes unneeded parameters and refactors the code which send the text.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not end up in debug message when searching in add ons