### PR TITLE
Bugfix: Fix bottom bar height for custom button view on iPad

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -620,7 +620,7 @@
     };
     
     mainMenu *menuItems = self.rightMenuItems[0];
-    CGFloat bottomPadding = [Utilities getBottomPadding];
+    CGFloat bottomPadding = IS_IPAD ? 0 : [Utilities getBottomPadding];
     CGFloat footerHeight = 0;
     if (menuItems.family == FamilyRemote) {
         footerHeight = TOOLBAR_HEIGHT + bottomPadding;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The bottom bar of the custom button view on iPad uses a wrong height.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix bottom bar height for custom button view on iPad