### PR TITLE
Bugfix: Present action sheet with UPnP players from correct origin (iPad)

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3395,7 +3395,7 @@
                 actiontitle = LOCALIZED_STR(@"Stop Recording");
             }
             UIAlertAction *action = [UIAlertAction actionWithTitle:actiontitle style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-                [self actionSheetHandler:actiontitle origin:origin];
+                [self actionSheetHandler:actiontitle origin:origin fromcontroller:fromctrl fromview:fromview];
             }];
             [actionView addAction:action];
         }
@@ -3523,7 +3523,7 @@
     [userDefaults setObject:sortAscDescSave forKey:sortKey];
 }
 
-- (void)actionSheetHandler:(NSString*)actiontitle origin:(CGPoint)origin {
+- (void)actionSheetHandler:(NSString*)actiontitle origin:(CGPoint)origin fromcontroller:(UIViewController*)fromctrl fromview:(UIView*)fromview {
     NSDictionary *item = nil;
     if (processAllItemsInSection) {
         selectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:[processAllItemsInSection longValue]];
@@ -3569,10 +3569,10 @@
                 
                 UIPopoverPresentationController *popPresenter = [actionView popoverPresentationController];
                 if (popPresenter != nil) {
-                    popPresenter.sourceView = self.view;
+                    popPresenter.sourceView = fromview;
                     popPresenter.sourceRect = CGRectMake(origin.x, origin.y, 1, 1);
                 }
-                [self presentViewController:actionView animated:YES completion:nil];
+                [fromctrl presentViewController:actionView animated:YES completion:nil];
             }
         }];
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Present UPnP player list from same origin, controller and view as the action sheet which listed "Play using...". This fixes an issue where the list was potentially shown outside of the visible area.

Screenshots: https://ibb.co/Kq4RpZ3

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Present action sheet with UPnP players from correct origin (iPad)