### PR TITLE
Bugfix: Bring back fullscreen info screen for album/artist

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1247,6 +1247,23 @@
         @[],
     ];
     
+    menu_Music.showInfo = @[
+        @YES,
+        @YES,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+        @NO,
+    ];
+    
     menu_Music.subItem.mainMethod = @[
         @{
             @"method": @"AudioLibrary.GetSongs",


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves an issue reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3210742#pid3210742).

This PR fixes a regression brought in by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1097. The configuration for music menu which enables the detail info screen for album/artists has been removed due to lack of testing the fullscreen mode for this use case.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Bring back fullscreen info screen for album/artist