### PR TITLE
Review and rework menu config

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -87,6 +87,7 @@
 - (void)sendWOL:(NSString*)MAC withPort:(NSInteger)WOLport;
 - (NSURL*)getServerJSONEndPoint;
 - (NSDictionary*)getServerHTTPHeaders;
+- (NSArray*)action_album;
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1240,23 +1240,6 @@
         @[],
     ];
     
-    menu_Music.showInfo = @[
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-    ];
-    
     menu_Music.subItem.mainMethod = @[
         @[
             @"AudioLibrary.GetSongs", @"method",
@@ -3447,14 +3430,6 @@
         [self action_queue_to_play],
     ];
     
-    menu_Videos.subItem.showInfo = @[
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-    ];
-    
     menu_Videos.subItem.filterModes = @[
         [self modes_icons_empty],
         [self modes_icons_empty],
@@ -4116,13 +4091,6 @@
     ];
         
     menu_TVShows.subItem.subItem.noConvertTime = YES;
-    menu_TVShows.subItem.subItem.showInfo = @[
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-    ];
 
 #pragma mark - Live TV
     menu_LiveTV.mainLabel = LOCALIZED_STR(@"Live TV");
@@ -4587,14 +4555,6 @@
         @[],
     ];
     
-    menu_LiveTV.subItem.showInfo = @[
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-    ];
-    
     menu_LiveTV.subItem.filterModes = @[
         [self modes_icons_empty],
         [self modes_icons_empty],
@@ -4682,14 +4642,6 @@
         @[],
         @[],
         @[],
-    ];
-    
-    menu_LiveTV.subItem.subItem.showInfo = @[
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
     ];
 
 #pragma mark - Radio
@@ -5153,14 +5105,6 @@
         @[],
     ];
     
-    menu_Radio.subItem.showInfo = @[
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-    ];
-    
     menu_Radio.subItem.filterModes = @[
         [self modes_icons_empty],
         [self modes_icons_empty],
@@ -5248,14 +5192,6 @@
         @[],
         @[],
         @[],
-    ];
-    
-    menu_Radio.subItem.subItem.showInfo = @[
-        @NO,
-        @NO,
-        @NO,
-        @NO,
-        @NO,
     ];
 
 #pragma mark - Pictures

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1745,12 +1745,12 @@
         [self action_album],
         [self action_filemode_music],
         [self action_queue_to_play],
+        @[],
         [self action_queue_to_play],
+        @[],
         [self action_queue_to_play],
-        [self action_queue_to_play],
-        [self action_queue_to_play],
-        [self action_queue_to_play],
-        [self action_queue_to_play],
+        @[],
+        @[],
         @[],
         [self action_queue_to_play],
         [self action_artist],
@@ -1970,11 +1970,7 @@
     menu_Music.subItem.subItem.thumbWidth = DEFAULT_THUMB_WIDTH;
     menu_Music.subItem.subItem.defaultThumb = @"nocover_music";
     menu_Music.subItem.subItem.sheetActions = @[
-        [self action_queue_to_play],
-        [self action_queue_to_play],
-        [self action_queue_to_play],
         @[],
-        [self action_queue_to_play],
         [self action_queue_to_play],
         [self action_queue_to_play],
         @[],
@@ -1982,7 +1978,11 @@
         @[],
         @[],
         @[],
-        [self action_queue_to_play],
+        @[],
+        @[],
+        @[],
+        @[],
+        @[],
         [self action_album],
     ];
     
@@ -2959,9 +2959,9 @@
         @[],
         @[],
         @[],
-        [self action_queue_to_play],
         @[],
-        [self action_queue_to_play],
+        @[],
+        @[],
     ];
     
 #pragma mark - Videos
@@ -3504,7 +3504,7 @@
         @[],
         @[],
         @[],
-        [self action_queue_to_play],
+        @[],
     ];
     
 #pragma mark - TV Shows
@@ -4102,9 +4102,9 @@
     menu_TVShows.subItem.subItem.sheetActions = @[
         @[],
         @[],
-        [self action_queue_to_play],
         @[],
-        [self action_queue_to_play],
+        @[],
+        @[],
     ];
         
     menu_TVShows.subItem.subItem.showRuntime = @[

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -2899,7 +2899,7 @@
         @NO,
         @NO,
         @NO,
-        @YES,
+        @NO,
     ];
     
     menu_Movies.subItem.filterModes = @[
@@ -3452,7 +3452,7 @@
         @NO,
         @NO,
         @NO,
-        @YES,
+        @NO,
     ];
     
     menu_Videos.subItem.filterModes = @[
@@ -4061,7 +4061,7 @@
         @YES,
         @YES,
         @YES,
-        @YES,
+        @NO,
     ];
     
     menu_TVShows.subItem.subItem.mainMethod = [@[

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1241,8 +1241,8 @@
     ];
     
     menu_Music.showInfo = @[
-        @YES,
-        @YES,
+        @NO,
+        @NO,
         @NO,
         @NO,
         @NO,
@@ -2524,11 +2524,11 @@
     
     menu_Movies.showInfo = @[
         @YES,
+        @NO,
+        @NO,
         @YES,
-        @YES,
-        @YES,
-        @YES,
-        @YES,
+        @NO,
+        @NO,
         @NO,
     ];
     
@@ -3275,8 +3275,8 @@
     menu_Videos.showInfo = @[
         @YES,
         @YES,
-        @YES,
-        @YES,
+        @NO,
+        @NO,
         @NO,
     ];
     
@@ -3793,7 +3793,7 @@
     ];
     
     menu_TVShows.showInfo = @[
-        @YES,
+        @NO,
         @YES,
         @NO,
         @NO,
@@ -4058,9 +4058,9 @@
     menu_TVShows.subItem.noConvertTime = YES;
     menu_TVShows.subItem.showInfo = @[
         @YES,
-        @YES,
-        @YES,
-        @YES,
+        @NO,
+        @NO,
+        @NO,
         @NO,
     ];
     
@@ -4117,11 +4117,11 @@
         
     menu_TVShows.subItem.subItem.noConvertTime = YES;
     menu_TVShows.subItem.subItem.showInfo = @[
-        @YES,
-        @YES,
-        @YES,
-        @YES,
-        @YES,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
     ];
 
 #pragma mark - Live TV
@@ -4455,7 +4455,7 @@
     
     menu_LiveTV.showInfo = @[
         @NO,
-        @YES,
+        @NO,
         @YES,
         @NO,
         @NO,
@@ -4685,11 +4685,11 @@
     ];
     
     menu_LiveTV.subItem.subItem.showInfo = @[
-        @YES,
-        @YES,
-        @YES,
-        @YES,
-        @YES,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
     ];
 
 #pragma mark - Radio
@@ -5021,7 +5021,7 @@
     
     menu_Radio.showInfo = @[
         @NO,
-        @YES,
+        @NO,
         @YES,
         @NO,
         @NO,
@@ -5251,11 +5251,11 @@
     ];
     
     menu_Radio.subItem.subItem.showInfo = @[
-        @YES,
-        @YES,
-        @YES,
-        @YES,
-        @YES,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
     ];
 
 #pragma mark - Pictures

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -2889,7 +2889,7 @@
         @[],
         [self action_queue_to_play],
         @[],
-        [self action_queue_to_moviedetails],
+        [self action_queue_to_play],
     ];
     
     menu_Movies.subItem.showInfo = @[
@@ -3444,7 +3444,7 @@
         @[],
         [self action_queue_to_play],
         @[],
-        [self action_queue_to_moviedetails],
+        [self action_queue_to_play],
     ];
     
     menu_Videos.subItem.showInfo = @[
@@ -4044,7 +4044,7 @@
         @[],
         [self action_queue_to_play],
         @[],
-        [self action_queue_to_moviedetails],
+        [self action_queue_to_play],
     ];
     
     menu_TVShows.subItem.showRuntime = @[

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -173,7 +173,7 @@
     };
 }
 
-- (NSArray*)action_queue_to_wiki {
+- (NSArray*)action_album {
     return @[
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
@@ -184,7 +184,7 @@
     ];
 }
 
-- (NSArray*)action_queue_to_fmcharts {
+- (NSArray*)action_artist {
     return @[
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
@@ -196,7 +196,7 @@
     ];
 }
 
-- (NSArray*)action_queue_to_shuffle {
+- (NSArray*)action_filemode_music {
     return @[
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
@@ -213,14 +213,14 @@
     ];
 }
 
-- (NSArray*)action_simple_queue_to_play {
+- (NSArray*)action_pictures {
     return @[
         LOCALIZED_STR(@"Queue"),
         LOCALIZED_STR(@"Play"),
     ];
 }
 
-- (NSArray*)action_queue_to_moviedetails {
+- (NSArray*)action_movie {
     return @[
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
@@ -229,7 +229,7 @@
     ];
 }
 
-- (NSArray*)action_queue_to_showcontent {
+- (NSArray*)action_playlist {
     return @[
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
@@ -240,7 +240,7 @@
     ];
 }
 
-- (NSArray*)action_queue_to_musicvideodetails {
+- (NSArray*)action_musicvideo {
     return @[
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
@@ -249,7 +249,7 @@
     ];
 }
 
-- (NSArray*)action_queue_to_episodedetails {
+- (NSArray*)action_episode {
     return @[
         LOCALIZED_STR(@"Queue after current"),
         LOCALIZED_STR(@"Queue"),
@@ -258,7 +258,7 @@
     ];
 }
 
-- (NSArray*)action_play_to_broadcastdetails {
+- (NSArray*)action_broadcast {
     return @[
         LOCALIZED_STR(@"Play"),
         LOCALIZED_STR(@"Record"),
@@ -266,7 +266,7 @@
     ];
 }
 
-- (NSArray*)action_play_to_channelguide {
+- (NSArray*)action_channel {
     return @[
         LOCALIZED_STR(@"Play"),
         LOCALIZED_STR(@"Record"),
@@ -1224,19 +1224,19 @@
     ];
 
     menu_Music.sheetActions = @[
-        [self action_queue_to_wiki],
-        [self action_queue_to_fmcharts],
-        [self action_queue_to_shuffle],
-        [self action_simple_queue_to_play],
-        [self action_queue_to_wiki],
+        [self action_album],
+        [self action_artist],
+        [self action_filemode_music],
         [self action_queue_to_play],
-        [self action_queue_to_wiki],
+        [self action_album],
         [self action_queue_to_play],
-        [self action_queue_to_wiki],
+        [self action_album],
+        [self action_queue_to_play],
+        [self action_album],
         [self action_queue_to_play],
         [self action_queue_to_play],
         @[],
-        [self action_queue_to_showcontent],
+        [self action_playlist],
         @[],
     ];
     
@@ -1741,9 +1741,9 @@
     menu_Music.subItem.defaultThumb = @"nocover_music";
     menu_Music.subItem.sheetActions = @[
         [self action_queue_to_play],
-        [self action_queue_to_wiki],
-        [self action_queue_to_wiki],
-        [self action_queue_to_shuffle],
+        [self action_album],
+        [self action_album],
+        [self action_filemode_music],
         [self action_queue_to_play],
         [self action_queue_to_play],
         [self action_queue_to_play],
@@ -1753,7 +1753,7 @@
         [self action_queue_to_play],
         @[],
         [self action_queue_to_play],
-        [self action_queue_to_fmcharts],
+        [self action_artist],
     ];
     
     menu_Music.subItem.showRuntime = @[
@@ -1983,7 +1983,7 @@
         @[],
         @[],
         [self action_queue_to_play],
-        [self action_queue_to_wiki],
+        [self action_album],
     ];
     
     menu_Music.subItem.subItem.showRuntime = @[
@@ -2513,13 +2513,13 @@
     menu_Movies.thumbWidth = DEFAULT_THUMB_WIDTH;
     menu_Movies.defaultThumb = @"nocover_movies";
     menu_Movies.sheetActions = @[
-        [self action_queue_to_moviedetails],
+        [self action_movie],
         @[],
         @[LOCALIZED_STR(@"Movie Set Details")],
-        [self action_queue_to_moviedetails],
-        [self action_simple_queue_to_play],
+        [self action_movie],
+        [self action_queue_to_play],
         @[],
-        [self action_queue_to_showcontent],
+        [self action_playlist],
     ];
     
     menu_Movies.showInfo = @[
@@ -2884,8 +2884,8 @@
     menu_Movies.subItem.defaultThumb = @"nocover_movies";
     menu_Movies.subItem.sheetActions = @[
         @[],
-        [self action_queue_to_moviedetails],
-        [self action_queue_to_moviedetails],
+        [self action_movie],
+        [self action_movie],
         @[],
         [self action_queue_to_play],
         @[],
@@ -3265,11 +3265,11 @@
     menu_Videos.thumbWidth = DEFAULT_THUMB_WIDTH;
     menu_Videos.defaultThumb = @"nocover_musicvideos";
     menu_Videos.sheetActions = @[
-        [self action_queue_to_musicvideodetails],
-        [self action_queue_to_musicvideodetails],
-        [self action_simple_queue_to_play],
+        [self action_musicvideo],
+        [self action_musicvideo],
+        [self action_queue_to_play],
         @[],
-        [self action_queue_to_showcontent],
+        [self action_playlist],
     ];
     
     menu_Videos.showInfo = @[
@@ -3786,10 +3786,10 @@
     menu_TVShows.defaultThumb = @"nocover_tvshows";
     menu_TVShows.sheetActions = @[
         @[LOCALIZED_STR(@"TV Show Details")],
-        [self action_queue_to_episodedetails],
-        [self action_simple_queue_to_play],
+        [self action_episode],
+        [self action_queue_to_play],
         @[],
-        [self action_queue_to_showcontent],
+        [self action_playlist],
     ];
     
     menu_TVShows.showInfo = @[
@@ -4040,7 +4040,7 @@
     menu_TVShows.subItem.thumbWidth = EPISODE_THUMB_WIDTH;
     menu_TVShows.subItem.defaultThumb = @"nocover_tvshows_episode";
     menu_TVShows.subItem.sheetActions = @[
-        [self action_queue_to_episodedetails],
+        [self action_episode],
         @[],
         [self action_queue_to_play],
         @[],
@@ -4446,7 +4446,7 @@
     menu_LiveTV.thumbWidth = DEFAULT_THUMB_WIDTH;
     menu_LiveTV.defaultThumb = @"nocover_channels";
     menu_LiveTV.sheetActions = @[
-        [self action_play_to_channelguide],
+        [self action_channel],
         @[],
         [self action_queue_to_play],
         @[LOCALIZED_STR(@"Delete timer")],
@@ -4580,8 +4580,8 @@
     menu_LiveTV.subItem.thumbWidth = LIVETV_THUMB_WIDTH;
     menu_LiveTV.subItem.defaultThumb = @"nocover_channels";
     menu_LiveTV.subItem.sheetActions = @[
-        [self action_play_to_broadcastdetails],
-        [self action_play_to_channelguide],
+        [self action_broadcast],
+        [self action_channel],
         @[],
         @[],
         @[],
@@ -4678,7 +4678,7 @@
     menu_LiveTV.subItem.subItem.defaultThumb = @"nocover_filemode";
     menu_LiveTV.subItem.subItem.sheetActions = @[
         @[],
-        [self action_play_to_broadcastdetails],
+        [self action_broadcast],
         @[],
         @[],
         @[],
@@ -5012,7 +5012,7 @@
     menu_Radio.thumbWidth = DEFAULT_THUMB_WIDTH;
     menu_Radio.defaultThumb = @"nocover_channels";
     menu_Radio.sheetActions = @[
-        [self action_play_to_channelguide],
+        [self action_channel],
         @[],
         [self action_queue_to_play],
         @[LOCALIZED_STR(@"Delete timer")],
@@ -5146,8 +5146,8 @@
     menu_Radio.subItem.thumbWidth = LIVETV_THUMB_WIDTH;
     menu_Radio.subItem.defaultThumb = @"nocover_channels";
     menu_Radio.subItem.sheetActions = @[
-        [self action_play_to_broadcastdetails],
-        [self action_play_to_channelguide],
+        [self action_broadcast],
+        [self action_channel],
         @[],
         @[],
         @[],
@@ -5244,7 +5244,7 @@
     menu_Radio.subItem.subItem.defaultThumb = @"nocover_filemode";
     menu_Radio.subItem.subItem.sheetActions = @[
         @[],
-        [self action_play_to_broadcastdetails],
+        [self action_broadcast],
         @[],
         @[],
         @[],
@@ -5349,7 +5349,7 @@
     ] mutableCopy];
     
     menu_Pictures.sheetActions = @[
-        [self action_simple_queue_to_play],
+        [self action_pictures],
         @[],
     ];
     
@@ -5420,7 +5420,7 @@
     menu_Pictures.subItem.thumbWidth = DEFAULT_THUMB_WIDTH;
     menu_Pictures.subItem.defaultThumb = @"nocover_filemode";
     menu_Pictures.subItem.sheetActions = @[
-        [self action_simple_queue_to_play],
+        [self action_pictures],
         @[],
     ];
     

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -229,15 +229,6 @@
     ];
 }
 
-- (NSArray*)action_queue_to_moviesetdetails {
-    return @[
-        LOCALIZED_STR(@"Queue after current"),
-        LOCALIZED_STR(@"Queue"),
-        LOCALIZED_STR(@"Play"),
-        LOCALIZED_STR(@"Movie Set Details"),
-    ];
-}
-
 - (NSArray*)action_queue_to_showcontent {
     return @[
         LOCALIZED_STR(@"Queue after current"),
@@ -2524,7 +2515,7 @@
     menu_Movies.sheetActions = @[
         [self action_queue_to_moviedetails],
         @[],
-        [self action_queue_to_moviesetdetails],
+        @[LOCALIZED_STR(@"Movie Set Details")],
         [self action_queue_to_moviedetails],
         [self action_simple_queue_to_play],
         @[],

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1751,7 +1751,7 @@
         [self action_queue_to_play],
         [self action_queue_to_play],
         [self action_queue_to_play],
-        [self action_queue_to_play],
+        @[],
         [self action_queue_to_play],
         [self action_queue_to_fmcharts],
     ];
@@ -1981,7 +1981,7 @@
         @[],
         @[],
         @[],
-        [self action_queue_to_play],
+        @[],
         [self action_queue_to_play],
         [self action_queue_to_wiki],
     ];
@@ -2888,7 +2888,7 @@
         [self action_queue_to_moviedetails],
         @[],
         [self action_queue_to_play],
-        [self action_queue_to_play],
+        @[],
         [self action_queue_to_moviedetails],
     ];
     
@@ -2960,7 +2960,7 @@
         @[],
         @[],
         [self action_queue_to_play],
-        [self action_queue_to_play],
+        @[],
         [self action_queue_to_play],
     ];
     
@@ -3443,7 +3443,7 @@
         @[],
         @[],
         [self action_queue_to_play],
-        [self action_queue_to_play],
+        @[],
         [self action_queue_to_moviedetails],
     ];
     
@@ -3503,7 +3503,7 @@
         @[],
         @[],
         @[],
-        [self action_queue_to_play],
+        @[],
         [self action_queue_to_play],
     ];
     
@@ -4043,7 +4043,7 @@
         [self action_queue_to_episodedetails],
         @[],
         [self action_queue_to_play],
-        [self action_queue_to_play],
+        @[],
         [self action_queue_to_moviedetails],
     ];
     
@@ -4103,7 +4103,7 @@
         @[],
         @[],
         [self action_queue_to_play],
-        [self action_queue_to_play],
+        @[],
         [self action_queue_to_play],
     ];
         

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4439,14 +4439,7 @@
     if (!sectionItem) {
         return;
     };
-    NSArray *sheetActions = @[
-        LOCALIZED_STR(@"Queue after current"),
-        LOCALIZED_STR(@"Queue"),
-        LOCALIZED_STR(@"Play"),
-        LOCALIZED_STR(@"Play in shuffle mode"),
-        LOCALIZED_STR(@"Album Details"),
-        LOCALIZED_STR(@"Search Wikipedia"),
-    ];
+    NSArray *sheetActions = [AppDelegate.instance action_album];
     selectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:0];
     NSMutableDictionary *item = [sectionItem mutableCopy];
     item[@"label"] = self.navigationItem.title;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Based on reviews, this PR applies several updates to the main menu config inside `AppDelegate`. 
- Remove non-working queue and play options for movie sets
- Remove non-working movie details for video playlist items
- Remove long-press options while browsing in addons
- Remove obsolete `showInfo` assignments to `YES`
- Rename methods to better match their function
- Avoid code duplication by using `action_album` also for album view actions

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Review and rework menu config