### PR TITLE
Improvement: NowPlaying info prioritizes release year when truncating

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -561,6 +561,9 @@
     NSString *year = [Utilities getYearFromItem:item[@"year"]];
     artist = [self formatArtistYear:artist year:year];
     
+    // Keep year always visible at the tail
+    artistName.lineBreakMode = year.length ? NSLineBreakByTruncatingMiddle : NSLineBreakByTruncatingTail;
+    
     // top to bottom: songName, artistName, albumName
     songName.text = title;
     artistName.text = artist;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
As suggested in the support forum this PR adds a small improvement to the NowPlaying screen. Prioritize the release year in the 2nd row when truncating. So, instead of always truncating the tail, we now truncate at middle, if a release year is given.

Screenshots: 
https://i.ibb.co/488Z1Yj/Bildschirmfoto-2024-09-25-um-21-32-03.png

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: NowPlaying info prioritizes release year when truncating