### PR TITLE
Improvement: Global connection status for iPhone

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -5943,16 +5943,12 @@
             @"offline": @[
                 @{
                     @"label": @"ServerInfo",
-                    @"bgColor": [self setColorRed:0.208 Green:0.208 Blue:0.208],
-                    @"fontColor": [self setColorRed:0.702 Green:0.702 Blue:0.702],
                 },
             ],
                    
             @"online": @[
                 @{
                     @"label": @"ServerInfo",
-                    @"bgColor": [self setColorRed:0.208 Green:0.208 Blue:0.208],
-                    @"fontColor": [self setColorRed:0.702 Green:0.702 Blue:0.702],
                 },
                 @{
                     @"label": @"VolumeControl",
@@ -5983,8 +5979,6 @@
             @"offline": @[
                 @{
                     @"label": @"ServerInfo",
-                    @"bgColor": [self setColorRed:0.208 Green:0.208 Blue:0.208],
-                    @"fontColor": [self setColorRed:0.702 Green:0.702 Blue:0.702],
                 },
                 @{
                     @"label": LOCALIZED_STR(@"LED Torch"),
@@ -5995,8 +5989,6 @@
             @"online": @[
                 @{
                     @"label": @"ServerInfo",
-                    @"bgColor": [self setColorRed:0.208 Green:0.208 Blue:0.208],
-                    @"fontColor": [self setColorRed:0.702 Green:0.702 Blue:0.702],
                 },
                 @{
                     @"label": @"VolumeControl",

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -5940,16 +5940,9 @@
     nowPlayingItem1.family = FamilyNowPlaying;
     nowPlayingItem1.mainMethod = @[
         @{
-            @"offline": @[
-                @{
-                    @"label": @"ServerInfo",
-                },
-            ],
+            @"offline": @[],
                    
             @"online": @[
-                @{
-                    @"label": @"ServerInfo",
-                },
                 @{
                     @"label": @"VolumeControl",
                     @"icon": @"volume",
@@ -5978,18 +5971,12 @@
         @{
             @"offline": @[
                 @{
-                    @"label": @"ServerInfo",
-                },
-                @{
                     @"label": LOCALIZED_STR(@"LED Torch"),
                     @"icon": @"torch",
                 },
             ],
                                    
             @"online": @[
-                @{
-                    @"label": @"ServerInfo",
-                },
                 @{
                     @"label": @"VolumeControl",
                     @"icon": @"volume",

--- a/XBMC Remote/MasterViewController.h
+++ b/XBMC Remote/MasterViewController.h
@@ -32,8 +32,6 @@
     CustomNavigationController *navController;
 }
 
-- (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName;
-
 @property (nonatomic, strong) NSMutableArray *mainMenu;
 @property (strong, nonatomic) DetailViewController *detailViewController;
 @property (strong, nonatomic) NowPlaying *nowPlaying;

--- a/XBMC Remote/MasterViewController.h
+++ b/XBMC Remote/MasterViewController.h
@@ -30,6 +30,7 @@
     HostManagementViewController *hostManagementViewController;
     BOOL itemIsActive;
     CustomNavigationController *navController;
+    UIImageView *globalConnectionStatus;
 }
 
 @property (nonatomic, strong) NSMutableArray *mainMenu;

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -51,6 +51,8 @@
                                    infoText, @"message",
                                    iconName, @"icon_connection",
                                    nil];
+    AppDelegate.instance.serverOnLine = status;
+    AppDelegate.instance.serverName = infoText;
     NSString *notificationName;
     if (status) {
         [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
@@ -61,8 +63,6 @@
         notificationName = @"XBMCServerConnectionFailed";
     }
     [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:nil userInfo:params];
-    AppDelegate.instance.serverOnLine = status;
-    AppDelegate.instance.serverName = infoText;
     itemIsActive = NO;
     [Utilities setStyleOfMenuItems:menuList active:status];
     if (status) {

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -16,7 +16,6 @@
 #import "Utilities.h"
 
 #define TOOLBAR_HEIGHT 44.0
-#define SERVER_INFO_HEIGHT 44.0
 #define RIGHT_MENU_ITEM_HEIGHT 50.0
 #define RIGHT_MENU_ICON_SIZE 18.0
 #define RIGHT_MENU_ICON_SPACING 16.0
@@ -50,10 +49,7 @@
 
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
     NSString *rowContent = tableData[indexPath.row][@"label"];
-    if ([rowContent isEqualToString:@"ServerInfo"]) {
-        return SERVER_INFO_HEIGHT;
-    }
-    else if ([rowContent isEqualToString:@"RemoteControl"]) {
+    if ([rowContent isEqualToString:@"RemoteControl"]) {
         return UIScreen.mainScreen.bounds.size.height - [self getRemoteViewOffsetY];
     }
     else if ([rowContent isEqualToString:@"VolumeControl"]) {
@@ -127,26 +123,7 @@
     NSString *iconName = @"blank";
     
     // Tailor cell layout for content type
-    if ([tableData[indexPath.row][@"label"] isEqualToString:@"ServerInfo"]) {
-        // Enable connection status icon and place it
-        status.frame = CGRectMake(STATUS_SPACING,
-                                  (SERVER_INFO_HEIGHT - RIGHT_MENU_ICON_SIZE) / 2,
-                                  RIGHT_MENU_ICON_SIZE,
-                                  RIGHT_MENU_ICON_SIZE);
-        status.image = [UIImage imageNamed:[Utilities getConnectionStatusIconName]];
-        status.alpha = 1.0;
-        status.hidden = NO;
-        
-        // Adapt text field to align with connection status
-        title.frame = CGRectMake(CGRectGetMaxX(status.frame) + STATUS_SPACING,
-                                 (SERVER_INFO_HEIGHT - RIGHT_MENU_ITEM_HEIGHT) / 2,
-                                 CGRectGetMaxX(cell.frame) - CGRectGetMaxX(status.frame) - 2 * STATUS_SPACING,
-                                 RIGHT_MENU_ITEM_HEIGHT);
-        title.font = [UIFont fontWithName:@"Roboto-Regular" size:13];
-        title.textAlignment = NSTextAlignmentLeft;
-        title.text = AppDelegate.instance.serverName;
-    }
-    else if ([tableData[indexPath.row][@"label"] isEqualToString:@"VolumeControl"]) {
+    if ([tableData[indexPath.row][@"label"] isEqualToString:@"VolumeControl"]) {
         volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectZero leftAnchor:ANCHOR_RIGHT_PEEK isSliderType:YES];
         [volumeSliderView startTimer];
         [cell.contentView addSubview:volumeSliderView];
@@ -255,11 +232,11 @@
 #pragma mark - Helper
 
 - (CGFloat)getRemoteViewOffsetY {
-    // Layout is (top-down): status bar > server info > volume slider > (menu items) > remote view
+    // Layout is (top-down): status bar > volume slider > (menu items) > remote view
     CGFloat statusBarHeight = [Utilities getTopPadding];
     CGFloat sliderHeight = volumeSliderView.frame.size.height;
     CGFloat menuItemsHeight = [Utilities hasRemoteToolBar] ? 0 : 3 * RIGHT_MENU_ITEM_HEIGHT;
-    return statusBarHeight + SERVER_INFO_HEIGHT + sliderHeight + menuItemsHeight;
+    return statusBarHeight + sliderHeight + menuItemsHeight;
 }
 
 #pragma mark - Table actions
@@ -723,34 +700,13 @@
     return foundIndex;
 }
 
-- (void)updateConnectionStatusAndName:(NSDictionary*)theData {
-    if (theData != nil) {
-        NSString *serverTxt = theData[@"message"];
-        NSString *icon_connection = theData[@"icon_connection"];
-        NSIndexPath *serverRow = [self getIndexPathForKey:@"label" withValue:@"ServerInfo" inArray:tableData];
-        if (serverRow != nil) {
-            UITableViewCell *cell = [menuTableView cellForRowAtIndexPath:serverRow];
-            if (serverTxt.length) {
-                UILabel *title = (UILabel*)[cell viewWithTag:XIB_RIGHT_MENU_CELL__TITLE];
-                title.text = serverTxt;
-            }
-            if (icon_connection.length) {
-                UIImageView *icon = (UIImageView*)[cell viewWithTag:XIB_RIGHT_MENU_CELL__ICON];
-                icon.image = [UIImage imageNamed:icon_connection];
-            }
-        }
-    }
-}
-
 - (void)connectionSuccess:(NSNotification*)note {
-    [self updateConnectionStatusAndName:note.userInfo];
     [self loadRightMenuContentConnected:YES];
     [menuTableView reloadData];
     moreButton.enabled = YES;
 }
 
 - (void)connectionFailed:(NSNotification*)note {
-    [self updateConnectionStatusAndName:note.userInfo];
     if (AppDelegate.instance.obj.serverIP.length != 0) {
         [self loadRightMenuContentConnected:YES];
         [menuTableView reloadData];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -71,16 +71,7 @@
 }
 
 - (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
-    NSDictionary *rgbColor = tableData[indexPath.row][@"bgColor"];
-    if (rgbColor.count) {
-        cell.backgroundColor = [UIColor colorWithRed:[rgbColor[@"red"] floatValue]
-                                               green:[rgbColor[@"green"] floatValue]
-                                                blue:[rgbColor[@"blue"] floatValue]
-                                               alpha:1];
-    }
-    else { // xcode xib bug with ipad?
-        cell.backgroundColor = UIColor.clearColor;
-    }
+    cell.backgroundColor = [Utilities getGrayColor:36 alpha:1];
 }
 
 - (UITableViewCell*)tableView:(UITableView*)tableView cellForRowAtIndexPath:(NSIndexPath*)indexPath {
@@ -207,19 +198,11 @@
         title.text = tableData[indexPath.row][@"label"];
         iconName = tableData[indexPath.row][@"icon"];
     }
-    if ([tableData[indexPath.row][@"fontColor"] count]) {
-        UIColor *fontColor = [UIColor colorWithRed:[tableData[indexPath.row][@"fontColor"][@"red"] floatValue]
-                                             green:[tableData[indexPath.row][@"fontColor"][@"green"] floatValue]
-                                              blue:[tableData[indexPath.row][@"fontColor"][@"blue"] floatValue]
-                                             alpha:1];
-        title.textColor = fontColor;
-        title.highlightedTextColor = fontColor;
-    }
-    else {
-        UIColor *fontColor = [Utilities getGrayColor:125 alpha:1];
-        title.textColor = fontColor;
-        title.highlightedTextColor = fontColor;
-    }
+    
+    UIColor *fontColor = [Utilities getGrayColor:125 alpha:1];
+    title.textColor = fontColor;
+    title.highlightedTextColor = fontColor;
+    
     if ([tableData[indexPath.row][@"label"] isEqualToString:LOCALIZED_STR(@"LED Torch")]) {
         icon.alpha = 0.8;
         if (torchIsOn) {
@@ -323,16 +306,12 @@
     tableData = [NSMutableArray new];
     for (NSDictionary *item in menuItem.mainMethod[0][menuKey]) {
         NSString *label = item[@"label"] ?: @"";
-        NSDictionary *bgColor = item[@"bgColor"] ?: @{};
-        NSDictionary *fontColor = item[@"fontColor"] ?: @{};
         NSString *icon = item[@"icon"] ?: @"blank";
         NSDictionary *action = item[@"action"] ?: @{};
         NSNumber *showTop = item[@"revealViewTop"] ?: @NO;
         
         NSDictionary *itemDict = @{
             @"label": label,
-            @"bgColor": bgColor,
-            @"fontColor": fontColor,
             @"icon": icon,
             @"action": action,
             @"revealViewTop": showTop,
@@ -376,8 +355,6 @@
         
         NSMutableDictionary *itemDict = [@{
             @"label": label,
-            @"bgColor": @{},
-            @"fontColor": @{},
             @"icon": icon,
             @"isSetting": isSetting,
             @"revealViewTop": @NO,
@@ -620,8 +597,6 @@
     
     infoCustomButton = @{
         @"label": LOCALIZED_STR(@"No custom button defined.\r\nPress \"...more\" below to add new ones."),
-        @"bgColor": @{},
-        @"fontColor": @{},
         @"icon": @"default-right-menu-icon",
         @"action": @{},
         @"revealViewTop": @NO,

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -117,27 +117,27 @@
                                    infoText, @"message",
                                    iconName, @"icon_connection",
                                    nil];
+    AppDelegate.instance.serverOnLine = status;
+    AppDelegate.instance.serverName = infoText;
+    NSString *notificationName;
     if (status) {
         [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
-        [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCServerConnectionSuccess" object:nil userInfo:params];
-        AppDelegate.instance.serverOnLine = YES;
-        AppDelegate.instance.serverName = infoText;
+        notificationName = @"XBMCServerConnectionSuccess";
         [volumeSliderView startTimer];
-        [xbmcInfo setTitle:infoText forState:UIControlStateNormal];
-        [Utilities setStyleOfMenuItems:menuViewController.tableView active:YES];
-        // Send trigger to start the defalt controller
-        [[NSNotificationCenter defaultCenter] postNotificationName: @"KodiStartDefaultController" object:nil userInfo:params];
     }
     else {
         [self.tcpJSONRPCconnection stopNetworkCommunication];
-        [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCServerConnectionFailed" object:nil userInfo:params];
-        AppDelegate.instance.serverOnLine = NO;
-        AppDelegate.instance.serverName = infoText;
-        [xbmcInfo setTitle:infoText forState:UIControlStateNormal];
-        [Utilities setStyleOfMenuItems:menuViewController.tableView active:NO];
+        notificationName = @"XBMCServerConnectionFailed";
         if (!extraTimer.valid) {
             extraTimer = [NSTimer scheduledTimerWithTimeInterval:CONNECTION_TIMEOUT target:self selector:@selector(offStackView) userInfo:nil repeats:NO];
         }
+    }
+    [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:nil userInfo:params];
+    [xbmcInfo setTitle:infoText forState:UIControlStateNormal];
+    [Utilities setStyleOfMenuItems:menuViewController.tableView active:status];
+    if (status) {
+        // Send trigger to start the defalt controller
+        [[NSNotificationCenter defaultCenter] postNotificationName: @"KodiStartDefaultController" object:nil userInfo:params];
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR introduces a globally visible connection status icon for iPhone. On iPad this was already visible in the right corner of the toolbar, on iPhone an upper left position on top of the navigation bar is chosen. With this change it is possible to recognize connection state without moving through the menus to a remote screen or the server list.

The status icon is not visible when entering the Kodi settings. I will not fix this as the code in this area will anyway change when the settings are moved to main menu.

Screenshots: https://ibb.co/g3CdX7c

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Global connection status for iPhone