### PR TITLE
Bugfix: avoid showing messages aligned with action sheets on iPhone

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -230,7 +230,7 @@
 
 - (void)addMessagesToRootView {
     // Add MessagesView to root view to be able to show messages on top
-    UIView *rootView = [Utilities topMostController].view;
+    UIView *rootView = [Utilities topMostControllerIgnoringClass:[UIAlertController class]].view;
     [rootView addSubview:messagesView];
 }
 

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -124,5 +124,6 @@ typedef enum {
 + (NSString*)getUrlStyleAddress:(NSString*)address;
 + (int)getActivePlayerID:(NSArray*)activePlayerList;
 + (UIViewController*)topMostController;
++ (UIViewController*)topMostControllerIgnoringClass:(Class)ignoredClass;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1436,8 +1436,16 @@
 }
 
 + (UIViewController*)topMostController {
+    return [self topMostControllerIgnoringClass:nil];
+}
+
++ (UIViewController*)topMostControllerIgnoringClass:(Class)ignoredClass {
     UIViewController *topController = UIApplication.sharedApplication.keyWindow.rootViewController;
     while (topController.presentedViewController) {
+        if ([topController.presentedViewController isKindOfClass:ignoredClass]) {
+            // We want to ignore any ignoredClass being the top most controller.
+            break;
+        }
         topController = topController.presentedViewController;
     }
     return topController;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Ignore `UIAlertController` as top most controller. This avoids showing messages aligned with action sheets on iPhone.

<a href="https://ibb.co/mSK0xyQ"><img src="https://i.ibb.co/8XwbhxF/Bildschirmfoto-2024-09-14-um-22-54-55.png" alt="Bildschirmfoto-2024-09-14-um-22-54-55" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: avoid showing messages aligned with action sheets on iPhone