### PR TITLE
Bugfix: Only attempt to create the collection view when supported

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1650,6 +1650,9 @@
 }
 
 - (void)setFlowLayoutParams {
+    if (![self collectionViewCanBeEnabled]) {
+        return;
+    }
     if (stackscrollFullscreen) {
         // Calculate the dimensions of the items to match the screen size.
         CGFloat screenwidth = IS_PORTRAIT ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT;
@@ -1676,7 +1679,7 @@
 #pragma mark - UICollectionView methods
 
 - (void)initCollectionView {
-    if (collectionView == nil) {
+    if ([self collectionViewCanBeEnabled] && !collectionView) {
         flowLayout = [FloatingHeaderFlowLayout new];
         [flowLayout setSearchBarHeight:self.searchController.searchBar.frame.size.height];
         


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Only attempt to create and layout the collection view when supported, which avoids a runtime warning when creating a flow layout with sizes of 0. Fixes a regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/984/commits/9d0f34a84e0189376ceda3a0409ef81cf2c814e7, for some cases already introduced with 1.14-b1.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Only attempt to create the collection view when supported