### PR TITLE
Improvement: Do not queue up JSON commands while disconnected to Kodi

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -21,7 +21,6 @@
 #import "ClearCacheView.h"
 #import "Utilities.h"
 
-#define SERVER_TIMEOUT 2.0
 #define CONNECTION_ICON_SIZE 18
 #define MENU_ICON_SIZE 30
 #define ICON_MARGIN 10

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -877,7 +877,7 @@
 }
 
 - (void)getActivePlayers {
-    [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:@{} withTimeout:2.0 onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+    [[Utilities getJsonRPC] callMethod:@"Player.GetActivePlayers" withParameters:@{} onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         // Do not process further, if the view is already off the view hierarchy.
         if (!self.viewIfLoaded.window) {
             return;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -21,7 +21,6 @@
 #import "Utilities.h"
 
 #define CONNECTION_TIMEOUT 240.0
-#define SERVER_TIMEOUT 2.0
 #define VIEW_PADDING 10 /* separation between toolbar views */
 #define TOOLBAR_HEIGHT 44
 #define XBMCLOGO_WIDTH 30

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -258,7 +258,6 @@
     [[Utilities getJsonRPC]
      callMethod:@"Application.GetProperties"
      withParameters:@{@"properties": @[@"muted"]}
-     withTimeout: SERVER_TIMEOUT
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
          if (error == nil && methodError == nil && [methodResult isKindOfClass:[NSDictionary class]]) {
              isMuted = [methodResult[@"muted"] boolValue];

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -17,7 +17,6 @@
 #define VOLUMEICON_PADDING 10 /* space left/right from volume icons */
 #define VOLUMELABEL_PADDING 5 /* space left/right from volume label */
 #define VOLUMESLIDER_HEIGHT 44
-#define SERVER_TIMEOUT 3.0
 #define VOLUME_HOLD_TIMEOUT 0.2
 #define VOLUME_REPEAT_TIMEOUT 0.05
 #define VOLUME_INFO_TIMEOUT 1.0

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.h
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.h
@@ -40,6 +40,9 @@
 #import <Foundation/Foundation.h>
 #import "DSJSONRPCError.h"
 
+#define JSONRPC_TIMEOUT_MAX 3600
+#define JSONRPC_TIMEOUT_DEFAULT 2
+
 @class DSJSONRPC;
 
 /**

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.h
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.h
@@ -78,5 +78,6 @@ typedef void (^DSJSONRPCCompletionHandler)(NSString *methodName, NSInteger callI
 - (NSInteger)callMethod:(NSString*)methodName onCompletion:(DSJSONRPCCompletionHandler)completionHandler;
 - (NSInteger)callMethod:(NSString*)methodName withParameters:(id)methodParams onCompletion:(DSJSONRPCCompletionHandler)completionHandler;
 - (NSInteger)callMethod:(NSString*)methodName withParameters:(id)methodParams withTimeout:(NSTimeInterval)timeout onCompletion:(DSJSONRPCCompletionHandler)completionHandler;
+- (NSInteger)callMethod:(NSString*)methodName withParameters:(id)methodParams withTimeout:(NSTimeInterval)timeout withConnectionCheck:(BOOL)connectioCheck onCompletion:(DSJSONRPCCompletionHandler)completionHandler;
 
 @end

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -40,6 +40,7 @@
 #import "AppDelegate.h"
 
 #define RPC_DOMAIN @"it.joethefox.json-rpc"
+#define MAX_SECONDS_JSONRPC_TIMEOUT 3600
 
 @interface DSJSONRPC () // Private
 @property (nonatomic, copy) NSURL *serviceEndpoint;
@@ -157,7 +158,7 @@
     [serviceRequest setValue:[NSString stringWithFormat:@"%i", (int)postData.length] forHTTPHeaderField:@"Content-Length"];
     serviceRequest.HTTPMethod = @"POST";
     serviceRequest.HTTPBody = postData;
-    serviceRequest.timeoutInterval = (timeout > 0) ? timeout : 3600;
+    serviceRequest.timeoutInterval = (timeout > 0) ? timeout : MAX_SECONDS_JSONRPC_TIMEOUT;
     
     // Perform the JSON-RPC method call
     NSURLSessionDataTask *rpcDataTask = [self.rpcSession dataTaskWithRequest:serviceRequest];

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -40,7 +40,6 @@
 #import "AppDelegate.h"
 
 #define RPC_DOMAIN @"it.joethefox.json-rpc"
-#define MAX_SECONDS_JSONRPC_TIMEOUT 3600
 
 @interface DSJSONRPC () // Private
 @property (nonatomic, copy) NSURL *serviceEndpoint;
@@ -162,7 +161,7 @@
     [serviceRequest setValue:[NSString stringWithFormat:@"%i", (int)postData.length] forHTTPHeaderField:@"Content-Length"];
     serviceRequest.HTTPMethod = @"POST";
     serviceRequest.HTTPBody = postData;
-    serviceRequest.timeoutInterval = (timeout > 0) ? timeout : MAX_SECONDS_JSONRPC_TIMEOUT;
+    serviceRequest.timeoutInterval = (timeout > 0) ? timeout : JSONRPC_TIMEOUT_MAX;
     
     // Perform the JSON-RPC method call
     NSURLSessionDataTask *rpcDataTask = [self.rpcSession dataTaskWithRequest:serviceRequest];

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -37,6 +37,7 @@
  */
 
 #import "DSJSONRPC.h"
+#import "AppDelegate.h"
 
 #define RPC_DOMAIN @"it.joethefox.json-rpc"
 
@@ -95,6 +96,20 @@
     
     // Generate a random Id for the call
     NSInteger aID = arc4random();
+    
+    // For actions without timeout we expect server to be connected already. Only the server heartbeat check uses timeout.
+    if (!timeout && !AppDelegate.instance.serverOnLine) {
+        if (completionHandler) {
+            NSError *aError = [NSError errorWithDomain:RPC_DOMAIN code:DSJSONRPCParseError userInfo:@{NSLocalizedDescriptionKey: LOCALIZED_STR(@"No connection")}];
+            NSDictionary *jsonErrorDict = @{
+                @"code": @(JSONRPCNoConnection),
+                @"message": LOCALIZED_STR(@"No connection"),
+            };
+            DSJSONRPCError *jsonRPCError = [DSJSONRPCError errorWithData:jsonErrorDict];
+            completionHandler(methodName, aID, nil, jsonRPCError, aError);
+        }
+        return aID;
+    }
     
     // Setup the JSON-RPC call payload
     NSArray *methodKeys = nil;

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -94,12 +94,16 @@
 }
 
 - (NSInteger)callMethod:(NSString*)methodName withParameters:(id)methodParams withTimeout:(NSTimeInterval)timeout onCompletion:(DSJSONRPCCompletionHandler)completionHandler {
+    return [self callMethod:methodName withParameters:methodParams withTimeout:0 withConnectionCheck:YES onCompletion:completionHandler];
+}
+
+- (NSInteger)callMethod:(NSString*)methodName withParameters:(id)methodParams withTimeout:(NSTimeInterval)timeout withConnectionCheck:(BOOL)connectioCheck onCompletion:(DSJSONRPCCompletionHandler)completionHandler {
     
     // Generate a random Id for the call
     NSInteger aID = arc4random();
     
-    // For actions without timeout we expect server to be connected already. Only the server heartbeat check uses timeout.
-    if (!timeout && !AppDelegate.instance.serverOnLine) {
+    // Check if the server is connected. If not, drop the request.
+    if (connectioCheck && !AppDelegate.instance.serverOnLine) {
         if (completionHandler) {
             NSError *aError = [NSError errorWithDomain:RPC_DOMAIN code:DSJSONRPCParseError userInfo:@{NSLocalizedDescriptionKey: LOCALIZED_STR(@"No connection")}];
             NSDictionary *jsonErrorDict = @{

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPCError.h
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPCError.h
@@ -46,6 +46,7 @@ typedef enum {
     JSONRPCInvalidParams = -32602,
     JSONRPCInternalError = -32603,
     JSONRPCInvalidObject = -32604,
+    JSONRPCNoConnection = -32605,
 } JSONRPCErrorType;
 
 

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -191,7 +191,8 @@ NSInputStream	*inStream;
     [[Utilities getJsonRPC]
      callMethod:@"Application.GetProperties"
      withParameters:checkServerParams
-     withTimeout: SERVER_TIMEOUT
+     withTimeout:SERVER_TIMEOUT
+     withConnectionCheck:NO
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         inCheck = NO;
         if (error == nil && methodError == nil) {
@@ -248,7 +249,8 @@ NSInputStream	*inStream;
     [[Utilities getJsonRPC]
      callMethod:@"Settings.GetSettingValue"
      withParameters:@{@"setting": @"filelists.ignorethewhensorting"}
-     withTimeout: SERVER_TIMEOUT
+     withTimeout:SERVER_TIMEOUT
+     withConnectionCheck:NO
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (!error && !methodError && [methodResult isKindOfClass:[NSDictionary class]]) {
             AppDelegate.instance.isIgnoreArticlesEnabled = [methodResult[@"value"] boolValue];
@@ -264,7 +266,8 @@ NSInputStream	*inStream;
     [[Utilities getJsonRPC]
      callMethod:@"JSONRPC.Version"
      withParameters:nil
-     withTimeout: SERVER_TIMEOUT
+     withTimeout:SERVER_TIMEOUT
+     withConnectionCheck:NO
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (!error && !methodError && [methodResult isKindOfClass:[NSDictionary class]]) {
             // Kodi 11 and earlier do not support "major"/"minor"/"patch" and reply with "version" only
@@ -294,7 +297,8 @@ NSInputStream	*inStream;
         [[Utilities getJsonRPC]
          callMethod:@"Settings.GetSettingValue"
          withParameters:@{@"setting": @"videolibrary.groupsingleitemsets"}
-         withTimeout: SERVER_TIMEOUT
+         withTimeout:SERVER_TIMEOUT
+         withConnectionCheck:NO
          onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
             if (!error && !methodError && [methodResult isKindOfClass:[NSDictionary class]]) {
                 AppDelegate.instance.isGroupSingleItemSetsEnabled = [methodResult[@"value"] boolValue];
@@ -315,7 +319,8 @@ NSInputStream	*inStream;
         [[Utilities getJsonRPC]
          callMethod:@"Settings.GetSettingValue"
          withParameters:@{@"setting": @"videolibrary.showemptytvshows"}
-         withTimeout: SERVER_TIMEOUT
+         withTimeout:SERVER_TIMEOUT
+         withConnectionCheck:NO
          onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
             if (!error && !methodError && [methodResult isKindOfClass:[NSDictionary class]]) {
                 AppDelegate.instance.isShowEmptyTvShowsEnabled = [methodResult[@"value"] boolValue];
@@ -337,7 +342,8 @@ NSInputStream	*inStream;
         [[Utilities getJsonRPC]
          callMethod:@"Application.GetProperties"
          withParameters:@{@"properties":@[@"sorttokens"]}
-         withTimeout: SERVER_TIMEOUT
+         withTimeout:SERVER_TIMEOUT
+         withConnectionCheck:NO
          onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
             if (!error && !methodError && [methodResult isKindOfClass:[NSDictionary class]]) {
                 AppDelegate.instance.KodiSorttokens = methodResult[@"sorttokens"];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3200734#pid3200734).

JSON commands are usually not using the `withTimeout` parameter. This lets the timeout internally be set to 1 hour as for sync of large databases the response times can be excessively long. Only the heartbeat JSON calls which are used to determine, if Kodi server is still connected, use `withTimeout` (typically the timeout is 3 sec).

This fact can be used to avoid sending JSON requests while the server is not connected. This avoids undesired queueing of JSON requests while the server is temporarily not connected.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Do not queue up JSON commands while disconnected to Kodi