### PR TITLE
Bugfix: Restore stronger font scaling for custom buttons

### DIFF
--- a/XBMC Remote/rightCellView.xib
+++ b/XBMC Remote/rightCellView.xib
@@ -24,7 +24,7 @@
                         <rect key="frame" x="10" y="12" width="25" height="25"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES"/>
                     </imageView>
-                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="3" contentMode="left" fixedFrame="YES" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.90000000000000002" translatesAutoresizingMaskIntoConstraints="NO" id="6">
+                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="3" contentMode="left" fixedFrame="YES" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="6">
                         <rect key="frame" x="24" y="0.0" width="202" height="50"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="20"/>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3210589#pid3210589).

Restore stronger font scaling for custom buttons. This will break too long button description into two line in case required.

Screenshots:
<a href="https://ibb.co/zmLJ1Yb"><img src="https://i.ibb.co/vcrYbGm/Bildschirmfoto-2024-09-26-um-06-46-25.png" alt="Bildschirmfoto-2024-09-26-um-06-46-25" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Restore stronger font scaling for custom buttons