### PR TITLE
Bugfix: Render scrubbing view on top of NowPlaying overlay on iPad

### DIFF
--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -683,7 +683,7 @@
 }
 
 - (void)handleStackScrollOffScreen:(NSNotification*)sender {
-    [self.view insertSubview:self.nowPlayingController.BottomView aboveSubview:rootView];
+    [self.view insertSubview:self.nowPlayingController.BottomView aboveSubview:self.nowPlayingController.songDetailsView];
 }
 
 - (void)handleXBMCServerHasChanged:(NSNotification*)sender {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Scrubbing view is part of `BottomView` and must be placed on top of `songDetailsView` once the scrollStack is switched off. Otherwise `songDetailsView` partially hides the scrubbing message.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Render scrubbing view on top of NowPlaying overlay on iPad