### PR TITLE
Maintenance: Do not set empty or dummy tableFooterViews

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5626,7 +5626,6 @@
     noItemsLabel.text = LOCALIZED_STR(@"No items found.");
     isViewDidLoad = YES;
     sectionHeight = LIST_SECTION_HEADER_HEIGHT;
-    dataList.tableFooterView = [UIView new];
     epglockqueue = dispatch_queue_create("com.epg.arrayupdate", DISPATCH_QUEUE_SERIAL);
     epgDict = [NSMutableDictionary new];
     epgDownloadQueue = [NSMutableArray new];
@@ -5637,7 +5636,6 @@
     localHourMinuteFormatter = [NSDateFormatter new];
     localHourMinuteFormatter.dateFormat = @"HH:mm";
     localHourMinuteFormatter.timeZone = [NSTimeZone systemTimeZone];
-    dataList.tableFooterView = [UIView new];
     
     [self initSearchController];
     self.navigationController.view.backgroundColor = UIColor.blackColor;

--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -26,8 +26,6 @@
 		_tableView.dataSource = self;
         _tableView.backgroundColor = UIColor.clearColor;
         mainMenuItems = menu;
-        UIView *footerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 1)];
-        _tableView.tableFooterView = footerView;
         _tableView.separatorInset = UIEdgeInsetsMake(0, cellLabelOffset, 0, 0);
         [self.view addSubview:_tableView];
 	}

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2795,7 +2795,6 @@
     
     ProgressSlider.minimumTrackTintColor = SLIDER_DEFAULT_COLOR;
     ProgressSlider.maximumTrackTintColor = UIColor.darkGrayColor;
-    playlistTableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];
     ProgressSlider.userInteractionEnabled = NO;
     [ProgressSlider setThumbImage:[UIImage new] forState:UIControlStateNormal];
     [ProgressSlider setThumbImage:[UIImage new] forState:UIControlStateHighlighted];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -625,7 +625,6 @@
     menuTableView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
     [menuTableView setScrollEnabled:[self.rightMenuItems[0] enableSection]];
     menuTableView.separatorInset = UIEdgeInsetsMake(0, 0, 0, 0);
-    menuTableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];
     [self.view addSubview:menuTableView];
 
     if (AppDelegate.instance.obj.serverIP.length != 0) {

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -136,8 +136,6 @@
         if (@available(iOS 15.0, *)) {
             _tableView.sectionHeaderTopPadding = 0;
         }
-        UIView *footerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 1)];
-		_tableView.tableFooterView = footerView;
         self.view.backgroundColor = UIColor.clearColor;
         [self.view addSubview:_tableView];
         

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -61,8 +61,6 @@
         _tableView.backgroundColor = UIColor.clearColor;
         _tableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
         mainMenuItems = menu;
-        UIView *footerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 1)];
-        _tableView.tableFooterView = footerView;
         [self.view addSubview:_tableView];
         
 		UIView *verticalLineView1 = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width, 0, 1, self.view.frame.size.height)];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
In several ViewControllers an empty or 1-line strong`UIView` was added as `tableFooterView`. This is not required and therefor removed.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Do not set empty or dummy tableFooterViews