### PR TITLE
Bugfix: Keep exit fullscreen button always reachable in iPad fullscreen

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5896,7 +5896,7 @@
         
         // Hide toolbar when search string is non-empty or no toolbar buttons exist
         BOOL hasEmptyToolbar = button1.hidden && button2.hidden && button3.hidden && button4.hidden && button5.hidden && button6.hidden && button7.hidden;
-        BOOL hideToolbar = hasNonEmptySearchString || hasEmptyToolbar;
+        BOOL hideToolbar = (hasNonEmptySearchString || hasEmptyToolbar) && !stackscrollFullscreen;
         [self hideButtonList:hideToolbar];
         
         // Hide index when search string is non-empty


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This allows the user to always end the fullscreen mode, even while search is active or after selecting an item from a filtered list.

Screenshots: https://ibb.co/fvjFDxY

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Keep exit fullscreen button always reachable in iPad fullscreen