### PR TITLE
Improvement: consistently enter full screen remote when tapping remote button (iPhone)

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2623,7 +2623,7 @@
         UIImage *remoteImg = [UIImage imageNamed:@"icon_menu_remote"];
         UIImage *powerImg = [UIImage imageNamed:@"icon_power"];
         self.navigationItem.rightBarButtonItems = @[
-            [[UIBarButtonItem alloc] initWithImage:remoteImg style:UIBarButtonItemStylePlain target:self action:@selector(revealUnderRight:)],
+            [[UIBarButtonItem alloc] initWithImage:remoteImg style:UIBarButtonItemStylePlain target:self action:@selector(showRemote)],
             [[UIBarButtonItem alloc] initWithImage:powerImg style:UIBarButtonItemStylePlain target:self action:@selector(powerControl)]
         ];
         self.slidingViewController.underRightViewController = nil;
@@ -2708,6 +2708,11 @@
 
 - (void)revealUnderRight:(id)sender {
     [self.slidingViewController anchorTopViewTo:ECLeft];
+}
+
+- (void)showRemote {
+    RemoteController *remote = [[RemoteController alloc] initWithNibName:@"RemoteController" bundle:nil];
+    [self.navigationController pushViewController:remote animated:YES];
 }
 
 - (void)powerControl {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses feedback given in [this forum thread](https://forum.kodi.tv/showthread.php?tid=378679).

On the NowPlaying screen the remote button was opening the embedded remote (which has limited buttons). With this commit also NowPlaying's remote button will enter the full screen remote as from any other menu. Swiping left the NowPlaying screen is still entering the embedded remote.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: consistently enter full screen remote when tapping remote button (iPhone)