### PR TITLE
Bugfix: Use correct bottom scroll inset for collection view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -855,11 +855,11 @@
     [self hideButtonListWhenEmpty];
 }
 
-- (void)setViewInset:(UIView*)view bottom:(CGFloat)bottomInset {
-    UIEdgeInsets viewInsets = dataList.contentInset;
+- (void)setViewInset:(UIScrollView*)scrollView bottom:(CGFloat)bottomInset {
+    UIEdgeInsets viewInsets = scrollView.contentInset;
     viewInsets.bottom = bottomInset;
-    dataList.contentInset = viewInsets;
-    dataList.scrollIndicatorInsets = viewInsets;
+    scrollView.contentInset = viewInsets;
+    scrollView.scrollIndicatorInsets = viewInsets;
 }
 
 - (void)hideButtonList:(BOOL)hide {


### PR DESCRIPTION


## Description
<!--- Detailed info for reviewers and developers -->
The method `setViewInset` shall process the _input_ parameter and not `dataList`. Fixes an issue with the collection view using wrong bottom inset for the scroll indicator.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use correct bottom scroll inset for collection view