### PR TITLE
Improvement: Small layout improvements to progressbar and iPad left menu

### DIFF
--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -36,6 +36,7 @@
 #define GET_MAINSCREEN_WIDTH CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds)
 #define STACKSCROLL_WIDTH (GET_MAINSCREEN_WIDTH - PAD_MENU_TABLE_WIDTH)
 #define ANCHOR_RIGHT_PEEK (GET_MAINSCREEN_WIDTH/10.0)
+#define IPAD_MENU_SEPARATOR_WIDTH 0.5
 
 /*
  * Other

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -85,7 +85,6 @@
     NSString *lastThumbnail;
     int choosedTab;
     NSString *notificationName;
-    __weak IBOutlet UIImageView *playlistLeftShadow;
     __weak IBOutlet UILabel *scrabbingMessage;
     __weak IBOutlet UILabel *scrabbingRate;
     UIView *toolbarBackground;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2282,9 +2282,9 @@
     CGFloat statusBar = [Utilities getTopPadding];
     CGFloat maxheight = height - bottomPadding - statusBar - TOOLBAR_HEIGHT;
     
-    CGFloat viewOriginX = isFullscreen ? 0 : PAD_MENU_TABLE_WIDTH + 2;
+    CGFloat viewOriginX = isFullscreen ? 0 : PAD_MENU_TABLE_WIDTH + IPAD_MENU_SEPARATOR_WIDTH;
     CGFloat viewOriginY = YPOS;
-    CGFloat viewWidth = isFullscreen ? width : width - (PAD_MENU_TABLE_WIDTH + 2);
+    CGFloat viewWidth = isFullscreen ? width : width - (PAD_MENU_TABLE_WIDTH + IPAD_MENU_SEPARATOR_WIDTH);
     CGFloat viewHeight = maxheight;
     nowPlayingView.frame = CGRectMake(viewOriginX, viewOriginY, viewWidth, viewHeight);
     
@@ -2406,7 +2406,6 @@
     
     nowPlayingView.hidden = NO;
     playlistView.hidden = NO;
-    playlistLeftShadow.hidden = NO;
     
     frame = playlistActionView.frame;
     frame.origin.y = CGRectGetHeight(playlistTableView.frame) - CGRectGetHeight(playlistActionView.frame);

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2726,8 +2726,6 @@
         self.view.backgroundColor = UIColor.clearColor;
     }
     
-    ProgressSlider.minimumTrackTintColor = SLIDER_DEFAULT_COLOR;
-    ProgressSlider.maximumTrackTintColor = UIColor.darkGrayColor;
     ProgressSlider.userInteractionEnabled = NO;
     [ProgressSlider setThumbImage:[UIImage new] forState:UIControlStateNormal];
     [ProgressSlider setThumbImage:[UIImage new] forState:UIControlStateHighlighted];
@@ -2763,7 +2761,7 @@
     // Colors
     self.navigationController.navigationBar.tintColor = ICON_TINT_COLOR;
     ProgressSlider.minimumTrackTintColor = UIColor.lightGrayColor;
-    ProgressSlider.maximumTrackTintColor = UIColor.grayColor;
+    ProgressSlider.maximumTrackTintColor = UIColor.darkGrayColor;
     albumName.textColor = UIColor.lightGrayColor;
     songName.textColor = UIColor.whiteColor;
     artistName.textColor = UIColor.whiteColor;

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -30,7 +30,6 @@
                 <outlet property="nowPlayingView" destination="92" id="95"/>
                 <outlet property="playlistActionView" destination="128" id="149"/>
                 <outlet property="playlistButton" destination="Z3l-yA-EDD" id="k08-dq-wTJ"/>
-                <outlet property="playlistLeftShadow" destination="211" id="212"/>
                 <outlet property="playlistTableView" destination="100" id="103"/>
                 <outlet property="playlistToolbarView" destination="h1i-BK-QLr" id="Kxz-AK-SDs"/>
                 <outlet property="playlistView" destination="93" id="96"/>
@@ -107,10 +106,6 @@
                                     <rect key="frame" x="141" y="165" width="37" height="37"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 </activityIndicatorView>
-                                <imageView hidden="YES" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" image="tableLeft" translatesAutoresizingMaskIntoConstraints="NO" id="211">
-                                    <rect key="frame" x="318" y="0.0" width="2" height="374"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" heightSizable="YES"/>
-                                </imageView>
                             </subviews>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
@@ -376,7 +371,7 @@
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </imageView>
                         <button opaque="NO" tag="88" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="117">
-                            <rect key="frame" x="236" y="8" width="73" height="28"/>
+                            <rect key="frame" x="235" y="8" width="74" height="28"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                             <gestureRecognizers/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
@@ -580,6 +575,5 @@
         <image name="now_playing_seek_backward" width="38" height="34"/>
         <image name="now_playing_seek_forward" width="38" height="34"/>
         <image name="now_playing_stop" width="38" height="34"/>
-        <image name="tableLeft" width="16" height="16"/>
     </resources>
 </document>

--- a/XBMC Remote/cellViewIPad.xib
+++ b/XBMC Remote/cellViewIPad.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,11 +16,6 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.20000000298023224" tag="4" contentMode="center" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="11">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="1"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
-                        <color key="backgroundColor" red="0.27628877758979797" green="0.27628877758979797" blue="0.27628877758979797" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    </imageView>
                     <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" tag="1" contentMode="scaleAspectFill" fixedFrame="YES" image="icon_menu_music" translatesAutoresizingMaskIntoConstraints="NO" id="4">
                         <rect key="frame" x="12" y="10" width="30" height="30"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -63,17 +63,11 @@
         mainMenuItems = menu;
         [self.view addSubview:_tableView];
         
-		UIView *verticalLineView1 = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width, 0, 1, self.view.frame.size.height)];
-		verticalLineView1.autoresizingMask = UIViewAutoresizingFlexibleHeight;
-		verticalLineView1.backgroundColor = [Utilities getGrayColor:0 alpha:0.8];
-		[self.view addSubview:verticalLineView1];
-        [self.view bringSubviewToFront:verticalLineView1];
-        
-        UIView *verticalLineView2 = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width + 1, 0, 1, self.view.frame.size.height)];
-		verticalLineView2.autoresizingMask = UIViewAutoresizingFlexibleHeight;
-		verticalLineView2.backgroundColor = [Utilities getGrayColor:77 alpha:0.6];
-		[self.view addSubview:verticalLineView2];
-        [self.view bringSubviewToFront:verticalLineView2];
+        UIView *verticalLineView = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width, 0, IPAD_MENU_SEPARATOR_WIDTH, self.view.frame.size.height)];
+        verticalLineView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
+        verticalLineView.backgroundColor = [Utilities getGrayColor:77 alpha:0.6];
+        [self.view addSubview:verticalLineView];
+        [self.view bringSubviewToFront:verticalLineView];
 	}
     return self;
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR does small but visible layout improvements:

1. Use `darkGrayColor` for progress slider's `maximumTrackTintColor`. Improves contrast to current position, especially on non-seekable items.
2. Menu and playlist now share same vertical gray separator of width 0.5. In consequence `playlistLeftShadow` has been removed. A define has been introduced to set the separator width.

Screenshots: https://ibb.co/ggjb81X

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Small layout improvements to progressbar and iPad left menu