### PR TITLE
Support "Play using..." to allow playback to an UPnP device

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -178,6 +178,7 @@
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
         LOCALIZED_STR(@"Play"),
+        LOCALIZED_STR(@"Play using..."),
         LOCALIZED_STR(@"Play in shuffle mode"),
         LOCALIZED_STR(@"Album Details"),
         LOCALIZED_STR(@"Search Wikipedia"),
@@ -189,6 +190,7 @@
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
         LOCALIZED_STR(@"Play"),
+        LOCALIZED_STR(@"Play using..."),
         LOCALIZED_STR(@"Play in shuffle mode"),
         LOCALIZED_STR(@"Artist Details"),
         LOCALIZED_STR(@"Search Wikipedia"),
@@ -201,6 +203,7 @@
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
         LOCALIZED_STR(@"Play"),
+        LOCALIZED_STR(@"Play using..."),
         LOCALIZED_STR(@"Play in shuffle mode"),
     ];
 }
@@ -210,6 +213,7 @@
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
         LOCALIZED_STR(@"Play"),
+        LOCALIZED_STR(@"Play using..."),
     ];
 }
 
@@ -225,6 +229,7 @@
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
         LOCALIZED_STR(@"Play"),
+        LOCALIZED_STR(@"Play using..."),
         LOCALIZED_STR(@"Movie Details"),
     ];
 }
@@ -245,6 +250,7 @@
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
         LOCALIZED_STR(@"Play"),
+        LOCALIZED_STR(@"Play using..."),
         LOCALIZED_STR(@"Music Video Details"),
     ];
 }
@@ -254,6 +260,7 @@
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
         LOCALIZED_STR(@"Play"),
+        LOCALIZED_STR(@"Play using..."),
         LOCALIZED_STR(@"Episode Details"),
     ];
 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3303,6 +3303,9 @@
                         [sheetActions addObject:actionString];
                     }
                 }
+                if (![VersionCheck hasPlayUsingSupport]) {
+                    [sheetActions removeObject:LOCALIZED_STR(@"Play using...")];
+                }
                 UIImageView *isRecordingImageView = (UIImageView*)[cell viewWithTag:EPG_VIEW_CELL_RECORDING_ICON];
                 BOOL isRecording = isRecordingImageView == nil ? NO : !isRecordingImageView.hidden;
                 UIViewController *showFromCtrl = [self topMostController];
@@ -4523,7 +4526,10 @@
     if (!sectionItem) {
         return;
     };
-    NSArray *sheetActions = [AppDelegate.instance action_album];
+    NSMutableArray *sheetActions = [[AppDelegate.instance action_album] mutableCopy];
+    if (![VersionCheck hasPlayUsingSupport]) {
+        [sheetActions removeObject:LOCALIZED_STR(@"Play using...")];
+    }
     selectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:0];
     NSMutableDictionary *item = [sectionItem mutableCopy];
     item[@"label"] = self.navigationItem.title;

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -96,6 +96,7 @@
     int storePosSeconds;
     long storedItemID;
     MessagesView *messagesView;
+    BOOL isRemotePlayer;
 }
 
 - (void)setNowPlayingDimension:(CGFloat)width height:(CGFloat)height YPOS:(CGFloat)YPOS fullscreen:(BOOL)isFullscreen;

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -25,6 +25,7 @@
     IBOutlet UILabel *artistName;
     IBOutlet UILabel *currentTime;
     IBOutlet UILabel *duration;
+    IBOutlet UILabel *upnp;
     IBOutlet UIImageView *jewelView;
     IBOutlet UIImageView *thumbnailView;
     IBOutlet UIView *BottomView;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -480,6 +480,7 @@
     repeatButton.hidden = YES;
     shuffleButton.hidden = YES;
     hiresImage.hidden = YES;
+    upnp.hidden = YES;
     musicPartyMode = NO;
     isRemotePlayer = NO;
     [self notifyChangeForBackgroundImage:nil coverImage:nil];
@@ -886,6 +887,7 @@
         if (error == nil && methodError == nil) {
             if ([methodResult isKindOfClass:[NSArray class]] && [methodResult count] > 0) {
                 isRemotePlayer = [methodResult[0][@"playertype"] isEqualToString:@"remote"];
+                upnp.hidden = !isRemotePlayer;
                 nothingIsPlaying = NO;
                 
                 // Set state machine variables for player / playlist
@@ -2898,6 +2900,12 @@
     artistName.textColor = UIColor.whiteColor;
     currentTime.textColor = UIColor.lightGrayColor;
     duration.textColor = UIColor.lightGrayColor;
+    
+    // UPnP indicator layout
+    upnp.textColor = KODI_BLUE_COLOR;
+    upnp.layer.cornerRadius = 4;
+    upnp.layer.borderColor = KODI_BLUE_COLOR.CGColor;
+    upnp.layer.borderWidth = 1;
     
     // Prepare and add blur effect
     UIVisualEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -481,6 +481,7 @@
     shuffleButton.hidden = YES;
     hiresImage.hidden = YES;
     musicPartyMode = NO;
+    isRemotePlayer = NO;
     [self notifyChangeForBackgroundImage:nil coverImage:nil];
     [self deselectPlaylistItem];
     [self showPlaylistTableAnimated:NO];
@@ -884,6 +885,7 @@
         }
         if (error == nil && methodError == nil) {
             if ([methodResult isKindOfClass:[NSArray class]] && [methodResult count] > 0) {
+                isRemotePlayer = [methodResult[0][@"playertype"] isEqualToString:@"remote"];
                 nothingIsPlaying = NO;
                 
                 // Set state machine variables for player / playlist
@@ -1688,7 +1690,7 @@
 }
 
 - (void)toggleSongDetails {
-    if ((nothingIsPlaying && songDetailsView.alpha == 0.0)) {
+    if ((nothingIsPlaying && songDetailsView.alpha == 0.0) || isRemotePlayer) {
         return;
     }
     [UIView animateWithDuration:0.2
@@ -2176,6 +2178,10 @@
     UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:indexPath];
     storeSelection = nil;
     [self setPlaylistCellProgressBar:cell hidden:YES];
+}
+
+- (NSIndexPath*)tableView:(UITableView*)tableView willSelectRowAtIndexPath:(NSIndexPath*)indexPath {
+    return isRemotePlayer ? nil : indexPath;
 }
 
 - (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath {

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -50,6 +50,7 @@
                 <outlet property="songSampleRateImage" destination="b3u-Km-zml" id="mcn-U2-3U2"/>
                 <outlet property="thumbnailView" destination="52" id="53"/>
                 <outlet property="transitionView" destination="98" id="Hxy-bA-FyS"/>
+                <outlet property="upnp" destination="0M5-Mc-Eeb" id="oX5-s4-i6s"/>
                 <outlet property="view" destination="1" id="3"/>
                 <outlet property="visualEffectView" destination="SBb-tf-htm" id="ds9-ix-GT7"/>
             </connections>
@@ -274,6 +275,15 @@
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <color key="shadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <size key="shadowOffset" width="1" height="1"/>
+                                                </label>
+                                                <label hidden="YES" opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="UPnP" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0M5-Mc-Eeb" userLabel="Label UPnP">
+                                                    <rect key="frame" x="135" y="31" width="40" height="18"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" red="0.66666666669999997" green="0.66666666669999997" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                     <color key="shadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <size key="shadowOffset" width="1" height="1"/>

--- a/XBMC Remote/VersionCheck.h
+++ b/XBMC Remote/VersionCheck.h
@@ -18,5 +18,6 @@
 + (BOOL)hasPvrSortSupport;
 + (BOOL)hasAlbumArtistOnlySupport;
 + (BOOL)hasInputButtonEventSupport;
++ (BOOL)hasPlayUsingSupport;
 
 @end

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -52,4 +52,12 @@
     return AppDelegate.instance.APImajorVersion >= 12;
 }
 
++ (BOOL)hasPlayUsingSupport {
+    // The implementation of "Play using..." needs both "GetPlayers" and "GetActivePlayers" with certain functionality.
+    // "Player.GetPlayers" is supported from API 8 on
+    // "Player.GetActivePlayers" supports "playertype" from API 9.6.0 on
+    // But only with Kodi 21 "Player.GetActivePlayers" returns active external players.
+    return AppDelegate.instance.serverVersion >= 21;
+}
+
 @end

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -81,6 +81,7 @@
 "Queue after current" = "Queue after current";
 "Queue" = "Queue";
 "Play" = "Play";
+"Play using..." = "Play using...";
 "Search Wikipedia" = "Search Wikipedia";
 "Search last.fm charts" = "Search last.fm charts";
 "Album Tracks" = "Album Tracks";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/51.

This PR introduces support for "Play using..." which allows to play content to an external UPnP device. When selecting "Play using..." from the context menu a new action sheet is shown which lists the supported players for the selected item. Once selecting a player, `Player.Open` is triggered for the selected item and player.

There are a few constraints:
- It is not possible to send a playlist item to a UPnP device. When attempting to do so, Kodi stops playback via UPnP and falls back to the default internal player. Therefore playlist items cannot be selected during UPnP playback.
- It is possible to skip to previous as long as this just restarts the title. When attempting to play a previous title, Kodi stops playback via UPnP and falls back to the default internal player.
- The codec information which is retrieved via `XMBC.GetLabels `does not work reliably in UPnP playback, so the codec overlay is blocked.
- Only works since JSON RPC 9.6.0 (since Kodi 18 / Leia) which added `playertype` to `Player.GetActivePlayers`

Other than that:
- It is possible to skip to next, to seek and play/pause.
- UPnP playback is signaled on the NowPlaying screen.

Video:
[Demo on iPhone 14 Pro simulator](https://www.dropbox.com/scl/fi/lm6u6wjkk4yzqokossa7l/Simulator-Screen-Recording-iPhone-14-Pro-2024-07-21-at-10.50.49.mp4?rlkey=57cnlj6g3qkkki2b2xf4iimrg&st=syyvs7in&dl=0)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Support "Play using..." to allow playback to an UPnP device