### PR TITLE
Bugfix: show correct title in Settings menu

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1329,8 +1329,7 @@
     enableCollectionView = newEnableCollectionView;
     recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
     [activeLayoutView setContentOffset:[(UITableView*)activeLayoutView contentOffset] animated:NO];
-    NSString *labelText = parameters[@"label"];
-    [self setFilternameLabel:labelText runFullscreenButtonCheck:YES forceHide:NO];
+    [self checkFullscreenButton:NO];
     [self addExtraProperties:mutableProperties newParams:mutableParameters params:parameters];
     if ([parameters[@"blackTableSeparator"] boolValue] && ![Utilities getPreferTvPosterMode]) {
         dataList.separatorColor = [Utilities getGrayColor:38 alpha:1];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5283,7 +5283,7 @@
     mainMenu *menuItem = self.detailItem;
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
     
-    BOOL useMainLabel = ![menuItem.mainLabel isEqualToString:menuItem.rootLabel];
+    BOOL useMainLabel = ![menuItem.mainLabel isEqualToString:menuItem.rootLabel] && ![menuItem.mainLabel isEqualToString:LOCALIZED_STR(@"XBMC Settings")];
     NSString *labelText = useMainLabel ? menuItem.mainLabel : parameters[@"label"];
     self.navigationItem.backButtonTitle = labelText;
     if (!albumView) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue brought up in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3208330#pid3208330).

1. Use correct name: As `rootLabel` is not set for Settings menu in `AppDelegate` (Settings is not a main menu entry), we need to avoid Settings menu titles fall back to `mainLabel`, but use the dedicated tab's name. 
2. Avoid flickering title: The tab's title does not need to be set inside `handleTabChange`,it is set later again -- called from `displayData:`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: show correct title in Settings menu