### PR TITLE
Rework virtual keyboard

### DIFF
--- a/XBMC Remote/XBMCVirtualKeyboard.h
+++ b/XBMC Remote/XBMCVirtualKeyboard.h
@@ -14,12 +14,6 @@
     UIView *inputAccView;
     UILabel *keyboardTitle;
     UITextField *backgroundTextField;
-    int paddingLeftRight;
-    int paddingTopBottom;
-    int textFieldHeight;
-    int textFontSize;
-    int keyboardTitleHeight;
-    CGFloat screenWidth;
 }
 
 @end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Remove several ivars and replace by macros. Adapt view and label sizes to match given title. The title label supports maximum 4 lines.

Screenshots:
<a href="https://ibb.co/kcSj4w0"><img src="https://i.ibb.co/6sWzHTb/Bildschirmfoto-2024-06-29-um-10-51-15.png" alt="Bildschirmfoto-2024-06-29-um-10-51-15" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Virtual keyboard title adapts size to given title instead of scaling down font