### PR TITLE
Bugfix: set speed via longpress NowPlaying's seek buttons

### DIFF
--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -461,6 +461,7 @@
                             </state>
                             <connections>
                                 <action selector="startVibrate:" destination="-1" eventType="touchUpInside" id="fRq-xr-c2f"/>
+                                <outletCollection property="gestureRecognizers" destination="162" appends="YES" id="AxH-Sx-ZVi"/>
                             </connections>
                         </button>
                         <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="4Kp-hV-AcM" userLabel="Button Playpause">
@@ -492,6 +493,7 @@
                             </state>
                             <connections>
                                 <action selector="startVibrate:" destination="-1" eventType="touchUpInside" id="zju-uy-9B2"/>
+                                <outletCollection property="gestureRecognizers" destination="164" appends="YES" id="RsE-qQ-xwL"/>
                             </connections>
                         </button>
                         <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="cnS-6H-tni" userLabel="Button Next">


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The feature was broken since version 1.15 (regression of the NowPlaying rework merged with https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1004). Since then it was only possible to change the playback speed via the remote screen's buttons. 

This PR just connects back the seek backward/forward buttons of the NowPlaying screen to the existing gestureRecognizer.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: set speed via longpress NowPlaying's seek buttons