### PR TITLE
Rework messages to centralized approach

### DIFF
--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -17,7 +17,6 @@
 #import "Utilities.h"
 #import "BDKCollectionIndexView.h"
 #import "FloatingHeaderFlowLayout.h"
-#import "MessagesView.h"
 #import <SafariServices/SafariServices.h>
 
 @class NowPlaying;
@@ -98,7 +97,6 @@
     NSDateFormatter *xbmcDateFormatter;
     NSDateFormatter *localHourMinuteFormatter;
     NSIndexPath *autoScrollTable;
-    MessagesView *messagesView;
     __weak IBOutlet UILabel *noItemsLabel;
     BOOL stackscrollFullscreen;
     BOOL forceCollection;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6063,9 +6063,6 @@
         [self setIpadInterface:itemSizes[@"ipad"]];
     }
     
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, DEFAULT_MSG_HEIGHT) deltaY:0 deltaX:0];
-    [self.view addSubview:messagesView];
-    
     // As default both list and grid views animate from right to left.
     frame = dataList.frame;
     frame.origin.x = viewWidth;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1635,7 +1635,7 @@
         // Selected favourite item is an unknown type -> throw an error
         else {
             NSString *message = [NSString stringWithFormat:@"%@ (type = '%@')", LOCALIZED_STR(@"Cannot do that"), item[@"type"]];
-            [messagesView showMessage:message timeout:2.0 color:[Utilities getSystemRed:0.95]];
+            [Utilities showMessage:message color:[Utilities getSystemRed:0.95]];
         }
     }
     else if (methods[@"method"] != nil && ![parameters[@"forceActionSheet"] boolValue] && !stackscrollFullscreen) {
@@ -3786,7 +3786,7 @@
     customButton *arrayButtons = [customButton new];
     [arrayButtons.buttons addObject:button];
     [arrayButtons saveData];
-    [messagesView showMessage:LOCALIZED_STR(@"Button added") timeout:2.0 color:[Utilities getSystemGreen:0.95]];
+    [Utilities showMessage:LOCALIZED_STR(@"Button added") color:[Utilities getSystemGreen:0.95]];
     if (IS_IPAD) {
         [[NSNotificationCenter defaultCenter] postNotificationName: @"UIInterfaceCustomButtonAdded" object: nil];
     }
@@ -4525,10 +4525,10 @@
 - (void)SimpleAction:(NSString*)action params:(NSDictionary*)parameters success:(NSString*)successMessage failure:(NSString*)failureMessage {
     [[Utilities getJsonRPC] callMethod:action withParameters:parameters onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (error == nil && methodError == nil) {
-            [messagesView showMessage:successMessage timeout:2.0 color:[Utilities getSystemGreen:0.95]];
+            [Utilities showMessage:successMessage color:[Utilities getSystemGreen:0.95]];
         }
         else {
-            [messagesView showMessage:failureMessage timeout:2.0 color:[Utilities getSystemRed:0.95]];
+            [Utilities showMessage:failureMessage color:[Utilities getSystemRed:0.95]];
         }
     }];
 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -481,16 +481,6 @@
     }
 }
 
-- (UIViewController*)topMostController {
-    UIViewController *topController = UIApplication.sharedApplication.keyWindow.rootViewController;
-
-    while (topController.presentedViewController) {
-        topController = topController.presentedViewController;
-    }
-
-    return topController;
-}
-
 - (void)setFilternameLabel:(NSString*)labelText runFullscreenButtonCheck:(BOOL)check forceHide:(BOOL)forceHide {
     self.navigationItem.title = [Utilities stripBBandHTML:labelText];
     if (IS_IPHONE) {
@@ -3254,7 +3244,7 @@
         UIImageView *isRecordingImageView = (UIImageView*)[cell viewWithTag:EPG_VIEW_CELL_RECORDING_ICON];
         BOOL isRecording = isRecordingImageView == nil ? NO : !isRecordingImageView.hidden;
         CGPoint sheetOrigin = CGPointMake(rectOriginX, rectOriginY);
-        UIViewController *showFromCtrl = [self topMostController];
+        UIViewController *showFromCtrl = [Utilities topMostController];
         [self showActionSheetOptions:title options:sheetActions recording:isRecording origin:sheetOrigin fromcontroller:showFromCtrl fromview:self.view];
     }
     else if (indexPath != nil) { // No actions found, revert back to standard play action
@@ -3284,7 +3274,7 @@
                 title = [NSString stringWithFormat:@"%@\n%@", title, season];
             }
             
-            UIViewController *showFromCtrl = [self topMostController];
+            UIViewController *showFromCtrl = [Utilities topMostController];
             UIView *showFromView = nil;
             if (IS_IPHONE) {
                 showFromView = self.view;
@@ -3366,7 +3356,7 @@
                 }
                 UIImageView *isRecordingImageView = (UIImageView*)[cell viewWithTag:EPG_VIEW_CELL_RECORDING_ICON];
                 BOOL isRecording = isRecordingImageView == nil ? NO : !isRecordingImageView.hidden;
-                UIViewController *showFromCtrl = [self topMostController];
+                UIViewController *showFromCtrl = [Utilities topMostController];
                 UIView *showFromView = nil;
                 if (IS_IPHONE) {
                     showFromView = self.view;

--- a/XBMC Remote/HostManagementViewController.h
+++ b/XBMC Remote/HostManagementViewController.h
@@ -10,7 +10,6 @@
 #import "ECSlidingViewController.h"
 #import "MasterViewController.h"
 #import "RightMenuViewController.h"
-#import "MessagesView.h"
 #import "DSJSONRPC.h"
 
 @class HostViewController;
@@ -28,7 +27,6 @@
     __weak IBOutlet UIButton *addHostButton;
     __weak IBOutlet UIView *supportedVersionView;
     __weak IBOutlet UILabel *supportedVersionLabel;
-    MessagesView *messagesView;
     __weak IBOutlet UIToolbar *bottomToolbar;
     __weak IBOutlet UIImageView *bottomToolbarShadowImageView;
     UITextView *serverInfoView;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -681,7 +681,7 @@
         actionView = [Utilities createAlertOK:LOCALIZED_STR(@"Select an XBMC Server from the list") message:nil];
     }
     else {
-        actionView = [Utilities createPowerControl:self messageView:messagesView];
+        actionView = [Utilities createPowerControl:self];
     }
     [self presentViewController:actionView animated:YES completion:nil];
 }

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -767,7 +767,7 @@
 
 - (void)connectionError:(NSNotification*)note {
     NSDictionary *theData = note.userInfo;
-    [messagesView showMessage:theData[@"error_message"] timeout:2.0 color:[Utilities getSystemRed:0.95]];
+    [Utilities showMessage:theData[@"error_message"] color:[Utilities getSystemRed:0.95]];
 }
 
 - (void)authFailed:(NSNotification*)note {

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -524,10 +524,6 @@
     frame.origin.y -= bottomPadding;
     serverInfoButton.frame = frame;
     
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, HOSTMANAGERVC_MSG_HEIGHT + deltaY) deltaY:deltaY deltaX:0];
-    messagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
-    [self.view addSubview:messagesView];
-    
     CGFloat toolbarHeight = bottomToolbar.frame.size.height;
     serverInfoView = [[UITextView alloc] initWithFrame:CGRectMake(MARGIN, deltaY + MARGIN, self.view.frame.size.width - 2 * MARGIN, self.view.frame.size.height - deltaY - toolbarHeight - 2 * MARGIN)];
     serverInfoView.autoresizingMask = UIViewAutoresizingFlexibleWidth |

--- a/XBMC Remote/MasterViewController.h
+++ b/XBMC Remote/MasterViewController.h
@@ -11,6 +11,7 @@
 #import "ECSlidingViewController.h"
 #import "tcpJSONRPC.h"
 #import "CustomNavigationController.h"
+#import "MessagesView.h"
 
 @class DetailViewController;
 @class NowPlaying;
@@ -31,6 +32,7 @@
     BOOL itemIsActive;
     CustomNavigationController *navController;
     UIImageView *globalConnectionStatus;
+    MessagesView *messagesView;
 }
 
 @property (nonatomic, strong) NSMutableArray *mainMenu;

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -402,12 +402,26 @@
                                                  name: @"VideoLibrary.OnCleanFinished"
                                                object: nil];
     
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(showNotificationMessage:)
+                                                 name: @"UIShowMessage"
+                                               object: nil];
+    
     self.view.backgroundColor = [Utilities getGrayColor:36 alpha:1];
     [menuList selectRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] animated:YES scrollPosition:UITableViewScrollPositionNone];
 }
 
 - (void)handleLibraryNotification:(NSNotification*)note {
-    [messagesView showMessage:note.name timeout:2.0 color:[Utilities getSystemGreen:0.95]];
+    [Utilities showMessage:note.name color:[Utilities getSystemGreen:0.95]];
+}
+
+- (void)showNotificationMessage:(NSNotification*)note {
+    NSDictionary *params = note.userInfo;
+    if (!params) {
+        return;
+    }
+    [self addMessagesToRootView];
+    [messagesView showMessage:params[@"message"] timeout:2.0 color:params[@"color"]];
 }
 
 - (void)connectionStatus:(NSNotification*)note {

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -230,7 +230,7 @@
 
 - (void)addMessagesToRootView {
     // Add MessagesView to root view to be able to show messages on top
-    UIView *rootView = UIApplication.sharedApplication.keyWindow.rootViewController.view;
+    UIView *rootView = [Utilities topMostController].view;
     [rootView addSubview:messagesView];
 }
 

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -191,6 +191,9 @@
         
         // Add connection status icon to root view of new controller
         [self addConnectionStatusToRootView];
+        
+        // Add MessagesView to root view to be able to show messages on top
+        [self addMessagesToRootView];
     }];
 }
 
@@ -224,6 +227,12 @@
 }
 
 #pragma mark - Helper
+
+- (void)addMessagesToRootView {
+    // Add MessagesView to root view to be able to show messages on top
+    UIView *rootView = UIApplication.sharedApplication.keyWindow.rootViewController.view;
+    [rootView addSubview:messagesView];
+}
 
 - (void)addConnectionStatusToRootView {
     // Add connection status icon to root view of new controller
@@ -289,6 +298,16 @@
     [super viewWillAppear:animated];
     self.slidingViewController.anchorRightPeekAmount = ANCHOR_RIGHT_PEEK;
     self.slidingViewController.underLeftWidthLayout = ECFullWidth;
+    
+    // Update dimension of message view
+    CGFloat deltaY = [Utilities getTopPaddingWithNavBar:self.navigationController];
+    [messagesView updateWithFrame:CGRectMake(0,
+                                             0,
+                                             UIScreen.mainScreen.bounds.size.width,
+                                             DEFAULT_MSG_HEIGHT + deltaY)
+                           deltaY:deltaY
+                           deltaX:0];
+    [self addMessagesToRootView];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
@@ -328,6 +347,8 @@
                                                                            CONNECTION_STATUS_SIZE)];
     [self addConnectionStatusToRootView];
     
+    messagesView = [[MessagesView alloc] initWithFrame:CGRectZero deltaY:0 deltaX:0];
+    
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleWillResignActive:)
                                                  name: @"UIApplicationWillResignActiveNotification"
@@ -361,8 +382,32 @@
                                                  name: @"KodiStartDefaultController"
                                                object: nil];
     
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handleLibraryNotification:)
+                                                 name: @"AudioLibrary.OnScanFinished"
+                                               object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handleLibraryNotification:)
+                                                 name: @"AudioLibrary.OnCleanFinished"
+                                               object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handleLibraryNotification:)
+                                                 name: @"VideoLibrary.OnScanFinished"
+                                               object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handleLibraryNotification:)
+                                                 name: @"VideoLibrary.OnCleanFinished"
+                                               object: nil];
+    
     self.view.backgroundColor = [Utilities getGrayColor:36 alpha:1];
     [menuList selectRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] animated:YES scrollPosition:UITableViewScrollPositionNone];
+}
+
+- (void)handleLibraryNotification:(NSNotification*)note {
+    [messagesView showMessage:note.name timeout:2.0 color:[Utilities getSystemGreen:0.95]];
 }
 
 - (void)connectionStatus:(NSNotification*)note {

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -11,7 +11,6 @@
 #import "UIImageView+WebCache.h"
 #import "RightMenuViewController.h"
 #import "OBSlider.h"
-#import "MessagesView.h"
 
 @class ShowInfoViewController;
 @class RemoteController;
@@ -98,7 +97,6 @@
     BOOL ignoreAutoscrollPlaylist;
     int storePosSeconds;
     long storedItemID;
-    MessagesView *messagesView;
     BOOL isRemotePlayer;
 }
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2647,12 +2647,6 @@
                                     height:nowPlayingView.frame.size.height];
     }
     
-    UIView *rootView = IS_IPHONE ? UIApplication.sharedApplication.keyWindow.rootViewController.view : self.view;
-    CGFloat deltaY = IS_IPHONE ? UIApplication.sharedApplication.statusBarFrame.size.height : 0;
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, DEFAULT_MSG_HEIGHT + deltaY) deltaY:deltaY deltaX:0];
-    messagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
-    [rootView addSubview:messagesView];
-    
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleEnterForeground:)
                                                  name: @"UIApplicationWillEnterForegroundNotification"

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2267,7 +2267,7 @@
         else {
             [playlistTableView reloadData];
             [playlistTableView selectRowAtIndexPath:storeSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
-            [messagesView showMessage:LOCALIZED_STR(@"Cannot do that") timeout:2.0 color:[Utilities getSystemRed:0.95]];
+            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
         }
     }];
 }
@@ -2297,7 +2297,7 @@
             else {
                 [playlistTableView reloadData];
                 [playlistTableView selectRowAtIndexPath:storeSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
-                [messagesView showMessage:LOCALIZED_STR(@"Cannot do that") timeout:2.0 color:[Utilities getSystemRed:0.95]];
+                [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
             }
         }];
     }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2728,7 +2728,7 @@
     if (AppDelegate.instance.obj.serverIP.length == 0) {
         return;
     }
-    UIAlertController *actionView = [Utilities createPowerControl:self messageView:messagesView];
+    UIAlertController *actionView = [Utilities createPowerControl:self];
     [self presentViewController:actionView animated:YES completion:nil];
 }
 

--- a/XBMC Remote/RemoteController.h
+++ b/XBMC Remote/RemoteController.h
@@ -8,7 +8,6 @@
 
 #import <UIKit/UIKit.h>
 #import "DSJSONRPC.h"
-#import "MessagesView.h"
 
 typedef enum {
     remoteTop,
@@ -49,7 +48,6 @@ typedef enum {
     BOOL isGestureViewActive;
     NSDictionary *subsDictionary;
     NSDictionary *audiostreamsDictionary;
-    MessagesView *messagesView;
 }
 
 - (IBAction)startVibrate:(id)sender;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -395,8 +395,8 @@
         
 # pragma mark - view Effects
 
-- (void)showSubInfo:(NSString*)message timeout:(NSTimeInterval)timeout color:(UIColor*)color {
-    [messagesView showMessage:message timeout:timeout color:color];
+- (void)showSubInfo:(NSString*)message color:(UIColor*)color {
+    [Utilities showMessage:message color:color];
 }
 
 # pragma mark - ToolBar
@@ -532,7 +532,7 @@
                                      [self showActionSubtitles:actionSheetTitles];
                                  }
                                  else {
-                                     [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") timeout:2.0 color:[Utilities getSystemRed:0.95]];
+                                     [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") color:[Utilities getSystemRed:0.95]];
                                  }
                              }
                          }
@@ -540,7 +540,7 @@
                  }];
             }
             else {
-                [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") timeout:2.0 color:[Utilities getSystemRed:0.95]];
+                [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") color:[Utilities getSystemRed:0.95]];
             }
         }
     }];
@@ -575,7 +575,7 @@
                                      [self showActionAudiostreams:actionSheetTitles];
                                  }
                                  else {
-                                     [self showSubInfo:LOCALIZED_STR(@"Audiostreams not available") timeout:2.0 color:[Utilities getSystemRed:0.95]];
+                                     [self showSubInfo:LOCALIZED_STR(@"Audiostreams not available") color:[Utilities getSystemRed:0.95]];
                                  }
                              }
                         }
@@ -583,7 +583,7 @@
                  }];
             }
             else {
-                [self showSubInfo:LOCALIZED_STR(@"Audiostream not available") timeout:2.0 color:[Utilities getSystemRed:0.95]];
+                [self showSubInfo:LOCALIZED_STR(@"Audiostream not available") color:[Utilities getSystemRed:0.95]];
             }
         }
     }];
@@ -666,7 +666,7 @@
                             id audiostreamIndex = audiostreamsDictionary[@"audiostreams"][i][@"index"];
                             if (audiostreamIndex) {
                                 [self playbackAction:@"Player.SetAudioStream" params:@{@"stream": audiostreamIndex}];
-                                [self showSubInfo:actiontitle timeout:2.0 color:[Utilities getSystemGreen:0.95]];
+                                [self showSubInfo:actiontitle color:[Utilities getSystemGreen:0.95]];
                             }
                         }
                     }
@@ -694,7 +694,7 @@
         UIAlertAction *action_cancel = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:nil];
 
         UIAlertAction *action_disable = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Disable subtitles") style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
-            [self showSubInfo:LOCALIZED_STR(@"Subtitles disabled") timeout:2.0 color:[Utilities getSystemGreen:0.95]];
+            [self showSubInfo:LOCALIZED_STR(@"Subtitles disabled") color:[Utilities getSystemGreen:0.95]];
             [self playbackAction:@"Player.SetSubtitle" params:@{@"subtitle": @"off"}];
         }];
         if ([subsDictionary[@"subtitleenabled"] boolValue]) {
@@ -712,7 +712,7 @@
                             if (subsIndex) {
                                 [self playbackAction:@"Player.SetSubtitle" params:@{@"subtitle": subsIndex}];
                                 [self playbackAction:@"Player.SetSubtitle" params:@{@"subtitle": @"on"}];
-                                [self showSubInfo:actiontitle timeout:2.0 color:[Utilities getSystemGreen:0.95]];
+                                [self showSubInfo:actiontitle color:[Utilities getSystemGreen:0.95]];
                             }
                         }
                     }

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1378,7 +1378,7 @@
     if (AppDelegate.instance.obj.serverIP.length == 0) {
         return;
     }
-    UIAlertController *actionView = [Utilities createPowerControl:self messageView:messagesView];
+    UIAlertController *actionView = [Utilities createPowerControl:self];
     [self presentViewController:actionView animated:YES completion:nil];
 }
 

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1363,18 +1363,6 @@
     
     gestureZoneImageView.layer.minificationFilter = kCAFilterTrilinear;
     self.view.backgroundColor = [UIColor colorWithPatternImage:[UIImage imageNamed:@"backgroundImage_repeat"]];
-    
-    UIView *rootView = IS_IPHONE ? UIApplication.sharedApplication.keyWindow.rootViewController.view : self.view;
-    CGFloat deltaY = IS_IPHONE ? UIApplication.sharedApplication.statusBarFrame.size.height : 0;
-    CGFloat messageWidth = IS_IPHONE ? UIApplication.sharedApplication.statusBarFrame.size.width : TransitionalView.frame.size.width;
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0,
-                                                                  0,
-                                                                  messageWidth,
-                                                                  DEFAULT_MSG_HEIGHT + deltaY)
-                                                deltaY:deltaY
-                                                deltaX:0];
-    messagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
-    [rootView addSubview:messagesView];
 }
 
 - (void)handleSettingsButton:(id)sender {

--- a/XBMC Remote/RightMenuViewController.h
+++ b/XBMC Remote/RightMenuViewController.h
@@ -11,7 +11,6 @@
 #import "DSJSONRPC.h"
 #import "RemoteController.h"
 #import "VolumeSliderView.h"
-#import "MessagesView.h"
 
 @interface RightMenuViewController : UIViewController <UITableViewDelegate, UITableViewDataSource> {
     UITableView *menuTableView;
@@ -19,7 +18,6 @@
     VolumeSliderView *volumeSliderView;
     RemoteController *remoteControllerView;
     BOOL torchIsOn;
-    MessagesView *messagesView;
     NSUInteger editableRowStartAt;
     UIButton *editTableButton;
     UIButton *moreButton;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -522,10 +522,10 @@
     }
     [[Utilities getJsonRPC] callMethod:action withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (methodError == nil && error == nil) {
-            [messagesView showMessage:LOCALIZED_STR(@"Command executed") timeout:2.0 color:[Utilities getSystemGreen:0.95]];
+            [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:[Utilities getSystemGreen:0.95]];
         }
         else {
-            [messagesView showMessage:LOCALIZED_STR(@"Cannot do that") timeout:2.0 color:[Utilities getSystemRed:0.95]];
+            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
         }
         if ([sender respondsToSelector:@selector(setUserInteractionEnabled:)]) {
             [sender setUserInteractionEnabled:YES];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -568,10 +568,8 @@
     CGFloat deltaY = [Utilities getTopPadding];
     self.peekLeftAmount = ANCHOR_RIGHT_PEEK;
     CGRect frame = UIScreen.mainScreen.bounds;
-    CGFloat deltaX = ANCHOR_RIGHT_PEEK;
     if (IS_IPAD) {
         frame.size.width = STACKSCROLL_WIDTH;
-        deltaX = 0;
         deltaY = 0;
         self.peekLeftAmount = 0;
     }
@@ -620,9 +618,6 @@
             moreButton.enabled = YES;
         }
     }
-    deltaY = UIApplication.sharedApplication.statusBarFrame.size.height;
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, DEFAULT_MSG_HEIGHT + deltaY) deltaY:deltaY deltaX:deltaX];
-    [self.view addSubview:messagesView];
     
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(connectionSuccess:)

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -643,30 +643,6 @@
                                              selector: @selector(reloadCustomButtonTable:)
                                                  name: @"UIInterfaceCustomButtonAdded"
                                                object: nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(showNotificationMessage:)
-                                                 name: @"AudioLibrary.OnScanFinished"
-                                               object: nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(showNotificationMessage:)
-                                                 name: @"AudioLibrary.OnCleanFinished"
-                                               object: nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(showNotificationMessage:)
-                                                 name: @"VideoLibrary.OnScanFinished"
-                                               object: nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(showNotificationMessage:)
-                                                 name: @"VideoLibrary.OnCleanFinished"
-                                               object: nil];
-}
-
-- (void)showNotificationMessage:(NSNotification*)note {
-    [messagesView showMessage:note.name timeout:2.0 color:[Utilities getSystemGreen:0.95]];
 }
 
 - (void)reloadCustomButtonTable:(NSNotification*)note {

--- a/XBMC Remote/SettingsValuesViewController.h
+++ b/XBMC Remote/SettingsValuesViewController.h
@@ -7,7 +7,6 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "MessagesView.h"
 
 typedef enum {
     cDefault,
@@ -33,7 +32,6 @@ typedef enum {
     UILabel *scrubbingMessage;
     UILabel *scrubbingRate;
     UILabel *footerDescription;
-    MessagesView *messagesView;
     BOOL fromItself;
 }
 

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -876,24 +876,6 @@
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
     tap.cancelsTouchesInView = NO;
     [self.view addGestureRecognizer:tap];
-    
-    messagesView = [[MessagesView alloc] initWithFrame:CGRectZero deltaY:0 deltaX:0];
-}
-
-- (void)viewDidLayoutSubviews {
-    [super viewDidLayoutSubviews];
-    
-    CGFloat deltaY = 0;
-    CGRect frame = UIScreen.mainScreen.bounds;
-    if (IS_IPAD) {
-        frame.size.width = STACKSCROLL_WIDTH;
-    }
-    else {
-        deltaY = [Utilities getTopPaddingWithNavBar:self.navigationController];
-    }
-    
-    [messagesView updateWithFrame:CGRectMake(0, 0, frame.size.width, deltaY + DEFAULT_MSG_HEIGHT) deltaY:deltaY deltaX:0];
-    [self.view addSubview:messagesView];
 }
 
 - (void)didReceiveMemoryWarning {

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -295,7 +295,7 @@
     customButton *arrayButtons = [customButton new];
     [arrayButtons.buttons addObject:button];
     [arrayButtons saveData];
-    [messagesView showMessage:LOCALIZED_STR(@"Button added") timeout:2.0 color:[Utilities getSystemGreen:0.95]];
+    [Utilities showMessage:LOCALIZED_STR(@"Button added") color:[Utilities getSystemGreen:0.95]];
     if (IS_IPAD) {
         [[NSNotificationCenter defaultCenter] postNotificationName:@"UIInterfaceCustomButtonAdded" object:nil];
     }
@@ -311,10 +311,10 @@
     [[Utilities getJsonRPC] callMethod:action withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         [activityIndicator stopAnimating];
         if (methodError == nil && error == nil) {
-            [messagesView showMessage:LOCALIZED_STR(@"Command executed") timeout:2.0 color:[Utilities getSystemGreen:0.95]];
+            [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:[Utilities getSystemGreen:0.95]];
         }
         else {
-            [messagesView showMessage:LOCALIZED_STR(@"Cannot do that") timeout:2.0 color:[Utilities getSystemRed:0.95]];
+            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
         }
         if ([sender respondsToSelector:@selector(setUserInteractionEnabled:)]) {
             [sender setUserInteractionEnabled:YES];

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -123,5 +123,6 @@ typedef enum {
 + (void)wakeUp:(NSString*)macAddress;
 + (NSString*)getUrlStyleAddress:(NSString*)address;
 + (int)getActivePlayerID:(NSArray*)activePlayerList;
++ (UIViewController*)topMostController;
 
 @end

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -66,6 +66,7 @@ typedef enum {
 + (UIAlertController*)createAlertCopyClipboard:(NSString*)title message:(NSString*)msg;
 + (UIAlertController*)createPowerControl:(UIViewController*)ctrl messageView:(MessagesView*)messageView;
 + (void)SFloadURL:(NSString*)url fromctrl:(UIViewController<SFSafariViewControllerDelegate>*)fromctrl;
++ (void)showMessage:(NSString*)messageText color:(UIColor*)messageColor;
 + (DSJSONRPC*)getJsonRPC;
 + (void)setWebImageAuthorizationOnSuccessNotification:(NSNotification*)note;
 + (NSDictionary*)indexKeyedDictionaryFromArray:(NSArray*)array;

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -64,7 +64,7 @@ typedef enum {
 + (CGRect)createCoverInsideJewel:(UIImageView*)jewelView jewelType:(eJewelType)type;
 + (UIAlertController*)createAlertOK:(NSString*)title message:(NSString*)msg;
 + (UIAlertController*)createAlertCopyClipboard:(NSString*)title message:(NSString*)msg;
-+ (UIAlertController*)createPowerControl:(UIViewController*)ctrl messageView:(MessagesView*)messageView;
++ (UIAlertController*)createPowerControl:(UIViewController*)ctrl;
 + (void)SFloadURL:(NSString*)url fromctrl:(UIViewController<SFSafariViewControllerDelegate>*)fromctrl;
 + (void)showMessage:(NSString*)messageText color:(UIColor*)messageColor;
 + (DSJSONRPC*)getJsonRPC;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1435,4 +1435,12 @@
     return activePlayerID;
 }
 
++ (UIViewController*)topMostController {
+    UIViewController *topController = UIApplication.sharedApplication.keyWindow.rootViewController;
+    while (topController.presentedViewController) {
+        topController = topController.presentedViewController;
+    }
+    return topController;
+}
+
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -551,10 +551,10 @@
         [[Utilities getJsonRPC] callMethod:command withParameters:@{} onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
             if (messageView) {
                 if (methodError == nil && error == nil) {
-                    [messageView showMessage:LOCALIZED_STR(@"Command executed") timeout:2.0 color:[Utilities getSystemGreen:0.95]];
+                    [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:[Utilities getSystemGreen:0.95]];
                 }
                 else {
-                    [messageView showMessage:LOCALIZED_STR(@"Cannot do that") timeout:2.0 color:[Utilities getSystemRed:0.95]];
+                    [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
                 }
             }
             else {
@@ -584,10 +584,10 @@
             if (messageView) {
                 if ([Utilities isValidMacAddress:AppDelegate.instance.obj.serverHWAddr]) {
                     [Utilities wakeUp:AppDelegate.instance.obj.serverHWAddr];
-                    [messageView showMessage:LOCALIZED_STR(@"Command executed") timeout:2.0 color:[Utilities getSystemGreen:0.95]];
+                    [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:[Utilities getSystemGreen:0.95]];
                 }
                 else {
-                    [messageView showMessage:LOCALIZED_STR(@"Cannot do that") timeout:2.0 color:[Utilities getSystemRed:0.95]];
+                    [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
                 }
             }
             else {
@@ -723,6 +723,17 @@
         }
         [ctrl presentViewController:svc animated:YES completion:nil];
     }
+}
+
++ (void)showMessage:(NSString*)messageText color:(UIColor*)messageColor {
+    if (!messageText || ![messageColor isKindOfClass:[UIColor class]]) {
+        return;
+    }
+    NSDictionary *params = @{
+        @"message": messageText,
+        @"color": messageColor,
+    };
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"UIShowMessage" object:nil userInfo:params];
 }
 
 + (DSJSONRPC*)getJsonRPC {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -600,6 +600,30 @@
                                              selector: @selector(handlePlaylistHeaderUpdate:)
                                                  name: @"PlaylistHeaderUpdate"
                                                object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handleLibraryNotification:)
+                                                 name: @"AudioLibrary.OnScanFinished"
+                                               object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handleLibraryNotification:)
+                                                 name: @"AudioLibrary.OnCleanFinished"
+                                               object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handleLibraryNotification:)
+                                                 name: @"VideoLibrary.OnScanFinished"
+                                               object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(handleLibraryNotification:)
+                                                 name: @"VideoLibrary.OnCleanFinished"
+                                               object: nil];
+}
+
+- (void)handleLibraryNotification:(NSNotification*)note {
+    [messagesView showMessage:note.name timeout:2.0 color:[Utilities getSystemGreen:0.95]];
 }
 
 - (void)handlePlaylistHeaderUpdate:(NSNotification*)sender {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -215,7 +215,7 @@
         [self toggleSetup];
         return;
     }
-    UIAlertController *actionView = [Utilities createPowerControl:self messageView:messagesView];
+    UIAlertController *actionView = [Utilities createPowerControl:self];
     UIPopoverPresentationController *popPresenter = [actionView popoverPresentationController];
     if (popPresenter != nil) {
         popPresenter.sourceView = powerButton;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -620,10 +620,23 @@
                                              selector: @selector(handleLibraryNotification:)
                                                  name: @"VideoLibrary.OnCleanFinished"
                                                object: nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver: self
+                                             selector: @selector(showNotificationMessage:)
+                                                 name: @"UIShowMessage"
+                                               object: nil];
 }
 
 - (void)handleLibraryNotification:(NSNotification*)note {
-    [messagesView showMessage:note.name timeout:2.0 color:[Utilities getSystemGreen:0.95]];
+    [Utilities showMessage:note.name color:[Utilities getSystemGreen:0.95]];
+}
+
+- (void)showNotificationMessage:(NSNotification*)note {
+    NSDictionary *params = note.userInfo;
+    if (!params) {
+        return;
+    }
+    [messagesView showMessage:params[@"message"] timeout:2.0 color:params[@"color"]];
 }
 
 - (void)handlePlaylistHeaderUpdate:(NSNotification*)sender {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR reworks the approach on how messages are shown. Before, each `UIViewController` had an own instance of `MessagesView` and the messages were presented by it. Now, there is only a single instance of `MessagesView` in either the iPad's or iPhone's main controller. All other `UIVewController`s send notifications which are consumed by this central instance and shown from there. This allows to reduce code to layout and create several instances and it easily aligns the layout of the messages. 
In addition, this PR brings back the messages after executing action from the "Power Menu" (e.g. Audio Library Scan). Those were lost as part of refactoring and unifying the power menu.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Use centralized approach to show messages
Bugfix: Show power menu related messages again