### PR TITLE
Bugfix: Embedded remote needs transparent background

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -67,7 +67,14 @@
 }
 
 - (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
-    cell.backgroundColor = [Utilities getGrayColor:36 alpha:1];
+    NSString *rowContent = tableData[indexPath.row][@"label"];
+    if ([rowContent isEqualToString:@"RemoteControl"] ||
+        [rowContent isEqualToString:@"VolumeControl"]) {
+        cell.backgroundColor = UIColor.clearColor;
+    }
+    else {
+        cell.backgroundColor = [Utilities getGrayColor:36 alpha:1];
+    }
 }
 
 - (UITableViewCell*)tableView:(UITableView*)tableView cellForRowAtIndexPath:(NSIndexPath*)indexPath {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Elements of embedded remote need a transparent background. Others keep default custom button background color. This lets the embedded remote use the gradient background which darkens on top at bottom.

Screenshots (left = new, right = before):
<a href="https://ibb.co/pbFGpvV"><img src="https://i.ibb.co/LY7bfzj/Bildschirmfoto-2024-06-28-um-15-01-37.png" alt="Bildschirmfoto-2024-06-28-um-15-01-37" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Embedded remote needs transparent background