### PR TITLE
Maintenance: Rework shuffle and repeat status change and button update

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -314,6 +314,24 @@
     return [Utilities applyRoundedEdgesImage:source drawBorder:YES];
 }
 
+- (void)updateRepeatButton:(NSString*)mode {
+    if ([mode isEqualToString:@"all"]) {
+        UIImage *image = [UIImage imageNamed:@"button_repeat_all"];
+        image = [Utilities colorizeImage:image withColor:KODI_BLUE_COLOR];
+        [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
+    }
+    else if ([mode isEqualToString:@"one"]) {
+        UIImage *image = [UIImage imageNamed:@"button_repeat_one"];
+        image = [Utilities colorizeImage:image withColor:KODI_BLUE_COLOR];
+        [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
+    }
+    else {
+        UIImage *image = [UIImage imageNamed:@"button_repeat"];
+        image = [Utilities colorizeImage:image withColor:IS_IPAD ? UIColor.whiteColor : UIColor.lightGrayColor];
+        [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
+    }
+}
+
 #pragma mark - JSON management
 
 - (void)setCoverSize:(NSString*)type {
@@ -730,24 +748,8 @@
                                  BOOL canrepeat = [methodResult[@"canrepeat"] boolValue] && !musicPartyMode;
                                  if (canrepeat) {
                                      repeatStatus = methodResult[@"repeat"];
-                                     if (repeatButton.hidden) {
-                                         repeatButton.hidden = NO;
-                                     }
-                                     if ([repeatStatus isEqualToString:@"all"]) {
-                                         UIImage *image = [UIImage imageNamed:@"button_repeat_all"];
-                                         image = [Utilities colorizeImage:image withColor:KODI_BLUE_COLOR];
-                                         [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
-                                     }
-                                     else if ([repeatStatus isEqualToString:@"one"]) {
-                                         UIImage *image = [UIImage imageNamed:@"button_repeat_one"];
-                                         image = [Utilities colorizeImage:image withColor:KODI_BLUE_COLOR];
-                                         [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
-                                     }
-                                     else {
-                                         UIImage *image = [UIImage imageNamed:@"button_repeat"];
-                                         image = [Utilities colorizeImage:image withColor:IS_IPAD ? UIColor.whiteColor : UIColor.lightGrayColor];
-                                         [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
-                                     }
+                                     [self updateRepeatButton:repeatStatus];
+                                     repeatButton.hidden = NO;
                                  }
                                  else if (!repeatButton.hidden) {
                                      repeatButton.hidden = YES;
@@ -1681,44 +1683,29 @@
 - (IBAction)changeRepeat:(id)sender {
     repeatButton.highlighted = YES;
     [self performSelector:@selector(toggleHighlight:) withObject:repeatButton afterDelay:.1];
+    
+    // Gather the next repeat status
+    NSString *newRepeatStatus = @"all";
+    if ([repeatStatus isEqualToString:@"off"]) {
+        newRepeatStatus = @"all";
+    }
+    else if ([repeatStatus isEqualToString:@"all"]) {
+        newRepeatStatus = @"one";
+    }
+    else if ([repeatStatus isEqualToString:@"one"]) {
+        newRepeatStatus = @"off";
+    }
+    
+    // Send the command to Kodi
     if (AppDelegate.instance.serverVersion > 11) {
         [self SimpleAction:@"Player.SetRepeat" params:@{@"playerid": @(currentPlayerID), @"repeat": @"cycle"} reloadPlaylist:NO startProgressBar:NO];
-        if ([repeatStatus isEqualToString:@"off"]) {
-            UIImage *image = [UIImage imageNamed:@"button_repeat_all"];
-            image = [Utilities colorizeImage:image withColor:KODI_BLUE_COLOR];
-            [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
-        }
-        else if ([repeatStatus isEqualToString:@"all"]) {
-            UIImage *image = [UIImage imageNamed:@"button_repeat_one"];
-            image = [Utilities colorizeImage:image withColor:KODI_BLUE_COLOR];
-            [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
-        }
-        else if ([repeatStatus isEqualToString:@"one"]) {
-            UIImage *image = [UIImage imageNamed:@"button_repeat"];
-            image = [Utilities colorizeImage:image withColor:IS_IPAD ? UIColor.whiteColor : UIColor.lightGrayColor];
-            [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
-        }
     }
     else {
-        if ([repeatStatus isEqualToString:@"off"]) {
-            [self SimpleAction:@"Player.Repeat" params:@{@"playerid": @(currentPlayerID), @"state": @"all"} reloadPlaylist:NO startProgressBar:NO];
-            UIImage *image = [UIImage imageNamed:@"button_repeat_all"];
-            image = [Utilities colorizeImage:image withColor:KODI_BLUE_COLOR];
-            [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
-        }
-        else if ([repeatStatus isEqualToString:@"all"]) {
-            [self SimpleAction:@"Player.Repeat" params:@{@"playerid": @(currentPlayerID), @"state": @"one"} reloadPlaylist:NO startProgressBar:NO];
-            UIImage *image = [UIImage imageNamed:@"button_repeat_one"];
-            image = [Utilities colorizeImage:image withColor:KODI_BLUE_COLOR];
-            [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
-        }
-        else if ([repeatStatus isEqualToString:@"one"]) {
-            [self SimpleAction:@"Player.Repeat" params:@{@"playerid": @(currentPlayerID), @"state": @"off"} reloadPlaylist:NO startProgressBar:NO];
-            UIImage *image = [UIImage imageNamed:@"button_repeat"];
-            image = [Utilities colorizeImage:image withColor:IS_IPAD ? UIColor.whiteColor : UIColor.lightGrayColor];
-            [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
-        }
+        [self SimpleAction:@"Player.Repeat" params:@{@"playerid": @(currentPlayerID), @"state": newRepeatStatus} reloadPlaylist:NO startProgressBar:NO];
     }
+    
+    // Update the button status
+    [self updateRepeatButton:newRepeatStatus];
 }
 
 #pragma mark - Touch Events & Gestures


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1020.

This PR reworks the implementation for changing and displaying the repeat and shuffle modes. It reduces code duplication by adding helper methods to update the repeat and shuffle buttons.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Rework shuffle and repeat status change and button update