### PR TITLE
Improvement: Remove confirmation of power menu actions

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -671,7 +671,7 @@
         actionView = [Utilities createAlertOK:LOCALIZED_STR(@"Select an XBMC Server from the list") message:nil];
     }
     else {
-        actionView = [Utilities createPowerControl:self];
+        actionView = [Utilities createPowerControl];
     }
     [self presentViewController:actionView animated:YES completion:nil];
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2701,7 +2701,7 @@
     if (AppDelegate.instance.obj.serverIP.length == 0) {
         return;
     }
-    UIAlertController *actionView = [Utilities createPowerControl:self];
+    UIAlertController *actionView = [Utilities createPowerControl];
     [self presentViewController:actionView animated:YES completion:nil];
 }
 

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1378,7 +1378,7 @@
     if (AppDelegate.instance.obj.serverIP.length == 0) {
         return;
     }
-    UIAlertController *actionView = [Utilities createPowerControl:self];
+    UIAlertController *actionView = [Utilities createPowerControl];
     [self presentViewController:actionView animated:YES completion:nil];
 }
 

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -64,7 +64,7 @@ typedef enum {
 + (CGRect)createCoverInsideJewel:(UIImageView*)jewelView jewelType:(eJewelType)type;
 + (UIAlertController*)createAlertOK:(NSString*)title message:(NSString*)msg;
 + (UIAlertController*)createAlertCopyClipboard:(NSString*)title message:(NSString*)msg;
-+ (UIAlertController*)createPowerControl:(UIViewController*)ctrl;
++ (UIAlertController*)createPowerControl;
 + (void)SFloadURL:(NSString*)url fromctrl:(UIViewController<SFSafariViewControllerDelegate>*)fromctrl;
 + (void)showMessage:(NSString*)messageText color:(UIColor*)messageColor;
 + (DSJSONRPC*)getJsonRPC;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -548,7 +548,7 @@
     }];
 }
 
-+ (UIAlertController*)createPowerControl:(UIViewController*)ctrl {
++ (UIAlertController*)createPowerControl {
     NSString *title = [NSString stringWithFormat:@"%@\n%@", AppDelegate.instance.obj.serverDescription, AppDelegate.instance.obj.serverIP];
     UIAlertController *actionView = [UIAlertController alertControllerWithTitle:title message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     
@@ -557,12 +557,10 @@
             // In this case we want to have a user interaction popup instead of a short-lived message.
             if ([Utilities isValidMacAddress:AppDelegate.instance.obj.serverHWAddr]) {
                 [Utilities wakeUp:AppDelegate.instance.obj.serverHWAddr];
-                UIAlertController *alertView = [Utilities createAlertOK:LOCALIZED_STR(@"Command executed") message:nil];
-                [ctrl presentViewController:alertView animated:YES completion:nil];
+                [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:[Utilities getSystemGreen:0.95]];
             }
             else {
-                UIAlertController *alertView = [Utilities createAlertOK:LOCALIZED_STR(@"Warning") message:LOCALIZED_STR(@"No server MAC address defined")];
-                [ctrl presentViewController:alertView animated:YES completion:nil];
+                [Utilities showMessage:LOCALIZED_STR(@"No server MAC address defined") color:[Utilities getSystemRed:0.95]];
             }
         }];
         [actionView addAction:action_wake];

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -536,28 +536,16 @@
     return alertView;
 }
 
-+ (void)powerAction:(NSString*)command ctrl:(UIViewController*)ctrl message:(NSString*)alertMessage ok:(NSString*)okMessage {
-    alertMessage = alertMessage ?: @"";
-    okMessage = okMessage ?: LOCALIZED_STR(@"Yes");
-    UIAlertController *alertView = [UIAlertController alertControllerWithTitle:alertMessage message:nil preferredStyle:UIAlertControllerStyleAlert];
-    UIAlertAction *cancelButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:nil];
-    UIAlertAction *okButton = [UIAlertAction actionWithTitle:okMessage style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        if (!command) {
-            return;
++ (void)powerAction:(NSString*)command {
+    [[Utilities getJsonRPC] callMethod:command withParameters:@{} onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+        // User already confirmed, so we only show a short-lived message.
+        if (methodError == nil && error == nil) {
+            [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:[Utilities getSystemGreen:0.95]];
         }
-        [[Utilities getJsonRPC] callMethod:command withParameters:@{} onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-            // User already confirmed, so we only show a short-lived message.
-            if (methodError == nil && error == nil) {
-                [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:[Utilities getSystemGreen:0.95]];
-            }
-            else {
-                [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
-            }
-        }];
+        else {
+            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
+        }
     }];
-    [alertView addAction:cancelButton];
-    [alertView addAction:okButton];
-    [ctrl presentViewController:alertView animated:YES completion:nil];
 }
 
 + (UIAlertController*)createPowerControl:(UIViewController*)ctrl {
@@ -581,74 +569,47 @@
     }
     else {
         UIAlertAction *action_pwr_off_system = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Power off System") style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
-            [self powerAction:@"System.Shutdown" 
-                         ctrl:ctrl
-                      message:LOCALIZED_STR(@"Are you sure you want to power off your XBMC system now?")
-                           ok:LOCALIZED_STR(@"Power off")];
+            [self powerAction:@"System.Shutdown"];
         }];
         [actionView addAction:action_pwr_off_system];
         
         UIAlertAction *action_quit_kodi = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Quit XBMC application") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"Application.Quit" 
-                         ctrl:ctrl
-                      message:LOCALIZED_STR(@"Are you sure you want to quit XBMC application now?")
-                           ok:LOCALIZED_STR(@"Quit")];
+            [self powerAction:@"Application.Quit"];
         }];
         [actionView addAction:action_quit_kodi];
         
         UIAlertAction *action_hibernate = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Hibernate") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"System.Hibernate" 
-                         ctrl:ctrl
-                      message:LOCALIZED_STR(@"Are you sure you want to hibernate your XBMC system now?")
-                           ok:LOCALIZED_STR(@"Hibernate")];
+            [self powerAction:@"System.Hibernate"];
         }];
         [actionView addAction:action_hibernate];
         
         UIAlertAction *action_suspend = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Suspend") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"System.Suspend"
-                         ctrl:ctrl
-                      message:LOCALIZED_STR(@"Are you sure you want to suspend your XBMC system now?")
-                           ok:LOCALIZED_STR(@"Suspend")];
+            [self powerAction:@"System.Suspend"];
         }];
         [actionView addAction:action_suspend];
         
         UIAlertAction *action_reboot = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Reboot") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"System.Reboot" 
-                         ctrl:ctrl
-                      message:LOCALIZED_STR(@"Are you sure you want to reboot your XBMC system now?")
-                           ok:LOCALIZED_STR(@"Reboot")];
+            [self powerAction:@"System.Reboot" ];
         }];
         [actionView addAction:action_reboot];
         
         UIAlertAction *action_scan_audio_lib = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Update Audio Library") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"AudioLibrary.Scan" 
-                         ctrl:ctrl
-                      message:LOCALIZED_STR(@"Are you sure you want to update your audio library now?")
-                           ok:LOCALIZED_STR(@"Update Audio")];
+            [self powerAction:@"AudioLibrary.Scan"];
         }];
         [actionView addAction:action_scan_audio_lib];
         
         UIAlertAction *action_clean_audio_lib = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Clean Audio Library") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"AudioLibrary.Clean"
-                         ctrl:ctrl
-                      message:LOCALIZED_STR(@"Are you sure you want to clean your audio library now?")
-                           ok:LOCALIZED_STR(@"Clean Audio")];
+            [self powerAction:@"AudioLibrary.Clean"];
         }];
         [actionView addAction:action_clean_audio_lib];
         
         UIAlertAction *action_scan_video_lib = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Update Video Library") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"VideoLibrary.Scan" 
-                         ctrl:ctrl
-                      message:LOCALIZED_STR(@"Are you sure you want to update your video library now?")
-                           ok:LOCALIZED_STR(@"Update Video")];
+            [self powerAction:@"VideoLibrary.Scan"];
         }];
         [actionView addAction:action_scan_video_lib];
         
         UIAlertAction *action_clean_video_lib = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Clean Video Library") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"VideoLibrary.Clean" 
-                         ctrl:ctrl 
-                      message:LOCALIZED_STR(@"Are you sure you want to clean your video library now?")
-                           ok:LOCALIZED_STR(@"Clean Video")];
+            [self powerAction:@"VideoLibrary.Clean"];
         }];
         [actionView addAction:action_clean_video_lib];
     }

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -204,7 +204,7 @@
         [self toggleSetup];
         return;
     }
-    UIAlertController *actionView = [Utilities createPowerControl:self];
+    UIAlertController *actionView = [Utilities createPowerControl];
     UIPopoverPresentationController *popPresenter = [actionView popoverPresentationController];
     if (popPresenter != nil) {
         popPresenter.sourceView = powerButton;

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -56,14 +56,20 @@
 "Pictures Add-ons" = "Pictures Add-ons";
 
 "Power off System" = "Power off System";
+"Power off" = "Power off";
 "Hibernate" = "Hibernate";
 "Suspend" = "Suspend";
 "Reboot" = "Reboot";
 "Quit XBMC application" = "Quit Kodi application";
 "Update Audio Library" = "Update Audio Library";
+"Update Audio" = "Update Audio";
 "Clean Audio Library" = "Clean Audio Library";
+"Clean Audio" = "Clean Audio";
 "Update Video Library" = "Update Video Library";
+"Update Video" = "Update Video";
 "Clean Video Library" = "Clean Video Library";
+"Clean Video" = "Clean Video";
+"Quit" = "Quit";
 
 "Keyboard" = "Keyboard";
 "Gesture Zone" = "Gesture Zone";
@@ -123,6 +129,15 @@
 "Are you sure you want to clear the music playlist?" = "Are you sure you want to clear the music playlist?";
 "Are you sure you want to clear the video playlist?" = "Are you sure you want to clear the video playlist?";
 "Are you sure you want to clear the picture playlist?" = "Are you sure you want to clear the picture playlist?";
+"Are you sure you want to power off your XBMC system now?" = "Are you sure you want to power off your Kodi system now?";
+"Are you sure you want to hibernate your XBMC system now?" = "Are you sure you want to hibernate your Kodi system now?";
+"Are you sure you want to suspend your XBMC system now?" = "Are you sure you want to suspend your Kodi system now?";
+"Are you sure you want to reboot your XBMC system now?" = "Are you sure you want to reboot your Kodi system now?";
+"Are you sure you want to quit XBMC application now?" = "Are you sure you want to quit Kodi application now?";
+"Are you sure you want to update your audio library now?" = "Are you sure you want to update your audio library now?";
+"Are you sure you want to clean your audio library now?" = "Are you sure you want to clean your audio library now?";
+"Are you sure you want to update your video library now?" = "Are you sure you want to update your video library now?";
+"Are you sure you want to clean your video library now?" = "Are you sure you want to clean your video library now?";
 
 "DIRECTED BY" = "DIRECTED BY";
 "RUNTIME" = "RUNTIME";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -56,20 +56,14 @@
 "Pictures Add-ons" = "Pictures Add-ons";
 
 "Power off System" = "Power off System";
-"Power off" = "Power off";
 "Hibernate" = "Hibernate";
 "Suspend" = "Suspend";
 "Reboot" = "Reboot";
 "Quit XBMC application" = "Quit Kodi application";
 "Update Audio Library" = "Update Audio Library";
-"Update Audio" = "Update Audio";
 "Clean Audio Library" = "Clean Audio Library";
-"Clean Audio" = "Clean Audio";
 "Update Video Library" = "Update Video Library";
-"Update Video" = "Update Video";
 "Clean Video Library" = "Clean Video Library";
-"Clean Video" = "Clean Video";
-"Quit" = "Quit";
 
 "Keyboard" = "Keyboard";
 "Gesture Zone" = "Gesture Zone";
@@ -129,15 +123,6 @@
 "Are you sure you want to clear the music playlist?" = "Are you sure you want to clear the music playlist?";
 "Are you sure you want to clear the video playlist?" = "Are you sure you want to clear the video playlist?";
 "Are you sure you want to clear the picture playlist?" = "Are you sure you want to clear the picture playlist?";
-"Are you sure you want to power off your XBMC system now?" = "Are you sure you want to power off your Kodi system now?";
-"Are you sure you want to hibernate your XBMC system now?" = "Are you sure you want to hibernate your Kodi system now?";
-"Are you sure you want to suspend your XBMC system now?" = "Are you sure you want to suspend your Kodi system now?";
-"Are you sure you want to reboot your XBMC system now?" = "Are you sure you want to reboot your Kodi system now?";
-"Are you sure you want to quit XBMC application now?" = "Are you sure you want to quit Kodi application now?";
-"Are you sure you want to update your audio library now?" = "Are you sure you want to update your audio library now?";
-"Are you sure you want to clean your audio library now?" = "Are you sure you want to clean your audio library now?";
-"Are you sure you want to update your video library now?" = "Are you sure you want to update your video library now?";
-"Are you sure you want to clean your video library now?" = "Are you sure you want to clean your video library now?";
 
 "DIRECTED BY" = "DIRECTED BY";
 "RUNTIME" = "RUNTIME";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1116.

This PR removes the need confirm power menu actions which include updating/cleaning libraries, leaving Kodi application,  shutting down or hibernating the Kodi system. It also lets Wake-on-LAN only show success (when the command could be issued) or failure (when in need of MAC address).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Remove confirmation of power menu actions