### PR TITLE
Bugfix: Global Search might not show ratings for movies and TV shows

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2725,6 +2725,7 @@
         else {
             genre.hidden = NO;
             runtimeyear.hidden = NO;
+            rating.hidden = NO;
         }
         [self setCellImageView:cell.urlImageView cell:cell dictItem:item url:stringURL size:CGSizeMake(thumbWidth, cellHeight) defaultImg:displayThumb];
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This fixes rating not being visible for movies and TV Shows in Global Search after once showing cells without this field. Reason is that cell reuse requires the rating label to be explicitly made visible.

Screenshots (left = before, right = after): https://ibb.co/M18hykN

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Global Search might not show ratings for movies and TV shows