### PR TITLE
Bugfix: Avoid resizing of NowPlaying view and font on iPhone

### DIFF
--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -107,7 +107,7 @@
     MessagesView *messagesView;
 }
 
-- (void)setNowPlayingDimension:(int)width height:(int)height YPOS:(int)YPOS fullscreen:(BOOL)isFullscreen;
+- (void)setNowPlayingDimension:(CGFloat)width height:(CGFloat)height YPOS:(CGFloat)YPOS fullscreen:(BOOL)isFullscreen;
 - (id)initWithNibName:(NSString*)nibNameOrNil bundle:(NSBundle*)nibBundleOrNil;
 - (IBAction)startVibrate:(id)sender;
 - (void)toggleSongDetails;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -47,8 +47,8 @@
 #define COVERVIEW_PADDING 10
 #define SEGMENTCONTROL_WIDTH 122
 #define SEGMENTCONTROL_HEIGHT 32
-#define BOTTOMVIEW_WIDTH 320
-#define BOTTOMVIEW_HEIGHT 158
+#define BOTTOMVIEW_WIDTH 320.0
+#define BOTTOMVIEW_HEIGHT 158.0
 #define TOOLBAR_HEIGHT 44
 #define SHUFFLE_REPEAT_VERTICAL_PADDING 3
 #define SHUFFLE_REPEAT_HORIZONTAL_PADDING 5
@@ -2313,32 +2313,35 @@
 
 #pragma mark - Interface customizations
 
-- (void)setNowPlayingDimensionIPhone:(int)width height:(int)height {
-    CGFloat scaleX = width / BottomView.frame.size.width;
-    CGFloat scaleY = height / BottomView.frame.size.height;
+- (void)setNowPlayingDimensionIPhone:(CGFloat)width height:(CGFloat)height {
+    CGFloat scaleX = width / BOTTOMVIEW_WIDTH;
+    CGFloat scaleY = height / BOTTOMVIEW_HEIGHT;
     CGFloat scale = MIN(scaleX, scaleY);
     
     [self setFontSizes:scale];
     
-    // Set correct size for background image
-    CGRect frame = transitionView.frame;
+    // Get padding and reserved height (= top padding, bottom padding and tool bar)
     CGFloat topBarHeight = [Utilities getTopPaddingWithNavBar:self.navigationController];
-    frame.size.height += topBarHeight;
+    CGFloat reservedHeight = [Utilities getBottomPadding] + topBarHeight + CGRectGetHeight(playlistToolbarView.frame);
+    
+    // Set correct size for background image and views
+    CGRect frame = transitionView.frame;
+    frame.size.height = GET_MAINSCREEN_HEIGHT;
     frame.origin.y = -topBarHeight;
     transitionView.frame = frame;
     
     frame = nowPlayingView.frame;
-    frame.size.height -= topBarHeight;
+    frame.size.height = GET_MAINSCREEN_HEIGHT - reservedHeight;
     frame.origin.y = topBarHeight;
     nowPlayingView.frame = frame;
     
     frame = playlistView.frame;
-    frame.size.height -= topBarHeight;
+    frame.size.height = GET_MAINSCREEN_HEIGHT - reservedHeight;
     frame.origin.y = topBarHeight;
     playlistView.frame = frame;
     
-    CGFloat newWidth = floor(BottomView.frame.size.width * scale);
-    CGFloat newHeight = floor(BottomView.frame.size.height * scale);
+    CGFloat newWidth = floor(BOTTOMVIEW_WIDTH * scale);
+    CGFloat newHeight = floor(BOTTOMVIEW_HEIGHT * scale);
     
     BottomView.frame = CGRectMake((nowPlayingView.frame.size.width - newWidth) / 2,
                                   nowPlayingView.frame.size.height - newHeight,
@@ -2360,7 +2363,7 @@
     fullscreenCover.frame = visualEffectView.frame = transitionView.frame;
 }
 
-- (void)setNowPlayingDimension:(int)width height:(int)height YPOS:(int)YPOS fullscreen:(BOOL)isFullscreen {
+- (void)setNowPlayingDimension:(CGFloat)width height:(CGFloat)height YPOS:(CGFloat)YPOS fullscreen:(BOOL)isFullscreen {
     CGRect frame;
     
     // Maximum allowed height excludes status bar, toolbar and safe area


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3190952#pid3190952).

The layout function `setNowPlayingDimensionIPhone:height` can be called multiple times, resulting in changing the view and font sizes again. It is needed to use _absolute_ and not _relative_ size changes. In addition use `CGFloat` as input type and for the reference sizes `BOTTOMVIEW_WIDTH` and `BOTTOMVIEW_HEIGHT` when calculating the factors for resizing.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid resizing of NowPlaying view and font on iPhone