### PR TITLE
Bugfix: Fix memory leak when calculating average color

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -54,7 +54,7 @@
 
 + (UIColor*)averageColor:(UIImage*)image inverse:(BOOL)inverse autoColorCheck:(BOOL)autoColorCheck {
     CGImageRef inputImageRef = [image CGImage];
-    if (inputImageRef == nil) {
+    if (inputImageRef == NULL) {
         return UIColor.clearColor;
     }
     

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -53,8 +53,8 @@
 }
 
 + (UIColor*)averageColor:(UIImage*)image inverse:(BOOL)inverse autoColorCheck:(BOOL)autoColorCheck {
-    CGImageRef rawImageRef = [image CGImage];
-    if (rawImageRef == nil) {
+    CGImageRef inputImageRef = [image CGImage];
+    if (inputImageRef == nil) {
         return UIColor.clearColor;
     }
     
@@ -64,7 +64,7 @@
         return [Utilities getSystemGray2];
     }
     
-    CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(rawImageRef);
+    CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(inputImageRef);
     int infoMask = (bitmapInfo & kCGBitmapAlphaInfoMask);
     BOOL anyNonAlpha = (infoMask == kCGImageAlphaNone ||
                         infoMask == kCGImageAlphaNoneSkipFirst ||
@@ -74,12 +74,8 @@
 //    }
     
     // Enforce images are converted to default (ARGB or RGB, 32bpp, ByteOrderDefault) before analyzing them
-    if (anyNonAlpha && (bitmapInfo != kCGImageAlphaNoneSkipLast || CGImageGetBitsPerPixel(rawImageRef) != 32)) {
-        rawImageRef = [Utilities create32bppImage:rawImageRef format:kCGImageAlphaNoneSkipLast];
-    }
-    else if (!anyNonAlpha && (bitmapInfo != kCGImageAlphaPremultipliedFirst || CGImageGetBitsPerPixel(rawImageRef) != 32)) {
-        rawImageRef = [Utilities create32bppImage:rawImageRef format:kCGImageAlphaPremultipliedFirst];
-    }
+    uint32_t alphaFormat = anyNonAlpha ? kCGImageAlphaNoneSkipLast : kCGImageAlphaPremultipliedFirst;
+    CGImageRef rawImageRef = [Utilities create32bppImage:inputImageRef format:alphaFormat];
     if (rawImageRef == NULL) {
         return UIColor.clearColor;
     }
@@ -145,6 +141,7 @@
         blue = tmp;
     }
 	CFRelease(data);
+    CGImageRelease(rawImageRef);
     
 	return [UIColor colorWithRed:f * red green:f * green blue:f * blue alpha:1];
 }

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -40,16 +40,16 @@
     return context;
 }
 
-+ (CGImageRef)create32bppImage:(CGImageRef)imageRef format:(uint32_t)format {
-    CGContextRef ctx = [Utilities createBitmapContextFromImage:imageRef format:format];
++ (CGImageRef)create32bppImage:(CGImageRef)imageRefIn format:(uint32_t)format {
+    CGContextRef ctx = [Utilities createBitmapContextFromImage:imageRefIn format:format];
     if (ctx == NULL) {
         return NULL;
     }
-    CGRect rect = CGRectMake(0, 0, CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
-    CGContextDrawImage(ctx, rect, imageRef);
-    imageRef = CGBitmapContextCreateImage(ctx);
+    CGRect rect = CGRectMake(0, 0, CGImageGetWidth(imageRefIn), CGImageGetHeight(imageRefIn));
+    CGContextDrawImage(ctx, rect, imageRefIn);
+    CGImageRef imageRefOut = CGBitmapContextCreateImage(ctx);
     CGContextRelease(ctx);
-    return imageRef;
+    return imageRefOut;
 }
 
 + (UIColor*)averageColor:(UIImage*)image inverse:(BOOL)inverse autoColorCheck:(BOOL)autoColorCheck {

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -69,9 +69,9 @@
     BOOL anyNonAlpha = (infoMask == kCGImageAlphaNone ||
                         infoMask == kCGImageAlphaNoneSkipFirst ||
                         infoMask == kCGImageAlphaNoneSkipLast);
-//    if (!anyNonAlpha) {
-//        return UIColor.clearColor;
-//    }
+    //    if (!anyNonAlpha) {
+    //        return UIColor.clearColor;
+    //    }
     
     // Enforce images are converted to default (ARGB or RGB, 32bpp, ByteOrderDefault) before analyzing them
     uint32_t alphaFormat = anyNonAlpha ? kCGImageAlphaNoneSkipLast : kCGImageAlphaPremultipliedFirst;
@@ -80,26 +80,26 @@
         return UIColor.clearColor;
     }
     
-	CFDataRef data = CGDataProviderCopyData(CGImageGetDataProvider(rawImageRef));
+    CFDataRef data = CGDataProviderCopyData(CGImageGetDataProvider(rawImageRef));
     const UInt8 *rawPixelData = CFDataGetBytePtr(data);
     
     NSUInteger imageHeight = CGImageGetHeight(rawImageRef);
     NSUInteger imageWidth  = CGImageGetWidth(rawImageRef);
     NSUInteger bytesPerRow = CGImageGetBytesPerRow(rawImageRef);
-	NSUInteger stride = CGImageGetBitsPerPixel(rawImageRef) / 8;
+    NSUInteger stride = CGImageGetBitsPerPixel(rawImageRef) / 8;
     
     // DEBUG
     /*
-    bitmapInfo = CGImageGetBitmapInfo(rawImageRef);
-    infoMask = (bitmapInfo & kCGBitmapAlphaInfoMask);
-    BOOL isARGB = infoMask == kCGImageAlphaPremultipliedFirst;
-    BOOL isRGBA = infoMask == kCGImageAlphaPremultipliedLast;
-    BOOL isRGBa = infoMask == kCGImageAlphaLast;
-    BOOL isaRGB = infoMask == kCGImageAlphaFirst;
-    BOOL isxRGB = infoMask == kCGImageAlphaNoneSkipFirst;
-    BOOL isRGBx = infoMask == kCGImageAlphaNoneSkipLast;
-    BOOL isRGB = infoMask == kCGImageAlphaNone;
-    */
+     bitmapInfo = CGImageGetBitmapInfo(rawImageRef);
+     infoMask = (bitmapInfo & kCGBitmapAlphaInfoMask);
+     BOOL isARGB = infoMask == kCGImageAlphaPremultipliedFirst;
+     BOOL isRGBA = infoMask == kCGImageAlphaPremultipliedLast;
+     BOOL isRGBa = infoMask == kCGImageAlphaLast;
+     BOOL isaRGB = infoMask == kCGImageAlphaFirst;
+     BOOL isxRGB = infoMask == kCGImageAlphaNoneSkipFirst;
+     BOOL isRGBx = infoMask == kCGImageAlphaNoneSkipLast;
+     BOOL isRGB = infoMask == kCGImageAlphaNone;
+     */
     
     UInt64 red   = 0;
     UInt64 green = 0;
@@ -140,10 +140,10 @@
         red = blue;
         blue = tmp;
     }
-	CFRelease(data);
+    CFRelease(data);
     CGImageRelease(rawImageRef);
     
-	return [UIColor colorWithRed:f * red green:f * green blue:f * blue alpha:1];
+    return [UIColor colorWithRed:f * red green:f * green blue:f * blue alpha:1];
 }
 
 + (UIColor*)limitSaturation:(UIColor*)color_in satmax:(CGFloat)satmax {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes a memory leak in `averageColor:inverse:autoColorCheck:` where `rawImageRef` was created but never released. This caused a _massive_ memory leak in the use case of TV or Radio channel lists in grid view.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix memory leak when calculating average color
