### PR TITLE
Improve playlist user experience

### DIFF
--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -94,6 +94,8 @@
     int currentPlayerID;
     int currentPlaylistID;
     BOOL isSlideshowActive;
+    NSTimer *ignoreAutoscrollTimer;
+    BOOL ignoreAutoscrollPlaylist;
     int storePosSeconds;
     long storedItemID;
     MessagesView *messagesView;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2284,7 +2284,7 @@
                     [playlistTableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationRight];
                     [playlistTableView endUpdates];
                 }
-                if (storeSelection && indexPath.row<storeSelection.row) {
+                if (storeSelection && indexPath.row < storeSelection.row) {
                     storeSelection = [NSIndexPath indexPathForRow:storeSelection.row - 1 inSection:storeSelection.section];
                 }
             }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -736,7 +736,7 @@
 - (void)setPlaylistPosition:(long)playlistPosition forPlayer:(int)playerID {
     if (playlistData.count <= playlistPosition ||
         currentPlaylistID != playerID ||
-        ![playlistTableView numberOfSections]) {
+        playlistTableView.numberOfSections == 0) {
         return;
     }
     // Make current cell's progress bar invisible

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2585,11 +2585,11 @@
                                                 SEGMENTCONTROL_WIDTH,
                                                 SEGMENTCONTROL_HEIGHT);
     playlistSegmentedControl.tintColor = UIColor.whiteColor;
-    [playlistSegmentedControl addTarget:self action:@selector(segmentValueChanged:) forControlEvents: UIControlEventValueChanged];
+    [playlistSegmentedControl addTarget:self action:@selector(segmentValueChanged:) forControlEvents:UIControlEventValueChanged];
     [playlistActionView addSubview:playlistSegmentedControl];
 }
 
-- (void)segmentValueChanged:(UISegmentedControl *)segment {
+- (void)segmentValueChanged:(UISegmentedControl*)segment {
     [self editTable:nil forceClose:YES];
     if (playlistData.count && (playlistTableView.dragging || playlistTableView.decelerating)) {
         NSArray *visiblePaths = [playlistTableView indexPathsForVisibleRows];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2591,10 +2591,6 @@
 
 - (void)segmentValueChanged:(UISegmentedControl*)segment {
     [self editTable:nil forceClose:YES];
-    if (playlistData.count && (playlistTableView.dragging || playlistTableView.decelerating)) {
-        NSArray *visiblePaths = [playlistTableView indexPathsForVisibleRows];
-        [playlistTableView scrollToRowAtIndexPath:visiblePaths[0] atScrollPosition:UITableViewScrollPositionMiddle animated:NO];
-    }
     switch (segment.selectedSegmentIndex) {
         case PLAYERID_MUSIC:
             currentPlaylistID = PLAYERID_MUSIC;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -736,6 +736,7 @@
 - (void)setPlaylistPosition:(long)playlistPosition forPlayer:(int)playerID {
     if (playlistData.count <= playlistPosition ||
         currentPlaylistID != playerID ||
+        playlistTableView.editing ||
         playlistTableView.numberOfSections == 0) {
         return;
     }
@@ -2205,7 +2206,7 @@
 }
 
 - (BOOL)tableView:(UITableView*)tableView canEditRowAtIndexPath:(NSIndexPath*)indexPath {
-    return !(storeSelection && storeSelection.row == indexPath.row);
+    return YES;
 }
 
 - (BOOL)tableView:(UITableView*)tableview canMoveRowAtIndexPath:(NSIndexPath*)indexPath {
@@ -2331,6 +2332,7 @@
     }
     else {
         storeSelection = [playlistTableView indexPathForSelectedRow];
+        [self deselectPlaylistItem];
         [playlistTableView setEditing:YES animated:YES];
         editTableButton.selected = YES;
     }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2267,6 +2267,7 @@
         else {
             [playlistTableView reloadData];
             [playlistTableView selectRowAtIndexPath:storeSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
+            [messagesView showMessage:LOCALIZED_STR(@"Cannot do that") timeout:2.0 color:[Utilities getSystemRed:0.95]];
         }
     }];
 }
@@ -2296,6 +2297,7 @@
             else {
                 [playlistTableView reloadData];
                 [playlistTableView selectRowAtIndexPath:storeSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
+                [messagesView showMessage:LOCALIZED_STR(@"Cannot do that") timeout:2.0 color:[Utilities getSystemRed:0.95]];
             }
         }];
     }
@@ -2643,13 +2645,13 @@
         
         [self setNowPlayingDimensionIPhone:nowPlayingView.frame.size.width
                                     height:nowPlayingView.frame.size.height];
-        
-        UIView *rootView = IS_IPHONE ? UIApplication.sharedApplication.keyWindow.rootViewController.view : self.view;
-        CGFloat deltaY = IS_IPHONE ? UIApplication.sharedApplication.statusBarFrame.size.height : 0;
-        messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, DEFAULT_MSG_HEIGHT + deltaY) deltaY:deltaY deltaX:0];
-        messagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
-        [rootView addSubview:messagesView];
     }
+    
+    UIView *rootView = IS_IPHONE ? UIApplication.sharedApplication.keyWindow.rootViewController.view : self.view;
+    CGFloat deltaY = IS_IPHONE ? UIApplication.sharedApplication.statusBarFrame.size.height : 0;
+    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, DEFAULT_MSG_HEIGHT + deltaY) deltaY:deltaY deltaX:0];
+    messagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
+    [rootView addSubview:messagesView];
     
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleEnterForeground:)


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/645.

### Motivation
This PR is triggered by user feedback (forums and AppStore review) on playlists jumping while scrolling/editing. Main reason for this complaint is the playlist always automatically scrolls the current playing item into the middle of the view. While this works well (you can see previous and next items) while just letting playback do its job, it becomes a hassle when user drags the playlist to view different section of it, or when user is editing. This PR reworks this in two areas editing and dragging. 

### Editing
When entering editing mode all items are generally editable, instead of keeping the current playing item not editable. This has the benefit that highlighting the current playing item can be fully removed, which simplifies the logic and also resolves a glitch (see above linked issue). So, the user can simply scroll, remove and move item without being impacted by the playback updates. Downside is that user can now also end up in attempting to edit the current playing item, which will not (and did never) work. In this case an error message is shown.
Impressions: [https://www.dropbox.com/scl/fi/bq7ecjijo...a6zag&dl=0](https://www.dropbox.com/scl/fi/bq7ecjijo33dv9q6v9tez/Simulator-Screen-Recording-iPad-8th-generation-2024-08-14-at-08.53.13.mp4?rlkey=u6377mnylnyuadotgbtq7tv33&st=634a6zag&dl=0)

### Dragging
If a user drags the playlist to review a different section this now stops the automatic scrolling to the playing item for several seconds (at the time of raining this PR: 10 seconds). It is a compromise to have the freedom to drag/review the playlist without a jumpy playlist, but it also restores the standard behavior automatically.
Impressions: [https://www.dropbox.com/scl/fi/mqvevvw5w...7ydy6&dl=0](https://www.dropbox.com/scl/fi/mqvevvw5w1gui6ivugc6a/Simulator-Screen-Recording-iPad-8th-generation-2024-08-14-at-08.42.32.mp4?rlkey=a2udk4k9qf8q1ndtj0u6cp59e&st=ipa7ydy6&dl=0)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: playlist does not autoscroll while user edits/scrolls