### PR TITLE
No need to invalidate timers in dealloc

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2994,9 +2994,6 @@
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver: self];
-    [updateInfoTimer invalidate];
-    [debounceTimer invalidate];
-    [ignoreAutoscrollTimer invalidate];
 }
 
 - (BOOL)shouldAutorotate {

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -329,7 +329,6 @@
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver: self];
-    [self stopTimer];
 }
 
 @end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves a review finding from https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1104.

Calling `invalidate` on `NSTimer` instances in `dealloc` is not required.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: No need to invalidate timers in dealloc