### PR TITLE
Maintenance: Rework iPhone menu button implementation

### DIFF
--- a/XBMC Remote/HostManagementViewController.h
+++ b/XBMC Remote/HostManagementViewController.h
@@ -7,9 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "ECSlidingViewController.h"
 #import "MasterViewController.h"
-#import "RightMenuViewController.h"
 #import "DSJSONRPC.h"
 
 @class HostViewController;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -489,10 +489,6 @@
     [self.slidingViewController anchorTopViewTo:ECRight];
 }
 
-- (void)revealUnderRight:(NSNotification*)note {
-    [self.slidingViewController anchorTopViewTo:ECLeft];
-}
-
 - (void)viewDidLoad {
     [super viewDidLoad];
     CGFloat deltaY = [Utilities getTopPaddingWithNavBar:self.navigationController];
@@ -636,10 +632,6 @@
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(revealMenu:)
                                                  name: @"RevealMenu"
-                                               object: nil];
-    [[NSNotificationCenter defaultCenter] addObserver: self
-                                             selector: @selector(revealUnderRight:)
-                                                 name: @"revealUnderRight"
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(connectionSuccess:)

--- a/XBMC Remote/InitialSlidingViewController.h
+++ b/XBMC Remote/InitialSlidingViewController.h
@@ -13,6 +13,8 @@
     CustomNavigationController *navController;
 }
 
+- (void)handleMenuButton;
+
 @property (nonatomic, strong) NSMutableArray *mainMenu;
 
 @end

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -42,7 +42,7 @@
     self.topViewController = navController;
 }
 
-- (void)revealMenu:(id)sender {
+- (void)handleMenuButton {
     [[NSNotificationCenter defaultCenter] postNotificationName: @"RevealMenu" object: nil];
 }
 

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -45,9 +45,6 @@
 - (void)revealMenu:(id)sender {
     [[NSNotificationCenter defaultCenter] postNotificationName: @"RevealMenu" object: nil];
 }
-- (void)revealUnderRight:(id)sender {
-    [[NSNotificationCenter defaultCenter] postNotificationName: @"revealUnderRight" object: nil];
-}
 
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];

--- a/XBMC Remote/MasterViewController.h
+++ b/XBMC Remote/MasterViewController.h
@@ -8,7 +8,6 @@
 
 #import <UIKit/UIKit.h>
 #import "DSJSONRPC.h"
-#import "ECSlidingViewController.h"
 #import "tcpJSONRPC.h"
 #import "CustomNavigationController.h"
 #import "MessagesView.h"

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -16,6 +16,7 @@
 #import "HostViewController.h"
 #import "AppDelegate.h"
 #import "HostManagementViewController.h"
+#import "InitialSlidingViewController.h"
 #import "tcpJSONRPC.h"
 #import "XBMCVirtualKeyboard.h"
 #import "ClearCacheView.h"
@@ -175,7 +176,7 @@
     object.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:menuImg 
                                                                                style:UIBarButtonItemStylePlain
                                                                               target:nil
-                                                                              action:@selector(revealMenu:)];
+                                                                              action:@selector(handleMenuButton)];
     
     if (hideBottonLine) {
         [navController hideNavBarBottomLine:YES];
@@ -195,9 +196,6 @@
         // Add MessagesView to root view to be able to show messages on top
         [self addMessagesToRootView];
     }];
-}
-
-- (void)revealMenu:(id)sender {
 }
 
 - (BOOL)tableView:(UITableView*)tableView canEditRowAtIndexPath:(NSIndexPath*)indexPath {

--- a/XBMC Remote/RightMenuViewController.h
+++ b/XBMC Remote/RightMenuViewController.h
@@ -7,7 +7,6 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "ECSlidingViewController.h"
 #import "DSJSONRPC.h"
 #import "RemoteController.h"
 #import "VolumeSliderView.h"


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Use better matching method name `handleMenuButton` and declare it properly as method of `InitialSlidingViewController`. In addition, remove a not needed includes, not needed method `revealUnderRight:` and its related notification `"revealUnderRight"`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Rework iPhone menu button implementation