### PR TITLE
Improvement: Handle longpress for sources and support play/queue

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1240,7 +1240,7 @@
         [self action_queue_to_wiki],
         [self action_queue_to_fmcharts],
         [self action_queue_to_shuffle],
-        @[],
+        [self action_simple_queue_to_play],
         [self action_queue_to_wiki],
         [self action_queue_to_play],
         [self action_queue_to_wiki],
@@ -2530,7 +2530,7 @@
         @[],
         [self action_queue_to_moviesetdetails],
         [self action_queue_to_moviedetails],
-        @[],
+        [self action_simple_queue_to_play],
         @[],
         [self action_queue_to_showcontent],
     ];
@@ -3280,7 +3280,7 @@
     menu_Videos.sheetActions = @[
         [self action_queue_to_musicvideodetails],
         [self action_queue_to_musicvideodetails],
-        @[],
+        [self action_simple_queue_to_play],
         @[],
         [self action_queue_to_showcontent],
     ];
@@ -3800,7 +3800,7 @@
     menu_TVShows.sheetActions = @[
         @[LOCALIZED_STR(@"TV Show Details")],
         [self action_queue_to_episodedetails],
-        @[],
+        [self action_simple_queue_to_play],
         @[],
         [self action_queue_to_showcontent],
     ];
@@ -5360,6 +5360,11 @@
             @"Files.GetDirectory", @"method",
         ],
     ] mutableCopy];
+    
+    menu_Pictures.sheetActions = @[
+        [self action_simple_queue_to_play],
+        @[],
+    ];
     
     menu_Pictures.subItem.mainParameters = [@[
         @[

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -589,6 +589,7 @@
     
     NSString *seasonNumber = [NSString stringWithFormat:@"%@", item[mainFields[@"row10"]]];
     NSString *family = [NSString stringWithFormat:@"%@", mainFields[@"row8"]];
+    NSNumber *isFilemode = @([item[@"filetype"] length] != 0);
     
     NSString *row19key = mainFields[@"row19"] ?: @"episode";
     id row19obj = @"";
@@ -617,6 +618,7 @@
                                  seasonNumber, @"season",
                                  row19obj, row19key,
                                  family, @"family",
+                                 isFilemode, @"isFilemode",
                                  item[mainFields[@"row6"]], mainFields[@"row6"],
                                  item[mainFields[@"row8"]], mainFields[@"row8"],
                                  year, @"year",
@@ -1462,7 +1464,7 @@
     else { // CHILD IS FILEMODE
         NSNumber *filemodeRowHeight = parameters[@"rowHeight"] ?: @44;
         NSNumber *filemodeThumbWidth = parameters[@"thumbWidth"] ?: @44;
-        if ([item[@"filetype"] length] != 0) { // WE ARE ALREADY IN BROWSING FILES MODE
+        if ([item[@"isFilemode"] boolValue]) { // WE ARE ALREADY IN BROWSING FILES MODE
             if ([item[@"filetype"] isEqualToString:@"directory"]) {
                 [parameters removeAllObjects];
                 parameters = [Utilities indexKeyedMutableDictionaryFromArray:menuItem.mainParameters[choosedTab]];
@@ -2634,7 +2636,7 @@
         if (tvshowsView && choosedTab == 0) {
             displayThumb = defaultThumb = @"nocover_tvshows_banner";
         }
-        if ([item[@"filetype"] length] != 0 ||
+        if ([item[@"isFilemode"] boolValue] ||
             [item[@"family"] isEqualToString:@"file"] ||
             [item[@"family"] isEqualToString:@"type"] ||
             [item[@"family"] isEqualToString:@"genreid"] ||
@@ -4767,6 +4769,12 @@
                                                                                    sec2min:secondsToMinute
                                                                                  useBanner:tvshowsView
                                                                                    useIcon:recordingListView];
+                             
+                             // JSON API does not return the expected "filetype" when retrieving list of "sources".
+                             // The correct "filetype" is "directory".
+                             if ([itemid isEqualToString:@"sources"]) {
+                                 newDict[@"filetype"] = @"directory";
+                             }
                              
                              // Check if we need to ignore the current item
                              BOOL isRadioItem = [item[@"radio"] boolValue] ||


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Add support for longpress on source directories via adding `sheetActions`. To be able to Play/Queue a source directory the key `"filetype"` must be set programmatically to `"directory"` as the API does not return this.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Handle longpress for sources and support play/queue