### PR TITLE
Bugfix: EXIF details font toggling between bold and normal

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -910,6 +910,8 @@
                  songSampleRate.text = bitrate;
                  songSampleRate.hidden = NO;
                  songSampleRateImage.image = nil;
+                 
+                 itemDescription.font  = [UIFont systemFontOfSize:descriptionFontSize];
              }
              else if (currentPlayerID == PLAYERID_VIDEO) {
                  [self setSongDetails:songCodec image:songCodecImage item:methodResult[@"VideoPlayer.VideoResolution"]];
@@ -921,6 +923,8 @@
                  songBitRate.text = aspect;
                  songBitRateImage.image = [self loadImageFromName:@"aspect"];
                  songBitRateImage.hidden = songBitRate.hidden = aspect.length == 0;
+                 
+                 itemDescription.font  = [UIFont systemFontOfSize:descriptionFontSize];
              }
              else if (currentPlayerID == PLAYERID_PICTURES) {
                  NSString *filename = [Utilities getStringFromItem:methodResult[@"Slideshow.Filename"]];
@@ -2380,7 +2384,6 @@
 }
 
 - (void)setFontSizes:(CGFloat)scale {
-    itemDescription.font  = [UIFont systemFontOfSize:floor(12 * scale)];
     albumName.font        = [UIFont systemFontOfSize:floor(16 * scale)];
     songName.font         = [UIFont boldSystemFontOfSize:floor(20 * scale)];
     artistName.font       = [UIFont systemFontOfSize:floor(16 * scale)];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3201148#pid3201148).

A bold font is used to display EXIF data, using an attributed text inside the label `itemDescription`. Therefore it is causing trouble when resetting the font and font size of `itemDescription` when the NowPlaying dimensions were change, e.g. when switching to fullscreen or back. Instead we only keep the desired font size and set the font inside the conditions for VIDEO and MUSIC playback.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: EXIF details font toggling between bold and normal