### PR TITLE
Bugfix: Restore fix for vertical pos of custom button view

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -565,7 +565,7 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    CGFloat deltaY = UIApplication.sharedApplication.statusBarFrame.size.height;
+    CGFloat deltaY = [Utilities getTopPadding];
     self.peekLeftAmount = ANCHOR_RIGHT_PEEK;
     CGRect frame = UIScreen.mainScreen.bounds;
     CGFloat deltaX = ANCHOR_RIGHT_PEEK;
@@ -620,6 +620,7 @@
             moreButton.enabled = YES;
         }
     }
+    deltaY = UIApplication.sharedApplication.statusBarFrame.size.height;
     messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, frame.size.width, DEFAULT_MSG_HEIGHT + deltaY) deltaY:deltaY deltaX:deltaX];
     [self.view addSubview:messagesView];
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Restores using `getTopPadding`, which avoids vertical moving custom button view after coming back from settings. Applies same message height as for remote only for the messages.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Restore fix for vertical pos of custom button view