### PR TITLE
Improvement: Show playlist item count in header

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2194,7 +2194,6 @@
 }
 
 - (void)tableView:(UITableView*)tableView moveRowAtIndexPath:(NSIndexPath*)sourceIndexPath toIndexPath:(NSIndexPath*)destinationIndexPath {
-    
     if (sourceIndexPath.row >= playlistData.count ||
         sourceIndexPath.row == destinationIndexPath.row) {
         return;
@@ -2249,7 +2248,6 @@
 }
 
 - (void)tableView:(UITableView*)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath*)indexPath {
-
     if (editingStyle == UITableViewCellEditingStyleDelete) {
         NSString *actionRemove = @"Playlist.Remove";
         NSDictionary *paramsRemove = @{

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -121,6 +121,15 @@
 
 #pragma mark - utility
 
+- (NSString*)getPlaylistHeaderLabel {
+    NSString *headerLabel = LOCALIZED_STR(@"Playlist");
+    NSUInteger numItems = playlistData.count;
+    if (numItems > 0) {
+        headerLabel = [NSString stringWithFormat:@"%@ (%lu)", headerLabel, numItems];
+    }
+    return headerLabel;
+}
+
 - (void)updateBlurredCoverBackground:(UIImage*)image {
     // Show blurred cover background (iPhone only, as iPad uses other layout)
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
@@ -1285,6 +1294,18 @@
     else {
         [Utilities AnimView:playlistTableView AnimDuration:0.3 Alpha:1.0 XPos:0];
     }
+    
+    // Define playlist header label, adding number of playlist items in brackets
+    NSString *playlistLabel = [self getPlaylistHeaderLabel];
+    if (!playlistView.hidden) {
+        self.navigationItem.title = playlistLabel;
+    }
+    // For iPad send a notification with the label
+    if (IS_IPAD) {
+        NSDictionary *params = @{@"playlistHeaderLabel": playlistLabel};
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"PlaylistHeaderUpdate" object:nil userInfo:params];
+    }
+    
     [playlistTableView performSelectorOnMainThread:@selector(reloadData) withObject:nil waitUntilDone:YES];
     [activityIndicatorView stopAnimating];
     lastSelected = SELECTED_NONE;
@@ -1505,7 +1526,7 @@
     if (!nowPlayingView.hidden) {
         transitionFromView = nowPlayingView;
         transitionToView = playlistView;
-        self.navigationItem.title = LOCALIZED_STR(@"Playlist");
+        self.navigationItem.title = [self getPlaylistHeaderLabel];
         self.navigationItem.titleView.hidden = YES;
         animationOptionTransition = UIViewAnimationOptionTransitionCrossDissolve;
         effectColor = UIColor.clearColor;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -578,9 +578,19 @@
                                              selector: @selector(handleNowPlayingFullscreenToggle)
                                                  name: @"NowPlayingFullscreenToggle"
                                                object: nil];
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handlePlaylistHeaderUpdate:)
+                                                 name: @"PlaylistHeaderUpdate"
+                                               object: nil];
     
     [(gradientUIView*)self.view setColoursWithCGColors:[Utilities getGrayColor:36 alpha:1].CGColor
                                                endColor:[Utilities getGrayColor:22 alpha:1].CGColor];
+}
+
+- (void)handlePlaylistHeaderUpdate:(NSNotification*)sender {
+    NSDictionary *userInfo = sender.userInfo;
+    NSString *headerText = userInfo[@"playlistHeaderLabel"];
+    playlistHeader.text = headerText;
 }
 
 - (void)handleNowPlayingFullscreenToggle {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/976.

Adds the amount of items for a playlist to the playlist header, e.g. "Playlist (16)".

Screenshots: https://ibb.co/2PT6G4Q

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Show playlist item count in header