### PR TITLE
Rework animations and content of iPad corner info

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -481,7 +481,7 @@
     }
 }
 
-- (void)setFilternameLabel:(NSString*)labelText runFullscreenButtonCheck:(BOOL)check forceHide:(BOOL)forceHide {
+- (void)setFilternameLabel:(NSString*)labelText {
     self.navigationItem.title = [Utilities stripBBandHTML:labelText];
     if (IS_IPHONE) {
         return;
@@ -495,9 +495,6 @@
     // fade in
     [UIView animateWithDuration:0.1 animations:^{
         topNavigationLabel.alpha = 1;
-        if (check) {
-            [self checkFullscreenButton:forceHide];
-        }
     }];
 }
 
@@ -1106,7 +1103,8 @@
 
     [Utilities AnimView:moreItemsViewController.view AnimDuration:0.3 Alpha:1.0 XPos:0];
     NSString *labelText = LOCALIZED_STR_ARGS(@"More (%d)", (int)(count - MAX_NORMAL_BUTTONS));
-    [self setFilternameLabel:labelText runFullscreenButtonCheck:YES forceHide:YES];
+    [self checkFullscreenButton:YES];
+    [self setFilternameLabel:labelText];
     [activityIndicatorView stopAnimating];
 }
 
@@ -5452,7 +5450,7 @@
     if (!albumView) {
         labelText = [labelText stringByAppendingFormat:@" (%d)", numResults];
     }
-    [self setFilternameLabel:labelText runFullscreenButtonCheck:NO forceHide:NO];
+    [self setFilternameLabel:labelText];
     
     if (!self.richResults.count) {
         [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -486,15 +486,20 @@
     if (IS_IPHONE) {
         return;
     }
-    // fade out
-    [UIView animateWithDuration:0.3 animations:^{
+    [UIView animateWithDuration:0.1
+                     animations:^{
+        // fade out
         topNavigationLabel.alpha = 0;
-    }];
-    // update label
-    topNavigationLabel.text = labelText;
-    // fade in
-    [UIView animateWithDuration:0.1 animations:^{
-        topNavigationLabel.alpha = 1;
+                     }
+                     completion:^(BOOL finished) {
+        // update label
+        topNavigationLabel.text = labelText;
+        // fade in
+        [UIView animateWithDuration:0.1
+                         animations:^{
+            topNavigationLabel.alpha = 1;
+                         }
+                         completion:nil];
     }];
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -482,7 +482,8 @@
 }
 
 - (void)setFilternameLabel:(NSString*)labelText {
-    self.navigationItem.title = [Utilities stripBBandHTML:labelText];
+    labelText = [Utilities stripBBandHTML:labelText];
+    self.navigationItem.title = labelText;
     if (IS_IPHONE) {
         return;
     }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6229,11 +6229,13 @@
                 [self.view addGestureRecognizer:twoFingerPinch];
             }
             topNavigationLabel.frame = CGRectMake(0, 0, titleView.frame.size.width - fullscreenButton.frame.size.width - buttonPadding * 2, 44);
+            topNavigationLabel.alpha = 0;
             fullscreenButton.hidden = NO;
             twoFingerPinch.enabled = YES;
         }
         else {
             topNavigationLabel.frame = CGRectMake(0, 0, titleView.frame.size.width - 4, 44);
+            topNavigationLabel.alpha = 0;
             fullscreenButton.hidden = YES;
             twoFingerPinch.enabled = NO;
         }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves an issue (4th issue) reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3210210#pid3210210).

On iPad the so-called corner info (bottom right info text shown in the pane's bottom toolbar) changes its width, depending on whether the "fullscreen" button is shown or not. When changing a tab it is important to make the old text invisible (alpha = 0) before the width is adapted and the new text is displayed (alpha = 1). This avoids visual glitches, especially caused by changing from 1-lined to 2-lined texts.

In addition, this PR 
- reworks the corner info animation to properly serialize fade out, text update and fade in,
- strips bb/html code for iPad corner info as well (already was done for iPhone).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Avoid visual glitch in iPad corner info when changing tabs
Improvement: Correct fading animation for corner info
Improvement: Strip bb/html code for iPad corner info
