### PR TITLE
Maintenance: Handle type check inside the time conversion helper

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1265,10 +1265,7 @@
                            NSString *movieid = [Utilities getStringFromItem:item[@"id"]];
                            NSString *channel = [Utilities getStringFromItem:item[@"channel"]];
                            NSString *genre = [Utilities getStringFromItem:item[@"genre"]];
-                           NSString *durationTime = @"";
-                           if ([item[@"duration"] isKindOfClass:[NSNumber class]]) {
-                               durationTime = [Utilities convertTimeFromSeconds:item[@"duration"]];
-                           }
+                           NSString *durationTime = [Utilities convertTimeFromSeconds:item[@"duration"]];
                            NSString *thumbnailPath = [self getNowPlayingThumbnailPath:item];
                            NSString *stringURL = [Utilities formatStringURL:thumbnailPath serverURL:serverURL];
                            NSNumber *tvshowid = @([item[@"tvshowid"] longValue]);

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -752,7 +752,7 @@
 
 + (NSString*)convertTimeFromSeconds:(NSNumber*)seconds {
     NSString *result = @"";
-    if (seconds == nil) {
+    if (![seconds respondsToSelector:@selector(intValue)]) {
         return result;
     }
     int secs = [seconds intValue];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Check if input variable responds to "intValue" inside the helper method `convertTimeFromSeconds` instead of only checking for `NSNumber` type outside.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Handle type check inside the time conversion helper