### PR TITLE
Maintenance: Rework AppDelegate to use appropriate types

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -518,52 +518,52 @@
     ];
     
     menu_Music.mainMethod = @[
-        @[
-            @"AudioLibrary.GetAlbums", @"method",
-            @"AudioLibrary.GetAlbumDetails", @"extra_info_method",
-        ],
-        @[
-            @"AudioLibrary.GetArtists", @"method",
-            @"AudioLibrary.GetArtistDetails", @"extra_info_method",
-        ],
-        @[
-            @"AudioLibrary.GetGenres", @"method",
-        ],
-        @[
-            @"Files.GetSources", @"method",
-        ],
-        @[
-            @"AudioLibrary.GetRecentlyAddedAlbums", @"method",
-            @"AudioLibrary.GetAlbumDetails", @"extra_info_method",
-        ],
-        @[
-            @"AudioLibrary.GetRecentlyAddedSongs", @"method",
-        ],
-        @[
-            @"AudioLibrary.GetAlbums", @"method",
-            @"AudioLibrary.GetAlbumDetails", @"extra_info_method",
-        ],
-        @[
-            @"AudioLibrary.GetSongs", @"method",
-        ],
-        @[
-            @"AudioLibrary.GetRecentlyPlayedAlbums", @"method",
-        ],
-        @[
-            @"AudioLibrary.GetRecentlyPlayedSongs", @"method",
-        ],
-        @[
-            @"AudioLibrary.GetSongs", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"AudioLibrary.GetRoles", @"method",
-        ],
+        @{
+            @"method": @"AudioLibrary.GetAlbums",
+            @"extra_info_method": @"AudioLibrary.GetAlbumDetails",
+        },
+        @{
+            @"method": @"AudioLibrary.GetArtists",
+            @"extra_info_method": @"AudioLibrary.GetArtistDetails",
+        },
+        @{
+            @"method": @"AudioLibrary.GetGenres",
+        },
+        @{
+            @"method": @"Files.GetSources",
+        },
+        @{
+            @"method": @"AudioLibrary.GetRecentlyAddedAlbums",
+            @"extra_info_method": @"AudioLibrary.GetAlbumDetails",
+        },
+        @{
+            @"method": @"AudioLibrary.GetRecentlyAddedSongs",
+        },
+        @{
+            @"method": @"AudioLibrary.GetAlbums",
+            @"extra_info_method": @"AudioLibrary.GetAlbumDetails",
+        },
+        @{
+            @"method": @"AudioLibrary.GetSongs",
+        },
+        @{
+            @"method": @"AudioLibrary.GetRecentlyPlayedAlbums",
+        },
+        @{
+            @"method": @"AudioLibrary.GetRecentlyPlayedSongs",
+        },
+        @{
+            @"method": @"AudioLibrary.GetSongs",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"AudioLibrary.GetRoles",
+        },
     ];
     
     menu_Music.mainParameters = [@[
@@ -1248,45 +1248,45 @@
     ];
     
     menu_Music.subItem.mainMethod = @[
-        @[
-            @"AudioLibrary.GetSongs", @"method",
-            @YES, @"albumView",
-        ],
-        @[
-            @"AudioLibrary.GetAlbums", @"method",
-            @"AudioLibrary.GetAlbumDetails", @"extra_info_method",
-        ],
-        @[
-            @"AudioLibrary.GetAlbums", @"method",
-            @"AudioLibrary.GetAlbumDetails", @"extra_info_method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"AudioLibrary.GetSongs", @"method",
-            @YES, @"albumView",
-        ],
-        @[],
-        @[
-            @"AudioLibrary.GetSongs", @"method",
-            @YES, @"albumView",
-        ],
-        @[],
-        @[
-            @"AudioLibrary.GetSongs", @"method",
-            @YES, @"albumView",
-        ],
-        @[],
-        @[],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[],
-        @[
-            @"AudioLibrary.GetArtists", @"method",
-            @"AudioLibrary.GetArtistDetails", @"extra_info_method",
-        ],
+        @{
+            @"method": @"AudioLibrary.GetSongs",
+            @"albumView": @YES,
+        },
+        @{
+            @"method": @"AudioLibrary.GetAlbums",
+            @"extra_info_method": @"AudioLibrary.GetAlbumDetails",
+        },
+        @{
+            @"method": @"AudioLibrary.GetAlbums",
+            @"extra_info_method": @"AudioLibrary.GetAlbumDetails",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"AudioLibrary.GetSongs",
+            @"albumView": @YES,
+        },
+        @{},
+        @{
+            @"method": @"AudioLibrary.GetSongs",
+            @"albumView": @YES,
+        },
+        @{},
+        @{
+            @"method": @"AudioLibrary.GetSongs",
+            @"albumView": @YES,
+        },
+        @{},
+        @{},
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{},
+        @{
+            @"method": @"AudioLibrary.GetArtists",
+            @"extra_info_method": @"AudioLibrary.GetArtistDetails",
+        },
     ];
     
     menu_Music.subItem.mainParameters = [@[
@@ -1764,35 +1764,35 @@
     ];
     
     menu_Music.subItem.subItem.mainMethod = @[
-        @[],
-        @[
-            @"AudioLibrary.GetSongs", @"method",
-            @YES, @"albumView",
-        ],
-        @[
-            @"AudioLibrary.GetSongs", @"method",
-            @YES, @"albumView",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"AudioLibrary.GetAlbums", @"method",
-            @"AudioLibrary.GetAlbumDetails", @"extra_info_method",
-        ],
+        @{},
+        @{
+            @"method": @"AudioLibrary.GetSongs",
+            @"albumView": @YES,
+        },
+        @{
+            @"method": @"AudioLibrary.GetSongs",
+            @"albumView": @YES,
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"AudioLibrary.GetAlbums",
+            @"extra_info_method": @"AudioLibrary.GetAlbumDetails",
+        },
     ];
     
     menu_Music.subItem.subItem.mainParameters = [@[
@@ -1994,23 +1994,23 @@
     ];
     
     menu_Music.subItem.subItem.subItem.mainMethod = @[
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[
-            @"AudioLibrary.GetSongs", @"method",
-            @YES, @"albumView",
-        ],
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{
+            @"method": @"AudioLibrary.GetSongs",
+            @"albumView": @YES,
+        },
     ];
     
     menu_Music.subItem.subItem.subItem.mainParameters = [@[
@@ -2135,33 +2135,33 @@
     ];
     
     menu_Movies.mainMethod = @[
-        @[
-            @"VideoLibrary.GetMovies", @"method",
-            @"VideoLibrary.GetMovieDetails", @"extra_info_method",
-        ],
-        @[
-            @"VideoLibrary.GetGenres", @"method",
-        ],
-        @[
-            @"VideoLibrary.GetMovieSets", @"method",
-            @"VideoLibrary.GetMovieSetDetails", @"extra_info_method",
-        ],
-        @[
-            @"VideoLibrary.GetRecentlyAddedMovies", @"method",
-            @"VideoLibrary.GetMovieDetails", @"extra_info_method",
-        ],
-        @[
-            @"VideoLibrary.GetTags", @"method",
-        ],
-        @[
-            @"Files.GetSources", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
+        @{
+            @"method": @"VideoLibrary.GetMovies",
+            @"extra_info_method": @"VideoLibrary.GetMovieDetails",
+        },
+        @{
+            @"method": @"VideoLibrary.GetGenres",
+        },
+        @{
+            @"method": @"VideoLibrary.GetMovieSets",
+            @"extra_info_method": @"VideoLibrary.GetMovieSetDetails",
+        },
+        @{
+            @"method": @"VideoLibrary.GetRecentlyAddedMovies",
+            @"extra_info_method": @"VideoLibrary.GetMovieDetails",
+        },
+        @{
+            @"method": @"VideoLibrary.GetTags",
+        },
+        @{
+            @"method": @"Files.GetSources",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
     ];
     
     menu_Movies.mainParameters = [@[
@@ -2566,27 +2566,27 @@
     ];
     
     menu_Movies.subItem.mainMethod = [@[
-        @[],
-        @[
-            @"VideoLibrary.GetMovies", @"method",
-            @"VideoLibrary.GetMovieDetails", @"extra_info_method",
-        ],
-        @[
-            @"VideoLibrary.GetMovies", @"method",
-            @"VideoLibrary.GetMovieDetails", @"extra_info_method",
-        ],
-        @[],
-        @[
-            @"VideoLibrary.GetMovies", @"method",
-            @"VideoLibrary.GetMovieDetails", @"extra_info_method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[],
+        @{},
+        @{
+            @"method": @"VideoLibrary.GetMovies",
+            @"extra_info_method": @"VideoLibrary.GetMovieDetails",
+        },
+        @{
+            @"method": @"VideoLibrary.GetMovies",
+            @"extra_info_method": @"VideoLibrary.GetMovieDetails",
+        },
+        @{},
+        @{
+            @"method": @"VideoLibrary.GetMovies",
+            @"extra_info_method": @"VideoLibrary.GetMovieDetails",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{},
     ] mutableCopy];
     
     menu_Movies.subItem.noConvertTime = YES;
@@ -3033,18 +3033,18 @@
 
     menu_Movies.subItem.subItem.noConvertTime = YES;
     menu_Movies.subItem.subItem.mainMethod = [@[
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[],
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{},
     ] mutableCopy];
     
     menu_Movies.subItem.subItem.mainParameters = [@[
@@ -3102,23 +3102,23 @@
     ];
     
     menu_Videos.mainMethod = @[
-        @[
-            @"VideoLibrary.GetMusicVideos", @"method",
-            @"VideoLibrary.GetMusicVideoDetails", @"extra_info_method",
-        ],
-        @[
-            @"VideoLibrary.GetRecentlyAddedMusicVideos", @"method",
-            @"VideoLibrary.GetMusicVideoDetails", @"extra_info_method",
-        ],
-        @[
-            @"Files.GetSources", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
+        @{
+            @"method": @"VideoLibrary.GetMusicVideos",
+            @"extra_info_method": @"VideoLibrary.GetMusicVideoDetails",
+        },
+        @{
+            @"method": @"VideoLibrary.GetRecentlyAddedMusicVideos",
+            @"extra_info_method": @"VideoLibrary.GetMusicVideoDetails",
+        },
+        @{
+            @"method": @"Files.GetSources",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
     ];
     
     menu_Videos.mainParameters = [@[
@@ -3412,15 +3412,15 @@
     ];
     
     menu_Videos.subItem.mainMethod = [@[
-        @[],
-        @[],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[],
+        @{},
+        @{},
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{},
     ] mutableCopy];
     
     menu_Videos.subItem.noConvertTime = YES;
@@ -3580,15 +3580,15 @@
 
     menu_Videos.subItem.subItem.noConvertTime = YES;
     menu_Videos.subItem.subItem.mainMethod = [@[
-        @[],
-        @[],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[],
+        @{},
+        @{},
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{},
     ] mutableCopy];
     
     menu_Videos.subItem.subItem.mainParameters = [@[
@@ -3636,23 +3636,24 @@
     ];
     
     menu_TVShows.mainMethod = [@[
-        @[  @"VideoLibrary.GetTVShows", @"method",
-            @"VideoLibrary.GetTVShowDetails", @"extra_info_method",
-            @YES, @"tvshowsView",
-        ],
-        @[
-            @"VideoLibrary.GetRecentlyAddedEpisodes", @"method",
-            @"VideoLibrary.GetEpisodeDetails", @"extra_info_method",
-        ],
-        @[
-            @"Files.GetSources", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
+        @{  
+            @"method": @"VideoLibrary.GetTVShows",
+            @"extra_info_method": @"VideoLibrary.GetTVShowDetails",
+            @"tvshowsView": @YES,
+        },
+        @{
+            @"method": @"VideoLibrary.GetRecentlyAddedEpisodes",
+            @"extra_info_method": @"VideoLibrary.GetEpisodeDetails",
+        },
+        @{
+            @"method": @"Files.GetSources",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
     ] mutableCopy];
     
     menu_TVShows.mainParameters = [@[
@@ -3924,20 +3925,20 @@
     ];
     
     menu_TVShows.subItem.mainMethod = [@[
-        @[
-            @"VideoLibrary.GetEpisodes", @"method",
-            @"VideoLibrary.GetEpisodeDetails", @"extra_info_method",
-            @YES, @"episodesView",
-            @"VideoLibrary.GetSeasons", @"extra_section_method",
-        ],
-        @[],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[],
+        @{
+            @"method": @"VideoLibrary.GetEpisodes",
+            @"extra_info_method": @"VideoLibrary.GetEpisodeDetails",
+            @"episodesView": @YES,
+            @"extra_section_method": @"VideoLibrary.GetSeasons",
+        },
+        @{},
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{},
     ] mutableCopy];
     
     menu_TVShows.subItem.mainParameters = [@[
@@ -4180,15 +4181,15 @@
     ];
     
     menu_TVShows.subItem.subItem.mainMethod = [@[
-        @[],
-        @[],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[],
+        @{},
+        @{},
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{},
     ] mutableCopy];
                                         
     menu_TVShows.subItem.subItem.mainParameters = [@[
@@ -4247,23 +4248,23 @@
     ];
     
     menu_LiveTV.mainMethod = [@[
-        @[
-            @"PVR.GetChannels", @"method",
-            @YES, @"channelListView",
-        ],
-        @[
-            @"PVR.GetChannelGroups", @"method",
-        ],
-        @[
-            @"PVR.GetRecordings", @"method",
-            @"PVR.GetRecordingDetails", @"extra_info_method",
-        ],
-        @[
-            @"PVR.GetTimers", @"method",
-        ],
-        @[
-            @"PVR.GetTimers", @"method",
-        ],
+        @{
+            @"method": @"PVR.GetChannels",
+            @"channelListView": @YES,
+        },
+        @{
+            @"method": @"PVR.GetChannelGroups",
+        },
+        @{
+            @"method": @"PVR.GetRecordings",
+            @"extra_info_method": @"PVR.GetRecordingDetails",
+        },
+        @{
+            @"method": @"PVR.GetTimers",
+        },
+        @{
+            @"method": @"PVR.GetTimers",
+        },
     ] mutableCopy];
     
     menu_LiveTV.mainParameters = [@[
@@ -4578,17 +4579,17 @@
     ];
     
     menu_LiveTV.subItem.mainMethod = [@[
-        @[
-            @"PVR.GetBroadcasts", @"method",
-            @YES, @"channelGuideView",
-        ],
-        @[
-            @"PVR.GetChannels", @"method",
-            @YES, @"channelListView",
-        ],
-        @[],
-        @[],
-        @[],
+        @{
+            @"method": @"PVR.GetBroadcasts",
+            @"channelGuideView": @YES,
+        },
+        @{
+            @"method": @"PVR.GetChannels",
+            @"channelListView": @YES,
+        },
+        @{},
+        @{},
+        @{},
     ] mutableCopy];
     
     menu_LiveTV.subItem.noConvertTime = YES;
@@ -4705,14 +4706,14 @@
     
     menu_LiveTV.subItem.subItem.noConvertTime = YES;
     menu_LiveTV.subItem.subItem.mainMethod = [@[
-        @[],
-        @[
-            @"PVR.GetBroadcasts", @"method",
-            @YES, @"channelGuideView",
-        ],
-        @[],
-        @[],
-        @[],
+        @{},
+        @{
+            @"method": @"PVR.GetBroadcasts",
+            @"channelGuideView": @YES,
+        },
+        @{},
+        @{},
+        @{},
     ] mutableCopy];
     
     menu_LiveTV.subItem.subItem.mainParameters = [@[
@@ -4799,23 +4800,23 @@
     ];
     
     menu_Radio.mainMethod = [@[
-        @[
-            @"PVR.GetChannels", @"method",
-            @YES, @"channelListView",
-        ],
-        @[
-            @"PVR.GetChannelGroups", @"method",
-        ],
-        @[
-            @"PVR.GetRecordings", @"method",
-            @"PVR.GetRecordingDetails", @"extra_info_method",
-        ],
-        @[
-            @"PVR.GetTimers", @"method",
-        ],
-        @[
-            @"PVR.GetTimers", @"method",
-        ],
+        @{
+            @"method": @"PVR.GetChannels",
+            @"channelListView": @YES,
+        },
+        @{
+            @"method": @"PVR.GetChannelGroups",
+        },
+        @{
+            @"method": @"PVR.GetRecordings",
+            @"extra_info_method": @"PVR.GetRecordingDetails",
+        },
+        @{
+            @"method": @"PVR.GetTimers",
+        },
+        @{
+            @"method": @"PVR.GetTimers",
+        },
     ] mutableCopy];
     
     menu_Radio.mainParameters = [@[
@@ -5128,17 +5129,17 @@
     ];
     
     menu_Radio.subItem.mainMethod = [@[
-        @[
-            @"PVR.GetBroadcasts", @"method",
-            @YES, @"channelGuideView",
-        ],
-        @[
-            @"PVR.GetChannels", @"method",
-            @YES, @"channelListView",
-        ],
-        @[],
-        @[],
-        @[],
+        @{
+            @"method": @"PVR.GetBroadcasts",
+            @"channelGuideView": @YES,
+        },
+        @{
+            @"method": @"PVR.GetChannels",
+            @"channelListView": @YES,
+        },
+        @{},
+        @{},
+        @{},
     ] mutableCopy];
     
     menu_Radio.subItem.noConvertTime = YES;
@@ -5255,14 +5256,14 @@
     
     menu_Radio.subItem.subItem.noConvertTime = YES;
     menu_Radio.subItem.subItem.mainMethod = [@[
-        @[],
-        @[
-            @"PVR.GetBroadcasts", @"method",
-            @YES, @"channelGuideView",
-        ],
-        @[],
-        @[],
-        @[],
+        @{},
+        @{
+            @"method": @"PVR.GetBroadcasts",
+            @"channelGuideView": @YES,
+        },
+        @{},
+        @{},
+        @{},
     ] mutableCopy];
     
     menu_Radio.subItem.subItem.mainParameters = [@[
@@ -5345,12 +5346,12 @@
     ];
     
     menu_Pictures.mainMethod = [@[
-        @[
-            @"Files.GetSources", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
+        @{
+            @"method": @"Files.GetSources",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
     ] mutableCopy];
     
     menu_Pictures.mainParameters = [@[
@@ -5416,12 +5417,12 @@
     menu_Pictures.defaultThumb = @"nocover_filemode";
     
     menu_Pictures.subItem.mainMethod = [@[
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
     ] mutableCopy];
     
     menu_Pictures.sheetActions = @[
@@ -5501,12 +5502,12 @@
     ];
     
     menu_Pictures.subItem.subItem.mainMethod = [@[
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
-        @[
-            @"Files.GetDirectory", @"method",
-        ],
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
     ] mutableCopy];
     
     menu_Pictures.subItem.subItem.mainParameters = [@[
@@ -5529,9 +5530,9 @@
     ];
     
     menu_Favourites.mainMethod = [@[
-        @[
-            @"Favourites.GetFavourites", @"method",
-        ],
+        @{
+            @"method": @"Favourites.GetFavourites",
+        },
     ] mutableCopy];
     
     menu_Favourites.mainParameters = [@[
@@ -5664,24 +5665,24 @@
     ];
     
     xbmcSettings.mainMethod = [@[
-        @[
-            @"Settings.GetSections", @"method",
-        ],
-        @[
-            @"Addons.GetAddons", @"method",
-        ],
-        @[
-            @"Addons.GetAddons", @"method",
-        ],
-        @[
-            @"Addons.GetAddons", @"method",
-        ],
-        @[
-            @"JSONRPC.Introspect", @"method",
-        ],
-        @[
-            @"JSONRPC.Introspect", @"method",
-        ],
+        @{
+            @"method": @"Settings.GetSections",
+        },
+        @{
+            @"method": @"Addons.GetAddons",
+        },
+        @{
+            @"method": @"Addons.GetAddons",
+        },
+        @{
+            @"method": @"Addons.GetAddons",
+        },
+        @{
+            @"method": @"JSONRPC.Introspect",
+        },
+        @{
+            @"method": @"JSONRPC.Introspect",
+        },
     ] mutableCopy];
     
     xbmcSettings.mainParameters = [@[
@@ -5890,14 +5891,14 @@
     
     xbmcSettings.subItem.disableNowPlaying = YES;
     xbmcSettings.subItem.mainMethod = [@[
-        @[
-            @"Settings.GetCategories", @"method",
-        ],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
+        @{
+            @"method": @"Settings.GetCategories",
+        },
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
     ] mutableCopy];
     
     xbmcSettings.subItem.mainParameters = [@[
@@ -5954,9 +5955,9 @@
     
     xbmcSettings.subItem.subItem.disableNowPlaying = YES;
     xbmcSettings.subItem.subItem.mainMethod = [@[
-        @[
-            @"Settings.GetSettings", @"method",
-        ],
+        @{
+            @"method": @"Settings.GetSettings",
+        },
     ] mutableCopy];
     
     xbmcSettings.subItem.subItem.mainParameters = [@[

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -567,8 +567,8 @@
     ];
     
     menu_Music.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
@@ -576,8 +576,8 @@
                         @"artist",
                         @"playcount",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"year",
                         @"thumbnail",
@@ -592,8 +592,8 @@
                             @"art",
                         ],
                 },
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Album"),
                         LOCALIZED_STR(@"Artist"),
@@ -608,24 +608,24 @@
                         @"playcount",
                         @"random",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Albums"), @"label",
-            @YES, @"enableCollectionView",
-            @YES, @"enableLibraryCache",
-            @YES, @"enableLibraryFullScreen",
-            [self watchedListenedString], @"watchedListenedStrings",
-            [self itemSizes_Musicfullscreen], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Albums"),
+            @"enableCollectionView": @YES,
+            @"enableLibraryCache": @YES,
+            @"enableLibraryFullScreen": @YES,
+            @"watchedListenedStrings": [self watchedListenedString],
+            @"itemSizes": [self itemSizes_Musicfullscreen],
+        },
             
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"artist" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"thumbnail",
                         @"genre",
                 ]
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"thumbnail",
                         @"genre",
@@ -646,41 +646,41 @@
                             @"art",
                         ],
                 },
-            }, @"extra_info_parameters",
-            LOCALIZED_STR(@"Artists"), @"label",
-            @"nocover_artist", @"defaultThumb",
-            @YES, @"enableCollectionView",
-            @YES, @"enableLibraryCache",
-            @YES, @"enableLibraryFullScreen",
-            [self itemSizes_Musicfullscreen], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Artists"),
+            @"defaultThumb": @"nocover_artist",
+            @"enableCollectionView": @YES,
+            @"enableLibraryCache": @YES,
+            @"enableLibraryFullScreen": @YES,
+            @"itemSizes": [self itemSizes_Musicfullscreen],
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                     @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Genres"), @"label",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @0, @"thumbWidth",
-            @YES, @"enableLibraryCache",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Genres"),
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @0,
+            @"enableLibraryCache": @YES,
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"music",
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
@@ -688,8 +688,8 @@
                         @"artist",
                         @"playcount",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"year",
                         @"thumbnail",
@@ -704,15 +704,15 @@
                             @"art",
                         ],
                 },
-            }, @"extra_info_parameters",
-           LOCALIZED_STR(@"Added Albums"), @"label",
-           LOCALIZED_STR(@"Recently added albums"), @"morelabel",
-           @YES, @"enableCollectionView",
-           [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Added Albums"),
+            @"morelabel": LOCALIZED_STR(@"Recently added albums"),
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"genre",
@@ -726,13 +726,13 @@
                         @"album",
                         @"file",
                 ],
-            }, @"parameters",
-           LOCALIZED_STR(@"Added Songs"), @"label",
-           LOCALIZED_STR(@"Recently added songs"), @"morelabel",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Added Songs"),
+            @"morelabel": LOCALIZED_STR(@"Recently added songs"),
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"playcount" order:@"descending" ignorearticle:NO],
                 @"limits": @{
                         @"start": @0,
@@ -744,8 +744,8 @@
                         @"artist",
                         @"playcount",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"year",
                         @"thumbnail",
@@ -755,8 +755,8 @@
                         @"albumlabel",
                         @"fanart",
                 ],
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Top 100 Albums"),
                         LOCALIZED_STR(@"Album"),
@@ -774,15 +774,15 @@
                             @"art",
                         ],
                 },
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Top 100 Albums"), @"label",
-            LOCALIZED_STR(@"Top 100 Albums"), @"morelabel",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Top 100 Albums"),
+            @"morelabel": LOCALIZED_STR(@"Top 100 Albums"),
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
             
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"playcount" order:@"descending" ignorearticle:NO],
                 @"limits": @{
                         @"start": @0,
@@ -801,8 +801,8 @@
                         @"file",
                         @"album",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Top 100 Songs"),
                         LOCALIZED_STR(@"Track"),
@@ -821,14 +821,14 @@
                         @"rating",
                         @"year",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Top 100 Songs"), @"label",
-            LOCALIZED_STR(@"Top 100 Songs"), @"morelabel",
-            @5, @"numberOfStars",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Top 100 Songs"),
+            @"morelabel": LOCALIZED_STR(@"Top 100 Songs"),
+            @"numberOfStars": @5,
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
@@ -836,15 +836,15 @@
                         @"artist",
                         @"playcount",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Played albums"), @"label",
-            LOCALIZED_STR(@"Recently played albums"), @"morelabel",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Played albums"),
+            @"morelabel": LOCALIZED_STR(@"Recently played albums"),
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"genre",
@@ -858,13 +858,13 @@
                         @"album",
                         @"file",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Played songs"), @"label",
-            LOCALIZED_STR(@"Recently played songs"), @"morelabel",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Played songs"),
+            @"morelabel": LOCALIZED_STR(@"Recently played songs"),
+        },
                             
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"genre",
@@ -878,8 +878,8 @@
                         @"album",
                         @"file",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Name"),
                         LOCALIZED_STR(@"Rating"),
@@ -900,16 +900,16 @@
                         @"genre",
                         @"random",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"All songs"), @"label",
-            LOCALIZED_STR(@"All songs"), @"morelabel",
-            @YES, @"enableLibraryCache",
-            @5, @"numberOfStars",
-            [self watchedListenedString], @"watchedListenedStrings",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"All songs"),
+            @"morelabel": LOCALIZED_STR(@"All songs"),
+            @"enableLibraryCache": @YES,
+            @"numberOfStars": @5,
+            @"watchedListenedStrings": [self watchedListenedString],
+        },
                             
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"music",
                 @"directory": @"addons://sources/audio",
@@ -917,18 +917,18 @@
                         @"thumbnail",
                         @"file",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Music Add-ons"), @"label",
-            LOCALIZED_STR(@"Music Add-ons"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Music Add-ons"),
+            @"morelabel": LOCALIZED_STR(@"Music Add-ons"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"music",
                 @"directory": @"special://musicplaylists",
@@ -946,29 +946,29 @@
                         @"album",
                         @"duration",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Music Playlists"), @"label",
-            LOCALIZED_STR(@"Music Playlists"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"isMusicPlaylist",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Music Playlists"),
+            @"morelabel": LOCALIZED_STR(@"Music Playlists"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"isMusicPlaylist": @YES,
+        },
                             
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                     @"title",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Music Roles"), @"label",
-            LOCALIZED_STR(@"Music Roles"), @"morelabel",
-            @"nocover_artist", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Music Roles"),
+            @"morelabel": LOCALIZED_STR(@"Music Roles"),
+            @"defaultThumb": @"nocover_artist",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"itemSizes": [self itemSizes_Music],
+        },
     ] mutableCopy];
     
     menu_Music.mainFields = @[
@@ -1290,8 +1290,8 @@
     ];
     
     menu_Music.subItem.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"track" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"genre",
@@ -1307,12 +1307,12 @@
                         @"file",
                         @"fanart",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Songs"), @"label",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Songs"),
+        },
         
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"year" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
@@ -1320,8 +1320,8 @@
                         @"artist",
                         @"playcount",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"year",
                         @"thumbnail",
@@ -1336,14 +1336,14 @@
                             @"art",
                         ],
                 },
-            }, @"extra_info_parameters",
-            LOCALIZED_STR(@"Albums"), @"label",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Albums"),
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
@@ -1351,8 +1351,8 @@
                         @"artist",
                         @"playcount",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"year",
                         @"thumbnail",
@@ -1367,8 +1367,8 @@
                             @"art",
                         ],
                 },
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Album"),
                         LOCALIZED_STR(@"Artist"),
@@ -1381,16 +1381,16 @@
                         @"year",
                         @"playcount",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Albums"), @"label",
-            @YES, @"enableCollectionView",
-            @YES, @"enableLibraryCache",
-            [self watchedListenedString], @"watchedListenedStrings",
-            [self itemSizes_Music], @"itemSizes",
-         ],
+            },
+            @"label": LOCALIZED_STR(@"Albums"),
+            @"enableCollectionView": @YES,
+            @"enableLibraryCache": @YES,
+            @"watchedListenedStrings": [self watchedListenedString],
+            @"itemSizes": [self itemSizes_Music],
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": filemodeMusicType,
                 @"file_properties": @[
@@ -1398,15 +1398,15 @@
                     @"art",
                     @"playcount",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"track" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"genre",
@@ -1422,14 +1422,14 @@
                         @"file",
                         @"fanart",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Songs"), @"label",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Songs"),
+        },
                                   
-        @[],
+        @{},
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"track" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"genre",
@@ -1445,14 +1445,14 @@
                         @"file",
                         @"fanart",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Songs"), @"label",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Songs"),
+        },
                                   
-        @[],
+        @{},
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"track" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"genre",
@@ -1468,31 +1468,31 @@
                         @"file",
                         @"fanart",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Songs"), @"label",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Songs"),
+        },
                                   
-        @[],
-        @[],
+        @{},
+        @{},
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"file_properties": @[
                     @"thumbnail",
                 ],
                 @"media": @"music",
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @DEFAULT_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Movie], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @DEFAULT_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Movie],
+        },
         
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"file_properties": @[
                         @"thumbnail",
@@ -1500,23 +1500,23 @@
                         @"duration",
                 ],
                 @"media": @"music",
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"albumartistsonly": @NO,
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"thumbnail",
                         @"genre",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"thumbnail",
                         @"genre",
@@ -1537,12 +1537,12 @@
                             @"art",
                         ],
                 },
-            }, @"extra_info_parameters",
-            LOCALIZED_STR(@"Artists"), @"label",
-            @"nocover_artist", @"defaultThumb",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Musicfullscreen], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Artists"),
+            @"defaultThumb": @"nocover_artist",
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Musicfullscreen],
+        },
     ] mutableCopy];
     
     menu_Music.subItem.mainFields = @[
@@ -1796,10 +1796,10 @@
     ];
     
     menu_Music.subItem.subItem.mainParameters = [@[
-        @[],
+        @{},
 
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"track" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"genre",
@@ -1815,12 +1815,12 @@
                         @"file",
                         @"fanart",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Songs"), @"label",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Songs"),
+        },
           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"track" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"genre",
@@ -1836,29 +1836,29 @@
                         @"file",
                         @"fanart",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Songs"), @"label",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Songs"),
+        },
           
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @DEFAULT_THUMB_WIDTH, @"thumbWidth",
-        ],
-        @[
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @DEFAULT_THUMB_WIDTH, @"thumbWidth",
-        ],
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @DEFAULT_THUMB_WIDTH,
+        },
+        @{
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @DEFAULT_THUMB_WIDTH,
+        },
           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"year" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
@@ -1866,8 +1866,8 @@
                         @"artist",
                         @"playcount",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"year",
                         @"thumbnail",
@@ -1882,12 +1882,12 @@
                             @"art",
                         ],
                 },
-            }, @"extra_info_parameters",
-            LOCALIZED_STR(@"Albums"), @"label",
-            @YES, @"enableCollectionView",
-            @"roleid", @"combinedFilter",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Albums"),
+            @"enableCollectionView": @YES,
+            @"combinedFilter": @"roleid",
+            @"itemSizes": [self itemSizes_Music],
+        },
     ] mutableCopy];
     
     menu_Music.subItem.subItem.mainFields = @[
@@ -2014,21 +2014,21 @@
     ];
     
     menu_Music.subItem.subItem.subItem.mainParameters = [@[
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[
-            @{
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"track" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"genre",
@@ -2044,9 +2044,9 @@
                         @"file",
                         @"fanart",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Songs"), @"label",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Songs"),
+        },
     ] mutableCopy];
     
     menu_Music.subItem.subItem.subItem.mainFields = @[
@@ -2165,8 +2165,8 @@
     ];
     
     menu_Movies.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
@@ -2180,8 +2180,8 @@
                         @"file",
                         @"dateadded",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"year",
                         @"playcount",
@@ -2202,8 +2202,8 @@
                         @"dateadded",
                         @"tagline",
                 ],
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Year"),
@@ -2222,31 +2222,31 @@
                         @"playcount",
                         @"random",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Movies"), @"label",
-            @YES, @"FrodoExtraArt",
-            @YES, @"enableCollectionView",
-            @YES, @"enableLibraryCache",
-            @YES, @"enableLibraryFullScreen",
-            [self itemSizes_Moviefullscreen], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Movies"),
+            @"FrodoExtraArt": @YES,
+            @"enableCollectionView": @YES,
+            @"enableLibraryCache": @YES,
+            @"enableLibraryFullScreen": @YES,
+            @"itemSizes": [self itemSizes_Moviefullscreen],
+        },
               
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"type": @"movie",
                 @"properties": @[
                     @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Movie Genres"), @"label",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @0, @"thumbWidth",
-            @YES, @"enableLibraryCache",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Movie Genres"),
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @0,
+            @"enableLibraryCache": @YES,
+        },
               
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"thumbnail",
@@ -2254,16 +2254,16 @@
                         @"fanart",
                         @"playcount",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                     @"thumbnail",
                     @"plot",
                     @"fanart",
                     @"playcount",
                 ],
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Name"),
                         LOCALIZED_STR(@"Play count"),
@@ -2272,17 +2272,17 @@
                         @"label",
                         @"playcount",
                 ],
-            }, @"available_sort_methods",
-            @YES, @"FrodoExtraArt",
-            @YES, @"enableCollectionView",
-            @YES, @"enableLibraryCache",
-            @"nocover_movie_sets", @"defaultThumb",
-            [self itemSizes_Movie], @"itemSizes",
-            LOCALIZED_STR(@"Movie Sets"), @"label",
-        ],
+            },
+            @"FrodoExtraArt": @YES,
+            @"enableCollectionView": @YES,
+            @"enableLibraryCache": @YES,
+            @"defaultThumb": @"nocover_movie_sets",
+            @"itemSizes": [self itemSizes_Movie],
+            @"label": LOCALIZED_STR(@"Movie Sets"),
+        },
               
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
@@ -2295,9 +2295,9 @@
                         @"fanart",
                         @"file",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Added Movies"), @"label",
-            @{
+            },
+            @"label": LOCALIZED_STR(@"Added Movies"),
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"year",
                         @"playcount",
@@ -2318,59 +2318,59 @@
                         @"dateadded",
                         @"tagline",
                 ],
-            }, @"extra_info_parameters",
-            @YES, @"FrodoExtraArt",
-            @YES, @"enableCollectionView",
-            @YES, @"collectionViewRecentlyAdded",
-            @YES, @"enableLibraryFullScreen",
-            [self itemSizes_MovieRecentlyfullscreen], @"itemSizes",
-        ],
+            },
+            @"FrodoExtraArt": @YES,
+            @"enableCollectionView": @YES,
+            @"collectionViewRecentlyAdded": @YES,
+            @"enableLibraryFullScreen": @YES,
+            @"itemSizes": [self itemSizes_MovieRecentlyfullscreen],
+        },
         
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"type": @"movie",
                 @"properties": @[],
-            }, @"parameters",
-            LOCALIZED_STR(@"Movie Tags"), @"label",
-            LOCALIZED_STR(@"Movie Tags"), @"morelabel",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @0, @"thumbWidth",
-            @YES, @"enableLibraryCache",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Movie Tags"),
+            @"morelabel": LOCALIZED_STR(@"Movie Tags"),
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @0,
+            @"enableLibraryCache": @YES,
+        },
 
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            LOCALIZED_STR(@"Files"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"morelabel": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
               
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"directory": @"addons://sources/video",
                 @"properties": @[
                     @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Video Add-ons"), @"label",
-            LOCALIZED_STR(@"Video Add-ons"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Video Add-ons"),
+            @"morelabel": LOCALIZED_STR(@"Video Add-ons"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
 
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"directory": @"special://videoplaylists",
@@ -2382,14 +2382,14 @@
                         @"thumbnail",
                         @"file",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Video Playlists"), @"label",
-            LOCALIZED_STR(@"Video Playlists"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"isVideoPlaylist",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Video Playlists"),
+            @"morelabel": LOCALIZED_STR(@"Video Playlists"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"isVideoPlaylist": @YES,
+        },
     ] mutableCopy];
     
     menu_Movies.mainFields = @[
@@ -2592,10 +2592,10 @@
     menu_Movies.subItem.noConvertTime = YES;
 
     menu_Movies.subItem.mainParameters = [@[
-        @[],
+        @{},
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
@@ -2608,8 +2608,8 @@
                         @"file",
                         @"dateadded",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"year",
                         @"playcount",
@@ -2630,8 +2630,8 @@
                         @"dateadded",
                         @"tagline",
                 ],
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Year"),
@@ -2648,17 +2648,17 @@
                         @"dateadded",
                         @"playcount",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Movies"), @"label",
-            @"nocover_movies", @"defaultThumb",
-            @YES, @"FrodoExtraArt",
-            @YES, @"enableCollectionView",
-            @YES, @"enableLibraryCache",
-            [self itemSizes_Movie], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Movies"),
+            @"defaultThumb": @"nocover_movies",
+            @"FrodoExtraArt": @YES,
+            @"enableCollectionView": @YES,
+            @"enableLibraryCache": @YES,
+            @"itemSizes": [self itemSizes_Movie],
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"year" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
@@ -2671,8 +2671,8 @@
                         @"file",
                         @"dateadded",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"year",
                         @"playcount",
@@ -2693,8 +2693,8 @@
                         @"dateadded",
                         @"tagline",
                 ],
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Year"),
@@ -2711,18 +2711,18 @@
                         @"dateadded",
                         @"playcount",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Movies"), @"label",
-            @"nocover_movies", @"defaultThumb",
-            @YES, @"FrodoExtraArt",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Movie], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Movies"),
+            @"defaultThumb": @"nocover_movies",
+            @"FrodoExtraArt": @YES,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Movie],
+        },
                                   
-        @[],
+        @{},
         
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
@@ -2735,8 +2735,8 @@
                         @"file",
                         @"dateadded",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"year",
                         @"playcount",
@@ -2757,8 +2757,8 @@
                         @"dateadded",
                         @"tagline",
                 ],
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Year"),
@@ -2775,17 +2775,17 @@
                         @"dateadded",
                         @"playcount",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Movies"), @"label",
-            @"nocover_movies", @"defaultThumb",
-            @YES, @"FrodoExtraArt",
-            @YES, @"enableCollectionView",
-            @YES, @"enableLibraryCache",
-            [self itemSizes_Movie], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Movies"),
+            @"defaultThumb": @"nocover_movies",
+            @"FrodoExtraArt": @YES,
+            @"enableCollectionView": @YES,
+            @"enableLibraryCache": @YES,
+            @"itemSizes": [self itemSizes_Movie],
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": filemodeVideoType,
                 @"file_properties": @[
@@ -2793,31 +2793,31 @@
                     @"art",
                     @"playcount",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"file_properties": @[
                     @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Video Add-ons"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Video Add-ons"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"file_properties": @[
                         @"year",
@@ -2841,15 +2841,15 @@
                         @"tagline",
                 ],
                 @"media": @"video",
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @PORTRAIT_ROW_HEIGHT, @"rowHeight",
-            @DEFAULT_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            @YES, @"FrodoExtraArt",
-            [self itemSizes_Movie], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @PORTRAIT_ROW_HEIGHT,
+            @"thumbWidth": @DEFAULT_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"FrodoExtraArt": @YES,
+            @"itemSizes": [self itemSizes_Movie],
+        },
     ] mutableCopy];
     
     menu_Movies.subItem.mainFields = @[
@@ -3048,17 +3048,17 @@
     ] mutableCopy];
     
     menu_Movies.subItem.subItem.mainParameters = [@[
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[],
-        @[
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
-        @[],
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
+        @{
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
+        @{},
     ] mutableCopy];
     
     menu_Movies.subItem.subItem.mainFields = @[
@@ -3122,8 +3122,8 @@
     ];
     
     menu_Videos.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"artist",
@@ -3139,8 +3139,8 @@
                         @"fanart",
                         @"resume",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"artist",
                         @"year",
@@ -3160,8 +3160,8 @@
                         @"art",
                     ],
                 },
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Artist"),
@@ -3178,22 +3178,22 @@
                             @"playcount",
                             @"random",
                 ],
-            }, @"available_sort_methods",
-            @{
+            },
+            @"kodiExtrasPropertiesMinimumVersion": @{
                 @"18": @[
                     @"art",
                 ],
-            }, @"kodiExtrasPropertiesMinimumVersion",
-            LOCALIZED_STR(@"Music Videos"), @"label",
-            LOCALIZED_STR(@"Music Videos"), @"morelabel",
-            @YES, @"enableCollectionView",
-            @YES, @"enableLibraryCache",
-            @YES, @"enableLibraryFullScreen",
-            [self itemSizes_Moviefullscreen], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Music Videos"),
+            @"morelabel": LOCALIZED_STR(@"Music Videos"),
+            @"enableCollectionView": @YES,
+            @"enableLibraryCache": @YES,
+            @"enableLibraryFullScreen": @YES,
+            @"itemSizes": [self itemSizes_Moviefullscreen],
+        },
               
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                                 @"artist",
@@ -3209,8 +3209,8 @@
                                 @"fanart",
                                 @"resume",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"artist",
                         @"year",
@@ -3230,51 +3230,51 @@
                         @"art",
                     ],
                 },
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"kodiExtrasPropertiesMinimumVersion": @{
                 @"18": @[
                     @"art",
                 ],
-            }, @"kodiExtrasPropertiesMinimumVersion",
-            LOCALIZED_STR(@"Added Music Videos"), @"label",
-            @YES, @"enableCollectionView",
-            @YES, @"collectionViewRecentlyAdded",
-            @YES, @"enableLibraryFullScreen",
-            [self itemSizes_MovieRecentlyfullscreen], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Added Music Videos"),
+            @"enableCollectionView": @YES,
+            @"collectionViewRecentlyAdded": @YES,
+            @"enableLibraryFullScreen": @YES,
+            @"itemSizes": [self itemSizes_MovieRecentlyfullscreen],
+        },
         
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            LOCALIZED_STR(@"Files"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"morelabel": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
               
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"directory": @"addons://sources/video",
                 @"properties": @[
                     @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Video Add-ons"), @"label",
-            LOCALIZED_STR(@"Video Add-ons"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Video Add-ons"),
+            @"morelabel": LOCALIZED_STR(@"Video Add-ons"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
 
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"directory": @"special://videoplaylists",
@@ -3286,14 +3286,14 @@
                         @"thumbnail",
                         @"file",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Video Playlists"), @"label",
-            LOCALIZED_STR(@"Video Playlists"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"isVideoPlaylist",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Video Playlists"),
+            @"morelabel": LOCALIZED_STR(@"Video Playlists"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"isVideoPlaylist": @YES,
+        },
     ] mutableCopy];
     
     menu_Videos.mainFields = @[
@@ -3426,11 +3426,11 @@
     menu_Videos.subItem.noConvertTime = YES;
 
     menu_Videos.subItem.mainParameters = [@[
-        @[],
-        @[],
+        @{},
+        @{},
         
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": filemodeVideoType,
                 @"file_properties": @[
@@ -3438,31 +3438,31 @@
                     @"art",
                     @"playcount",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"file_properties": @[
                     @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Video Add-ons"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Video Add-ons"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"file_properties": @[
                         @"year",
@@ -3485,15 +3485,15 @@
                         @"resume",
                 ],
                 @"media": @"video",
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @PORTRAIT_ROW_HEIGHT, @"rowHeight",
-            @DEFAULT_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            @YES, @"FrodoExtraArt",
-            [self itemSizes_Movie], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @PORTRAIT_ROW_HEIGHT,
+            @"thumbWidth": @DEFAULT_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"FrodoExtraArt": @YES,
+            @"itemSizes": [self itemSizes_Movie],
+        },
     ] mutableCopy];
     
     menu_Videos.subItem.mainFields = @[
@@ -3592,14 +3592,14 @@
     ] mutableCopy];
     
     menu_Videos.subItem.subItem.mainParameters = [@[
-        @[],
-        @[],
-        @[],
-        @[
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
-        @[],
+        @{},
+        @{},
+        @{},
+        @{
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
+        @{},
     ] mutableCopy];
     
     menu_Videos.subItem.subItem.mainFields = @[
@@ -3657,8 +3657,8 @@
     ] mutableCopy];
     
     menu_TVShows.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"year",
@@ -3669,8 +3669,8 @@
                         @"studio",
                         @"episode",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"year",
                         @"playcount",
@@ -3686,8 +3686,8 @@
                         @"episode",
                         @"fanart",
                 ],
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Year"),
@@ -3700,18 +3700,18 @@
                         @"rating",
                         @"random",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"TV Shows"), @"label",
-            @YES, @"blackTableSeparator",
-            @YES, @"FrodoExtraArt",
-            @YES, @"enableLibraryCache",
-            @YES, @"enableCollectionView",
-            @YES, @"enableLibraryFullScreen",
-            [self itemSizes_Moviefullscreen], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"TV Shows"),
+            @"blackTableSeparator": @YES,
+            @"FrodoExtraArt": @YES,
+            @"enableLibraryCache": @YES,
+            @"enableCollectionView": @YES,
+            @"enableLibraryFullScreen": @YES,
+            @"itemSizes": [self itemSizes_Moviefullscreen],
+        },
                             
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"episode",
@@ -3723,8 +3723,8 @@
                         @"title",
                         @"season",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"episode",
                         @"thumbnail",
@@ -3743,47 +3743,47 @@
                         @"playcount",
                         @"resume",
                 ],
-            }, @"extra_info_parameters",
-            LOCALIZED_STR(@"Added Episodes"), @"label",
-            @DEFAULT_ROW_HEIGHT, @"rowHeight",
-            @EPISODE_THUMB_WIDTH, @"thumbWidth",
-            @"nocover_tvshows_episode", @"defaultThumb",
-            @YES, @"FrodoExtraArt",
-            //@YES, @"enableCollectionView",
-            [self itemSizes_TVShowsfullscreen], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Added Episodes"),
+            @"rowHeight": @DEFAULT_ROW_HEIGHT,
+            @"thumbWidth": @EPISODE_THUMB_WIDTH,
+            @"defaultThumb": @"nocover_tvshows_episode",
+            @"FrodoExtraArt": @YES,
+            //@"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_TVShowsfullscreen],
+        },
                             
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
                             
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"directory": @"addons://sources/video",
                 @"properties": @[
                     @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Video Add-ons"), @"label",
-            LOCALIZED_STR(@"Video Add-ons"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Video Add-ons"),
+            @"morelabel": LOCALIZED_STR(@"Video Add-ons"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
         
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"directory": @"special://videoplaylists",
@@ -3795,14 +3795,14 @@
                         @"thumbnail",
                         @"file",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Video Playlists"), @"label",
-            LOCALIZED_STR(@"Video Playlists"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"isVideoPlaylist",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Video Playlists"),
+            @"morelabel": LOCALIZED_STR(@"Video Playlists"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"isVideoPlaylist": @YES,
+        },
     ] mutableCopy];
 
     menu_TVShows.mainFields = @[
@@ -3942,8 +3942,8 @@
     ] mutableCopy];
     
     menu_TVShows.subItem.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"episode" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"episode",
@@ -3957,8 +3957,8 @@
                         @"file",
                         @"title",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"episode",
                         @"thumbnail",
@@ -3977,8 +3977,8 @@
                         @"playcount",
                         @"file",
                 ],
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"extra_section_parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"season",
@@ -3988,16 +3988,16 @@
                         @"episode",
                         @"art",
                 ],
-            }, @"extra_section_parameters",
-            LOCALIZED_STR(@"Episodes"), @"label",
-            @YES, @"disableFilterParameter",
-            @YES, @"FrodoExtraArt",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Episodes"),
+            @"disableFilterParameter": @YES,
+            @"FrodoExtraArt": @YES,
+        },
 
-        @[],
+        @{},
                                     
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": filemodeVideoType,
                 @"file_properties": @[
@@ -4005,31 +4005,31 @@
                     @"art",
                     @"playcount",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
                                     
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"media": @"video",
                 @"file_properties": @[
                     @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Video Add-ons"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Video Add-ons"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
         
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"file_properties": @[
                         @"year",
@@ -4052,15 +4052,15 @@
                         @"resume",
                 ],
                 @"media": @"video",
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @PORTRAIT_ROW_HEIGHT, @"rowHeight",
-            @DEFAULT_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            @YES, @"FrodoExtraArt",
-            [self itemSizes_Movie], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @PORTRAIT_ROW_HEIGHT,
+            @"thumbWidth": @DEFAULT_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"FrodoExtraArt": @YES,
+            @"itemSizes": [self itemSizes_Movie],
+        },
     ] mutableCopy];
     
     menu_TVShows.subItem.mainFields = @[
@@ -4193,14 +4193,14 @@
     ] mutableCopy];
                                         
     menu_TVShows.subItem.subItem.mainParameters = [@[
-        @[],
-        @[],
-        @[],
-        @[
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
-        @[],
+        @{},
+        @{},
+        @{},
+        @{
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
+        @{},
     ] mutableCopy];
     
     menu_TVShows.subItem.subItem.mainFields = @[
@@ -4268,44 +4268,44 @@
     ] mutableCopy];
     
     menu_LiveTV.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"channelgroupid": @"alltv",
                 @"properties": @[
                         @"thumbnail",
                         @"channelnumber",
                         @"channel",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"kodiExtrasPropertiesMinimumVersion": @{
                 @"17": @[
                     @"isrecording",
                 ],
-            }, @"kodiExtrasPropertiesMinimumVersion",
-            LOCALIZED_STR(@"All channels"), @"label",
-            @"nocover_channels", @"defaultThumb",
-            @YES, @"disableFilterParameter",
-            @LIVETV_ROW_HEIGHT, @"rowHeight",
-            @LIVETV_THUMB_WIDTH_SMALL, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"All channels"),
+            @"defaultThumb": @"nocover_channels",
+            @"disableFilterParameter": @YES,
+            @"rowHeight": @LIVETV_ROW_HEIGHT,
+            @"thumbWidth": @LIVETV_THUMB_WIDTH_SMALL,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"channeltype": @"tv",
-            }, @"parameters",
-            LOCALIZED_STR(@"Channel Groups"), @"label",
-            LOCALIZED_STR(@"Channel Groups"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Channel Groups"),
+            @"morelabel": LOCALIZED_STR(@"Channel Groups"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
 
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"title",
@@ -4326,8 +4326,8 @@
                         @"radio",
                         @"directory",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"title",
                         @"starttime",
@@ -4346,8 +4346,8 @@
                         @"file",
                         @"directory",
                 ],
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Channel"),
@@ -4364,19 +4364,19 @@
                         @"runtime",
                         @"random",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Recordings"), @"label",
-            LOCALIZED_STR(@"Recordings"), @"morelabel",
-            @"nocover_recording", @"defaultThumb",
-            @CHANNEL_EPG_ROW_HEIGHT, @"rowHeight",
-            @LIVETV_THUMB_WIDTH_SMALL, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            @YES, @"enableLibraryCache",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Recordings"),
+            @"morelabel": LOCALIZED_STR(@"Recordings"),
+            @"defaultThumb": @"nocover_recording",
+            @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
+            @"thumbWidth": @LIVETV_THUMB_WIDTH_SMALL,
+            @"enableCollectionView": @YES,
+            @"enableLibraryCache": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"title",
@@ -4398,8 +4398,8 @@
                         @"isreminder",
                         @"directory",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Date"),
@@ -4410,18 +4410,18 @@
                         @"starttime",
                         @"runtime",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Timers"), @"label",
-            LOCALIZED_STR(@"Timers"), @"morelabel",
-            @"nocover_timers", @"defaultThumb",
-            @DEFAULT_ROW_HEIGHT, @"rowHeight",
-            @DEFAULT_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Timers"),
+            @"morelabel": LOCALIZED_STR(@"Timers"),
+            @"defaultThumb": @"nocover_timers",
+            @"rowHeight": @DEFAULT_ROW_HEIGHT,
+            @"thumbWidth": @DEFAULT_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
         
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"title",
@@ -4443,8 +4443,8 @@
                         @"isreminder",
                         @"directory",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Date"),
@@ -4455,15 +4455,15 @@
                         @"starttime",
                         @"runtime",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Timer rules"), @"label",
-            LOCALIZED_STR(@"Timer rules"), @"morelabel",
-            @"nocover_timerrules", @"defaultThumb",
-            @DEFAULT_ROW_HEIGHT, @"rowHeight",
-            @DEFAULT_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Timer rules"),
+            @"morelabel": LOCALIZED_STR(@"Timer rules"),
+            @"defaultThumb": @"nocover_timerrules",
+            @"rowHeight": @DEFAULT_ROW_HEIGHT,
+            @"thumbWidth": @DEFAULT_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
     ] mutableCopy];
     
     menu_LiveTV.mainFields = @[
@@ -4595,8 +4595,8 @@
     menu_LiveTV.subItem.noConvertTime = YES;
     
     menu_LiveTV.subItem.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"properties": @[
                         @"title",
                         @"starttime",
@@ -4607,41 +4607,41 @@
                         @"isactive",
                         @"hastimer",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Live TV"), @"label",
-            @"icon_video", @"defaultThumb",
-            @YES, @"disableFilterParameter",
-            @CHANNEL_EPG_ROW_HEIGHT, @"rowHeight",
-            @LIVETV_THUMB_WIDTH, @"thumbWidth",
-            [self itemSizes_Music], @"itemSizes",
-            @YES, @"forceActionSheet",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Live TV"),
+            @"defaultThumb": @"icon_video",
+            @"disableFilterParameter": @YES,
+            @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
+            @"thumbWidth": @LIVETV_THUMB_WIDTH,
+            @"itemSizes": [self itemSizes_Music],
+            @"forceActionSheet": @YES,
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"properties": @[
                         @"thumbnail",
                         @"channelnumber",
                         @"channel",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"kodiExtrasPropertiesMinimumVersion": @{
                 @"17": @[
                     @"isrecording",
                 ],
-            }, @"kodiExtrasPropertiesMinimumVersion",
-            LOCALIZED_STR(@"Live TV"), @"label",
-            @"nocover_channels", @"defaultThumb",
-            @YES, @"disableFilterParameter",
-            @LIVETV_ROW_HEIGHT, @"rowHeight",
-            @LIVETV_THUMB_WIDTH_SMALL, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Live TV"),
+            @"defaultThumb": @"nocover_channels",
+            @"disableFilterParameter": @YES,
+            @"rowHeight": @LIVETV_ROW_HEIGHT,
+            @"thumbWidth": @LIVETV_THUMB_WIDTH_SMALL,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
                                   
-        @[],
-        @[],
-        @[],
+        @{},
+        @{},
+        @{},
     ] mutableCopy];
     
     menu_LiveTV.subItem.mainFields = @[
@@ -4717,10 +4717,10 @@
     ] mutableCopy];
     
     menu_LiveTV.subItem.subItem.mainParameters = [@[
-        @[],
+        @{},
                                             
-         @[
-            @{
+        @{
+            @"parameters": @{
                 @"properties": @[
                         @"title",
                         @"starttime",
@@ -4731,19 +4731,19 @@
                         @"isactive",
                         @"hastimer",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Live TV"), @"label",
-            @"icon_video", @"defaultThumb",
-            @YES, @"disableFilterParameter",
-            @CHANNEL_EPG_ROW_HEIGHT, @"rowHeight",
-            @LIVETV_THUMB_WIDTH, @"thumbWidth",
-            [self itemSizes_Music], @"itemSizes",
-            @YES, @"forceActionSheet",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Live TV"),
+            @"defaultThumb": @"icon_video",
+            @"disableFilterParameter": @YES,
+            @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
+            @"thumbWidth": @LIVETV_THUMB_WIDTH,
+            @"itemSizes": [self itemSizes_Music],
+            @"forceActionSheet": @YES,
+        },
                                             
-        @[],
-        @[],
-        @[],
+        @{},
+        @{},
+        @{},
     ] mutableCopy];
     
     menu_LiveTV.subItem.subItem.mainFields = @[
@@ -4820,44 +4820,44 @@
     ] mutableCopy];
     
     menu_Radio.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"channelgroupid": @"allradio",
                 @"properties": @[
                         @"thumbnail",
                         @"channelnumber",
                         @"channel",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"kodiExtrasPropertiesMinimumVersion": @{
                 @"17": @[
                     @"isrecording",
                 ],
-            }, @"kodiExtrasPropertiesMinimumVersion",
-            LOCALIZED_STR(@"All channels"), @"label",
-            @"nocover_channels", @"defaultThumb",
-            @YES, @"disableFilterParameter",
-            @LIVETV_ROW_HEIGHT, @"rowHeight",
-            @LIVETV_THUMB_WIDTH_SMALL, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"All channels"),
+            @"defaultThumb": @"nocover_channels",
+            @"disableFilterParameter": @YES,
+            @"rowHeight": @LIVETV_ROW_HEIGHT,
+            @"thumbWidth": @LIVETV_THUMB_WIDTH_SMALL,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"channeltype": @"radio",
-            }, @"parameters",
-            LOCALIZED_STR(@"Channel Groups"), @"label",
-            LOCALIZED_STR(@"Channel Groups"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Channel Groups"),
+            @"morelabel": LOCALIZED_STR(@"Channel Groups"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
 
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"title",
@@ -4878,8 +4878,8 @@
                         @"radio",
                         @"directory",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"extra_info_parameters": @{
                 @"properties": @[
                         @"title",
                         @"starttime",
@@ -4898,8 +4898,8 @@
                         @"file",
                         @"directory",
                 ],
-            }, @"extra_info_parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Channel"),
@@ -4914,19 +4914,19 @@
                         @"runtime",
                         @"random",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Recordings"), @"label",
-            LOCALIZED_STR(@"Recordings"), @"morelabel",
-            @"nocover_recording", @"defaultThumb",
-            @CHANNEL_EPG_ROW_HEIGHT, @"rowHeight",
-            @LIVETV_THUMB_WIDTH_SMALL, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            @YES, @"enableLibraryCache",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Recordings"),
+            @"morelabel": LOCALIZED_STR(@"Recordings"),
+            @"defaultThumb": @"nocover_recording",
+            @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
+            @"thumbWidth": @LIVETV_THUMB_WIDTH_SMALL,
+            @"enableCollectionView": @YES,
+            @"enableLibraryCache": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"title",
@@ -4948,8 +4948,8 @@
                         @"isreminder",
                         @"directory",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Date"),
@@ -4960,18 +4960,18 @@
                         @"starttime",
                         @"runtime",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Timers"), @"label",
-            LOCALIZED_STR(@"Timers"), @"morelabel",
-            @"nocover_timers", @"defaultThumb",
-            @DEFAULT_ROW_HEIGHT, @"rowHeight",
-            @DEFAULT_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Timers"),
+            @"morelabel": LOCALIZED_STR(@"Timers"),
+            @"defaultThumb": @"nocover_timers",
+            @"rowHeight": @DEFAULT_ROW_HEIGHT,
+            @"thumbWidth": @DEFAULT_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
         
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"properties": @[
                         @"title",
@@ -4993,8 +4993,8 @@
                         @"isreminder",
                         @"directory",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Title"),
                         LOCALIZED_STR(@"Date"),
@@ -5005,15 +5005,15 @@
                         @"starttime",
                         @"runtime",
                 ],
-            }, @"available_sort_methods",
-            LOCALIZED_STR(@"Timer rules"), @"label",
-            LOCALIZED_STR(@"Timer rules"), @"morelabel",
-            @"nocover_timerrules", @"defaultThumb",
-            @DEFAULT_ROW_HEIGHT, @"rowHeight",
-            @DEFAULT_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Timer rules"),
+            @"morelabel": LOCALIZED_STR(@"Timer rules"),
+            @"defaultThumb": @"nocover_timerrules",
+            @"rowHeight": @DEFAULT_ROW_HEIGHT,
+            @"thumbWidth": @DEFAULT_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
     ] mutableCopy];
     
     menu_Radio.mainFields = @[
@@ -5145,8 +5145,8 @@
     menu_Radio.subItem.noConvertTime = YES;
     
     menu_Radio.subItem.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"properties": @[
                         @"title",
                         @"starttime",
@@ -5157,41 +5157,41 @@
                         @"isactive",
                         @"hastimer",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Radio"), @"label",
-            @"icon_video", @"defaultThumb",
-            @YES, @"disableFilterParameter",
-            @CHANNEL_EPG_ROW_HEIGHT, @"rowHeight",
-            @LIVETV_THUMB_WIDTH, @"thumbWidth",
-            [self itemSizes_Music], @"itemSizes",
-            @YES, @"forceActionSheet",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Radio"),
+            @"defaultThumb": @"icon_video",
+            @"disableFilterParameter": @YES,
+            @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
+            @"thumbWidth": @LIVETV_THUMB_WIDTH,
+            @"itemSizes": [self itemSizes_Music],
+            @"forceActionSheet": @YES,
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"properties": @[
                         @"thumbnail",
                         @"channelnumber",
                         @"channel",
                 ],
-            }, @"parameters",
-            @{
+            },
+            @"kodiExtrasPropertiesMinimumVersion": @{
                 @"17": @[
                     @"isrecording",
                 ],
-            }, @"kodiExtrasPropertiesMinimumVersion",
-            LOCALIZED_STR(@"Radio"), @"label",
-            @"nocover_channels", @"defaultThumb",
-            @YES, @"disableFilterParameter",
-            @LIVETV_ROW_HEIGHT, @"rowHeight",
-            @LIVETV_THUMB_WIDTH_SMALL, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Radio"),
+            @"defaultThumb": @"nocover_channels",
+            @"disableFilterParameter": @YES,
+            @"rowHeight": @LIVETV_ROW_HEIGHT,
+            @"thumbWidth": @LIVETV_THUMB_WIDTH_SMALL,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
                                   
-        @[],
-        @[],
-        @[],
+        @{},
+        @{},
+        @{},
     ] mutableCopy];
     
     menu_Radio.subItem.mainFields = @[
@@ -5267,10 +5267,10 @@
     ] mutableCopy];
     
     menu_Radio.subItem.subItem.mainParameters = [@[
-        @[],
+        @{},
                                             
-         @[
-            @{
+        @{
+            @"parameters": @{
                 @"properties": @[
                         @"title",
                         @"starttime",
@@ -5281,19 +5281,19 @@
                         @"isactive",
                         @"hastimer",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Radio"), @"label",
-            @"icon_video", @"defaultThumb",
-            @YES, @"disableFilterParameter",
-            @CHANNEL_EPG_ROW_HEIGHT, @"rowHeight",
-            @LIVETV_THUMB_WIDTH, @"thumbWidth",
-            [self itemSizes_Music], @"itemSizes",
-            @YES, @"forceActionSheet",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Radio"),
+            @"defaultThumb": @"icon_video",
+            @"disableFilterParameter": @YES,
+            @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
+            @"thumbWidth": @LIVETV_THUMB_WIDTH,
+            @"itemSizes": [self itemSizes_Music],
+            @"forceActionSheet": @YES,
+        },
                                             
-        @[],
-        @[],
-        @[],
+        @{},
+        @{},
+        @{},
     ] mutableCopy];
     
     menu_Radio.subItem.subItem.mainFields = @[
@@ -5355,34 +5355,34 @@
     ] mutableCopy];
     
     menu_Pictures.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"pictures",
-            }, @"parameters",
-            LOCALIZED_STR(@"Pictures"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Pictures"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
                           
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"pictures",
                 @"directory": @"addons://sources/image",
                 @"properties": @[
                     @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Pictures Add-ons"), @"label",
-            LOCALIZED_STR(@"Pictures Add-ons"), @"morelabel",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Pictures Add-ons"),
+            @"morelabel": LOCALIZED_STR(@"Pictures Add-ons"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
     ] mutableCopy];
     
     menu_Pictures.mainFields = @[
@@ -5431,33 +5431,33 @@
     ];
     
     menu_Pictures.subItem.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"label" order:@"ascending" ignorearticle:NO],
                 @"media": @"pictures",
                 @"file_properties": @[
                     @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Files"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Files"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
                                   
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"none" order:@"ascending" ignorearticle:NO],
                 @"media": @"pictures",
                 @"file_properties": @[
                     @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Video Add-ons"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Video Add-ons"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
     ] mutableCopy];
     
     menu_Pictures.subItem.mainFields = @[
@@ -5511,8 +5511,8 @@
     ] mutableCopy];
     
     menu_Pictures.subItem.subItem.mainParameters = [@[
-        @[],
-        @[],
+        @{},
+        @{},
     ] mutableCopy];
     
     menu_Pictures.subItem.subItem.mainFields = @[
@@ -5536,22 +5536,22 @@
     ] mutableCopy];
     
     menu_Favourites.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"properties": @[
                         @"thumbnail",
                         @"path",
                         @"window",
                         @"windowparameter",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Favourites"), @"label",
-            @"nocover_favourites", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @FILEMODE_THUMB_WIDTH, @"thumbWidth",
-            @YES, @"enableCollectionView",
-            [self itemSizes_Music], @"itemSizes",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Favourites"),
+            @"defaultThumb": @"nocover_favourites",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+            @"enableCollectionView": @YES,
+            @"itemSizes": [self itemSizes_Music],
+        },
     ] mutableCopy];
     
     menu_Favourites.mainFields = @[
@@ -5594,12 +5594,12 @@
     menu_Search.thumbWidth = DEFAULT_THUMB_WIDTH;
     menu_Search.defaultThumb = @"nocover_filemode";
     menu_Search.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"sort": [self sortmethod:@"itemgroup" order:@"ascending" ignorearticle:NO],
-            }, @"parameters",
-            LOCALIZED_STR(@"Global Search"), @"label",
-            @{
+            },
+            @"label": LOCALIZED_STR(@"Global Search"),
+            @"available_sort_methods": @{
                 @"label": @[
                         LOCALIZED_STR(@"Type"),
                         LOCALIZED_STR(@"Name"),
@@ -5608,9 +5608,9 @@
                         @"itemgroup",
                         @"label",
                 ],
-            }, @"available_sort_methods",
-            @YES, @"enableLibraryCache",
-        ],
+            },
+            @"enableLibraryCache": @YES,
+        },
     ] mutableCopy];
     
 #pragma mark - XBMC Server Management
@@ -5686,17 +5686,17 @@
     ] mutableCopy];
     
     xbmcSettings.mainParameters = [@[
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"level": @"expert",
-            }, @"parameters",
-            LOCALIZED_STR(@"XBMC Settings"), @"label",
-            @(IS_IPHONE), @"animationStartBottomScreen",
-            @0, @"thumbWidth",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"XBMC Settings"),
+            @"animationStartBottomScreen": @(IS_IPHONE),
+            @"thumbWidth": @0,
+        },
                                    
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"type": @"xbmc.addon.executable",
                 @"enabled": @YES,
                 @"properties": @[
@@ -5705,17 +5705,17 @@
                         @"summary",
                         @"thumbnail",
                 ],
-            }, @"parameters",
-             LOCALIZED_STR(@"Programs"), @"label",
-             @"nocover_filemode", @"defaultThumb",
-             @SETTINGS_ROW_HEIGHT, @"rowHeight",
-             @SETTINGS_THUMB_WIDTH_BIG, @"thumbWidth",
-            [self itemSizes_Music], @"itemSizes",
-            @YES, @"enableCollectionView",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Programs"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @SETTINGS_ROW_HEIGHT,
+            @"thumbWidth": @SETTINGS_THUMB_WIDTH_BIG,
+            @"itemSizes": [self itemSizes_Music],
+            @"enableCollectionView": @YES,
+        },
                                    
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"type": @"xbmc.addon.video",
                 @"enabled": @YES,
                 @"properties": @[
@@ -5724,17 +5724,17 @@
                         @"summary",
                         @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Video Add-ons"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @SETTINGS_ROW_HEIGHT, @"rowHeight",
-            @SETTINGS_THUMB_WIDTH_BIG, @"thumbWidth",
-            [self itemSizes_Music], @"itemSizes",
-            @YES, @"enableCollectionView",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Video Add-ons"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @SETTINGS_ROW_HEIGHT,
+            @"thumbWidth": @SETTINGS_THUMB_WIDTH_BIG,
+            @"itemSizes": [self itemSizes_Music],
+            @"enableCollectionView": @YES,
+        },
                                    
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"type": @"xbmc.addon.audio",
                 @"enabled": @YES,
                 @"properties": @[
@@ -5743,42 +5743,42 @@
                         @"summary",
                         @"thumbnail",
                 ],
-            }, @"parameters",
-            LOCALIZED_STR(@"Music Add-ons"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @SETTINGS_ROW_HEIGHT, @"rowHeight",
-            @SETTINGS_THUMB_WIDTH_BIG, @"thumbWidth",
-            [self itemSizes_Music], @"itemSizes",
-            @YES, @"enableCollectionView",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Music Add-ons"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @SETTINGS_ROW_HEIGHT,
+            @"thumbWidth": @SETTINGS_THUMB_WIDTH_BIG,
+            @"itemSizes": [self itemSizes_Music],
+            @"enableCollectionView": @YES,
+        },
                                    
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"filter": @{
                         @"id": @"Input.ExecuteAction",
                         @"type": @"method",
                 },
-            }, @"parameters",
-            LOCALIZED_STR(@"Kodi actions"), @"label",
-            @"default-right-action-icon", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @0, @"thumbWidth",
-            LOCALIZED_STR(@"Execute a specific action"), @"morelabel",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Kodi actions"),
+            @"defaultThumb": @"default-right-action-icon",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @0,
+            @"morelabel": LOCALIZED_STR(@"Execute a specific action"),
+        },
                                    
-        @[
-            @{
+        @{
+            @"parameters": @{
                 @"filter": @{
                         @"id": @"GUI.ActivateWindow",
                         @"type": @"method",
                 },
-            }, @"parameters",
-            LOCALIZED_STR(@"Kodi windows"), @"label",
-            @"default-right-window-icon", @"defaultThumb",
-            @FILEMODE_ROW_HEIGHT, @"rowHeight",
-            @0, @"thumbWidth",
-            LOCALIZED_STR(@"Activate a specific window"), @"morelabel",
-        ],
+            },
+            @"label": LOCALIZED_STR(@"Kodi windows"),
+            @"defaultThumb": @"default-right-window-icon",
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @0,
+            @"morelabel": LOCALIZED_STR(@"Activate a specific window"),
+        },
     ] mutableCopy];
     
     xbmcSettings.mainFields = @[
@@ -5902,32 +5902,32 @@
     ] mutableCopy];
     
     xbmcSettings.subItem.mainParameters = [@[
-        @[
-            LOCALIZED_STR(@"Settings"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @SETTINGS_ROW_HEIGHT, @"rowHeight",
-            @0, @"thumbWidth",
-        ],
+        @{
+            @"label": LOCALIZED_STR(@"Settings"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @SETTINGS_ROW_HEIGHT,
+            @"thumbWidth": @0,
+        },
 
-        @[
-            @YES, @"forceActionSheet",
-        ],
+        @{
+            @"forceActionSheet": @YES,
+        },
 
-        @[
-            @YES, @"forceActionSheet",
-        ],
+        @{
+            @"forceActionSheet": @YES,
+        },
 
-        @[
-            @YES, @"forceActionSheet",
-        ],
+        @{
+            @"forceActionSheet": @YES,
+        },
 
-        @[
-            @YES, @"forceActionSheet",
-        ],
+        @{
+            @"forceActionSheet": @YES,
+        },
 
-        @[
-            @YES, @"forceActionSheet",
-        ],
+        @{
+            @"forceActionSheet": @YES,
+        },
     ] mutableCopy];
     
     xbmcSettings.subItem.mainFields = @[
@@ -5961,12 +5961,12 @@
     ] mutableCopy];
     
     xbmcSettings.subItem.subItem.mainParameters = [@[
-        @[
-            LOCALIZED_STR(@"Settings"), @"label",
-            @"nocover_filemode", @"defaultThumb",
-            @SETTINGS_ROW_HEIGHT, @"rowHeight",
-            @0, @"thumbWidth",
-        ],
+        @{
+            @"label": LOCALIZED_STR(@"Settings"),
+            @"defaultThumb": @"nocover_filemode",
+            @"rowHeight": @SETTINGS_ROW_HEIGHT,
+            @"thumbWidth": @0,
+        },
     ] mutableCopy];
     
     xbmcSettings.subItem.subItem.mainFields = @[
@@ -6196,8 +6196,7 @@
     // Search for the method index with the desired sub label (e.g. "All Songs")
     int k;
     for (k = 0; k < menuItem.mainMethod.count; ++k) {
-        id paramArray = menuItem.mainParameters[k];
-        id parameters = [Utilities indexKeyedDictionaryFromArray:paramArray];
+        id parameters = menuItem.mainParameters[k];
         if ([parameters[@"label"] isEqualToString:subLabel]) {
             break;
         }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1950,7 +1950,7 @@
     // Get the index titles
     NSMutableArray *tmpArr = [[NSMutableArray alloc] initWithArray:self.sectionArray];
     if (tmpArr.count > 1) {
-        [tmpArr replaceObjectAtIndex:0 withObject:@"🔍"];
+        tmpArr[0] = @"🔍";
     }
     if (self.sectionArray.count > 1 && !episodesView && !channelGuideView) {
         self.indexView.indexTitles = [NSArray arrayWithArray:tmpArr];
@@ -6323,7 +6323,7 @@
     };
     NSMutableArray *sortOptions = [sortDictionary[@"label"] mutableCopy];
     if (sortMethodIndex != -1) {
-        [sortOptions replaceObjectAtIndex:sortMethodIndex withObject:[NSString stringWithFormat:@"\u2713 %@", sortOptions[sortMethodIndex]]];
+        sortOptions[sortMethodIndex] = [NSString stringWithFormat:@"\u2713 %@", sortOptions[sortMethodIndex]];
     }
     [self showActionSheet:nil sheetActions:sortOptions item:item rectOriginX:[button7 convertPoint:button7.center toView:buttonsView.superview].x rectOriginY:buttonsView.center.y - button7.frame.size.height / 2];
 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -863,7 +863,7 @@
 - (void)setButtonViewContent:(int)activeTab {
     mainMenu *menuItem = self.detailItem;
     NSDictionary *methods = menuItem.mainMethod[choosedTab];
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     
     // Build basic button list
     [self buildButtons:activeTab];
@@ -1089,7 +1089,7 @@
         }
         [moreMenu addObject:
          [NSDictionary dictionaryWithObjectsAndKeys:
-          [NSString stringWithFormat:@"%@", [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[i]][@"morelabel"]], @"label",
+          [NSString stringWithFormat:@"%@", menuItem.mainParameters[i][@"morelabel"]], @"label",
           icon, @"icon",
           nil]];
     }
@@ -1258,7 +1258,7 @@
     if (newChoosedTab == choosedTab) {
         // Read relevant data from configuration
         methods = menuItem.mainMethod[choosedTab];
-        parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+        parameters = menuItem.mainParameters[choosedTab];
         mutableParameters = [parameters[@"parameters"] mutableCopy];
         mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
         
@@ -1296,7 +1296,7 @@
         }
         // Read relevant data from configuration (important: new value for chooseTab)
         methods = menuItem.mainMethod[choosedTab];
-        parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+        parameters = menuItem.mainParameters[choosedTab];
         mutableParameters = [parameters[@"parameters"] mutableCopy];
         mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
     }
@@ -1349,7 +1349,7 @@
     selectedIndexPath = indexPath;
     mainMenu *menuItem = [self getMainMenu:item];
     NSMutableArray *sheetActions = menuItem.sheetActions[choosedTab];
-    NSMutableDictionary *parameters = [Utilities indexKeyedMutableDictionaryFromArray:[menuItem.subItem mainParameters][choosedTab]];
+    NSMutableDictionary *parameters = menuItem.subItem.mainParameters[choosedTab];
     int rectOriginX = point.x;
     int rectOriginY = point.y;
     NSDictionary *mainFields = menuItem.mainFields[choosedTab];
@@ -1365,7 +1365,7 @@
         id obj = item[mainFields[@"row6"]];
         id objKey = mainFields[@"row6"];
         if (AppDelegate.instance.serverVersion > 11 && ![parameters[@"disableFilterParameter"] boolValue]) {
-            NSDictionary *currentParams = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+            NSDictionary *currentParams = menuItem.mainParameters[choosedTab];
             obj = [NSDictionary dictionaryWithObjectsAndKeys:
                    obj, objKey,
                    currentParams[@"parameters"][@"filter"][parameters[@"combinedFilter"]], parameters[@"combinedFilter"],
@@ -1460,7 +1460,7 @@
         if ([item[@"filetype"] length] != 0 && ![item[@"isSources"] boolValue]) { // WE ARE ALREADY IN BROWSING FILES MODE
             if ([item[@"filetype"] isEqualToString:@"directory"]) {
                 [parameters removeAllObjects];
-                parameters = [Utilities indexKeyedMutableDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+                parameters = menuItem.mainParameters[choosedTab];
                 NSMutableArray *newParameters = [NSMutableArray arrayWithObjects:
                                                [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                                 item[mainFields[@"row6"]], @"directory",
@@ -1575,7 +1575,7 @@
     mainMenu *menuItem = [self getMainMenu:item];
     NSDictionary *methods = menuItem.subItem.mainMethod[choosedTab];
     NSMutableArray *sheetActions = [menuItem.sheetActions[choosedTab] mutableCopy];
-    NSMutableDictionary *parameters = [Utilities indexKeyedMutableDictionaryFromArray:[menuItem.subItem mainParameters][choosedTab]];
+    NSMutableDictionary *parameters = menuItem.subItem.mainParameters[choosedTab];
     int rectOriginX = point.x;
     int rectOriginY = point.y;
     if ([item[@"family"] isEqualToString:@"id"]) {
@@ -1641,7 +1641,7 @@
         else {
             NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
             if (![userDefaults boolForKey:@"song_preference"] || [parameters[@"forceActionSheet"] boolValue]) {
-                sheetActions = [self getPlaylistActions:sheetActions item:item params:[Utilities indexKeyedMutableDictionaryFromArray:menuItem.mainParameters[choosedTab]]];
+                sheetActions = [self getPlaylistActions:sheetActions item:item params:menuItem.mainParameters[choosedTab]];
                 selectedIndexPath = indexPath;
                 [self showActionSheet:indexPath sheetActions:sheetActions item:item rectOriginX:rectOriginX rectOriginY:rectOriginY];
             }
@@ -2122,7 +2122,7 @@
 
 - (void)choseParams { // DA OTTIMIZZARE TROPPI IF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     if ([parameters[@"defaultThumb"] length] != 0 && ![parameters[@"defaultThumb"] isEqualToString:@"(null)"]) {
         defaultThumb = parameters[@"defaultThumb"];
     }
@@ -3326,7 +3326,7 @@
             }
             NSInteger numActions = sheetActions.count;
             if (numActions) {
-                sheetActions = [self getPlaylistActions:sheetActions item:item params:[Utilities indexKeyedMutableDictionaryFromArray:menuItem.mainParameters[choosedTab]]];
+                sheetActions = [self getPlaylistActions:sheetActions item:item params:menuItem.mainParameters[choosedTab]];
                 NSString *title = [NSString stringWithFormat:@"%@", item[@"label"]];
                 if (item[@"genre"] != nil && ![item[@"genre"] isEqualToString:@""]) {
                     title = [NSString stringWithFormat:@"%@\n%@", title, item[@"genre"]];
@@ -3495,7 +3495,7 @@
     
     // Store the rich data
     mainMenu *menuItem = [self getMainMenu:item];
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
     NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
     if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
@@ -3714,7 +3714,7 @@
         [self saveCustomButton:newButton];
     }
     else {
-        NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+        NSDictionary *parameters = menuItem.mainParameters[choosedTab];
         NSMutableDictionary *sortDictionary = parameters[@"available_sort_methods"];
         if (sortDictionary[@"label"] != nil) {
             // In case of random still find index despite leading @"\u2713". This avoids inversion of sort order.
@@ -3787,7 +3787,7 @@
 - (void)searchWeb:(NSDictionary*)item indexPath:(NSIndexPath*)indexPath serviceURL:(NSString*)serviceURL {
     mainMenu *menuItem = self.detailItem;
     if (menuItem.mainParameters.count > 0) {
-        NSMutableDictionary *parameters = [Utilities indexKeyedMutableDictionaryFromArray:menuItem.mainParameters[0]];
+        NSMutableDictionary *parameters = menuItem.mainParameters[0];
         if (parameters[@"fromWikipedia"] != [NSNull null]) {
             if ([parameters[@"fromWikipedia"] boolValue]) {
                 [self goBack:nil];
@@ -4082,7 +4082,7 @@
 - (void)exploreItem:(NSDictionary*)item {
     mainMenu *menuItem = [self getMainMenu:item];
     NSDictionary *mainFields = menuItem.mainFields[choosedTab];
-    NSMutableDictionary *parameters = [Utilities indexKeyedMutableDictionaryFromArray:[menuItem.subItem mainParameters][choosedTab]];
+    NSMutableDictionary *parameters = menuItem.subItem.mainParameters[choosedTab];
     NSNumber *libraryRowHeight = parameters[@"rowHeight"] ?: @(menuItem.subItem.rowHeight);
     NSNumber *libraryThumbWidth = parameters[@"thumbWidth"] ?: @(menuItem.subItem.thumbWidth);
     NSNumber *filemodeRowHeight = parameters[@"rowHeight"] ?: @44;
@@ -4552,7 +4552,7 @@
 - (void)prepareShowAlbumInfo:(id)sender {
     mainMenu *menuItem = self.detailItem;
     if (menuItem.mainParameters.count > 0) {
-        NSMutableDictionary *parameters = [Utilities indexKeyedMutableDictionaryFromArray:menuItem.mainParameters[0]];
+        NSMutableDictionary *parameters = menuItem.mainParameters[0];
         if (parameters[@"fromShowInfo"] != [NSNull null]) {
             if ([parameters[@"fromShowInfo"] boolValue]) {
                 [self goBack:nil];
@@ -4577,7 +4577,7 @@
 
 - (void)showInfo:(NSIndexPath*)indexPath menuItem:(mainMenu*)menuItem item:(NSDictionary*)item tabToShow:(int)tabToShow {
     NSDictionary *methods = menuItem.mainMethod[tabToShow];
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[tabToShow]];
+    NSDictionary *parameters = menuItem.mainParameters[tabToShow];
     
     NSMutableDictionary *mutableParameters = [parameters[@"extra_info_parameters"] mutableCopy];
     NSMutableArray *mutableProperties = [parameters[@"extra_info_parameters"][@"properties"] mutableCopy];
@@ -4708,7 +4708,7 @@
         return;
     }
     NSDictionary *methods = menuItem.mainMethod[choosedTab];
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
     NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
     [self addExtraProperties:mutableProperties newParams:mutableParameters params:parameters];
@@ -4732,7 +4732,7 @@
     NSArray *itemsAndTabs = AppDelegate.instance.globalSearchMenuLookup;
     
     mainMenu *menuItem = self.detailItem;
-    NSMutableDictionary *parameters = [[Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]] mutableCopy];
+    NSMutableDictionary *parameters = [menuItem.mainParameters[choosedTab] mutableCopy];
     if ([self loadedDataFromDisk:nil parameters:parameters refresh:forceRefresh]) {
         return;
     }
@@ -4784,7 +4784,7 @@
         // Save and display
         choosedTab = 0;
         mainMenu *menuItem = self.detailItem;
-        NSMutableDictionary *parameters = [[Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]] mutableCopy];
+        NSMutableDictionary *parameters = [menuItem.mainParameters[choosedTab] mutableCopy];
         [self saveData:parameters];
         [self indexAndDisplayData];
         return;
@@ -4792,7 +4792,7 @@
     mainMenu *menuItem = itemsAndTabs[index][0];
     int activeTab = [itemsAndTabs[index][1] intValue];
     NSDictionary *methods = menuItem.mainMethod[activeTab];
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[activeTab]];
+    NSDictionary *parameters = menuItem.mainParameters[activeTab];
     NSDictionary *mainFields = menuItem.mainFields[activeTab];
     NSString *methodToCall = methods[@"method"];
     NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
@@ -4954,7 +4954,7 @@
          // If we are reading PVR timer, we need to filter them for the current mode in postprocessing. Ignore
          // scheduled recordings, if we are in timer rules mode. Or ignore timer rules, if scheduled recordings
          // are listed.
-         NSDictionary *menuParam = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+         NSDictionary *menuParam = menuItem.mainParameters[choosedTab];
          BOOL isTimerMethod = [methodToCall isEqualToString:@"PVR.GetTimers"];
          BOOL ignoreTimerRulesItems = isTimerMethod && [menuParam[@"label"] isEqualToString:LOCALIZED_STR(@"Timers")];
          BOOL ignoreTimerItems = isTimerMethod && [menuParam[@"label"] isEqualToString:LOCALIZED_STR(@"Timer rules")];
@@ -5058,7 +5058,7 @@
                      if ([itemType isKindOfClass:[NSDictionary class]]) {
                          itemDict = itemType[itemField];
                          if ([itemDict isKindOfClass:[NSArray class]]) {
-                             NSString *sublabel = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]][@"morelabel"] ?: @"";
+                             NSString *sublabel = menuItem.mainParameters[choosedTab][@"morelabel"] ?: @"";
                              for (id item in itemDict) {
                                  if ([item isKindOfClass:[NSString class]]) {
                                      NSDictionary *listEntry = @{
@@ -5202,7 +5202,7 @@
 - (BOOL)isSortDifferentToDefault {
     BOOL isDifferent = NO;
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     NSString *defaultSortMethod = parameters[@"parameters"][@"sort"][@"method"];
     NSString *defaultSortOrder = parameters[@"parameters"][@"sort"][@"order"];
     if (sortMethodName != nil && ![sortMethodName isEqualToString:defaultSortMethod]) {
@@ -5221,7 +5221,7 @@
 
 - (void)indexAndDisplayData {
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     NSDictionary *methods = menuItem.mainMethod[choosedTab];
     NSArray *copyRichResults = [self.richResults copy];
     BOOL addUITableViewIndexSearch = NO;
@@ -5444,7 +5444,7 @@
     [self choseParams];
     numResults = (int)self.richResults.count;
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     
     BOOL useMainLabel = ![menuItem.mainLabel isEqualToString:menuItem.rootLabel] && ![menuItem.mainLabel isEqualToString:LOCALIZED_STR(@"XBMC Settings")];
     NSString *labelText = useMainLabel ? menuItem.mainLabel : parameters[@"label"];
@@ -5738,7 +5738,7 @@
 
 - (BOOL)collectionViewCanBeEnabled {
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     return ([parameters[@"enableCollectionView"] boolValue]);
 }
 
@@ -5748,7 +5748,7 @@
     }
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     NSDictionary *methods = menuItem.mainMethod[choosedTab];
     NSMutableDictionary *tempDict = [NSMutableDictionary dictionaryWithDictionary:parameters[@"parameters"]];
     if (AppDelegate.instance.serverVersion > 11) {
@@ -5993,7 +5993,7 @@
     }
     filterModeType = ViewModeDefault;
     NSDictionary *methods = menuItem.mainMethod[choosedTab];
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     watchedListenedStrings = parameters[@"watchedListenedStrings"];
     [self checkDiskCache];
     numberOfStars = 10;
@@ -6208,7 +6208,7 @@
 - (void)checkFullscreenButton:(BOOL)forceHide {
     mainMenu *menuItem = self.detailItem;
     if (IS_IPAD && menuItem.enableSection) {
-        NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+        NSDictionary *parameters = menuItem.mainParameters[choosedTab];
         if ([self collectionViewCanBeEnabled] && ([parameters[@"enableLibraryFullScreen"] boolValue] && !forceHide)) {
             int buttonPadding = 1;
             if (fullscreenButton == nil) {
@@ -6251,7 +6251,7 @@
 
 - (void)checkDiskCache {
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     BOOL diskcache_preference = [userDefaults boolForKey:@"diskcache_preference"];
     enableDiskCache = diskcache_preference && [parameters[@"enableLibraryCache"] boolValue];
@@ -6268,7 +6268,7 @@
     }
     mainMenu *menuItem = self.detailItem;
     NSDictionary *methods = menuItem.mainMethod[choosedTab];
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     if ([self collectionViewCanBeEnabled] && self.view.superview != nil && ![methods[@"method"] isEqualToString:@""]) {
         NSMutableDictionary *tempDict = [NSMutableDictionary dictionaryWithDictionary:parameters[@"parameters"]];
         if (AppDelegate.instance.serverVersion > 11) {
@@ -6316,7 +6316,7 @@
     if (choosedTab >= menuItem.mainParameters.count) {
         return;
     }
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     NSDictionary *sortDictionary = parameters[@"available_sort_methods"];
     NSDictionary *item = @{
         @"label": LOCALIZED_STR(@"Sort by"),

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -450,6 +450,31 @@
 
 #pragma mark - Utility
 
+- (void)enterSubmenuOfMenu:(mainMenu*)menuItem label:(NSString*)label params:(NSDictionary*)parameters {
+    menuItem.subItem.mainLabel = label;
+    mainMenu *newMenuItem = [menuItem.subItem copy];
+    newMenuItem.mainParameters[choosedTab] = parameters;
+    newMenuItem.chooseTab = choosedTab;
+    if (IS_IPHONE) {
+        DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
+        detailViewController.detailItem = newMenuItem;
+        [self.navigationController pushViewController:detailViewController animated:YES];
+    }
+    else {
+        if (stackscrollFullscreen) {
+            [self toggleFullscreen:nil];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.6f * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:newMenuItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
+                [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:NO];
+            });
+        }
+        else {
+            DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:newMenuItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
+            [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:NO];
+        }
+    }
+}
+
 - (void)addFileProperties:(NSMutableDictionary*)dict {
     if (dict[@"file_properties"] != nil) {
         dict[@"properties"] = [dict[@"file_properties"] mutableCopy];
@@ -1426,33 +1451,7 @@
         if (parameters[@"parameters"][@"albumartistsonly"]) {
             newParameters[@"parameters"][@"albumartistsonly"] = parameters[@"parameters"][@"albumartistsonly"];
         }
-        menuItem.subItem.mainLabel = item[@"label"];
-        mainMenu *newMenuItem = [menuItem.subItem copy];
-        newMenuItem.mainParameters[choosedTab] = newParameters;
-        newMenuItem.chooseTab = choosedTab;
-        if (IS_IPHONE) {
-            DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
-            detailViewController.detailItem = newMenuItem;
-            [self.navigationController pushViewController:detailViewController animated:YES];
-        }
-        else {
-            if (stackscrollFullscreen) {
-                [self toggleFullscreen:nil];
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.6f * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-                    DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:newMenuItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
-                    [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:NO];
-                });
-            }
-            else if ([self isModal]) {
-                DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:newMenuItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
-                iPadDetailViewController.modalPresentationStyle = UIModalPresentationFormSheet;
-                [self presentViewController:iPadDetailViewController animated:YES completion:nil];
-            }
-            else {
-                DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:newMenuItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
-                [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:NO];
-            }
-        }
+        [self enterSubmenuOfMenu:menuItem label:item[@"label"] params:newParameters];
     }
     else { // CHILD IS FILEMODE
         NSNumber *filemodeRowHeight = parameters[@"rowHeight"] ?: @44;
@@ -1544,28 +1543,7 @@
             if ([item[@"family"] isEqualToString:@"sectionid"] || [item[@"family"] isEqualToString:@"categoryid"]) {
                 newParameters[@"parameters"][@"level"] = @"expert";
             }
-            menuItem.subItem.mainLabel = item[@"label"];
-            mainMenu *newMenuItem = [menuItem.subItem copy];
-            newMenuItem.mainParameters[choosedTab] = newParameters;
-            newMenuItem.chooseTab = choosedTab;
-            if (IS_IPHONE) {
-                DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
-                detailViewController.detailItem = newMenuItem;
-                [self.navigationController pushViewController:detailViewController animated:YES];
-            }
-            else {
-                if (stackscrollFullscreen) {
-                    [self toggleFullscreen:nil];
-                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.6f * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-                        DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:newMenuItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
-                        [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:NO];
-                    });
-                }
-                else {
-                    DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:newMenuItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
-                    [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:NO];
-                }
-            }
+            [self enterSubmenuOfMenu:menuItem label:item[@"label"] params:newParameters];
         }
     }
 }
@@ -4108,28 +4086,7 @@
                                           @"Files.GetDirectory", @"exploreCommand",
                                           @([parameters[@"disableFilterParameter"] boolValue]), @"disableFilterParameter",
                                           nil];
-    menuItem.subItem.mainLabel = item[@"label"];
-    mainMenu *newMenuItem = [menuItem.subItem copy];
-    newMenuItem.mainParameters[choosedTab] = newParameters;
-    newMenuItem.chooseTab = choosedTab;
-    if (IS_IPHONE) {
-        DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
-        detailViewController.detailItem = newMenuItem;
-        [self.navigationController pushViewController:detailViewController animated:YES];
-    }
-    else {
-        if (stackscrollFullscreen) {
-            [self toggleFullscreen:nil];
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.6f * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-                DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:newMenuItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
-                [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:NO];
-            });
-        }
-        else {
-            DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:newMenuItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
-            [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:NO];
-        }
-    }
+    [self enterSubmenuOfMenu:menuItem label:item[@"label"] params:newParameters];
 }
 
 - (void)deleteTimer:(NSDictionary*)item indexPath:(NSIndexPath*)indexPath {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1392,7 +1392,7 @@
         if (parameters[@"kodiExtrasPropertiesMinimumVersion"]) {
             kodiExtrasPropertiesMinimumVersion = parameters[@"kodiExtrasPropertiesMinimumVersion"];
         }
-        NSMutableArray *newParameters = [NSMutableArray arrayWithObjects:
+        NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                        [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                         obj, objKey,
                                         parameters[@"parameters"][@"properties"], @"properties",
@@ -1418,17 +1418,17 @@
                                        parameters[@"watchedListenedStrings"], @"watchedListenedStrings",
                                        nil];
         if (parameters[@"available_sort_methods"] != nil) {
-            [newParameters addObjectsFromArray:@[parameters[@"available_sort_methods"], @"available_sort_methods"]];
+            newParameters[@"available_sort_methods"] = parameters[@"available_sort_methods"];
         }
         if (parameters[@"combinedFilter"]) {
-            [newParameters addObjectsFromArray:@[parameters[@"combinedFilter"], @"combinedFilter"]];
+            newParameters[@"combinedFilter"] = parameters[@"combinedFilter"];
         }
         if (parameters[@"parameters"][@"albumartistsonly"]) {
-            newParameters[0][@"albumartistsonly"] = parameters[@"parameters"][@"albumartistsonly"];
+            newParameters[@"parameters"][@"albumartistsonly"] = parameters[@"parameters"][@"albumartistsonly"];
         }
         menuItem.subItem.mainLabel = item[@"label"];
         mainMenu *newMenuItem = [menuItem.subItem copy];
-        [[newMenuItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
+        newMenuItem.mainParameters[choosedTab] = newParameters;
         newMenuItem.chooseTab = choosedTab;
         if (IS_IPHONE) {
             DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
@@ -1459,9 +1459,8 @@
         NSNumber *filemodeThumbWidth = parameters[@"thumbWidth"] ?: @44;
         if ([item[@"filetype"] length] != 0 && ![item[@"isSources"] boolValue]) { // WE ARE ALREADY IN BROWSING FILES MODE
             if ([item[@"filetype"] isEqualToString:@"directory"]) {
-                [parameters removeAllObjects];
                 parameters = menuItem.mainParameters[choosedTab];
-                NSMutableArray *newParameters = [NSMutableArray arrayWithObjects:
+                NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                                [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                                 item[mainFields[@"row6"]], @"directory",
                                                 parameters[@"parameters"][@"media"], @"media",
@@ -1478,7 +1477,7 @@
                                                nil];
                 menuItem.mainLabel = item[@"label"];
                 mainMenu *newMenuItem = [menuItem copy];
-                [[newMenuItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
+                newMenuItem.mainParameters[choosedTab] = newParameters;
                 newMenuItem.chooseTab = choosedTab;
                 if (IS_IPHONE) {
                     DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
@@ -1524,10 +1523,10 @@
                 fileModeKey = @"filter";
                 objValue = [NSDictionary dictionaryWithObjectsAndKeys:
                             item[mainFields[@"row6"]], @"category",
-                            menuItem.mainParameters[choosedTab][0][@"section"], @"section",
+                            menuItem.mainParameters[choosedTab][@"parameters"][@"section"], @"section",
                             nil];
             }
-            NSMutableArray *newParameters = [NSMutableArray arrayWithObjects:
+            NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                            [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                             objValue, fileModeKey,
                                             parameters[@"parameters"][@"media"], @"media",
@@ -1543,11 +1542,11 @@
                                            @([parameters[@"disableFilterParameter"] boolValue]), @"disableFilterParameter",
                                            nil];
             if ([item[@"family"] isEqualToString:@"sectionid"] || [item[@"family"] isEqualToString:@"categoryid"]) {
-                newParameters[0][@"level"] = @"expert";
+                newParameters[@"parameters"][@"level"] = @"expert";
             }
             menuItem.subItem.mainLabel = item[@"label"];
             mainMenu *newMenuItem = [menuItem.subItem copy];
-            [[newMenuItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
+            newMenuItem.mainParameters[choosedTab] = newParameters;
             newMenuItem.chooseTab = choosedTab;
             if (IS_IPHONE) {
                 DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
@@ -4091,7 +4090,7 @@
     if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
         [mutableProperties addObject:@"art"];
     }
-    NSMutableArray *newParameters = [NSMutableArray arrayWithObjects:
+    NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                    [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                     item[mainFields[@"row6"]], @"directory",
                                     parameters[@"parameters"][@"media"], @"media",
@@ -4111,7 +4110,7 @@
                                    nil];
     menuItem.subItem.mainLabel = item[@"label"];
     mainMenu *newMenuItem = [menuItem.subItem copy];
-    [[newMenuItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
+    newMenuItem.mainParameters[choosedTab] = newParameters;
     newMenuItem.chooseTab = choosedTab;
     if (IS_IPHONE) {
         DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
@@ -5343,7 +5342,7 @@
             [self.richResults removeAllObjects];
         }
         NSDictionary *epgparams = [NSDictionary dictionaryWithObjectsAndKeys:
-                                   menuItem.mainParameters[choosedTab][0][@"channelid"], @"channelid",
+                                   menuItem.mainParameters[choosedTab][@"parameters"][@"channelid"], @"channelid",
                                    retrievedEPG, @"epgArray",
                                    nil];
         [NSThread detachNewThreadSelector:@selector(backgroundSaveEPGToDisk:) toTarget:self withObject:epgparams];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -371,7 +371,7 @@
     }
     if (mutableParameters != nil) {
         mainMenu *menuItem = self.detailItem;
-        NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
+        NSDictionary *methods = menuItem.mainMethod[choosedTab];
         NSString *viewKey = [self getCacheKey:methods[@"method"] parameters:mutableParameters];
         
         NSString *filename = [NSString stringWithFormat:@"%@.richResults.dat", viewKey];
@@ -862,7 +862,7 @@
 
 - (void)setButtonViewContent:(int)activeTab {
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
+    NSDictionary *methods = menuItem.mainMethod[choosedTab];
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
     
     // Build basic button list
@@ -1257,7 +1257,7 @@
     // Handle modes (pressing same tab) or changed tabs
     if (newChoosedTab == choosedTab) {
         // Read relevant data from configuration
-        methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
+        methods = menuItem.mainMethod[choosedTab];
         parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
         mutableParameters = [parameters[@"parameters"] mutableCopy];
         mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
@@ -1295,7 +1295,7 @@
             [buttonsIB[choosedTab] setSelected:YES];
         }
         // Read relevant data from configuration (important: new value for chooseTab)
-        methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
+        methods = menuItem.mainMethod[choosedTab];
         parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
         mutableParameters = [parameters[@"parameters"] mutableCopy];
         mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
@@ -1573,7 +1573,7 @@
 
 - (void)didSelectItemAtIndexPath:(NSIndexPath*)indexPath item:(NSDictionary*)item displayPoint:(CGPoint)point {
     mainMenu *menuItem = [self getMainMenu:item];
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:[menuItem.subItem mainMethod][choosedTab]];
+    NSDictionary *methods = menuItem.subItem.mainMethod[choosedTab];
     NSMutableArray *sheetActions = [menuItem.sheetActions[choosedTab] mutableCopy];
     NSMutableDictionary *parameters = [Utilities indexKeyedMutableDictionaryFromArray:[menuItem.subItem mainParameters][choosedTab]];
     int rectOriginX = point.x;
@@ -2551,7 +2551,7 @@
     }
     
     // In case no thumbs are shown and there is a child view or we are showing a setting, display disclosure indicator and adapt width.
-    NSDictionary *method = [Utilities indexKeyedDictionaryFromArray:[menuItem.subItem mainMethod][choosedTab]];
+    NSDictionary *method = menuItem.subItem.mainMethod[choosedTab];
     BOOL hasChild = method.count > 0;
     BOOL isSettingID = [item[@"family"] isEqualToString:@"id"];
     if (!thumbWidth && self.indexView.hidden && (hasChild || isSettingID)) {
@@ -3508,7 +3508,7 @@
 
 - (void)saveSortMethod:(NSString*)sortMethod parameters:(NSDictionary*)parameters {
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
+    NSDictionary *methods = menuItem.mainMethod[choosedTab];
     NSString *sortKey = [NSString stringWithFormat:@"%@_sort_method", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [userDefaults setObject:sortMethod forKey:sortKey];
@@ -3516,7 +3516,7 @@
 
 - (void)saveSortAscDesc:(NSString*)sortAscDescSave parameters:(NSDictionary*)parameters {
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
+    NSDictionary *methods = menuItem.mainMethod[choosedTab];
     NSString *sortKey = [NSString stringWithFormat:@"%@_sort_ascdesc", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [userDefaults setObject:sortAscDescSave forKey:sortKey];
@@ -4576,7 +4576,7 @@
 }
 
 - (void)showInfo:(NSIndexPath*)indexPath menuItem:(mainMenu*)menuItem item:(NSDictionary*)item tabToShow:(int)tabToShow {
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[tabToShow]];
+    NSDictionary *methods = menuItem.mainMethod[tabToShow];
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[tabToShow]];
     
     NSMutableDictionary *mutableParameters = [parameters[@"extra_info_parameters"] mutableCopy];
@@ -4707,7 +4707,7 @@
     if (choosedTab >= menuItem.mainParameters.count) {
         return;
     }
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
+    NSDictionary *methods = menuItem.mainMethod[choosedTab];
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
     NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
     NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
@@ -4791,7 +4791,7 @@
     }
     mainMenu *menuItem = itemsAndTabs[index][0];
     int activeTab = [itemsAndTabs[index][1] intValue];
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[activeTab]];
+    NSDictionary *methods = menuItem.mainMethod[activeTab];
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[activeTab]];
     NSDictionary *mainFields = menuItem.mainFields[activeTab];
     NSString *methodToCall = methods[@"method"];
@@ -5222,7 +5222,7 @@
 - (void)indexAndDisplayData {
     mainMenu *menuItem = self.detailItem;
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
+    NSDictionary *methods = menuItem.mainMethod[choosedTab];
     NSArray *copyRichResults = [self.richResults copy];
     BOOL addUITableViewIndexSearch = NO;
     BOOL isFileBrowsing = [methods[@"method"] isEqualToString:@"Files.GetDirectory"];
@@ -5749,7 +5749,7 @@
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     mainMenu *menuItem = self.detailItem;
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
+    NSDictionary *methods = menuItem.mainMethod[choosedTab];
     NSMutableDictionary *tempDict = [NSMutableDictionary dictionaryWithDictionary:parameters[@"parameters"]];
     if (AppDelegate.instance.serverVersion > 11) {
         if (tempDict[@"filter"] != nil) {
@@ -5992,7 +5992,7 @@
         choosedTab = 0;
     }
     filterModeType = ViewModeDefault;
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
+    NSDictionary *methods = menuItem.mainMethod[choosedTab];
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
     watchedListenedStrings = parameters[@"watchedListenedStrings"];
     [self checkDiskCache];
@@ -6267,7 +6267,7 @@
         [self.searchController setActive:NO];
     }
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
+    NSDictionary *methods = menuItem.mainMethod[choosedTab];
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
     if ([self collectionViewCanBeEnabled] && self.view.superview != nil && ![methods[@"method"] isEqualToString:@""]) {
         NSMutableDictionary *tempDict = [NSMutableDictionary dictionaryWithDictionary:parameters[@"parameters"]];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1393,30 +1393,30 @@
             kodiExtrasPropertiesMinimumVersion = parameters[@"kodiExtrasPropertiesMinimumVersion"];
         }
         NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                       [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                        obj, objKey,
-                                        parameters[@"parameters"][@"properties"], @"properties",
-                                        parameters[@"parameters"][@"sort"], @"sort",
-                                        item[mainFields[@"row15"]], key,
-                                        nil], @"parameters",
-                                       @([parameters[@"disableFilterParameter"] boolValue]), @"disableFilterParameter",
-                                       libraryRowHeight, @"rowHeight",
-                                       libraryThumbWidth, @"thumbWidth",
-                                       parameters[@"label"], @"label",
-                                       [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
-                                       @([parameters[@"FrodoExtraArt"] boolValue]), @"FrodoExtraArt",
-                                       @([parameters[@"enableLibraryCache"] boolValue]), @"enableLibraryCache",
-                                       @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
-                                       @([parameters[@"forceActionSheet"] boolValue]), @"forceActionSheet",
-                                       @([parameters[@"collectionViewRecentlyAdded"] boolValue]), @"collectionViewRecentlyAdded",
-                                       @([parameters[@"blackTableSeparator"] boolValue]), @"blackTableSeparator",
-                                       pvrExtraInfo, @"pvrExtraInfo",
-                                       kodiExtrasPropertiesMinimumVersion, @"kodiExtrasPropertiesMinimumVersion",
-                                       parameters[@"extra_info_parameters"], @"extra_info_parameters",
-                                       newSectionParameters, @"extra_section_parameters",
-                                       [NSString stringWithFormat:@"%@", parameters[@"defaultThumb"]], @"defaultThumb",
-                                       parameters[@"watchedListenedStrings"], @"watchedListenedStrings",
-                                       nil];
+                                              [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                               obj, objKey,
+                                               parameters[@"parameters"][@"properties"], @"properties",
+                                               parameters[@"parameters"][@"sort"], @"sort",
+                                               item[mainFields[@"row15"]], key,
+                                               nil], @"parameters",
+                                              @([parameters[@"disableFilterParameter"] boolValue]), @"disableFilterParameter",
+                                              libraryRowHeight, @"rowHeight",
+                                              libraryThumbWidth, @"thumbWidth",
+                                              parameters[@"label"], @"label",
+                                              [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
+                                              @([parameters[@"FrodoExtraArt"] boolValue]), @"FrodoExtraArt",
+                                              @([parameters[@"enableLibraryCache"] boolValue]), @"enableLibraryCache",
+                                              @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
+                                              @([parameters[@"forceActionSheet"] boolValue]), @"forceActionSheet",
+                                              @([parameters[@"collectionViewRecentlyAdded"] boolValue]), @"collectionViewRecentlyAdded",
+                                              @([parameters[@"blackTableSeparator"] boolValue]), @"blackTableSeparator",
+                                              pvrExtraInfo, @"pvrExtraInfo",
+                                              kodiExtrasPropertiesMinimumVersion, @"kodiExtrasPropertiesMinimumVersion",
+                                              parameters[@"extra_info_parameters"], @"extra_info_parameters",
+                                              newSectionParameters, @"extra_section_parameters",
+                                              [NSString stringWithFormat:@"%@", parameters[@"defaultThumb"]], @"defaultThumb",
+                                              parameters[@"watchedListenedStrings"], @"watchedListenedStrings",
+                                              nil];
         if (parameters[@"available_sort_methods"] != nil) {
             newParameters[@"available_sort_methods"] = parameters[@"available_sort_methods"];
         }
@@ -1461,20 +1461,20 @@
             if ([item[@"filetype"] isEqualToString:@"directory"]) {
                 parameters = menuItem.mainParameters[choosedTab];
                 NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                               [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                                item[mainFields[@"row6"]], @"directory",
-                                                parameters[@"parameters"][@"media"], @"media",
-                                                parameters[@"parameters"][@"sort"], @"sort",
-                                                parameters[@"parameters"][@"file_properties"], @"file_properties",
-                                                nil], @"parameters",
-                                               parameters[@"label"], @"label",
-                                               @"nocover_filemode", @"defaultThumb",
-                                               filemodeRowHeight, @"rowHeight",
-                                               filemodeThumbWidth, @"thumbWidth",
-                                               [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
-                                               @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
-                                               @([parameters[@"disableFilterParameter"] boolValue]), @"disableFilterParameter",
-                                               nil];
+                                                      [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                                       item[mainFields[@"row6"]], @"directory",
+                                                       parameters[@"parameters"][@"media"], @"media",
+                                                       parameters[@"parameters"][@"sort"], @"sort",
+                                                       parameters[@"parameters"][@"file_properties"], @"file_properties",
+                                                       nil], @"parameters",
+                                                      parameters[@"label"], @"label",
+                                                      @"nocover_filemode", @"defaultThumb",
+                                                      filemodeRowHeight, @"rowHeight",
+                                                      filemodeThumbWidth, @"thumbWidth",
+                                                      [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
+                                                      @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
+                                                      @([parameters[@"disableFilterParameter"] boolValue]), @"disableFilterParameter",
+                                                      nil];
                 menuItem.mainLabel = item[@"label"];
                 mainMenu *newMenuItem = [menuItem copy];
                 newMenuItem.mainParameters[choosedTab] = newParameters;
@@ -1527,20 +1527,20 @@
                             nil];
             }
             NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                           [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                            objValue, fileModeKey,
-                                            parameters[@"parameters"][@"media"], @"media",
-                                            parameters[@"parameters"][@"sort"], @"sort",
-                                            parameters[@"parameters"][@"file_properties"], @"file_properties",
-                                            nil], @"parameters",
-                                           parameters[@"label"], @"label",
-                                           @"nocover_filemode", @"defaultThumb",
-                                           filemodeRowHeight, @"rowHeight",
-                                           filemodeThumbWidth, @"thumbWidth",
-                                           [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
-                                           @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
-                                           @([parameters[@"disableFilterParameter"] boolValue]), @"disableFilterParameter",
-                                           nil];
+                                                  [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                                   objValue, fileModeKey,
+                                                   parameters[@"parameters"][@"media"], @"media",
+                                                   parameters[@"parameters"][@"sort"], @"sort",
+                                                   parameters[@"parameters"][@"file_properties"], @"file_properties",
+                                                   nil], @"parameters",
+                                                  parameters[@"label"], @"label",
+                                                  @"nocover_filemode", @"defaultThumb",
+                                                  filemodeRowHeight, @"rowHeight",
+                                                  filemodeThumbWidth, @"thumbWidth",
+                                                  [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
+                                                  @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
+                                                  @([parameters[@"disableFilterParameter"] boolValue]), @"disableFilterParameter",
+                                                  nil];
             if ([item[@"family"] isEqualToString:@"sectionid"] || [item[@"family"] isEqualToString:@"categoryid"]) {
                 newParameters[@"parameters"][@"level"] = @"expert";
             }
@@ -4091,23 +4091,23 @@
         [mutableProperties addObject:@"art"];
     }
     NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                   [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                    item[mainFields[@"row6"]], @"directory",
-                                    parameters[@"parameters"][@"media"], @"media",
-                                    parameters[@"parameters"][@"sort"], @"sort",
-                                    mutableProperties, @"file_properties",
-                                    nil], @"parameters",
-                                   libraryRowHeight, @"rowHeight",
-                                   libraryThumbWidth, @"thumbWidth",
-                                   parameters[@"label"], @"label",
-                                   @"nocover_filemode", @"defaultThumb",
-                                   filemodeRowHeight, @"rowHeight",
-                                   filemodeThumbWidth, @"thumbWidth",
-                                   [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
-                                   @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
-                                   @"Files.GetDirectory", @"exploreCommand",
-                                   @([parameters[@"disableFilterParameter"] boolValue]), @"disableFilterParameter",
-                                   nil];
+                                          [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                           item[mainFields[@"row6"]], @"directory",
+                                           parameters[@"parameters"][@"media"], @"media",
+                                           parameters[@"parameters"][@"sort"], @"sort",
+                                           mutableProperties, @"file_properties",
+                                           nil], @"parameters",
+                                          libraryRowHeight, @"rowHeight",
+                                          libraryThumbWidth, @"thumbWidth",
+                                          parameters[@"label"], @"label",
+                                          @"nocover_filemode", @"defaultThumb",
+                                          filemodeRowHeight, @"rowHeight",
+                                          filemodeThumbWidth, @"thumbWidth",
+                                          [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
+                                          @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
+                                          @"Files.GetDirectory", @"exploreCommand",
+                                          @([parameters[@"disableFilterParameter"] boolValue]), @"disableFilterParameter",
+                                          nil];
     menuItem.subItem.mainLabel = item[@"label"];
     mainMenu *newMenuItem = [menuItem.subItem copy];
     newMenuItem.mainParameters[choosedTab] = newParameters;
@@ -4666,9 +4666,9 @@
         }
     }
     NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                     newProperties, @"properties",
-                                     object, itemid,
-                                     nil];
+                                          newProperties, @"properties",
+                                          object, itemid,
+                                          nil];
     [[Utilities getJsonRPC]
      callMethod:methodToCall
      withParameters:newParameters

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1393,7 +1393,7 @@
 }
 
 - (void)showInfo:(NSDictionary*)item menuItem:(mainMenu*)menuItem indexPath:(NSIndexPath*)indexPath {
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
+    NSDictionary *methods = menuItem.mainMethod[choosedTab];
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
     
     NSMutableDictionary *mutableParameters = [parameters[@"extra_info_parameters"] mutableCopy];
@@ -2037,7 +2037,7 @@
     else {
         return;
     }
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:[menuItem.subItem mainMethod][choosedTab]];
+    NSDictionary *methods = menuItem.subItem.mainMethod[choosedTab];
     if (methods[@"method"] != nil) { // THERE IS A CHILD
         NSDictionary *mainFields = menuItem.mainFields[choosedTab];
         NSMutableDictionary *parameters = [Utilities indexKeyedMutableDictionaryFromArray:[menuItem.subItem mainParameters][choosedTab]];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1459,9 +1459,9 @@
         }
     }
     NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                     newProperties, @"properties",
-                                     object, itemid,
-                                     nil];
+                                          newProperties, @"properties",
+                                          object, itemid,
+                                          nil];
     [[Utilities getJsonRPC]
      callMethod:methodToCall
      withParameters:newParameters
@@ -2059,16 +2059,16 @@
             objKey = @"filter";
         }
         NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                       [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                        obj, objKey,
-                                        parameters[@"parameters"][@"properties"], @"properties",
-                                        parameters[@"parameters"][@"sort"], @"sort",
-                                        item[mainFields[@"row15"]], key,
-                                        nil], @"parameters", parameters[@"label"], @"label",
-                                       parameters[@"extra_info_parameters"], @"extra_info_parameters",
-                                       [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
-                                       @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
-                                       nil];
+                                              [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                               obj, objKey,
+                                               parameters[@"parameters"][@"properties"], @"properties",
+                                               parameters[@"parameters"][@"sort"], @"sort",
+                                               item[mainFields[@"row15"]], key,
+                                               nil], @"parameters", parameters[@"label"], @"label",
+                                              parameters[@"extra_info_parameters"], @"extra_info_parameters",
+                                              [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
+                                              @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
+                                              nil];
         menuItem.subItem.mainParameters[choosedTab] = newParameters;
         menuItem.subItem.chooseTab = choosedTab;
         fromItself = YES;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1394,7 +1394,7 @@
 
 - (void)showInfo:(NSDictionary*)item menuItem:(mainMenu*)menuItem indexPath:(NSIndexPath*)indexPath {
     NSDictionary *methods = menuItem.mainMethod[choosedTab];
-    NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
+    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
     
     NSMutableDictionary *mutableParameters = [parameters[@"extra_info_parameters"] mutableCopy];
     NSMutableArray *mutableProperties = [parameters[@"extra_info_parameters"][@"properties"] mutableCopy];
@@ -2040,7 +2040,7 @@
     NSDictionary *methods = menuItem.subItem.mainMethod[choosedTab];
     if (methods[@"method"] != nil) { // THERE IS A CHILD
         NSDictionary *mainFields = menuItem.mainFields[choosedTab];
-        NSMutableDictionary *parameters = [Utilities indexKeyedMutableDictionaryFromArray:[menuItem.subItem mainParameters][choosedTab]];
+        NSMutableDictionary *parameters = menuItem.subItem.mainParameters[choosedTab];
         NSString *key = @"null";
         if (item[mainFields[@"row15"]] != nil) {
             key = mainFields[@"row15"];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2058,7 +2058,7 @@
             }
             objKey = @"filter";
         }
-        NSMutableArray *newParameters = [NSMutableArray arrayWithObjects:
+        NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                        [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                         obj, objKey,
                                         parameters[@"parameters"][@"properties"], @"properties",
@@ -2069,7 +2069,7 @@
                                        [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
                                        @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
                                        nil];
-        [[menuItem.subItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
+        menuItem.subItem.mainParameters[choosedTab] = newParameters;
         menuItem.subItem.chooseTab = choosedTab;
         fromItself = YES;
         if (IS_IPHONE) {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -308,7 +308,7 @@ double round(double d) {
     NSDictionary *methods = choosedMenuItem.mainMethod[choosedTab];
     if (methods[@"method"] != nil) { // THERE IS A CHILD
         NSDictionary *mainFields = menuItem.mainFields[choosedTab];
-        NSMutableDictionary *parameters = [Utilities indexKeyedMutableDictionaryFromArray:[choosedMenuItem mainParameters][choosedTab]];
+        NSMutableDictionary *parameters = choosedMenuItem.mainParameters[choosedTab];
         id obj = @([item[mainFields[@"row6"]] intValue]);
         id objKey = mainFields[@"row6"];
         if (movieObj != nil && movieObjKey != nil) {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -329,22 +329,22 @@ double round(double d) {
                                     nil];
         }
         NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                       [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                        obj, objKey,
-                                        parameters[@"parameters"][@"properties"], @"properties",
-                                        parameters[@"parameters"][@"sort"], @"sort",
-                                        nil], @"parameters",
-                                       @(blackTableSeparator), @"blackTableSeparator",
-                                       parameters[@"label"], @"label",
-                                       @YES, @"fromShowInfo",
-                                       @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
-                                       [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
-                                       parameters[@"extra_info_parameters"], @"extra_info_parameters",
-                                       @([parameters[@"FrodoExtraArt"] boolValue]), @"FrodoExtraArt",
-                                       @([parameters[@"enableLibraryCache"] boolValue]), @"enableLibraryCache",
-                                       @([parameters[@"collectionViewRecentlyAdded"] boolValue]), @"collectionViewRecentlyAdded",
-                                       newSectionParameters, @"extra_section_parameters",
-                                       nil];
+                                              [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                               obj, objKey,
+                                               parameters[@"parameters"][@"properties"], @"properties",
+                                               parameters[@"parameters"][@"sort"], @"sort",
+                                               nil], @"parameters",
+                                              @(blackTableSeparator), @"blackTableSeparator",
+                                              parameters[@"label"], @"label",
+                                              @YES, @"fromShowInfo",
+                                              @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
+                                              [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
+                                              parameters[@"extra_info_parameters"], @"extra_info_parameters",
+                                              @([parameters[@"FrodoExtraArt"] boolValue]), @"FrodoExtraArt",
+                                              @([parameters[@"enableLibraryCache"] boolValue]), @"enableLibraryCache",
+                                              @([parameters[@"collectionViewRecentlyAdded"] boolValue]), @"collectionViewRecentlyAdded",
+                                              newSectionParameters, @"extra_section_parameters",
+                                              nil];
         choosedMenuItem.mainParameters[choosedTab] = newParameters;
         choosedMenuItem.chooseTab = choosedTab;
         if (![item[@"disableNowPlaying"] boolValue]) {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -328,7 +328,7 @@ double round(double d) {
                                     item[mainFields[@"row6"]], mainFields[@"row6"],
                                     nil];
         }
-        NSMutableArray *newParameters = [NSMutableArray arrayWithObjects:
+        NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                        [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                         obj, objKey,
                                         parameters[@"parameters"][@"properties"], @"properties",
@@ -345,7 +345,7 @@ double round(double d) {
                                        @([parameters[@"collectionViewRecentlyAdded"] boolValue]), @"collectionViewRecentlyAdded",
                                        newSectionParameters, @"extra_section_parameters",
                                        nil];
-        [[choosedMenuItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
+        choosedMenuItem.mainParameters[choosedTab] = newParameters;
         choosedMenuItem.chooseTab = choosedTab;
         if (![item[@"disableNowPlaying"] boolValue]) {
             choosedMenuItem.disableNowPlaying = NO;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -305,7 +305,7 @@ double round(double d) {
     else {
         return;
     }
-    NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:[choosedMenuItem mainMethod][choosedTab]];
+    NSDictionary *methods = choosedMenuItem.mainMethod[choosedTab];
     if (methods[@"method"] != nil) { // THERE IS A CHILD
         NSDictionary *mainFields = menuItem.mainFields[choosedTab];
         NSMutableDictionary *parameters = [Utilities indexKeyedMutableDictionaryFromArray:[choosedMenuItem mainParameters][choosedTab]];

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -69,8 +69,6 @@ typedef enum {
 + (void)showMessage:(NSString*)messageText color:(UIColor*)messageColor;
 + (DSJSONRPC*)getJsonRPC;
 + (void)setWebImageAuthorizationOnSuccessNotification:(NSNotification*)note;
-+ (NSDictionary*)indexKeyedDictionaryFromArray:(NSArray*)array;
-+ (NSMutableDictionary*)indexKeyedMutableDictionaryFromArray:(NSArray*)array;
 + (NSString*)convertTimeFromSeconds:(NSNumber*)seconds;
 + (NSString*)getItemIconFromDictionary:(NSDictionary*)dict;
 + (NSString*)getStringFromItem:(id)item;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -732,24 +732,6 @@
     }
 }
 
-+ (NSDictionary*)indexKeyedDictionaryFromArray:(NSArray*)array {
-    NSMutableDictionary *mutableDictionary = [NSMutableDictionary new];
-    NSInteger numelement = array.count;
-    for (int i = 0; i < numelement - 1; i += 2) {
-        mutableDictionary[array[i + 1]] = array[i];
-    }
-    return (NSDictionary*)mutableDictionary;
-}
-
-+ (NSMutableDictionary*)indexKeyedMutableDictionaryFromArray:(NSArray*)array {
-    NSMutableDictionary *mutableDictionary = [NSMutableDictionary new];
-    NSInteger numelement = array.count;
-    for (int i = 0; i < numelement - 1; i += 2) {
-        mutableDictionary[array[i + 1]] = array[i];
-    }
-    return (NSMutableDictionary*)mutableDictionary;
-}
-
 + (NSString*)convertTimeFromSeconds:(NSNumber*)seconds {
     NSString *result = @"";
     if (seconds == nil) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1102.

This PR addresses  a long-standing issue around `AppDelegate` in which the menu structure uses `NSArray` instead of `NSDictionary` in manifold places. Now this is reworked to use the desired type from the beginning, which requires some work in other controllers to adapt the processing of `mainMethod` and `mainParameters` to the new type.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Rework AppDelegate to use appropriate types