### PR TITLE
Bugfix: Error or no results when selecting an item from filtered list

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1430,7 +1430,6 @@
         mainMenu *newMenuItem = [menuItem.subItem copy];
         [[newMenuItem mainParameters] replaceObjectAtIndex:choosedTab withObject:newParameters];
         newMenuItem.chooseTab = choosedTab;
-        newMenuItem.currentFilterMode = filterModeType;
         if (IS_IPHONE) {
             DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
             detailViewController.detailItem = newMenuItem;
@@ -5992,7 +5991,7 @@
     if (choosedTab >= numTabs) {
         choosedTab = 0;
     }
-    filterModeType = menuItem.currentFilterMode;
+    filterModeType = ViewModeDefault;
     NSDictionary *methods = [Utilities indexKeyedDictionaryFromArray:menuItem.mainMethod[choosedTab]];
     NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];
     watchedListenedStrings = parameters[@"watchedListenedStrings"];

--- a/XBMC Remote/mainMenu.h
+++ b/XBMC Remote/mainMenu.h
@@ -50,7 +50,6 @@ typedef enum {
 @property (nonatomic, copy) NSArray *showRuntime;
 @property BOOL noConvertTime;
 @property (nonatomic, copy) NSArray *filterModes;
-@property ViewModes currentFilterMode;
 
 - (id)copyWithZone:(NSZone*)zone;
 

--- a/XBMC Remote/mainMenu.m
+++ b/XBMC Remote/mainMenu.m
@@ -10,7 +10,7 @@
 
 @implementation mainMenu
 
-@synthesize rootLabel, mainLabel, icon, family, mainButtons, mainMethod, mainFields, mainParameters, rowHeight, thumbWidth, defaultThumb, subItem, enableSection, sheetActions, showInfo, originYearDuration, widthLabel, showRuntime, noConvertTime, chooseTab, disableNowPlaying, filterModes, currentFilterMode;
+@synthesize rootLabel, mainLabel, icon, family, mainButtons, mainMethod, mainFields, mainParameters, rowHeight, thumbWidth, defaultThumb, subItem, enableSection, sheetActions, showInfo, originYearDuration, widthLabel, showRuntime, noConvertTime, chooseTab, disableNowPlaying, filterModes;
 
 - (id)copyWithZone:(NSZone*)zone {
     mainMenu *menuCopy = [[mainMenu allocWithZone: zone] init];
@@ -36,7 +36,6 @@
     menuCopy.showRuntime = [self.showRuntime copy];
     menuCopy.noConvertTime = self.noConvertTime;
     menuCopy.filterModes = [self.filterModes copy];
-    menuCopy.currentFilterMode = self.currentFilterMode;
     return menuCopy;
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Reset `filterModeType` in `viewDidLoad` and do not carry over to subview. This is not required and avoids showing errors or empty results when selecting an item from a filtered list (e.g. played/unplayed albums, album/song/default artists). This was broken since version 1.11.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Error or no results when selecting an item from filtered list