### PR TITLE
Bugfix: Use white scroll indicator in server list

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -572,6 +572,8 @@
     [serverInfoButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
     serverInfoButton.titleLabel.shadowOffset = CGSizeZero;
     
+    serverListTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
+    
     if (IS_IPAD) {
         self.edgesForExtendedLayout = 0;
         self.view.tintColor = APP_TINT_COLOR;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The server list scroll indicator shall be always white as the list uses a dark background always.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use white scroll indicator in server list