### PR TITLE
Bugfix: Ensure proper background color for section header in case of download error

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3038,16 +3038,14 @@
         [thumbImageView sd_setImageWithURL:[NSURL URLWithString:stringURL]
                           placeholderImage:[UIImage imageNamed:displayThumb]
                               completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
-            if (image) {
-                [self setViewColor:albumDetailView
-                             image:image
-                         isTopMost:isTopMost
-                            label1:artist
-                            label2:album
-                            label3:trackCount
-                            label4:released
-                        infoButton:albumInfoButton];
-            }
+            [self setViewColor:albumDetailView
+                         image:thumbImageView.image
+                     isTopMost:isTopMost
+                        label1:artist
+                        label2:album
+                        label3:trackCount
+                        label4:released
+                    infoButton:albumInfoButton];
         }];
     }
     else {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The error handling inside `sd_setImageWithURL` ensures the caller receives the `placeholderImage` in case of an error, e.g. when the image cannot be downloaded from the given URL. Therefore always use caller.image as input for the background color calculation inside `setViewColor`. Otherwise, in case `image == nil`, a transparent background could be selected.

Screenshots (left = before, mid = after, right = no error):
<a href="https://ibb.co/TbVST6L"><img src="https://i.ibb.co/vQ7GBpY/Bildschirmfoto-2024-10-05-um-20-18-15.png" alt="Bildschirmfoto-2024-10-05-um-20-18-15" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Ensure proper background color for section header in case of download  error