### PR TITLE
Rework presentation of search results

### DIFF
--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -63,6 +63,7 @@
     BOOL channelListView;
     BOOL recordingListView;
     BOOL globalSearchView;
+    BOOL useSectionInSearchResults;
     int albumViewHeight;
     int albumViewPadding;
     int artistFontSize;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5306,21 +5306,7 @@
     else {
         if (!albumView && sortbymethod && ![sortbymethod isEqualToString:@"random"] && ([self isSortDifferentToDefault] || [self isEligibleForSections:copyRichResults] || [sortbymethod isEqualToString:@"itemgroup"])) {
             addUITableViewIndexSearch = YES;
-            for (NSDictionary *item in copyRichResults) {
-                NSString *searchKey = @"";
-                if ([item[sortbymethod] isKindOfClass:[NSMutableArray class]] || [item[sortbymethod] isKindOfClass:[NSArray class]]) {
-                    searchKey = [item[sortbymethod] componentsJoinedByString:@""];
-                }
-                else {
-                    searchKey = item[sortbymethod];
-                }
-                NSString *key = [self getIndexTableKey:searchKey sortMethod:sortMethodName];
-                BOOL found = [[self.sections allKeys] containsObject:key];
-                if (!found) {
-                    [self.sections setValue:[NSMutableArray new] forKey:key];
-                }
-                [self.sections[key] addObject:item];
-            }
+            [self buildSectionsForList:copyRichResults sortMethod:sortbymethod];
         }
         else {
             [self.sections setValue:[NSMutableArray new] forKey:@""];
@@ -5337,6 +5323,24 @@
         selector = @selector(localizedStandardCompare:);
     }
     return selector;
+}
+
+- (void)buildSectionsForList:(NSArray*)itemList sortMethod:(NSString*)sortByMethod {
+    for (NSDictionary *item in itemList) {
+        NSString *searchKey = @"";
+        if ([item[sortByMethod] isKindOfClass:[NSMutableArray class]] || [item[sortByMethod] isKindOfClass:[NSArray class]]) {
+            searchKey = [item[sortByMethod] componentsJoinedByString:@""];
+        }
+        else {
+            searchKey = item[sortByMethod];
+        }
+        NSString *key = [self getIndexTableKey:searchKey sortMethod:sortMethodName];
+        BOOL found = [[self.sections allKeys] containsObject:key];
+        if (!found) {
+            [self.sections setValue:[NSMutableArray new] forKey:key];
+        }
+        [self.sections[key] addObject:item];
+    }
 }
 
     // first sort the index table ...

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5315,6 +5315,11 @@
             }
         }
     }
+    [self buildSectionsArraySortedAscending:sortAscending withIndexSearch:addUITableViewIndexSearch];
+    [self setSortButtonImage:sortAscDesc];
+    [self displayData];
+}
+
 - (SEL)buildSelectorForSortMethod:(NSString*)sortByMethod inArray:(NSArray*)itemList {
     // Use localizedStandardCompare for all NSString items to be sorted (provides correct order for multi-digit
     // numbers). But do not use for any other types as this crashes.
@@ -5343,6 +5348,7 @@
     }
 }
 
+- (void)buildSectionsArraySortedAscending:(BOOL)sortAscending withIndexSearch:(BOOL)addUITableViewIndexSearch {
     // first sort the index table ...
     NSMutableArray<NSString*> *sectionKeys = [[self applySortByMethod:[self.sections.allKeys copy] sortmethod:nil ascending:sortAscending selector:@selector(localizedStandardCompare:)] mutableCopy];
     // ... then add the search item on top of the sorted list when needed
@@ -5356,8 +5362,6 @@
     for (int i = 0; i < self.sectionArray.count; i++) {
         [self.sectionArrayOpen addObject:@(defaultValue)];
     }
-    [self setSortButtonImage:sortAscDesc];
-    [self displayData];
 }
 
 - (NSString*)getIndexTableKey:(NSString*)value sortMethod:(NSString*)sortMethod {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5840,6 +5840,9 @@
     showSearchbar = NO;
     [self showSearchBar];
     [self setIndexViewVisibility];
+    
+    // Scroll back to top with inactive searchbar visible on top.
+    activeLayoutView.contentOffset = CGPointMake(0, -activeLayoutView.contentInset.top);
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5890,11 +5890,11 @@
     // Set main parameters for the search and the result visualization
     NSPredicate *pred;
     if (globalSearchView) {
-        pred = [NSPredicate predicateWithFormat:@"label CONTAINS[cd] %@ || artist CONTAINS[cd] %@ || director CONTAINS[cd] %@", searchText, searchText, searchText];
+        pred = [NSPredicate predicateWithFormat:@"label CONTAINS[cd] %@ || year CONTAINS %@ || artist CONTAINS[cd] %@ || director CONTAINS[cd] %@", searchText, searchText, searchText, searchText];
         useSectionInSearchResults = [sortMethodName isEqualToString:@"itemgroup"];
     }
     else {
-        pred = [NSPredicate predicateWithFormat:@"label CONTAINS[cd] %@", searchText];
+        pred = [NSPredicate predicateWithFormat:@"label CONTAINS[cd] %@ || year CONTAINS %@", searchText, searchText];
         useSectionInSearchResults = NO;
     }
     

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5229,12 +5229,7 @@
         }
         // Only sort if the sort method is different to what Kodi server provides or if sort token must be applied
         if ([self isSortDifferentToDefault] || [self isEligibleForSorttokenSort]) {
-            // Use localizedStandardCompare for all NSString items to be sorted (provides correct order for multi-digit
-            // numbers). But do not use for any other types as this crashes.
-            SEL selector = nil;
-            if (copyRichResults.count > 0 && [copyRichResults[0][sortbymethod] isKindOfClass:[NSString class]]) {
-                selector = @selector(localizedStandardCompare:);
-            }
+            SEL selector = [self buildSelectorForSortMethod:sortbymethod inArray:copyRichResults];
             copyRichResults = [self applySortByMethod:copyRichResults sortmethod:sortbymethod ascending:sortAscending selector:selector];
         }
     }
@@ -5334,6 +5329,16 @@
             }
         }
     }
+- (SEL)buildSelectorForSortMethod:(NSString*)sortByMethod inArray:(NSArray*)itemList {
+    // Use localizedStandardCompare for all NSString items to be sorted (provides correct order for multi-digit
+    // numbers). But do not use for any other types as this crashes.
+    SEL selector = nil;
+    if (itemList.count > 0 && [itemList[0][sortByMethod] isKindOfClass:[NSString class]]) {
+        selector = @selector(localizedStandardCompare:);
+    }
+    return selector;
+}
+
     // first sort the index table ...
     NSMutableArray<NSString*> *sectionKeys = [[self applySortByMethod:[self.sections.allKeys copy] sortmethod:nil ascending:sortAscending selector:@selector(localizedStandardCompare:)] mutableCopy];
     // ... then add the search item on top of the sorted list when needed

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5901,7 +5901,7 @@
     if (useSectionInSearchResults) {
         // When showing filtered results with sections the filtered list must be identical to richResults in case of empty search string
         if (searchText.length) {
-            self.filteredListContent = [NSMutableArray arrayWithArray:[self.richResults filteredArrayUsingPredicate:pred]];
+            self.filteredListContent = [self sortfilteredList:[self.richResults filteredArrayUsingPredicate:pred]];
         }
         else {
             self.filteredListContent = [self.richResults mutableCopy];
@@ -5913,8 +5913,16 @@
         [self buildSectionsArraySortedAscending:YES withIndexSearch:self.filteredListContent.count > 0];
     }
     else {
-        self.filteredListContent = [NSMutableArray arrayWithArray:[self.richResults filteredArrayUsingPredicate:pred]];
+        self.filteredListContent = [self sortfilteredList:[self.richResults filteredArrayUsingPredicate:pred]];
     }
+}
+
+- (NSMutableArray*)sortfilteredList:(NSArray*)resultsList {
+    // Always sort search list by ascending label
+    NSString *sortByMethod = @"label";
+    SEL selector = [self buildSelectorForSortMethod:sortByMethod inArray:resultsList];
+    resultsList = [self applySortByMethod:resultsList sortmethod:sortByMethod ascending:YES selector:selector];
+    return [resultsList mutableCopy];
 }
 
 - (NSString*)getCurrentSortAscDesc:(NSDictionary*)methods withParameters:(NSDictionary*)parameters {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/733.

This PR reworks the presentation of search results and delivers two main improvements and a small one.
1. The search result list in Global Search does now show the section headers with the item type, e.g. movie or artists. This way it easy to recognize what type of item is shown in the list. 
2. All search results are now sorted by ascending label (for Global Search by "Type" within a section). This improves the user experience where Kodi does not provide sorted lists or the lists are sorted by something else, e.g. playcount for the "Top 100 Songs".
3. Support searching the "year" key in the data, which allows to search for release years of movies, TV Shows, music videos, albums, and songs.

Screenshots (in each pair: left = old, right = new):
<a href="https://ibb.co/sC39tBn"><img src="https://i.ibb.co/qC1YxZK/Bildschirmfoto-2024-09-29-um-17-26-20.png" alt="Bildschirmfoto-2024-09-29-um-17-26-20" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Show sections with item type for search results in Global Search
Improvement: Sort search results by ascending label
Improvement: Scroll back to top when search ended
Feature: Support searching year via the search field