### PR TITLE
Improvement and fixes for channel and recording lists

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -64,6 +64,7 @@
 #define IPAD_ALBUM_SECTION_HEIGHT 166
 #define INDEX_WIDTH 34
 #define RUNTIMEYEAR_WIDTH 63
+#define GENRE_HEIGHT 18
 #define EPGCHANNELTIME_WIDTH 40
 #define EPGCHANNELTIME_HEIGHT 12
 #define EPG_RECORDING_DOT_SIZE 12
@@ -2615,11 +2616,13 @@
             cell.urlImageView.autoresizingMask = UIViewAutoresizingNone;
         }
         if (channelListView) {
+            runtime.hidden = NO;
             CGRect frame = genre.frame;
             frame.size.width = title.frame.size.width;
+            frame.size.height = GENRE_HEIGHT;
             genre.frame = frame;
             genre.textColor = [Utilities get1stLabelColor];
-            genre.font = [UIFont boldSystemFontOfSize:genre.font.pointSize];
+            genre.font = [UIFont boldSystemFontOfSize:14];
             ProgressPieView *progressView = (ProgressPieView*)[cell viewWithTag:EPG_VIEW_CELL_PROGRESSVIEW];
             progressView.hidden = YES;
             UIImageView *isRecordingImageView = (UIImageView*)[cell viewWithTag:EPG_VIEW_CELL_RECORDING_ICON];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2602,6 +2602,9 @@
     genre.hidden = NO;
     runtimeyear.hidden = NO;
     if (!albumView && !episodesView && !channelGuideView) {
+        // Since recordings must be synced it is required to set recordingListView here.
+        recordingListView = [item[@"family"] isEqualToString:@"recordingid"];
+        
         if (channelListView || recordingListView) {
             CGRect frame;
             frame.origin.x = SMALL_PADDING;
@@ -2628,6 +2631,10 @@
                                     item, @"item",
                                     nil];
             [NSThread detachNewThreadSelector:@selector(getChannelEpgInfo:) toTarget:self withObject:params];
+        }
+        if (recordingListView) {
+            genre.textColor = [Utilities get2ndLabelColor];
+            genre.font = [UIFont systemFontOfSize:12];
         }
         NSString *stringURL = tvshowsView ? item[@"banner"] : item[@"thumbnail"];
         NSString *displayThumb = globalSearchView ? [self getGlobalSearchThumb:item] : defaultThumb;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR resolves two long-standing issues I was just recognizing.

1. Since the main menu supports separated Live TV and Radio menus the same instance of DetailVC is used for channel lists and recordings. For recording views a different height and font size for the genre label is used as well as hiding `runtime`. Due to cell reuse the `genre` label height, font size and `runtime` label's visibility must be explicitly set for channel list.
2. Since recordings must be synced it is required to set `recordingListView` separately. This enables some layout code formerly skipped. Also improve readability of recording plot by non-bold font.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Restore channel list layout after viewing recording list
Improvement: Better readability of recording plot