### PR TITLE
Rework RemoteController key handling

### DIFF
--- a/XBMC Remote/RemoteController.h
+++ b/XBMC Remote/RemoteController.h
@@ -57,6 +57,6 @@ typedef enum {
 - (void)resetRemote;
 - (id)initWithNibName:(NSString*)nibNameOrNil withEmbedded:(BOOL)withEmbedded bundle:(NSBundle*)nibBundleOrNil;
 @property (strong, nonatomic) id detailItem;
-@property (nonatomic, strong) NSTimer *holdVolumeTimer;
+@property (nonatomic, strong) NSTimer *holdKeyTimer;
 
 @end

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -345,11 +345,11 @@
                      [self processButtonPress:TAG_BUTTON_MENU];
                  }
                  else {
-                     [self GUIAction:@"Input.ContextMenu" params:@{} httpAPIcallback:@"SendKey(0xF043)"];
+                     [self processButtonLongPress:TAG_BUTTON_MENU];
                  }
              }
              else {
-                 [self GUIAction:@"Input.ContextMenu" params:@{} httpAPIcallback:@"SendKey(0xF043)"];
+                 [self processButtonLongPress:TAG_BUTTON_MENU];
              }
          }];
     }

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1019,70 +1019,74 @@ NSInteger buttonAction;
 
 # pragma mark - Gestures
 
+- (void)processButtonLongPress:(NSInteger)buttonTag {
+    switch (buttonTag) {
+        case TAG_BUTTON_FULLSCREEN:
+            [self GUIAction:@"Input.ExecuteAction" params:@{@"action": @"togglefullscreen"} httpAPIcallback:@"Action(199)"];
+            break;
+            
+        case TAG_BUTTON_SEEK_BACKWARD: // DECREASE PLAYBACK SPEED
+            [self playbackAction:@"Player.SetSpeed" params:@{@"speed": @"decrement"}];
+            break;
+            
+        case TAG_BUTTON_SEEK_FORWARD: // INCREASE PLAYBACK SPEED
+            [self playbackAction:@"Player.SetSpeed" params:@{@"speed": @"increment"}];
+            break;
+            
+        case TAG_BUTTON_INFO: // CODEC INFO
+            if (AppDelegate.instance.serverVersion > 16) {
+                [self GUIAction:@"Input.ExecuteAction" params:@{@"action": @"playerdebug"} httpAPIcallback:nil];
+            }
+            else {
+                [self GUIAction:@"Input.ShowCodec" params:@{} httpAPIcallback:@"SendKey(0xF04F)"];
+            }
+            break;
+
+        case TAG_BUTTON_SELECT: // CONTEXT MENU
+        case TAG_BUTTON_MENU:
+            [self GUIAction:@"Input.ContextMenu" params:@{} httpAPIcallback:@"SendKey(0xF043)"];
+            break;
+
+        case TAG_BUTTON_SUBTITLES: // SUBTITLES BUTTON
+            if (AppDelegate.instance.serverVersion > 12) {
+                [self GUIAction:@"GUI.ActivateWindow"
+                         params:@{@"window": @"subtitlesearch"}
+                httpAPIcallback:nil];
+            }
+            else {
+                [self GUIAction:@"Addons.ExecuteAddon"
+                         params:@{@"addonid": @"script.xbmc.subtitles"}
+                httpAPIcallback:@"ExecBuiltIn&parameter=RunScript(script.xbmc.subtitles)"];
+            }
+            break;
+            
+        case TAG_BUTTON_MOVIES:
+            [self GUIAction:@"GUI.ActivateWindow"
+                     params:@{@"window": @"pvr",
+                              @"parameters": @[@"31", @"0", @"10", @"0"]}
+            httpAPIcallback:nil];
+            break;
+            
+        case TAG_BUTTON_TVSHOWS:
+            [self GUIAction:@"GUI.ActivateWindow"
+                     params:@{@"window": @"pvrosdguide"}
+            httpAPIcallback:nil];
+            break;
+            
+        case TAG_BUTTON_PICTURES:
+            [self GUIAction:@"GUI.ActivateWindow"
+                     params:@{@"window": @"pvrosdchannels"}
+            httpAPIcallback:nil];
+            break;
+
+        default:
+            break;
+    }
+}
+
 - (IBAction)handleButtonLongPress:(UILongPressGestureRecognizer*)gestureRecognizer {
     if (gestureRecognizer.state == UIGestureRecognizerStateBegan) {
-        switch (gestureRecognizer.view.tag) {
-            case TAG_BUTTON_FULLSCREEN:
-                [self GUIAction:@"Input.ExecuteAction" params:@{@"action": @"togglefullscreen"} httpAPIcallback:@"Action(199)"];
-                break;
-                
-            case TAG_BUTTON_SEEK_BACKWARD: // DECREASE PLAYBACK SPEED
-                [self playbackAction:@"Player.SetSpeed" params:@{@"speed": @"decrement"}];
-                break;
-                
-            case TAG_BUTTON_SEEK_FORWARD: // INCREASE PLAYBACK SPEED
-                [self playbackAction:@"Player.SetSpeed" params:@{@"speed": @"increment"}];
-                break;
-                
-            case TAG_BUTTON_INFO: // CODEC INFO
-                if (AppDelegate.instance.serverVersion > 16) {
-                    [self GUIAction:@"Input.ExecuteAction" params:@{@"action": @"playerdebug"} httpAPIcallback:nil];
-                }
-                else {
-                    [self GUIAction:@"Input.ShowCodec" params:@{} httpAPIcallback:@"SendKey(0xF04F)"];
-                }
-                break;
-
-            case TAG_BUTTON_SELECT: // CONTEXT MENU
-            case TAG_BUTTON_MENU:
-                [self GUIAction:@"Input.ContextMenu" params:@{} httpAPIcallback:@"SendKey(0xF043)"];
-                break;
-
-            case TAG_BUTTON_SUBTITLES: // SUBTITLES BUTTON
-                if (AppDelegate.instance.serverVersion > 12) {
-                    [self GUIAction:@"GUI.ActivateWindow"
-                             params:@{@"window": @"subtitlesearch"}
-                    httpAPIcallback:nil];
-                }
-                else {
-                    [self GUIAction:@"Addons.ExecuteAddon"
-                             params:@{@"addonid": @"script.xbmc.subtitles"}
-                    httpAPIcallback:@"ExecBuiltIn&parameter=RunScript(script.xbmc.subtitles)"];
-                }
-                break;
-                
-            case TAG_BUTTON_MOVIES:
-                [self GUIAction:@"GUI.ActivateWindow"
-                         params:@{@"window": @"pvr",
-                                  @"parameters": @[@"31", @"0", @"10", @"0"]}
-                httpAPIcallback:nil];
-                break;
-                
-            case TAG_BUTTON_TVSHOWS:
-                [self GUIAction:@"GUI.ActivateWindow"
-                         params:@{@"window": @"pvrosdguide"}
-                httpAPIcallback:nil];
-                break;
-                
-            case TAG_BUTTON_PICTURES:
-                [self GUIAction:@"GUI.ActivateWindow"
-                         params:@{@"window": @"pvrosdchannels"}
-                httpAPIcallback:nil];
-                break;
-
-            default:
-                break;
-        }
+        [self processButtonLongPress:gestureRecognizer.view.tag];
     }
 }
 

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -281,36 +281,41 @@
 #pragma mark - Touch
 
 - (void)handleSwipeFrom:(UISwipeGestureRecognizer*)recognizer {
-    if (recognizer.direction == UISwipeGestureRecognizerDirectionRight) {
-        buttonAction = TAG_BUTTON_ARROW_RIGHT;
-        [self sendAction];
+    NSInteger buttonID;
+    switch (recognizer.direction) {
+        case UISwipeGestureRecognizerDirectionLeft:
+            buttonID = TAG_BUTTON_ARROW_LEFT;
+            break;
+            
+        case UISwipeGestureRecognizerDirectionRight:
+            buttonID = TAG_BUTTON_ARROW_RIGHT;
+            break;
+            
+        case UISwipeGestureRecognizerDirectionUp:
+            buttonID = TAG_BUTTON_ARROW_UP;
+            break;
+            
+        case UISwipeGestureRecognizerDirectionDown:
+            buttonID = TAG_BUTTON_ARROW_DOWN;
+            break;
+            
+        default:
+            return;
+            break;
     }
-    else if (recognizer.direction == UISwipeGestureRecognizerDirectionLeft) {
-        buttonAction = TAG_BUTTON_ARROW_LEFT;
-        [self sendAction];
-    }
-    else if (recognizer.direction == UISwipeGestureRecognizerDirectionUp) {
-        buttonAction = TAG_BUTTON_ARROW_UP;
-        [self sendAction];
-    }
-    else if (recognizer.direction == UISwipeGestureRecognizerDirectionDown) {
-        buttonAction = TAG_BUTTON_ARROW_DOWN;
-        [self sendAction];
-    }
+    [self processButtonPress:buttonID];
 }
 
 - (void)handleTouchpadDoubleTap {
-    buttonAction = TAG_BUTTON_BACK;
-    [self sendAction];
+    [self processButtonPress:TAG_BUTTON_BACK];
 }
 
 - (void)handleTouchpadSingleTap {
-    buttonAction = TAG_BUTTON_SELECT;
-    [self sendAction];
+    [self processButtonPress:TAG_BUTTON_SELECT];
 }
 
 - (void)twoFingersTap {
-    [self GUIAction:@"Input.Home" params:@{} httpAPIcallback:nil];
+    [self processButtonPress:TAG_BUTTON_HOME];
 }
 
 - (void)handleTouchpadLongPress:(UILongPressGestureRecognizer*)gestureRecognizer {
@@ -337,8 +342,7 @@
                      slideshowActive = methodResult[@"Window.IsActive(slideshow)"];
                  }
                  if ([fullscreenActive intValue] == 1 || [visualisationActive intValue] == 1 || [slideshowActive intValue] == 1) {
-                     buttonAction = TAG_BUTTON_MENU;
-                     [self sendActionNoRepeat];
+                     [self processButtonPress:TAG_BUTTON_MENU];
                  }
                  else {
                      [self GUIAction:@"Input.ContextMenu" params:@{} httpAPIcallback:@"SendKey(0xF043)"];
@@ -749,17 +753,6 @@ NSInteger buttonAction;
 - (IBAction)stopHoldKey:(id)sender {
     [self.holdVolumeTimer invalidate];
     buttonAction = 0;
-}
-
-- (void)sendActionNoRepeat {
-//    NSString *action;
-    switch (buttonAction) {
-        case TAG_BUTTON_MENU: // MENU OSD
-            [self GUIAction:@"Input.ShowOSD" params:@{} httpAPIcallback:@"SendKey(0xF04D)"];
-            break;
-        default:
-            break;
-    }
 }
 
 - (void)playerActionVideo:(NSInteger)videoButton actionMusic:(NSInteger)musicButton {

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -762,7 +762,7 @@ NSInteger buttonAction;
     }
 }
 
-- (void)playerStep:(NSString*)step musicPlayerGo:(NSString*)musicAction musicPlayerAction:(NSString*)musicMethod {
+- (void)playerActionVideo:(NSInteger)videoButton actionMusic:(NSInteger)musicButton {
     if (AppDelegate.instance.serverVersion > 11) {
         [[Utilities getJsonRPC]
          callMethod:@"GUI.GetProperties"
@@ -794,13 +794,10 @@ NSInteger buttonAction;
                                   PvrIsPlayingTv = [methodResult[@"Pvr.IsPlayingTv"] boolValue];
                               }
                               if (winID == WINDOW_FULLSCREEN_VIDEO && !PvrIsPlayingTv && !VideoPlayerHasMenu) {
-                                  [self playbackAction:@"Player.Seek" params:[Utilities buildPlayerSeekStepParams:step]];
+                                  [self processButtonPress:videoButton];
                               }
-                              else if (winID == WINDOW_VISUALISATION && musicAction != nil) {
-                                  [self playbackAction:@"Player.GoTo" params:@{@"to": musicAction}];
-                              }
-                              else if (winID == WINDOW_VISUALISATION && musicMethod != nil) {
-                                  [self GUIAction:@"Input.ExecuteAction" params:@{@"action": musicMethod} httpAPIcallback:nil];
+                              else if (winID == WINDOW_VISUALISATION) {
+                                  [self processButtonPress:musicButton];
                               }
                           }
                       }];
@@ -840,7 +837,7 @@ NSInteger buttonAction;
             }
             else {
                 [self GUIAction:@"Input.Up" params:@{} httpAPIcallback:nil];
-                [self playerStep:@"bigforward" musicPlayerGo:nil musicPlayerAction:@"increaserating"];
+                [self playerActionVideo:TAG_BUTTON_SEEK_FORWARD_BIG actionMusic:TAG_BUTTON_NEXT];
             }
             break;
             
@@ -850,7 +847,7 @@ NSInteger buttonAction;
             }
             else {
                 [self GUIAction:@"Input.Left" params:@{} httpAPIcallback:nil];
-                [self playerStep:@"smallbackward" musicPlayerGo:@"previous" musicPlayerAction:nil];
+                [self playerActionVideo:TAG_BUTTON_SEEK_BACKWARD actionMusic:TAG_BUTTON_SEEK_BACKWARD];
             }
             break;
             
@@ -860,7 +857,7 @@ NSInteger buttonAction;
             }
             else {
                 [self GUIAction:@"Input.Right" params:@{} httpAPIcallback:nil];
-                [self playerStep:@"smallforward" musicPlayerGo:@"next" musicPlayerAction:nil];
+                [self playerActionVideo:TAG_BUTTON_SEEK_FORWARD actionMusic:TAG_BUTTON_SEEK_FORWARD];
             }
             break;
             
@@ -870,7 +867,7 @@ NSInteger buttonAction;
             }
             else {
                 [self GUIAction:@"Input.Down" params:@{} httpAPIcallback:nil];
-                [self playerStep:@"bigbackward" musicPlayerGo:nil musicPlayerAction:@"decreaserating"];
+                [self playerActionVideo:TAG_BUTTON_SEEK_BACKWARD_BIG actionMusic:TAG_BUTTON_PREVIOUS];
             }
             break;
             

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -18,6 +18,7 @@
 #import "RightMenuViewController.h"
 #import "DetailViewController.h"
 #import "Utilities.h"
+#import "VersionCheck.h"
 
 #define ROTATION_TRIGGER 0.015
 #define REMOTE_PADDING (44 + 44 + 44) // Space unused above and below the popover and by remote toolbar
@@ -823,41 +824,54 @@ NSInteger buttonAction;
             self.holdVolumeTimer = [NSTimer scheduledTimerWithTimeInterval:0.1 target:self selector:@selector(sendAction) userInfo:nil repeats:YES];
         }
     }
-    NSString *action;
     switch (buttonAction) {
         case TAG_BUTTON_ARROW_UP:
-            action = @"Input.Up";
-            [self GUIAction:action params:@{} httpAPIcallback:nil];
-            [self playerStep:@"bigforward" musicPlayerGo:nil musicPlayerAction:@"increaserating"];
+            if ([VersionCheck hasInputButtonEventSupport]) {
+                [self GUIAction:@"Input.ButtonEvent" params:@{@"button": @"up", @"keymap": @"KB"} httpAPIcallback:nil];
+            }
+            else {
+                [self GUIAction:@"Input.Up" params:@{} httpAPIcallback:nil];
+                [self playerStep:@"bigforward" musicPlayerGo:nil musicPlayerAction:@"increaserating"];
+            }
             break;
             
         case TAG_BUTTON_ARROW_LEFT:
-            action = @"Input.Left";
-            [self GUIAction:action params:@{} httpAPIcallback:nil];
-            [self playerStep:@"smallbackward" musicPlayerGo:@"previous" musicPlayerAction:nil];
+            if ([VersionCheck hasInputButtonEventSupport]) {
+                [self GUIAction:@"Input.ButtonEvent" params:@{@"button": @"left", @"keymap": @"KB"} httpAPIcallback:nil];
+            }
+            else {
+                [self GUIAction:@"Input.Left" params:@{} httpAPIcallback:nil];
+                [self playerStep:@"smallbackward" musicPlayerGo:@"previous" musicPlayerAction:nil];
+            }
             break;
 
         case TAG_BUTTON_SELECT:
-            action = @"Input.Select";
-            [self GUIAction:action params:@{} httpAPIcallback:nil];
+            [self GUIAction:@"Input.Select" params:@{} httpAPIcallback:nil];
             [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputFinished" object:nil userInfo:nil];
             break;
 
         case TAG_BUTTON_ARROW_RIGHT:
-            action = @"Input.Right";
-            [self GUIAction:action params:@{} httpAPIcallback:nil];
-            [self playerStep:@"smallforward" musicPlayerGo:@"next" musicPlayerAction:nil];
+            if ([VersionCheck hasInputButtonEventSupport]) {
+                [self GUIAction:@"Input.ButtonEvent" params:@{@"button": @"right", @"keymap": @"KB"} httpAPIcallback:nil];
+            }
+            else {
+                [self GUIAction:@"Input.Right" params:@{} httpAPIcallback:nil];
+                [self playerStep:@"smallforward" musicPlayerGo:@"next" musicPlayerAction:nil];
+            }
             break;
             
         case TAG_BUTTON_ARROW_DOWN:
-            action = @"Input.Down";
-            [self GUIAction:action params:@{} httpAPIcallback:nil];
-            [self playerStep:@"bigbackward" musicPlayerGo:nil musicPlayerAction:@"decreaserating"];
+            if ([VersionCheck hasInputButtonEventSupport]) {
+                [self GUIAction:@"Input.ButtonEvent" params:@{@"button": @"down", @"keymap": @"KB"} httpAPIcallback:nil];
+            }
+            else {
+                [self GUIAction:@"Input.Down" params:@{} httpAPIcallback:nil];
+                [self playerStep:@"bigbackward" musicPlayerGo:nil musicPlayerAction:@"decreaserating"];
+            }
             break;
             
         case TAG_BUTTON_BACK:
-            action = @"Input.Back";
-            [self GUIAction:action params:@{} httpAPIcallback:nil];
+            [self GUIAction:@"Input.Back" params:@{} httpAPIcallback:nil];
             break;
             
         default:

--- a/XBMC Remote/VersionCheck.h
+++ b/XBMC Remote/VersionCheck.h
@@ -17,5 +17,6 @@
 + (BOOL)hasSortTokenReadSupport;
 + (BOOL)hasPvrSortSupport;
 + (BOOL)hasAlbumArtistOnlySupport;
++ (BOOL)hasInputButtonEventSupport;
 
 @end

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -47,4 +47,9 @@
     return AppDelegate.instance.APImajorVersion >= 4;
 }
 
++ (BOOL)hasInputButtonEventSupport {
+    // Input.ButtonEvent is supported from API 12 on
+    return AppDelegate.instance.APImajorVersion >= 12;
+}
+
 @end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/427.

This PR does some internal rework of how `RemoteController` handles key presses and touch pad events.

### Refactoring of key processing
Refactoring the processing of keys into two main methods `processButtonPress` and `processButtonLongPress`. Only in these methods key presses and interpreted and commands are sent to Kodi. This allowed to reduce some distributed preparation and calling of JSON API commands.

### Up/Down/Left/Right to match physical keyboard
Introducing `"Input.ButtonEvent"` (supported since Kodi 19) for the up/down/left/right buttons to match the behaviour of pressing the same on a physical keyboard. This resolves an issue where seek was behaving different while playing videos with and without the progress slider being visible.

_Remark:_ This now results in different behaviour between Kodi versions "older than 19" and "19 or later". Also the remote buttons behave different now for music playback compared to older App versions: Up/Down = Next/Previous (instead of rating up/down) and Left/Right = Seek backward/forward. This matches behaviour of keyboard presses.

### Rewriting auto-repeated key presses
The auto-repeating key presses are rewritten (similar to how this is done for volume button presses). This allows to reduce complexity and a global variable.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Internal refactoring of remote control button processing
Improvement: Consistent up/down/left/right behaviour of remote and physical keyboard