### PR TITLE
Maintenance: assigned value was never used (Xcode analyzer warning)

### DIFF
--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -107,7 +107,7 @@
             plusButton.frame = frame_tmp;
             
             muteIconColor = UIColor.blackColor;
-            muteBackgroundImage = [UIImage imageNamed:@"icon_dark"];
+            img = [UIImage imageNamed:@"icon_dark"];
             muteBackgroundImage = [Utilities colorizeImage:img withColor:UIColor.darkGrayColor];
             volumeIconColor = UIColor.grayColor;
         }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a warning shown by XCode analyzer that the value assigned to `muteBackgroundImage` was never used.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: assigned value was never used (Xcode analyzer warning)