### PR TITLE
Maintenance: Remove isViewDidLoad, rework iPad corner info and detail view

### DIFF
--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -90,7 +90,7 @@
     BOOL enableDiskCache;
     CGFloat iOSYDelta;
     __weak IBOutlet UIToolbar *buttonsViewBgToolbar;
-    BOOL isViewDidLoad;
+    BOOL loadAndPresentDataOnViewDidAppear;
     BOOL forceMusicAlbumMode;
     NSMutableDictionary *epgDict;
     NSMutableArray *epgDownloadQueue;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6198,7 +6198,19 @@
 - (void)initIpadCornerInfo {
     mainMenu *menuItem = self.detailItem;
     if (IS_IPAD && menuItem.enableSection) {
-        titleView = [[UIView alloc] initWithFrame:CGRectMake(STACKSCROLL_WIDTH - FIXED_SPACE_WIDTH, 0, FIXED_SPACE_WIDTH - 5, buttonsView.frame.size.height)];
+        // Add a reserved fixed space which is used for iPad corner info
+        for (UILabel *view in buttonsView.subviews) {
+            if ([view isKindOfClass:[UIToolbar class]]) {
+                UIToolbar *toolbar = (UIToolbar*)view;
+                UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
+                fixedSpace.width = FIXED_SPACE_WIDTH;
+                toolbar.items = [toolbar.items arrayByAddingObject:fixedSpace];
+                break;
+            }
+        }
+        
+        // Add the corner info view
+        titleView = [[UIView alloc] initWithFrame:CGRectMake(buttonsView.frame.size.width - FIXED_SPACE_WIDTH, 0, FIXED_SPACE_WIDTH - 5, buttonsView.frame.size.height)];
         titleView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleLeftMargin;
         topNavigationLabel.textAlignment = NSTextAlignmentRight;
         topNavigationLabel.font = [UIFont boldSystemFontOfSize:14];
@@ -6206,17 +6218,6 @@
         [titleView addSubview:topNavigationLabel];
         [buttonsView addSubview:titleView];
         [self checkFullscreenButton:NO];
-    }
-    else {
-        // Remove the reserved fixed space which is only used for iPad corner info
-        for (UILabel *view in buttonsView.subviews) {
-            if ([view isKindOfClass:[UIToolbar class]]) {
-                UIToolbar *bar = (UIToolbar*)view;
-                NSMutableArray *items = [NSMutableArray arrayWithArray:bar.items];
-                [items removeObjectAtIndex:15];
-                [bar setItems:items animated:NO];
-            }
-        }
     }
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5551,16 +5551,16 @@
     else {
         self.navigationController.navigationBar.tintColor = ICON_TINT_COLOR;
     }
-    if (isViewDidLoad) {
+    
+    // We load data only in viewDidAppear as loading/presenting is tightly coupled and we want
+    // the layout to be ready. We do not want to repeat loading/presenting, if we re-enter the
+    // same controller instance from another view, e.g. when coming back from detail view.
+    if (loadAndPresentDataOnViewDidAppear) {
         [self initIpadCornerInfo];
-        if (globalSearchView) {
-            [self retrieveGlobalData:NO];
-        }
-        else {
-            [self startRetrieveDataWithRefresh:NO];
-        }
-        isViewDidLoad = NO;
+        [self startRetrieveDataWithRefresh:NO];
+        loadAndPresentDataOnViewDidAppear = NO;
     }
+    
     if (channelListView || channelGuideView) {
         [channelListUpdateTimer invalidate];
         // Set up a timer that will always trigger at the start of each local minute. This supports
@@ -5949,7 +5949,7 @@
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     hiddenLabel = [userDefaults boolForKey:@"hidden_label_preference"];
     noItemsLabel.text = LOCALIZED_STR(@"No items found.");
-    isViewDidLoad = YES;
+    loadAndPresentDataOnViewDidAppear = YES;
     sectionHeight = LIST_SECTION_HEADER_HEIGHT;
     epglockqueue = dispatch_queue_create("com.epg.arrayupdate", DISPATCH_QUEUE_SERIAL);
     epgDict = [NSMutableDictionary new];

--- a/XBMC Remote/DetailViewController.xib
+++ b/XBMC Remote/DetailViewController.xib
@@ -75,7 +75,7 @@
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="OQd-aJ-obl"/>
                                         <barButtonItem style="plain" id="yuj-lW-yot">
                                             <button key="customView" hidden="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="117" userLabel="Button1">
-                                                <rect key="frame" x="0.0" y="7" width="34" height="30"/>
+                                                <rect key="frame" x="10.5" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                                 <state key="normal" backgroundImage="st_album">
@@ -93,7 +93,7 @@
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="IVe-28-sl6"/>
                                         <barButtonItem style="plain" id="cRW-wf-x2D">
                                             <button key="customView" hidden="YES" tag="1" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="119" userLabel="Button2">
-                                                <rect key="frame" x="34" y="7" width="34" height="30"/>
+                                                <rect key="frame" x="54.5" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                                 <state key="normal" backgroundImage="st_artist">
@@ -111,7 +111,7 @@
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="dSm-ED-j5s"/>
                                         <barButtonItem style="plain" id="4He-Lr-2WZ">
                                             <button key="customView" hidden="YES" tag="2" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="121" userLabel="Button3">
-                                                <rect key="frame" x="68" y="7" width="34" height="30"/>
+                                                <rect key="frame" x="99" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                                 <state key="normal" backgroundImage="st_genre">
@@ -129,7 +129,7 @@
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="Gi1-6Y-y4k"/>
                                         <barButtonItem style="plain" id="TE7-pJ-4WE">
                                             <button key="customView" hidden="YES" tag="3" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="122" userLabel="Button4">
-                                                <rect key="frame" x="102" y="7" width="34" height="30"/>
+                                                <rect key="frame" x="143" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                                 <state key="normal" backgroundImage="st_filemode">
@@ -147,7 +147,7 @@
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="ZdQ-hl-bWG"/>
                                         <barButtonItem style="plain" id="d4P-SH-Im4">
                                             <button key="customView" hidden="YES" tag="4" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="123" userLabel="Button5">
-                                                <rect key="frame" x="136" y="7" width="34" height="30"/>
+                                                <rect key="frame" x="187.5" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                                 <state key="normal" backgroundImage="st_more">
@@ -165,7 +165,7 @@
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="C79-Cc-JFa"/>
                                         <barButtonItem style="plain" id="rHQ-LZ-GMb">
                                             <button key="customView" hidden="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="kky-5P-ej6" userLabel="Button6">
-                                                <rect key="frame" x="170" y="5" width="34" height="34"/>
+                                                <rect key="frame" x="231.5" y="5" width="34" height="34"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" backgroundImage="st_view_list"/>
                                             </button>
@@ -173,13 +173,12 @@
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="bQB-y4-wNs"/>
                                         <barButtonItem style="plain" id="WWo-3h-QTx">
                                             <button key="customView" hidden="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="17m-9l-ySa" userLabel="Button7">
-                                                <rect key="frame" x="204" y="5" width="34" height="34"/>
+                                                <rect key="frame" x="276" y="5" width="34" height="34"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" backgroundImage="st_sort_asc"/>
                                             </button>
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="vF6-OW-tqm"/>
-                                        <barButtonItem width="120" style="plain" systemItem="fixedSpace" id="OXN-bQ-4yq"/>
                                     </items>
                                 </toolbar>
                             </subviews>

--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -82,7 +82,6 @@
     UIColor *foundTintColor;
     UILabel *viewTitle;
     __weak IBOutlet UIImageView *bottomShadow;
-    BOOL isViewDidLoad;
     UIImageView *isRecording;
     LogoBackgroundType logoBackgroundMode;
     UIBarButtonItem *doneButton;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -577,6 +577,10 @@ double round(double d) {
 }
 
 - (void)createInfo {
+    // Use mainLabel0 to check, if the info view already has been created
+    if (mainLabel0) {
+        return;
+    }
     // NEED TO BE OPTIMIZED. IT WORKS BUT THERE ARE TOO MANY IFS!
     NSMutableDictionary *item = self.detailItem;
     NSString *placeHolderImage = @"coverbox_back";
@@ -1877,10 +1881,7 @@ double round(double d) {
         viewTitle.textAlignment = NSTextAlignmentCenter;
         bottomShadow.hidden = YES;
     }
-    if (isViewDidLoad) {
-        [self createInfo];
-        isViewDidLoad = NO;
-    }
+    [self createInfo];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -1952,7 +1953,6 @@ double round(double d) {
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    isViewDidLoad = YES;
     fanartView.tag = FANART_FULLSCREEN_DISABLE;
     fanartView.userInteractionEnabled = YES;
     UITapGestureRecognizer *touchOnKenView = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(showBackground:)];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR does some refactoring to simplify the state machine and logic.
- Remove the need to use ivar `isViewDidLoad` in DetailViewController. Now iPad corner info only requires layout for iPad by adding a fixed space programmatically instead of adding it to xib and removing it for iPhone.
- Remove the need to use ivar `isViewDidLoad` in ShowInfoViewController. Now a check is done _inside_ `createInfo` to only run the layout once.


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Remove isViewDidLoad, rework iPad corner info and detail view