### PR TITLE
Feature: Follow Kodi's "Show empty TV shows" setting

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -120,6 +120,7 @@
 @property (nonatomic, assign) int APIpatchVersion;
 @property (nonatomic, assign) BOOL isIgnoreArticlesEnabled;
 @property (nonatomic, assign) BOOL isGroupSingleItemSetsEnabled;
+@property (nonatomic, assign) BOOL isShowEmptyTvShowsEnabled;
 @property (nonatomic, copy) NSArray *KodiSorttokens;
 @property (nonatomic, strong) GlobalData *obj;
 

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3564,6 +3564,7 @@
                         @"thumbnail",
                         @"genre",
                         @"studio",
+                        @"episode",
                 ],
             }, @"parameters",
             @{

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4661,6 +4661,9 @@
          // are movie sets, enable the postprocessing to ignore movies sets with only 1 movie.
          BOOL ignoreSingleMovieSets = !AppDelegate.instance.isGroupSingleItemSetsEnabled && [methodToCall isEqualToString:@"VideoLibrary.GetMovieSets"];
         
+         // If the feature to list empty TV Shows is disabled and the current results are TV Shows, ignore TV Shows without any episode.
+         BOOL ignoreEmptyTvShows = !AppDelegate.instance.isShowEmptyTvShowsEnabled && [methodToCall isEqualToString:@"VideoLibrary.GetTVShows"];
+        
          // If we are reading PVR recordings or PVR timers, we need to filter them for the current mode in
          // postprocessing. Ignore Radio recordings/timers, if we are in TV mode. Or ignore TV recordings/timers,
          // if we are in Radio mode.
@@ -4737,6 +4740,9 @@
                              }
                              else if (ignorePvrItem) {
                                  NSLog(@"Ignore PVR item as not matching current TV/Radio mode.");
+                             }
+                             else if (ignoreEmptyTvShows && [item[@"episode"] intValue] == 0) {
+                                 // Do nothing
                              }
                              else {
                                  [resultStoreArray addObject:newDict];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4712,12 +4712,12 @@
                              
                              // Check if we need to ignore the current item
                              BOOL isRadioItem = [item[@"radio"] boolValue] ||
-                             [item[@"isradio"] boolValue];
+                                                [item[@"isradio"] boolValue];
                              BOOL isTimerRule = [item[@"istimerrule"] boolValue];
                              BOOL ignorePvrItem = (ignoreRadioItems && isRadioItem) ||
-                             (ignoreTvItems && !isRadioItem) ||
-                             (ignoreTimerRulesItems && isTimerRule) ||
-                             (ignoreTimerItems && !isTimerRule);
+                                                  (ignoreTvItems && !isRadioItem) ||
+                                                  (ignoreTimerRulesItems && isTimerRule) ||
+                                                  (ignoreTimerItems && !isTimerRule);
                              
                              // Postprocessing of movie sets lists to ignore 1-movie-sets
                              if (ignoreSingleMovieSets) {

--- a/XBMC Remote/VersionCheck.h
+++ b/XBMC Remote/VersionCheck.h
@@ -13,6 +13,7 @@
 
 + (BOOL)hasRecordingIdPlaylistSupport;
 + (BOOL)hasGroupSingleItemSetsSupport;
++ (BOOL)hasShowEmptyTvShowsSupport;
 + (BOOL)hasSortTokenReadSupport;
 + (BOOL)hasPvrSortSupport;
 + (BOOL)hasAlbumArtistOnlySupport;

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -24,6 +24,13 @@
            (AppDelegate.instance.APImajorVersion == 6 && AppDelegate.instance.APIminorVersion == 32 && AppDelegate.instance.APIpatchVersion >= 4);
 }
 
++ (BOOL)hasShowEmptyTvShowsSupport {
+    // ShowEmptyTvShows is enabled (supported from API 6.32.1 on)
+    return (AppDelegate.instance.APImajorVersion >= 7) ||
+           (AppDelegate.instance.APImajorVersion == 6 && AppDelegate.instance.APIminorVersion >= 33) ||
+           (AppDelegate.instance.APImajorVersion == 6 && AppDelegate.instance.APIminorVersion == 32 && AppDelegate.instance.APIpatchVersion >= 1);
+}
+
 + (BOOL)hasSortTokenReadSupport {
     // Sort token can be read from API 9.5.0 on
     return (AppDelegate.instance.APImajorVersion == 9 && AppDelegate.instance.APIminorVersion >= 5) ||

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -283,6 +283,8 @@ NSInputStream	*inStream;
         [self readSorttokens];
         // Read 1-movie-set setting
         [self readGroupSingleItemSets];
+        
+        [self readShowEmptyTvShows];
     }];
 }
 
@@ -304,6 +306,27 @@ NSInputStream	*inStream;
     }
     else {
         AppDelegate.instance.isGroupSingleItemSetsEnabled = YES;
+    }
+}
+
+- (void)readShowEmptyTvShows {
+    // Check if ShowEmptyTvShows is enabled
+    if ([VersionCheck hasShowEmptyTvShowsSupport]) {
+        [[Utilities getJsonRPC]
+         callMethod:@"Settings.GetSettingValue"
+         withParameters:@{@"setting": @"videolibrary.showemptytvshows"}
+         withTimeout: SERVER_TIMEOUT
+         onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+            if (!error && !methodError && [methodResult isKindOfClass:[NSDictionary class]]) {
+                AppDelegate.instance.isShowEmptyTvShowsEnabled = [methodResult[@"value"] boolValue];
+            }
+            else {
+                AppDelegate.instance.isShowEmptyTvShowsEnabled = YES;
+            }
+        }];
+    }
+    else {
+        AppDelegate.instance.isShowEmptyTvShowsEnabled = YES;
     }
 }
 

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -279,8 +279,8 @@ NSInputStream	*inStream;
                 AppDelegate.instance.APIpatchVersion = 0;
             }
         }
-        // Read the sorttokens
         [self readSorttokens];
+        
         // Read 1-movie-set setting
         [self readGroupSingleItemSets];
         


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR implements the feature to follow Kodi's setting "Show empty TV shows" as suggested [in this forum thread](https://forum.kodi.tv/showthread.php?tid=359717&pid=3195435#pid3195435). The setting is read when the app is connecting to Kodi server and applied when reloading the library in the app via pull-to-sync.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Follow Kodi's "Show empty TV shows" setting