### PR TITLE
Bugfix: Fix top padding

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -493,7 +493,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    CGFloat deltaY = self.navigationController.navigationBar.frame.size.height + [Utilities getTopPadding];
+    CGFloat deltaY = [Utilities getTopPaddingWithNavBar:self.navigationController];
     if (IS_IPAD) {
         deltaY = 0;
     }
@@ -581,20 +581,17 @@
         self.navigationController.navigationBar.tintColor = ICON_TINT_COLOR;
     }
     else {
-        int barHeight = self.navigationController.navigationBar.frame.size.height;
-        int statusBarHeight = [Utilities getTopPadding];
-        
         CGRect frame = supportedVersionView.frame;
-        frame.origin.y = frame.origin.y + barHeight + statusBarHeight;
+        frame.origin.y = frame.origin.y + deltaY;
         supportedVersionView.frame = frame;
         
         frame = serverListTableView.frame;
-        frame.origin.y = frame.origin.y + barHeight + statusBarHeight;
-        frame.size.height = frame.size.height - (barHeight + statusBarHeight) - bottomPadding;
+        frame.origin.y = frame.origin.y + deltaY;
+        frame.size.height = frame.size.height - deltaY - bottomPadding;
         serverListTableView.frame = frame;
         
         frame = connectingActivityIndicator.frame;
-        frame.origin.y = frame.origin.y + barHeight + statusBarHeight;
+        frame.origin.y = frame.origin.y + deltaY;
         connectingActivityIndicator.frame = frame;
         
         UIButton *xbmcLogo = [[UIButton alloc] initWithFrame:CGRectMake(688, 964, 107, 37)];

--- a/XBMC Remote/MessagesView.h
+++ b/XBMC Remote/MessagesView.h
@@ -17,6 +17,7 @@
 }
 
 - (id)initWithFrame:(CGRect)frame deltaY:(CGFloat)deltaY deltaX:(CGFloat)deltaX;
+- (void)updateWithFrame:(CGRect)frame deltaY:(CGFloat)deltaY deltaX:(CGFloat)deltaX;
 - (void)showMessage:(NSString*)message timeout:(NSTimeInterval)timeout color:(UIColor*)color;
 
 @property (nonatomic, strong) UILabel *viewMessage;

--- a/XBMC Remote/MessagesView.m
+++ b/XBMC Remote/MessagesView.m
@@ -17,19 +17,7 @@
 - (id)initWithFrame:(CGRect)frame deltaY:(CGFloat)deltaY deltaX:(CGFloat)deltaX {
     self = [super initWithFrame:frame];
     if (self) {
-        CALayer *bottomBorder = [CALayer layer];
-        CGFloat borderSize = 0.5;
-        bottomBorder.frame = CGRectMake(0.0, frame.size.height - borderSize, frame.size.width, borderSize);
-        bottomBorder.backgroundColor = [Utilities getGrayColor:0 alpha:0.35].CGColor;
-        [self.layer addSublayer:bottomBorder];
-        self.backgroundColor = [Utilities getGrayColor:0 alpha:0.9];
-        messageOrigin = frame.origin.y;
-        slideHeight = frame.size.height;
-        if (IS_IPAD) {
-            slideHeight += [Utilities getTopPadding];
-        }
-        self.frame = CGRectMake(frame.origin.x, messageOrigin - slideHeight, frame.size.width, frame.size.height);
-        viewMessage = [[UILabel alloc] initWithFrame:CGRectMake(deltaX, deltaY, frame.size.width - deltaX, frame.size.height - deltaY)];
+        viewMessage = [UILabel new];
         viewMessage.backgroundColor = UIColor.clearColor;
         viewMessage.font = [UIFont boldSystemFontOfSize:16];
         viewMessage.adjustsFontSizeToFitWidth = YES;
@@ -37,10 +25,21 @@
         viewMessage.textColor = UIColor.whiteColor;
         viewMessage.textAlignment = NSTextAlignmentCenter;
         viewMessage.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
+        [self updateWithFrame:frame deltaY:deltaY deltaX:deltaX];
         [self addSubview:viewMessage];
         self.alpha = 0.0;
     }
     return self;
+}
+
+- (void)updateWithFrame:(CGRect)frame deltaY:(CGFloat)deltaY deltaX:(CGFloat)deltaX {
+    messageOrigin = frame.origin.y;
+    slideHeight = frame.size.height;
+    if (IS_IPAD) {
+        slideHeight += [Utilities getTopPadding];
+    }
+    self.frame = CGRectMake(frame.origin.x, messageOrigin - slideHeight, frame.size.width, frame.size.height);
+    viewMessage.frame = CGRectMake(deltaX, deltaY, frame.size.width - deltaX, frame.size.height - deltaY);
 }
 
 # pragma mark - view Effects

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2321,7 +2321,7 @@
     
     // Set correct size for background image
     CGRect frame = transitionView.frame;
-    CGFloat topBarHeight = self.navigationController.navigationBar.frame.size.height + [Utilities getTopPadding];
+    CGFloat topBarHeight = [Utilities getTopPaddingWithNavBar:self.navigationController];
     frame.size.height += topBarHeight;
     frame.origin.y = -topBarHeight;
     transitionView.frame = frame;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -650,7 +650,7 @@
         volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectZero leftAnchor:ANCHOR_RIGHT_PEEK isSliderType:YES];
         [volumeSliderView startTimer];
     }
-    menuTableView = [[UITableView alloc] initWithFrame:CGRectMake(self.peekLeftAmount, deltaY, frame.size.width - self.peekLeftAmount, self.view.frame.size.height - deltaY - footerHeight - 1) style:UITableViewStylePlain];
+    menuTableView = [[UITableView alloc] initWithFrame:CGRectMake(self.peekLeftAmount, deltaY, frame.size.width - self.peekLeftAmount, self.view.frame.size.height - deltaY - footerHeight) style:UITableViewStylePlain];
     menuTableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     menuTableView.delegate = self;
     menuTableView.dataSource = self;

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -144,15 +144,6 @@
         longPressGesture.delegate = self;
         [_tableView addGestureRecognizer:longPressGesture];
         
-        CGFloat deltaY = 0;
-        CGRect frame = UIScreen.mainScreen.bounds;
-        if (IS_IPAD) {
-            frame.size.width = STACKSCROLL_WIDTH;
-        }
-        else {
-            deltaY = 44 + [Utilities getTopPadding];
-        }
-        
         scrubbingView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, 44)];
         scrubbingView.center = CGPointMake((int)(frame.size.width / 2), (int)(frame.size.height / 2) + 50);
         scrubbingView.backgroundColor = [Utilities getGrayColor:0 alpha:0.9];
@@ -191,9 +182,6 @@
         [scrubbingView addSubview:scrubbingRate];
         
         [self.view insertSubview:scrubbingView aboveSubview:_tableView];
-
-        messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, deltaY + DEFAULT_MSG_HEIGHT) deltaY:deltaY deltaX:0];
-        [self.view addSubview:messagesView];
 	}
     return self;
 }
@@ -856,6 +844,24 @@
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
     tap.cancelsTouchesInView = NO;
     [self.view addGestureRecognizer:tap];
+    
+    messagesView = [[MessagesView alloc] initWithFrame:CGRectZero deltaY:0 deltaX:0];
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    
+    CGFloat deltaY = 0;
+    CGRect frame = UIScreen.mainScreen.bounds;
+    if (IS_IPAD) {
+        frame.size.width = STACKSCROLL_WIDTH;
+    }
+    else {
+        deltaY = [Utilities getTopPaddingWithNavBar:self.navigationController];
+    }
+    
+    [messagesView updateWithFrame:CGRectMake(0, 0, frame.size.width, deltaY + DEFAULT_MSG_HEIGHT) deltaY:deltaY deltaX:0];
+    [self.view addSubview:messagesView];
 }
 
 - (void)didReceiveMemoryWarning {

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -94,6 +94,7 @@ typedef enum {
 + (BOOL)hasRemoteToolBar;
 + (CGFloat)getBottomPadding;
 + (CGFloat)getTopPadding;
++ (CGFloat)getTopPaddingWithNavBar:(UINavigationController*)navCtrl;
 + (void)sendXbmcHttp:(NSString*)command;
 + (NSString*)getAppVersionString;
 + (void)checkForReviewRequest;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1094,7 +1094,12 @@
 }
 
 + (CGFloat)getTopPadding {
-    CGFloat topPadding = UIApplication.sharedApplication.statusBarFrame.size.height;
+    CGFloat topPadding = UIApplication.sharedApplication.keyWindow.safeAreaInsets.top;
+    return topPadding;
+}
+
++ (CGFloat)getTopPaddingWithNavBar:(UINavigationController*)navCtrl {
+    CGFloat topPadding = UIApplication.sharedApplication.statusBarFrame.size.height + navCtrl.navigationBar.frame.size.height;
     return topPadding;
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/889.

Generally it is correct to use `UIApplication.sharedApplication.keyWindow.safeAreaInsets.top` in `getTopPadding`. This resolves issues with moving and wrongly positioned tables in iPhone main menu and custom button view. For the HostManagementViewController we use `UIApplication.sharedApplication.statusBarFrame.size.height ` to read the size of the status bar.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix vertical origin of main menu and custom button view