### PR TITLE
Feature: Blurred cover for iPad

### DIFF
--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -124,6 +124,7 @@
 @property (strong, nonatomic) OBSlider *ProgressSlider;
 @property (strong, nonatomic) UIView *BottomView;
 @property (strong, nonatomic) UIView *playlistToolbarView;
+@property (strong, nonatomic) UIView *toolbarBackground;
 @property (strong, nonatomic) IBOutlet UIView *scrabbingView;
 @property (strong, nonatomic) IBOutlet UITextView *itemDescription;
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -450,7 +450,7 @@
     shuffleButton.hidden = YES;
     hiresImage.hidden = YES;
     musicPartyMode = 0;
-    [self notifyChangeForBackgroundImage:nil];
+    [self notifyChangeForBackgroundImage:nil coverImage:nil];
     [self hidePlaylistProgressbarWithDeselect:YES];
     [self showPlaylistTable];
     [self toggleSongDetails];
@@ -612,15 +612,13 @@
                                  NSString *serverURL = [Utilities getImageServerURL];
                                  NSString *thumbnailPath = [self getNowPlayingThumbnailPath:nowPlayingInfo];
                                  NSString *stringURL = [Utilities formatStringURL:thumbnailPath serverURL:serverURL];
+                                 NSString *fanart = [Utilities getStringFromItem:nowPlayingInfo[@"fanart"]];
                                  if (![lastThumbnail isEqualToString:stringURL] || [lastThumbnail isEqualToString:@""]) {
-                                     if (IS_IPAD) {
-                                         NSString *fanart = [Utilities getStringFromItem:nowPlayingInfo[@"fanart"]];
-                                         [self notifyChangeForBackgroundImage:fanart];
-                                     }
                                      if (!thumbnailPath.length) {
                                          UIImage *image = [UIImage imageNamed:@"coverbox_back"];
                                          [self processLoadedThumbImage:self thumb:thumbnailView image:image enableJewel:enableJewel];
                                          [self updateBlurredCoverBackground:nil];
+                                         [self notifyChangeForBackgroundImage:fanart coverImage:nil];
                                      }
                                      else {
                                          __weak UIImageView *thumb = thumbnailView;
@@ -631,6 +629,7 @@
                                               if (error == nil) {
                                                   [weakSelf processLoadedThumbImage:weakSelf thumb:thumb image:image enableJewel:enableJewel];
                                                   [weakSelf updateBlurredCoverBackground:image];
+                                                  [weakSelf notifyChangeForBackgroundImage:fanart coverImage:image];
                                               }
                                           }];
                                      }
@@ -806,10 +805,13 @@
     }];
 }
 
-- (void)notifyChangeForBackgroundImage:(NSString*)bgImagePath {
+- (void)notifyChangeForBackgroundImage:(NSString*)bgImagePath coverImage:(UIImage*)coverImage {
     if (IS_IPAD) {
-        NSDictionary *params = @{@"image": bgImagePath ?: @""};
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"UIViewChangeBackgroundImage" object:nil userInfo:params];
+        NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
+                                bgImagePath ?: @"", @"image",
+                                coverImage, @"cover",
+                                nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"IpadChangeBackgroundImage" object:nil userInfo:params];
     }
 }
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -37,6 +37,7 @@
 @synthesize ProgressSlider;
 @synthesize BottomView;
 @synthesize playlistToolbarView;
+@synthesize toolbarBackground;
 @synthesize scrabbingView;
 @synthesize itemDescription;
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -136,11 +136,11 @@
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     if ([userDefaults boolForKey:@"blurred_cover_preference"] && IS_IPHONE) {
         [Utilities imageView:fullscreenCover AnimDuration:1.0 Image:image];
-        visualEffectView.alpha = 1;
+        visualEffectView.hidden = NO;
     }
     else {
         fullscreenCover.image = nil;
-        visualEffectView.alpha = 0;
+        visualEffectView.hidden = YES;
     }
 }
 
@@ -458,7 +458,7 @@
     
     // Unload and hide blurred cover effect
     fullscreenCover.image = nil;
-    visualEffectView.alpha = 0;
+    visualEffectView.hidden = YES;
 }
 
 - (void)setButtonImageAndStartDemo:(UIImage*)buttonImage {

--- a/XBMC Remote/ViewControllerIPad.h
+++ b/XBMC Remote/ViewControllerIPad.h
@@ -42,6 +42,8 @@
     BOOL serverPicker;
     BOOL appInfo;
     UIImageView *fanartBackgroundImage;
+    UIImageView *coverBackgroundImage;
+    UIVisualEffectView *visualEffectView;
     BOOL isFullscreen;
     MessagesView *messagesView;
 }

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -610,6 +610,7 @@
     [UIView animateWithDuration:0.3
                      animations:^{
         playlistHeader.alpha = menuViewController.view.alpha = isFullscreen ? 0 : 1;
+        self.nowPlayingController.toolbarBackground.alpha = isFullscreen ? 0.4 : 1;
         [self.nowPlayingController setNowPlayingDimension:[self currentScreenBoundsDependOnOrientation].size.width
                                                    height:[self currentScreenBoundsDependOnOrientation].size.height
                                                      YPOS:-YPOS

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -627,12 +627,12 @@
     // Prefer blurred cover feature over fanart. Fall back to fanart, if no cover is present.
     if ([userDefaults boolForKey:@"blurred_cover_preference"] && coverImage) {
         // Enable blur effect and animate to cover image
-        visualEffectView.alpha = 1;
+        visualEffectView.hidden = NO;
         [Utilities imageView:coverBackgroundImage AnimDuration:1.0 Image:coverImage];
     }
     else {
         // Disable blur effect and remove cover image
-        visualEffectView.alpha = 0;
+        visualEffectView.hidden = YES;
         coverBackgroundImage.image = nil;
         
         // Load and animate background to fanart, if present.

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -395,7 +395,7 @@
 	rootView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 	rootView.backgroundColor = UIColor.clearColor;
 	
-    fanartBackgroundImage = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height)];
+    fanartBackgroundImage = [[UIImageView alloc] initWithFrame:self.view.bounds];
     fanartBackgroundImage.autoresizingMask = rootView.autoresizingMask;
     fanartBackgroundImage.contentMode = UIViewContentModeScaleAspectFill;
     fanartBackgroundImage.alpha = 0.05;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -642,12 +642,12 @@
             NSString *fanartURL = [Utilities formatStringURL:fanart serverURL:serverURL];
             [fanartBackgroundImage sd_setImageWithURL:[NSURL URLWithString:fanartURL]
                                             completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
-                UIImage *fanartImage = (error == nil && image != nil) ? image : [UIImage new];
+                UIImage *fanartImage = (error == nil && image != nil) ? image : nil;
                 [Utilities imageView:fanartBackgroundImage AnimDuration:1.0 Image:fanartImage];
             }];
         }
         else {
-            [Utilities imageView:fanartBackgroundImage AnimDuration:1.0 Image:[UIImage new]];
+            [Utilities imageView:fanartBackgroundImage AnimDuration:1.0 Image:nil];
         }
     }
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1039.

This PR implements the "blurred cover" feature for iPad. If this feature is enabled (this is the app's default) and no cover is present, or if this feature is disabled, the background shows the fanart. In fullscreen mode the toolbar is made semi-transparent for an improved look.

Screenshots: https://ibb.co/7r9hYC1

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Blurred cover for iPad