### PR TITLE
Rework settings grid view and animation when changing tabs

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -440,8 +440,6 @@
         filemodeVideoType = @"files";
         filemodeMusicType = @"files";
     }
-    NSNumber *animationStartBottomScreen = @YES;
-    NSNumber *animationStartX = @0;
     
     obj = [GlobalData getInstance];
     
@@ -456,8 +454,6 @@
         UINavigationBar.appearance.titleTextAttributes = navbarTitleTextAttributes;
     }
     else {
-        animationStartBottomScreen = @NO;
-        animationStartX = @STACKSCROLL_WIDTH;
         thumbWidth = (int)(PAD_TV_SHOWS_BANNER_WIDTH * transform);
         tvshowHeight = (int)(PAD_TV_SHOWS_BANNER_HEIGHT * transform);
     }
@@ -5622,8 +5618,7 @@
                 @"level": @"expert",
             }, @"parameters",
             LOCALIZED_STR(@"XBMC Settings"), @"label",
-            animationStartX, @"animationStartX",
-            animationStartBottomScreen, @"animationStartBottomScreen",
+            @(IS_IPHONE), @"animationStartBottomScreen",
             @0, @"thumbWidth",
         ],
                                    

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5864,14 +5864,12 @@
     // change the initial frame for the first table shown (list view). It is important
     // to apply this only change after the library view has been initialized as this
     // uses the list view frame to set its own frame.
-    frame = dataList.frame;
-    if (parameters[@"animationStartX"] != nil) {
-        frame.origin.x = [parameters[@"animationStartX"] intValue];
-    }
     if ([parameters[@"animationStartBottomScreen"] boolValue]) {
+        frame = dataList.frame;
+        frame.origin.x = 0;
         frame.origin.y = UIScreen.mainScreen.bounds.size.height;
+        dataList.frame = frame;
     }
-    dataList.frame = frame;
     
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleTabHasChanged:)

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1715,7 +1715,7 @@
 #pragma mark - UICollectionView methods
 
 - (void)initCollectionView {
-    if ([self collectionViewCanBeEnabled] && !collectionView) {
+    if (!collectionView) {
         flowLayout = [FloatingHeaderFlowLayout new];
         [flowLayout setSearchBarHeight:self.searchController.searchBar.frame.size.height];
         
@@ -5832,17 +5832,11 @@
     messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, DEFAULT_MSG_HEIGHT) deltaY:0 deltaX:0];
     [self.view addSubview:messagesView];
     
+    // As default both list and grid views animate from right to left.
     frame = dataList.frame;
-    if (parameters[@"animationStartX"] != nil) {
-        frame.origin.x = [parameters[@"animationStartX"] intValue];
-    }
-    else {
-        frame.origin.x = viewWidth;
-    }
-    if ([parameters[@"animationStartBottomScreen"] boolValue]) {
-        frame.origin.y = UIScreen.mainScreen.bounds.size.height;
-    }
+    frame.origin.x = viewWidth;
     dataList.frame = frame;
+    
     recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
     enableCollectionView = [self collectionViewIsEnabled];
     activeLayoutView = dataList;
@@ -5865,6 +5859,19 @@
     [dataList addGestureRecognizer:longPressGestureList];
     
     [activityIndicatorView startAnimating];
+    
+    // As an exception the settings on iPhone animate bottom-up. This requires to
+    // change the initial frame for the first table shown (list view). It is important
+    // to apply this only change after the library view has been initialized as this
+    // uses the list view frame to set its own frame.
+    frame = dataList.frame;
+    if (parameters[@"animationStartX"] != nil) {
+        frame.origin.x = [parameters[@"animationStartX"] intValue];
+    }
+    if ([parameters[@"animationStartBottomScreen"] boolValue]) {
+        frame.origin.y = UIScreen.mainScreen.bounds.size.height;
+    }
+    dataList.frame = frame;
     
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleTabHasChanged:)

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1320,11 +1320,9 @@
     BOOL newEnableCollectionView = [self collectionViewIsEnabled];
     [self setButtonViewContent:choosedTab];
     [self checkDiskCache];
-    NSTimeInterval animDuration = 0.3;
-    if (newEnableCollectionView != enableCollectionView) {
-        animDuration = 0.0;
-    }
-    [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:animDuration Alpha:1.0 XPos:viewWidth];
+    
+    [Utilities AnimView:(UITableView*)activeLayoutView AnimDuration:0.0 Alpha:1.0 XPos:viewWidth];
+    
     enableCollectionView = newEnableCollectionView;
     recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
     [activeLayoutView setContentOffset:[(UITableView*)activeLayoutView contentOffset] animated:NO];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Ensure `collectionView` is _always_ initialized in `viewDidLoad`, also if the first tab does not support grid view. Otherwise collection view is not initialized for other tabs of the same controller instance. Also ensure the change of the list view's start frame is only altered after the collection view was initialized. Both are relevant for the settings controller view.

In addition this PR simplifies the configuration for settings view's bottom-up start animation. Two variables, one key and one condition could be removed.

Last change is to ensure the start animation when changing tabs is always same, regardless of the gird/list mode of the former and new tab chosen.


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Grid view not working for settings menu
Improvement: Consistent animation when changing tab