### PR TITLE
Maintenance: Rework NowPlaying playback states

### DIFF
--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -51,7 +51,7 @@
     IBOutlet UIActivityIndicatorView *activityIndicatorView;
     int playerPlaying;
     BOOL PlayerPaused;
-    int musicPartyMode;
+    BOOL musicPartyMode;
     IBOutlet UIButton *editTableButton;
     IBOutlet UIButton *PartyModeButton;
     IBOutlet UIImageView *backgroundImageView;

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -81,7 +81,7 @@
     BOOL shuffled;
     NSString *repeatStatus;
     BOOL updateProgressBar;
-    int globalSeconds;
+    int totalSeconds;
     NSString *lastThumbnail;
     int choosedTab;
     NSString *notificationName;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -450,7 +450,7 @@
     repeatButton.hidden = YES;
     shuffleButton.hidden = YES;
     hiresImage.hidden = YES;
-    musicPartyMode = 0;
+    musicPartyMode = NO;
     [self notifyChangeForBackgroundImage:nil coverImage:nil];
     [self hidePlaylistProgressbarWithDeselect:YES];
     [self showPlaylistTable];
@@ -686,13 +686,11 @@
                                  if (updateProgressBar) {
                                      ProgressSlider.value = [(NSNumber*)methodResult[@"percentage"] floatValue];
                                  }
-                                 musicPartyMode = [methodResult[@"partymode"] intValue];
-                                 if (musicPartyMode) {
-                                     PartyModeButton.selected = YES;
-                                 }
-                                 else {
-                                     PartyModeButton.selected = NO;
-                                 }
+                                 
+                                 // Read PartyMode state and set button
+                                 musicPartyMode = [methodResult[@"partymode"] boolValue];
+                                 PartyModeButton.selected = musicPartyMode;
+                                 
                                  BOOL canrepeat = [methodResult[@"canrepeat"] boolValue] && !musicPartyMode;
                                  if (canrepeat) {
                                      repeatStatus = methodResult[@"repeat"];
@@ -2492,7 +2490,7 @@
             break;
     }
     lastSelected = SELECTED_NONE;
-    musicPartyMode = 0;
+    musicPartyMode = NO;
     [self createPlaylist:NO animTableView:YES];
 }
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -792,16 +792,7 @@
                                      [self updatePlaylistProgressbar:percentage actual:actualTime];
                                  }
                              }
-                             else {
-                                 PartyModeButton.selected = NO;
-                             }
                          }
-                         else {
-                             PartyModeButton.selected = NO;
-                         }
-                     }
-                     else {
-                         PartyModeButton.selected = NO;
                      }
                  }];
             }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -698,14 +698,13 @@
                                      repeatStatus = methodResult[@"repeat"];
                                      [self updateRepeatButton:repeatStatus];
                                  }
-                                 BOOL canshuffle = [methodResult[@"canshuffle"] boolValue] && !musicPartyMode;
-                                 if (canshuffle) {
+                                 
+                                 // Read shuffle capability and mode to set button state
+                                 BOOL canShuffle = [methodResult[@"canshuffle"] boolValue] && !musicPartyMode;
+                                 shuffleButton.hidden = !canShuffle;
+                                 if (canShuffle) {
                                      shuffled = [methodResult[@"shuffled"] boolValue];
                                      [self updateShuffleButton:shuffled];
-                                     shuffleButton.hidden = NO;
-                                 }
-                                 else if (!shuffleButton.hidden) {
-                                     shuffleButton.hidden = YES;
                                  }
                                  
                                  BOOL canseek = [methodResult[@"canseek"] boolValue];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -691,14 +691,12 @@
                                  musicPartyMode = [methodResult[@"partymode"] boolValue];
                                  PartyModeButton.selected = musicPartyMode;
                                  
-                                 BOOL canrepeat = [methodResult[@"canrepeat"] boolValue] && !musicPartyMode;
-                                 if (canrepeat) {
+                                 // Read repeat capability and mode to set button state
+                                 BOOL canRepeat = [methodResult[@"canrepeat"] boolValue] && !musicPartyMode;
+                                 repeatButton.hidden = !canRepeat;
+                                 if (canRepeat) {
                                      repeatStatus = methodResult[@"repeat"];
                                      [self updateRepeatButton:repeatStatus];
-                                     repeatButton.hidden = NO;
-                                 }
-                                 else if (!repeatButton.hidden) {
-                                     repeatButton.hidden = YES;
                                  }
                                  BOOL canshuffle = [methodResult[@"canshuffle"] boolValue] && !musicPartyMode;
                                  if (canshuffle) {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -683,8 +683,10 @@
                      if (error == nil && methodError == nil) {
                          if ([methodResult isKindOfClass:[NSDictionary class]]) {
                              if ([methodResult count]) {
+                                 // Read percentage of playback progress and set progress slider
+                                 float percentage = [Utilities getFloatValueFromItem:methodResult[@"percentage"]];
                                  if (updateProgressBar) {
-                                     ProgressSlider.value = [(NSNumber*)methodResult[@"percentage"] floatValue];
+                                     ProgressSlider.value = percentage;
                                  }
                                  
                                  // Read PartyMode state and set button
@@ -733,7 +735,6 @@
                                  int hours = [time[@"hours"] intValue];
                                  int minutes = [time[@"minutes"] intValue];
                                  int seconds = [time[@"seconds"] intValue];
-                                 float percentage = [(NSNumber*)methodResult[@"percentage"] floatValue];
                                  NSString *actualTime = [NSString stringWithFormat:@"%@%02i:%02i", (hoursGlobal == 0) ? @"" : [NSString stringWithFormat:@"%02i:", hours], minutes, seconds];
                                  if (updateProgressBar) {
                                      currentTime.text = actualTime;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -707,14 +707,15 @@
                                      [self updateShuffleButton:shuffled];
                                  }
                                  
-                                 BOOL canseek = [methodResult[@"canseek"] boolValue];
-                                 if (canseek && !ProgressSlider.userInteractionEnabled) {
+                                 // Read seek capability and mode to set progress bar state
+                                 BOOL canSeek = [methodResult[@"canseek"] boolValue];
+                                 if (canSeek && !ProgressSlider.userInteractionEnabled) {
                                      ProgressSlider.userInteractionEnabled = YES;
                                      UIImage *image = [UIImage imageNamed:@"pgbar_thumb_iOS7"];
                                      [ProgressSlider setThumbImage:image forState:UIControlStateNormal];
                                      [ProgressSlider setThumbImage:image forState:UIControlStateHighlighted];
                                  }
-                                 if (!canseek && ProgressSlider.userInteractionEnabled) {
+                                 if (!canSeek && ProgressSlider.userInteractionEnabled) {
                                      ProgressSlider.userInteractionEnabled = NO;
                                      [ProgressSlider setThumbImage:[UIImage new] forState:UIControlStateNormal];
                                      [ProgressSlider setThumbImage:[UIImage new] forState:UIControlStateHighlighted];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -762,10 +762,6 @@
                                      currentTime.hidden = YES;
                                      duration.hidden = YES;
                                  }
-                                 long playlistPosition = [methodResult[@"position"] longValue];
-                                 if (playlistPosition > -1) {
-                                     playlistPosition += 1;
-                                 }
                                  
                                  // Detect start of new song to update party mode playlist
                                  int posSeconds = [self getSecondsFromTimeDict:actualTimeDict];
@@ -773,10 +769,13 @@
                                      [self checkPartyMode];
                                  }
                                  storePosSeconds = posSeconds;
-                                 if (playlistPosition != lastSelected && playlistPosition > 0) {
-                                     if (playlistData.count >= playlistPosition && currentPlayerID == playerID) {
+                                 
+                                 // Update the playlist position and time when a new item plays, else update progress only
+                                 long playlistPosition = [methodResult[@"position"] longValue];
+                                 if (playlistPosition != lastSelected && playlistPosition != SELECTED_NONE) {
+                                     if (playlistData.count > playlistPosition && currentPlayerID == playerID) {
                                          [self hidePlaylistProgressbarWithDeselect:NO];
-                                         NSIndexPath *newSelection = [NSIndexPath indexPathForRow:playlistPosition - 1 inSection:0];
+                                         NSIndexPath *newSelection = [NSIndexPath indexPathForRow:playlistPosition inSection:0];
                                          UITableViewScrollPosition position = UITableViewScrollPositionMiddle;
                                          if (musicPartyMode) {
                                              position = UITableViewScrollPositionNone;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR reworks the playback states of NowPlaying when receiving the response to `@"Player.GetProperties"`. Variable names are improved (e.g. `canSeek` instead `canseek`), logic is simplified, comments are added, code sections are separated by new lines and existing helper methods are used.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Rework NowPlaying playback states