### PR TITLE
Bugfix: Only animate new library lists horizontally

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5183,10 +5183,10 @@
     [self setFlowLayoutParams];
     [activityIndicatorView stopAnimating];
     [activeLayoutView reloadData];
-    [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0 YPos:0];
     [dataList setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
     [collectionView layoutSubviews];
     [collectionView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
+    [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0 YPos:0];
     if (channelGuideView && autoScrollTable != nil && autoScrollTable.row < [dataList numberOfRowsInSection:autoScrollTable.section]) {
             [dataList scrollToRowAtIndexPath:autoScrollTable atScrollPosition:UITableViewScrollPositionTop animated: NO];
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a long standing issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3191003#pid3191003).

This PR resolves an issue where a list was animated both vertically _and_ horizontally instead of _only_ horizontally, if the former list had been scrolled before. This was caused by the content offset not being properly set before kicking off the animation.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Only animate new library lists horizontally