### PR TITLE
Bugfix: correct iPad stack bounce behaviour after fullscreen

### DIFF
--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -161,6 +161,8 @@
         for (int j = i + 1; j < numViews; j++) {
             [slideViews.subviews[i + 1] removeFromSuperview];
         }
+        viewAtRight = nil;
+        viewAtRight2 = nil;
     }
                      completion:^(BOOL finished) {}
     ];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3207569#pid3207569).

This PR resolves an issue where an iPad stack could show wrong bounce-behaviour after entering fullscreen from main stack while having active stacks right of the main stack. Solution is to clear `viewAtRight` and `viewAtRight2` after removing the related stacks from view.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: correct iPad stack bounce behaviour after fullscreen