### PR TITLE
Bugfix: calculate correct height of labels when using auto-layout

### DIFF
--- a/XBMC Remote/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/XBMC Remote/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -225,17 +225,9 @@ static char UIScrollViewPullToRefreshView;
         NSString *subtitle = self.subtitles[self.state];
         self.subtitleLabel.text = subtitle.length > 0 ? subtitle : nil;
         
-        CGRect titleRect = [self.titleLabel.text boundingRectWithSize:CGSizeMake(labelMaxWidth, self.titleLabel.font.lineHeight)
-                                             options:NSStringDrawingUsesLineFragmentOrigin
-                                          attributes:@{NSFontAttributeName:self.titleLabel.font}
-                                             context:nil];
-        CGSize titleSize = titleRect.size;
+        CGSize titleSize = [self.titleLabel sizeThatFits:CGSizeMake(labelMaxWidth, self.titleLabel.font.lineHeight)];
         
-        CGRect subtitleRect = [self.subtitleLabel.text boundingRectWithSize:CGSizeMake(labelMaxWidth, self.subtitleLabel.font.lineHeight)
-                                                              options:NSStringDrawingUsesLineFragmentOrigin
-                                                           attributes:@{NSFontAttributeName:self.subtitleLabel.font}
-                                                              context:nil];
-        CGSize subtitleSize = subtitleRect.size;
+        CGSize subtitleSize = [self.subtitleLabel sizeThatFits:CGSizeMake(labelMaxWidth, self.subtitleLabel.font.lineHeight)];
         
         CGFloat maxLabelWidth = MAX(titleSize.width, subtitleSize.width);
         CGFloat totalMaxWidth = leftViewWidth + margin + maxLabelWidth;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -956,12 +956,7 @@
 }
 
 + (CGSize)getSizeOfLabel:(UILabel*)label {
-    CGRect expectedLabelRect = [label.text boundingRectWithSize:CGSizeMake(label.frame.size.width, CGFLOAT_MAX)
-                                                        options:NSStringDrawingUsesLineFragmentOrigin
-                                                     attributes:@{NSFontAttributeName: label.font}
-                                                        context:nil];
-    CGSize labelSize = CGSizeMake(ceil(expectedLabelRect.size.width), ceil(expectedLabelRect.size.height));
-    return labelSize;
+    return [label sizeThatFits:CGSizeMake(label.frame.size.width, CGFLOAT_MAX)];
 }
 
 + (UIImage*)roundedCornerImage:(UIImage*)image drawBorder:(BOOL)drawBorder {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes an issue reported and discussed in the support forum (see [this post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3206508#pid3206508)). The underlying root cause looks like an iOS issue which came with iOS 16 and lets `boundingRectWithSize` return a wrong label size for some occasions. This PR drops `boundingRectWithSize` and uses `sizeThatFits` instead, which return the correct label dimension (correct = same as auto-layout uses).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: calculate correct height of labels when using auto-layout