### PR TITLE
Only show embedded trailer for youtube links

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1303,8 +1303,8 @@ double round(double d) {
         else if ([self isYoutubeLink:trailerComponents]) {
             embedVideoURL = [self getEmbeddedYoutubeLink:trailerComponents queryItemName:@"v"];
         }
-        else {
-            embedVideoURL = [NSURL URLWithString:trailerString];
+        else if ([self isEmbeddedYoutubeLink:trailerComponents]) {
+            embedVideoURL = trailerURL;
         }
         if (embedVideoURL != nil) {
             CGRect frame = CGRectMake(LEFT_RIGHT_PADDING, 0, clearLogoWidth, mainLabel1.frame.size.height);


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Other trailers can anyway not be played and the embedded trailer view is wasting space on the screen in such case.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Only show embedded trailer for youtube links