### PR TITLE
Bugfix: Use "Kodi blue" from official logo

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -345,7 +345,7 @@
 }
 
 + (UIColor*)getKodiBlue {
-    return RGBA(20, 178, 231, 1.0);
+    return RGBA(50, 174, 225, 1.0);
 }
 
 + (UIColor*)getSystemBlue {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The formerly used "Kodi blue" was too dark. Now updated this with the color taken from official logo from Kodi Wiki.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use "Kodi blue" from official logo