### PR TITLE
Bugfix: Ensure correct MasterVC connection icon on cell reuse

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -234,12 +234,8 @@
 - (void)setConnectionIcon:(UIImageView*)icon {
     // Load icon for top row in main menu
     UIImage *image = [UIImage imageNamed:@"st_kodi_action"];
-    if (!AppDelegate.instance.serverOnLine) {
-        icon.image = [Utilities colorizeImage:image withColor:UIColor.grayColor];
-    }
-    else {
-        icon.image = [Utilities colorizeImage:image withColor:KODI_BLUE_COLOR];
-    }
+    UIColor *iconColor = AppDelegate.instance.serverOnLine ? KODI_BLUE_COLOR : UIColor.grayColor;
+    icon.highlightedImage = icon.image = [Utilities colorizeImage:image withColor:iconColor];
     
     // Load icon for global connection status
     NSString *statusIconName = [Utilities getConnectionStatusIconName];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Also need to set `highlightedImage` to ensure the correct icon is shown when `cell` has been reused.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Ensure correct MasterVC connection icon on cell reuse