### PR TITLE
Bugfix: Use correct width for inactive searchbar

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2185,7 +2185,7 @@
     // Create non-used search controller. This is added as tableHeaderView and lets iOS gracefully handle insets
     UISearchController *searchCtrl = [[UISearchController alloc] initWithSearchResultsController:nil];
     searchCtrl.searchBar.showsCancelButton = YES;
-    searchCtrl.searchBar.frame = self.searchController.searchBar.frame;
+    searchCtrl.searchBar.frame = CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), CGRectGetHeight(self.searchController.searchBar.frame));
     searchCtrl.searchBar.searchBarStyle = UISearchBarStyleMinimal;
     searchCtrl.searchBar.barStyle = UIBarStyleBlack;
     searchCtrl.searchBar.autoresizingMask = UIViewAutoresizingFlexibleWidth;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1037.

With the rework of the searchbar it now became obvious that the dimension of the _inactive_ searchbar was not correctly set. The searchbar needs to use the the view's `bounds` width.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use correct width for inactive searchbar