### PR TITLE
Bugfix: Do not resize the iPad menu if in NowPlaying fullscreen

### DIFF
--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -238,6 +238,9 @@
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
+    if (isFullscreen) {
+        return;
+    }
     UITouch *touch = [touches anyObject];
     // Moving the playlist header
     CGPoint locationPoint = [touch locationInView:leftMenuView];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3200266#pid3200266).

While in NowPlaying fullscreen the iPad main menu should not be resizable. This is ensured with an early return in `touchesMoved:withEvent`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not resize the iPad menu if in NowPlaying fullscreen