### PR TITLE
Bugfix: Align playlist separator inset with main label

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1990,6 +1990,8 @@
         mainLabel.textColor = [Utilities get1stLabelColor];
         subLabel.textColor = [Utilities get2ndLabelColor];
         cornerLabel.textColor = [Utilities get2ndLabelColor];
+        
+        tableView.separatorInset = UIEdgeInsetsMake(0, CGRectGetMinX(mainLabel.frame), 0, 0);
     }
     NSDictionary *item = (playlistData.count > indexPath.row) ? playlistData[indexPath.row] : nil;
     UIImageView *thumb = (UIImageView*)[cell viewWithTag:XIB_PLAYLIST_CELL_COVER];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes the dimension of the separator for the playlist cells. It is now aligned with `mainLabel`.

Screenshots (left = fixed, right = before): 
<a href="https://ibb.co/fq7wsZh"><img src="https://i.ibb.co/wB1mf89/Bildschirmfoto-2024-06-16-um-12-36-02.png" alt="Bildschirmfoto-2024-06-16-um-12-36-02" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Align playlist separator inset with main label