### PR TITLE
Improvement: NowPlaying does not show default cover before cover art is loaded

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -643,6 +643,7 @@
                                          __typeof__(self) __weak weakSelf = self;
                                          [thumbnailView sd_setImageWithURL:[NSURL URLWithString:stringURL]
                                                           placeholderImage:[UIImage imageNamed:@"coverbox_back"]
+                                                                   options:SDWebImageDelayPlaceholder
                                                                  completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
                                               if (error == nil) {
                                                   [weakSelf processLoadedThumbImage:weakSelf thumb:thumb image:image enableJewel:enableJewel];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Configure SDWebImage to delay loading placeholder for NowPlaying cover. This avoids a shortly visible default cover before the final cover art is shown.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: NowPlaying does not show default cover before cover art is loaded