### PR TITLE
Bugfix: Do not show progressbar on pictures playlist

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -289,7 +289,7 @@
 - (void)setPlaylistCellProgressBar:(UITableViewCell*)cell hidden:(BOOL)value {
     // Do not unhide the playlist progress bar while in pictures playlist
     UIView *view = (UIView*)[cell viewWithTag:XIB_PLAYLIST_CELL_PROGRESSVIEW];
-    if (!value && currentPlayerID == PLAYERID_PICTURES) {
+    if (!value && selectedPlayerID == PLAYERID_PICTURES) {
         return;
     }
     if (value == view.hidden) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3201317#pid3201317).

We do not want to show the progressbar in pictures playlists (aka slideshow). Instead of checking for current active player `currentPlayerID` we need to check for the current shown playlist type `selectedPlayerID`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not show progressbar on pictures playlist