### PR TITLE
Improvement: Messages shall not be shown on iPhone main menu

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -417,7 +417,7 @@
 
 - (void)showNotificationMessage:(NSNotification*)note {
     NSDictionary *params = note.userInfo;
-    if (!params) {
+    if (!params || self.slidingViewController.underLeftShowing) {
         return;
     }
     [self addMessagesToRootView];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR blocks showing warning/error messages (aka "toaster messages") while the main menu is shown on iPhone. The iPhone main menu is shown in case the central`self.slidingViewController` shows its `underLeftController`, which can be checked by `self.slidingViewController.underLeftShowing`. This avoids that the user cannot enter the server connection view from main menu while the server cannot be connected and throws error warnings.

Screenshots:
<a href="https://ibb.co/LgHVJCy"><img src="https://i.ibb.co/FYCR0B1/Bildschirmfoto-2024-10-04-um-13-28-52.png" alt="Bildschirmfoto-2024-10-04-um-13-28-52" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Messages shall not be shown on iPhone main menu