### PR TITLE
Bugfix: another workaround to make list view scrollbars visible for iOS17

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2230,6 +2230,9 @@
     if (searchString.length == 0 && self.searchController.isActive) {
         [self.searchController setActive:NO];
     }
+    // Workaround iOS 17: Force scroll indicator visible.
+    dataList.showsVerticalScrollIndicator = YES;
+    dataList.showsHorizontalScrollIndicator = NO;
 }
 
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
@@ -5328,10 +5331,6 @@
     if (channelGuideView && autoScrollTable != nil && autoScrollTable.row < [dataList numberOfRowsInSection:autoScrollTable.section]) {
         [dataList scrollToRowAtIndexPath:autoScrollTable atScrollPosition:UITableViewScrollPositionTop animated: NO];
     }
-    
-    // Workaround iOS 17: Force scroll indicator visible. Called here, after all layout configurations and data reloads are finished.
-    dataList.showsVerticalScrollIndicator = YES;
-    dataList.showsHorizontalScrollIndicator = NO;
 }
 
 - (void)startChannelListUpdateTimer {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3208424#pid3208424).

To really catch all relevant use cases simply apply the iOS17 workaround in `scrollViewDidScroll`, which is called every time scrolling is performed.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: another workaround to make list view scrollbars visible for iOS17