### PR TITLE
Bugfix: Use white scroll indicator for RightMenuVC

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -648,6 +648,7 @@
     menuTableView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
     [menuTableView setScrollEnabled:[self.rightMenuItems[0] enableSection]];
     menuTableView.separatorInset = UIEdgeInsetsMake(0, 0, 0, 0);
+    menuTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
     [self.view addSubview:menuTableView];
 
     if (AppDelegate.instance.obj.serverIP.length != 0) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Improve readability of scroll indicator in `RightMenuViewController`. This always uses dark background and cells with dark background. So the scroll indicator should be set to `UIScrollViewIndicatorStyleWhite`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use white scroll indicator for RightMenuVC