### PR TITLE
Feature: Queue and Play a season via longpress menu

### DIFF
--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -125,6 +125,7 @@
     BOOL showkeyboard;
     __weak UIAlertController *actionView;
     NSIndexPath *selectedIndexPath;
+    NSNumber *processAllItemsInSection;
 }
 
 - (id)initWithFrame:(CGRect)frame;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3351,15 +3351,15 @@
                 UIImageView *isRecordingImageView = (UIImageView*)[cell viewWithTag:EPG_VIEW_CELL_RECORDING_ICON];
                 BOOL isRecording = isRecordingImageView == nil ? NO : !isRecordingImageView.hidden;
                 UIViewController *showFromCtrl = [self topMostController];
-                UIView *showfromview = nil;
+                UIView *showFromView = nil;
                 if (IS_IPHONE) {
-                    showfromview = self.view;
+                    showFromView = self.view;
                 }
                 else {
-                    showfromview = enableCollectionView ? collectionView : [showFromCtrl.view superview];
+                    showFromView = enableCollectionView ? collectionView : [showFromCtrl.view superview];
                 }
-                CGPoint sheetOrigin = [activeRecognizer locationInView:showfromview];
-                [self showActionSheetOptions:title options:sheetActions recording:isRecording origin:sheetOrigin fromcontroller:showFromCtrl fromview:showfromview];
+                CGPoint sheetOrigin = [activeRecognizer locationInView:showFromView];
+                [self showActionSheetOptions:title options:sheetActions recording:isRecording origin:sheetOrigin fromcontroller:showFromCtrl fromview:showFromView];
             }
             // In case of Global Search restore choosedTab after processing
             if (globalSearchView) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4232,10 +4232,10 @@
         [cellActivityIndicator stopAnimating];
         return;
     }
-    NSDictionary *playlistParams = [NSDictionary dictionaryWithObjectsAndKeys:
-                                                    @(playlistid), @"playlistid",
-                                                    playlistItems, @"item",
-                                                    nil];
+    NSDictionary *playlistParams = @{
+        @"playlistid": @(playlistid),
+        @"item": playlistItems,
+    };
     if (afterCurrent) {
         NSDictionary *params = @{
             @"playerid": @(playlistid),
@@ -4377,10 +4377,10 @@
                     [cellActivityIndicator stopAnimating];
                     return;
                 }
-                NSDictionary *playlistParams = [NSDictionary dictionaryWithObjectsAndKeys:
-                                                                @(playlistid), @"playlistid",
-                                                                playlistItems, @"item",
-                                                                nil];
+                NSDictionary *playlistParams = @{
+                    @"playlistid": @(playlistid),
+                    @"item": playlistItems,
+                };
                 NSDictionary *playbackParams = [NSDictionary dictionaryWithObjectsAndKeys:
                                                 @{@"playlistid": @(playlistid), @"position": @(pos)}, @"item",
                                                 optionsValue, optionsParam,


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/399.

This PR implements a longpress menu for seasons which allows to queue after current, queue and play a whole season.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Queue and Play a season via longpress menu