### PR TITLE
Bugfix: Fix order of play control buttons for iPad

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2350,11 +2350,11 @@
     NSArray *toolbarButtonList = @[
         @{@"buttonTag": @(TAG_SHUFFLE),         @"originY": @(buttonCenterY + SHUFFLE_REPEAT_VERTICAL_PADDING)},
         @{@"buttonTag": @(TAG_ID_STOP),         @"originY": @(buttonCenterY)},
-        @{@"buttonTag": @(TAG_SEEK_BACKWARD),   @"originY": @(buttonCenterY)},
         @{@"buttonTag": @(TAG_ID_PREVIOUS),     @"originY": @(buttonCenterY)},
+        @{@"buttonTag": @(TAG_SEEK_BACKWARD),   @"originY": @(buttonCenterY)},
         @{@"buttonTag": @(TAG_ID_PLAYPAUSE),    @"originY": @(buttonCenterY)}, /* this is central button */
-        @{@"buttonTag": @(TAG_ID_NEXT),         @"originY": @(buttonCenterY)},
         @{@"buttonTag": @(TAG_SEEK_FORWARD),    @"originY": @(buttonCenterY)},
+        @{@"buttonTag": @(TAG_ID_NEXT),         @"originY": @(buttonCenterY)},
         @{@"buttonTag": @(TAG_ID_TOGGLE),       @"originY": @(buttonCenterY)},
         @{@"buttonTag": @(TAG_REPEAT),          @"originY": @(buttonCenterY + SHUFFLE_REPEAT_VERTICAL_PADDING)},
     ];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes the order of the play control buttons for iPad. 
Wrong order as STOP, SEEK BACK, _PREV_, PLAY, _NEXT_, SEEK FWD, ...
Correct order is STOP, _PREV_, SEEK BACK, PLAY, SEEK FWD, _NEXT_, ...

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix order of play control buttons for iPad