### PR TITLE
Let NowPlaying handle entering background

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2543,6 +2543,11 @@
                                                object: nil];
     
     [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handleDidEnterBackground:)
+                                                 name: @"UIApplicationDidEnterBackgroundNotification"
+                                               object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleXBMCPlaylistHasChanged:)
                                                  name: @"XBMCPlaylistHasChanged"
                                                object: nil];
@@ -2583,7 +2588,7 @@
 }
 
 - (void)handleDidEnterBackground:(NSNotification*)sender {
-    [self viewWillDisappear:YES];
+    [timer invalidate];
 }
 
 - (void)enablePopGestureRecognizer:(id)sender {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Register to `UIApplicationDidEnterBackgroundNotification` and end `timer`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Let NowPlaying handle entering background