### PR TITLE
Bugfix: Use same message dimension for remote and custom button screen

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -558,7 +558,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    CGFloat deltaY = [Utilities getTopPadding];
+    CGFloat deltaY = UIApplication.sharedApplication.statusBarFrame.size.height;
     self.peekLeftAmount = ANCHOR_RIGHT_PEEK;
     CGRect frame = UIScreen.mainScreen.bounds;
     CGFloat deltaX = ANCHOR_RIGHT_PEEK;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes and issue reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3205628#pid3205628).

This PR just ensures there same dimension of `MessagesView` instances are used for both remote screen and custom button view.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use same message dimension for remote and custom button screen