### PR TITLE
Bugfix: Roating and leaving iPad fanart fullscreen

### DIFF
--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -161,8 +161,6 @@
         for (int j = i + 1; j < numViews; j++) {
             [slideViews.subviews[i + 1] removeFromSuperview];
         }
-        viewAtRight = nil;
-        viewAtRight2 = nil;
     }
                      completion:^(BOOL finished) {}
     ];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This reverts commit c1a0a06958bea76521c9b62505ddc7d26177aca7, reversing changes made to 44f11f82c51beb2b86d54970d79a500e33d03dc9.

Caused more trouble than it fixed. The change broke full screen fanart for e.g. movies on iPad. Not rotating anymore and not leaving fullscreen into a working stack view.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Rotating and leaving iPad fanart fullscreen