### PR TITLE
Bugfix: Resolve never ending Global Search animation

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4608,8 +4608,8 @@
                     }
                 }
             }
-            [self loadDetailedData:itemsAndTabs index:index + 1 results:richData];
         }
+        [self loadDetailedData:itemsAndTabs index:index + 1 results:richData];
     }];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an error reported via a recent AppStore review. 

Even in case the JSON API responds with error for the current request it is required to send the next set of Global Search JSON requests and walk through the whole list of Global Search JSON commands. This ensures we are not stuck with a never ending animation.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Resolve never ending Global Search animation