### PR TITLE
Bugfix: Show playlist progress bar when scrolling cells back to visible area

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2166,7 +2166,8 @@
              placeholderImage:defaultThumb
                       options:SDWebImageScaleToNativeSize];
     [Utilities applyRoundedEdgesView:thumb drawBorder:YES];
-    [self setPlaylistCellProgressBar:cell hidden:YES];
+    BOOL active = indexPath.row == lastSelected;
+    [self setPlaylistCellProgressBar:cell hidden:!active];
     
     return cell;
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3206710#pid3206710).

This avoids the playing item not showing the progress bar when scrolled out of and then back into the visible area. The PR just makes the progress bar visible, if the (reused) cell's index matches the current playing playlist index.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show playlist progress bar when scrolling cells back to visible area
