### PR TITLE
Maintenance: Remove UI colorization code from NowPlaying and ViewControllerIpad

### DIFF
--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -89,7 +89,6 @@
     __weak IBOutlet UILabel *scrabbingMessage;
     __weak IBOutlet UILabel *scrabbingRate;
     UIView *toolbarBackground;
-    UIColor *foundEffectColor;
     UISegmentedControl *playlistSegmentedControl;
     __weak IBOutlet UILabel *noItemsLabel;
     NSString *storeLiveTVTitle;

--- a/XBMC Remote/ViewControllerIPad.h
+++ b/XBMC Remote/ViewControllerIPad.h
@@ -8,7 +8,6 @@
 
 #import <UIKit/UIKit.h>
 #import "DSJSONRPC.h"
-#import "gradientUIView.h"
 #import "tcpJSONRPC.h"
 #import "MessagesView.h"
 

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -17,7 +17,6 @@
 #import "AppInfoViewController.h"
 #import "XBMCVirtualKeyboard.h"
 #import "ClearCacheView.h"
-#import "gradientUIView.h"
 #import "CustomNavigationController.h"
 #import "Utilities.h"
 
@@ -567,10 +566,6 @@
                                                  name: @"XBMCServerConnectionFailed"
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(handleChangeBackgroundGradientColor:)
-                                                 name: @"UIViewChangeBackgroundGradientColor"
-                                               object: nil];
-    [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleChangeBackgroundImage:)
                                                  name: @"UIViewChangeBackgroundImage"
                                                object: nil];
@@ -582,9 +577,6 @@
                                              selector: @selector(handlePlaylistHeaderUpdate:)
                                                  name: @"PlaylistHeaderUpdate"
                                                object: nil];
-    
-    [(gradientUIView*)self.view setColoursWithCGColors:[Utilities getGrayColor:36 alpha:1].CGColor
-                                               endColor:[Utilities getGrayColor:22 alpha:1].CGColor];
 }
 
 - (void)handlePlaylistHeaderUpdate:(NSNotification*)sender {
@@ -621,13 +613,6 @@
     else {
         [Utilities imageView:fanartBackgroundImage AnimDuration:1.0 Image:[UIImage new]];
     }
-}
-
-- (void)handleChangeBackgroundGradientColor:(NSNotification*)sender {
-    UIColor *startColor = (UIColor*)[sender.userInfo objectForKey:@"startColor"];
-    UIColor *endColor = (UIColor*)[sender.userInfo objectForKey:@"endColor"];
-    [(gradientUIView*)self.view setColoursWithCGColors:startColor.CGColor endColor:endColor.CGColor];
-    [(gradientUIView*)self.view setNeedsDisplay];
 }
 
 - (void)handleTcpJSONRPCShowSetup:(NSNotification*)sender {

--- a/XBMC Remote/ViewControllerIPad.xib
+++ b/XBMC Remote/ViewControllerIPad.xib
@@ -13,7 +13,7 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="2" customClass="gradientUIView">
+        <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="2" userLabel="View" customClass="gradientUIView">
             <rect key="frame" x="0.0" y="0.0" width="768" height="1004"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1021.

This PR removes all code related to UI colorization in NowPlaying (navigation bar items, labels and progress bar) and ViewControllerIpad.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Remove UI colorization code from NowPlaying and ViewControllerIpad