### PR TITLE
Improvement: Use transparent background for grid / collection view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1837,16 +1837,7 @@
         if (stringURL.length) {
             [cell.posterThumbnail sd_setImageWithURL:[NSURL URLWithString:stringURL]
                                     placeholderImage:[UIImage imageNamed:displayThumb]
-                                             options:SDWebImageScaleToNativeSize
-                                           completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
-                UIColor *averageColor = [Utilities averageColor:image inverse:NO autoColorCheck:YES];
-                CGFloat hue, saturation, brightness, alpha;
-                BOOL ok = [averageColor getHue:&hue saturation:&saturation brightness:&brightness alpha:&alpha];
-                if (ok) {
-                    UIColor *bgColor = [UIColor colorWithHue:hue saturation:saturation brightness:0.2 alpha:alpha];
-                    cell.backgroundColor = bgColor;
-                }
-            }];
+                                             options:SDWebImageScaleToNativeSize];
         }
         else {
             cell.posterThumbnail.image = [UIImage imageNamed:displayThumb];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1685,6 +1685,7 @@
         flowLayout.minimumLineSpacing = cellMinimumLineSpacing;
         flowLayout.minimumInteritemSpacing = cellMinimumLineSpacing;
     }
+    flowLayout.collectionView.backgroundColor = UIColor.clearColor;
 }
 
 #pragma mark - UICollectionView methods
@@ -1699,7 +1700,7 @@
         collectionView = [[UICollectionView alloc] initWithFrame:dataList.frame collectionViewLayout:flowLayout];
         collectionView.contentInset = dataList.contentInset;
         collectionView.scrollIndicatorInsets = dataList.scrollIndicatorInsets;
-        collectionView.backgroundColor = [Utilities getGrayColor:0 alpha:0.5];
+        collectionView.backgroundColor = UIColor.clearColor;
         collectionView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
         collectionView.delegate = self;
         collectionView.dataSource = self;

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -48,6 +48,7 @@
         _posterLabel.numberOfLines = 2;
         _posterLabel.adjustsFontSizeToFitWidth = YES;
         _posterLabel.minimumScaleFactor = 1.0;
+        [Utilities applyRoundedEdgesView:_posterLabel drawBorder:NO];
 
         [_labelImageView addSubview:_posterLabel];
         [self.contentView addSubview:_labelImageView];

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -30,6 +30,7 @@
         _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectMake(borderWidth, borderWidth, frame.size.width - borderWidth * 2, frame.size.height - borderWidth * 2)];
         _posterThumbnail.clipsToBounds = YES;
         _posterThumbnail.contentMode = UIViewContentModeScaleAspectFill;
+        self.contentView.backgroundColor = UIColor.clearColor;
         [self.contentView addSubview:_posterThumbnail];
         
         _labelImageView = [[UIImageView alloc] initWithFrame:CGRectMake(borderWidth, frame.size.height - labelHeight, frame.size.width - borderWidth * 2, labelHeight - borderWidth)];

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -19,14 +19,14 @@
     if (self) {
         self.restorationIdentifier = @"recentlyAddedCell";
         self.backgroundColor = UIColor.grayColor;
-        int labelHeight = (int)(frame.size.height * 0.19);
-        int genreHeight = (int)(frame.size.height * 0.12);
-        int yearHeight = (int)(frame.size.height * 0.12);
-        int borderWidth = 2;
-        int posterWidth = (int)(frame.size.height * 0.66) + 1;
-        int fanartWidth = frame.size.width - posterWidth;
-        int posterStartX = borderWidth;
-        int startX = borderWidth * 2 + posterWidth;
+        CGFloat labelHeight = (floor)(frame.size.height * 0.18);
+        CGFloat genreHeight = (floor)(frame.size.height * 0.11);
+        CGFloat yearHeight = (floor)(frame.size.height * 0.11);
+        CGFloat borderWidth = 1.0 / UIScreen.mainScreen.scale;
+        CGFloat posterWidth = (ceil)(frame.size.height * 0.67);
+        CGFloat fanartWidth = frame.size.width - posterWidth;
+        CGFloat posterStartX = borderWidth;
+        CGFloat startX = borderWidth * 2 + posterWidth;
 
         _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectMake(posterStartX, borderWidth, posterWidth, frame.size.height - borderWidth * 2)];
         _posterThumbnail.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
@@ -48,12 +48,9 @@
         labelImageView.image = [UIImage imageNamed:@"cell_bg"];
         labelImageView.highlightedImage = [UIImage imageNamed:@"cell_bg_selected"];
         
-        int posterYOffset = 4;
-        int labelPadding = 4;
-        if (IS_IPHONE) {
-            posterYOffset = 0;
-        }
-         _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, posterYOffset, fanartWidth - labelPadding -borderWidth * 4, labelHeight - borderWidth)];
+        CGFloat posterYOffset = IS_IPAD ? 4 : 0;
+        CGFloat labelPadding = 4;
+         _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, posterYOffset, fanartWidth - labelPadding - borderWidth * 4, labelHeight - borderWidth)];
         _posterLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterLabel.backgroundColor = UIColor.clearColor;
         _posterLabel.textColor = UIColor.whiteColor;

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -18,7 +18,7 @@
     self = [super initWithFrame:frame];
     if (self) {
         self.restorationIdentifier = @"recentlyAddedCell";
-        self.backgroundColor = UIColor.grayColor;
+        self.backgroundColor = UIColor.clearColor;
         CGFloat labelHeight = (floor)(frame.size.height * 0.18);
         CGFloat genreHeight = (floor)(frame.size.height * 0.11);
         CGFloat yearHeight = (floor)(frame.size.height * 0.11);


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The grid / collection view was using a darker background as the list views. This PR applies changes to let the grid/collection views have the standard application background by using transparent backgrounds where needed. For rounded corners this also required a change to the `PosterCell` class to let a label view follow the borders of the underlying cover. For recently added posters the blue "selected" highlighting is reduced to 1 pixel and the non-selected state simply uses clear background. This enlarges the covers/fanart visibly.

Screenshots (left = old, right = new):

<a href="https://ibb.co/9N8z5tk"><img src="https://i.ibb.co/1LvhW6t/Bildschirmfoto-2024-05-20-um-17-14-42.png" alt="Bildschirmfoto-2024-05-20-um-17-14-42" border="0"></a>

<a href="https://ibb.co/rZCqKQy"><img src="https://i.ibb.co/THVJDwh/Bildschirmfoto-2024-05-20-um-17-14-57.png" alt="Bildschirmfoto-2024-05-20-um-17-14-57" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Use transparent background for grid / collection view