### PR TITLE
Improvement: allow toolbar buttons while active search

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1067,7 +1067,7 @@
 
 - (void)showMore {
     if ([self doesShowSearchResults] || self.searchController.isActive) {
-        return;
+        [self.searchController setActive:NO];
     }
     mainMenu *menuItem = self.detailItem;
     self.indexView.hidden = YES;
@@ -1233,7 +1233,7 @@
 
 - (void)handleChangeTab:(int)newChoosedTab fromMoreItems:(BOOL)fromMoreItems {
     if ([self doesShowSearchResults] || self.searchController.isActive) {
-        return;
+        [self.searchController setActive:NO];
     }
     if (!activityIndicatorView.hidden) {
         return;
@@ -3820,7 +3820,7 @@
 
 - (void)toggleFullscreen:(id)sender {
     if ([self doesShowSearchResults] || self.searchController.isActive) {
-        return;
+        [self.searchController setActive:NO];
     }
     [activityIndicatorView startAnimating];
     NSTimeInterval animDuration = 0.5;
@@ -6108,7 +6108,7 @@
 
 - (void)handleChangeLibraryView {
     if ([self doesShowSearchResults] || self.searchController.isActive) {
-        return;
+        [self.searchController setActive:NO];
     }
     mainMenu *menuItem = self.detailItem;
     NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
@@ -6153,7 +6153,7 @@
 
 - (void)handleChangeSortLibrary {
     if ([self doesShowSearchResults] || self.searchController.isActive) {
-        return;
+        [self.searchController setActive:NO];
     }
     selectedIndexPath = nil;
     mainMenu *menuItem = self.detailItem;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses an issue raised in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3207569#pid3207569).

Since search bar was reworked in the past months, it is now possible to end an active search via `[self.searchController setActive:NO]` and then continue to execute the toolbar buttons presses. This improves the user experience compared to just ignoring button presses, which was done in an earlier change (https://github.com/xbmc/Official-Kodi-Remote-iOS/commit/c618ffff93904db041ee4dcc9fd30157748f561a) to avoid undesired / improper behaviour.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: allow toolbar buttons while active search