### PR TITLE
Bugfix: Ensure correct cell height in heightForRowAtIndexPath

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2219,7 +2219,8 @@
 }
 
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
-    return cellHeight;
+    NSDictionary *item = [self getItemFromIndexPath:indexPath];
+    return globalSearchView ? [self getGlobalSearchThumbsize:item].y : cellHeight;
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView*)tableView {


### PR DESCRIPTION
Method heightForRowAtIndexPath shall use same logic as inside cellForRowAtIndexPath.

## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3211465#pid3211465).

The cell re-use in Global Search is more sensitive as it shows different types of content with different cell layouts. This PR fixes an issue where the cell's height was mismatching between `heightForRowAtIndexPath` and the content used in `cellForRowAtIndexPath`. Now, both use the same logic to retrieve the cell's height.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Ensure correct cell height in heightForRowAtIndexPath