### PR TITLE
Bugfix: Deselect menu when closing all stack views on iPad

### DIFF
--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -102,6 +102,7 @@
 }
 
 - (void)handleRemoveStack {
+    [self handleDeselectSection];
     [AppDelegate.instance.windowController.stackScrollViewController offView];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3193994#pid3193994).

When using the "NowPlaying" button from the iPad toolbar, all stack views are closed. At the same time the current active menu item (e.g. "Music" or "TV Shows") should be deselected.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Deselect menu when closing all stack views on iPad