### PR TITLE
Bugfix: Avoid scroll up arrow to be shortly visible on iPad's detail info screen

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -201,16 +201,16 @@ double round(double d) {
             rightSwipe.direction = UISwipeGestureRecognizerDirectionRight;
             [self.view addGestureRecognizer:rightSwipe];
         }
-        // Place the up and down arrows
+        // Place the up and down arrows. Keep them invisible for now.
         CGFloat bottomPadding = [Utilities getBottomPadding];
         CGRect frame = arrow_continue_down.frame;
         frame.origin.y -= bottomPadding;
         arrow_continue_down.frame = frame;
-        arrow_continue_down.alpha = ARROW_ALPHA;
+        arrow_continue_down.alpha = 0;
         frame = arrow_back_up.frame;
         frame.origin.y += scrollView.contentInset.top;
         arrow_back_up.frame = frame;
-        arrow_back_up.alpha = ARROW_ALPHA;
+        arrow_back_up.alpha = 0;
     }
     if (![self.detailItem[@"disableNowPlaying"] boolValue]) {
         UISwipeGestureRecognizer *leftSwipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFromLeft:)];

--- a/XBMC Remote/ShowInfoViewController.xib
+++ b/XBMC Remote/ShowInfoViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -75,7 +75,7 @@
                         <outlet property="delegate" destination="-1" id="34"/>
                     </connections>
                 </scrollView>
-                <button opaque="NO" alpha="0.5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="87" userLabel="Arrow Continue Button">
+                <button opaque="NO" alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="87" userLabel="Arrow Continue Button">
                     <rect key="frame" x="285" y="381" width="30" height="30"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -90,7 +90,7 @@
                         <action selector="scrollDown:" destination="-1" eventType="touchUpInside" id="89"/>
                     </connections>
                 </button>
-                <button opaque="NO" alpha="0.5" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WHd-MZ-RVV" userLabel="Arrow Back Button">
+                <button opaque="NO" alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WHd-MZ-RVV" userLabel="Arrow Back Button">
                     <rect key="frame" x="285" y="5" width="30" height="30"/>
                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The scroll top/down arrows need to be initialized invisible (alpha = 0). Otherwise setting `scrollView.contentInset` for iPad calls  `scrollViewDidScroll` which would result in fading out the arrow visibly with a 0.3 seconds animation. This does not happen on iPhone, but starting with invisible arrows is desired in any case.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid scroll up arrow to be shortly visible on iPad's detail info screen