### PR TITLE
Bugfix: Avoid error response when requesting "art" with Kodi 11 or earlier

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -454,7 +454,7 @@
         [dict removeObjectForKey:@"file_properties"];
         
         // Kodi 11 does not support art for file properties
-        if (AppDelegate.instance.serverVersion < 11) {
+        if (AppDelegate.instance.serverVersion <= 11) {
             [dict[@"properties"] removeObject:@"art"];
         }
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Kodi <= 11 (not only < 11) does not support "art".

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid error response when requesting "art" with Kodi 11 or earlier