### PR TITLE
Bugfix: Make scroll indicators visible in iOS17

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5228,6 +5228,10 @@
     if (channelGuideView && autoScrollTable != nil && autoScrollTable.row < [dataList numberOfRowsInSection:autoScrollTable.section]) {
             [dataList scrollToRowAtIndexPath:autoScrollTable atScrollPosition:UITableViewScrollPositionTop animated: NO];
     }
+    
+    // Workaround iOS 17: Force scroll indicator visible. Called here, after all layout configurations and data reloads are finished.
+    dataList.showsVerticalScrollIndicator = YES;
+    dataList.showsHorizontalScrollIndicator = NO;
 }
 
 - (void)startChannelListUpdateTimer {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5226,7 +5226,7 @@
     [collectionView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
     [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0 YPos:0];
     if (channelGuideView && autoScrollTable != nil && autoScrollTable.row < [dataList numberOfRowsInSection:autoScrollTable.section]) {
-            [dataList scrollToRowAtIndexPath:autoScrollTable atScrollPosition:UITableViewScrollPositionTop animated: NO];
+        [dataList scrollToRowAtIndexPath:autoScrollTable atScrollPosition:UITableViewScrollPositionTop animated: NO];
     }
     
     // Workaround iOS 17: Force scroll indicator visible. Called here, after all layout configurations and data reloads are finished.

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2580,7 +2580,7 @@
     frame = rating.frame;
     frame.origin.x = menuItem.originYearDuration;
     rating.frame = frame;
-    rating.text = [NSString stringWithFormat:@"%@", item[@"rating"]];
+    rating.text = [Utilities getRatingFromItem:item[@"rating"]];
     cell.urlImageView.contentMode = UIViewContentModeScaleAspectFill;
     genre.hidden = NO;
     runtimeyear.hidden = NO;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1007.

As discussed in https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1044 a workaround was found to make the scroll indicator visible again for several views. This PR introduces this workaround for the main library view only. Other view do not seem to be impacted by this problem.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Make scroll indicators visible in iOS17