### PR TITLE
Improvement: Avoid glitches of searchbar animation when leaving iPad fullscreen

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3927,49 +3927,49 @@
                               delay:0
                             options:UIViewAnimationOptionCurveEaseInOut
                          animations:^{
-                             collectionView.alpha = 0;
-                             dataList.alpha = 0;
-                         }
+            collectionView.alpha = 0;
+            dataList.alpha = 0;
+        }
                          completion:^(BOOL finished) {
-                             viewWidth = STACKSCROLL_WIDTH;
-                             button1.alpha = button2.alpha = button3.alpha = button4.alpha = button5.alpha = button6.alpha = button7.alpha = buttonsViewBgToolbar.alpha = topNavigationLabel.alpha = 1.0;
-                             if ([self collectionViewCanBeEnabled]) {
-                                 button6.hidden = NO;
-                             }
-                             sectionArray = [storeSectionArray copy];
-                             sections = [storeSections mutableCopy];
-                             [self choseParams];
-                             if (forceCollection) {
-                                 forceCollection = NO;
-                                 [Utilities SetView:activeLayoutView Alpha:0.0 XPos:viewWidth];
-                                 enableCollectionView = NO;
-                                 [self configureLibraryView];
-                                 [Utilities SetView:activeLayoutView Alpha:0.0 XPos:0];
-                             }
-                             [self setFlowLayoutParams];
-                             [collectionView.collectionViewLayout invalidateLayout];
-                             [collectionView reloadData];
-                             [collectionView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
-                             NSDictionary *params = @{@"duration": @(animDuration)};
-                             [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollFullScreenDisabled" object:self.view userInfo:params];
-                             [UIView animateWithDuration:0.2
-                                                   delay:0.0
-                                                 options:UIViewAnimationOptionCurveEaseInOut
-                                              animations:^{
-                                                  collectionView.alpha = 1;
-                                                  dataList.alpha = 1;
-                                                  [fullscreenButton setImage:[UIImage imageNamed:@"button_fullscreen"] forState:UIControlStateNormal];
-                                                  fullscreenButton.backgroundColor = UIColor.clearColor;
-                                              }
-                                              completion:^(BOOL finished) {
-                                                  [activityIndicatorView stopAnimating];
-                                              }
-                              ];
-                             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, animDuration * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-                                 moreItemsViewController.view.hidden = NO;
-                             });
-                         }
-         ];
+            viewWidth = STACKSCROLL_WIDTH;
+            button1.alpha = button2.alpha = button3.alpha = button4.alpha = button5.alpha = button6.alpha = button7.alpha = buttonsViewBgToolbar.alpha = topNavigationLabel.alpha = 1.0;
+            if ([self collectionViewCanBeEnabled]) {
+                button6.hidden = NO;
+            }
+            sectionArray = [storeSectionArray copy];
+            sections = [storeSections mutableCopy];
+            [self choseParams];
+            if (forceCollection) {
+                forceCollection = NO;
+                [Utilities SetView:activeLayoutView Alpha:0.0 XPos:viewWidth];
+                enableCollectionView = NO;
+                [self configureLibraryView];
+                [Utilities SetView:activeLayoutView Alpha:0.0 XPos:0];
+            }
+            [self setFlowLayoutParams];
+            [collectionView.collectionViewLayout invalidateLayout];
+            [collectionView reloadData];
+            [collectionView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
+            NSDictionary *params = @{@"duration": @(animDuration)};
+            [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollFullScreenDisabled" object:self.view userInfo:params];
+            [UIView animateWithDuration:0.2
+                                  delay:0.0
+                                options:UIViewAnimationOptionCurveEaseInOut
+                             animations:^{
+                collectionView.alpha = 1;
+                dataList.alpha = 1;
+                [fullscreenButton setImage:[UIImage imageNamed:@"button_fullscreen"] forState:UIControlStateNormal];
+                fullscreenButton.backgroundColor = UIColor.clearColor;
+            }
+                             completion:^(BOOL finished) {
+                [activityIndicatorView stopAnimating];
+            }
+            ];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, animDuration * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+                moreItemsViewController.view.hidden = NO;
+            });
+        }
+        ];
     }
     else {
         stackscrollFullscreen = YES;
@@ -3977,60 +3977,60 @@
                               delay:0
                             options:UIViewAnimationOptionCurveEaseInOut
                          animations:^{
-                             collectionView.alpha = 0;
-                             dataList.alpha = 0;
-                             button1.alpha = button2.alpha = button3.alpha = button4.alpha = button5.alpha = button6.alpha = button7.alpha = buttonsViewBgToolbar.alpha = topNavigationLabel.alpha = 0.0;
-                         }
+            collectionView.alpha = 0;
+            dataList.alpha = 0;
+            button1.alpha = button2.alpha = button3.alpha = button4.alpha = button5.alpha = button6.alpha = button7.alpha = buttonsViewBgToolbar.alpha = topNavigationLabel.alpha = 0.0;
+        }
                          completion:^(BOOL finished) {
-                             button6.hidden = YES;
-                             moreItemsViewController.view.hidden = YES;
-                             if (!enableCollectionView) {
-                                 forceCollection = YES;
-                                 [Utilities SetView:activeLayoutView Alpha:0.0 XPos:viewWidth];
-                                 enableCollectionView = YES;
-                                 [self configureLibraryView];
-                                 [Utilities SetView:activeLayoutView Alpha:0.0 XPos:0];
-                             }
-                             else {
-                                 forceCollection = NO;
-                             }
-                             storeSectionArray = [sectionArray copy];
-                             storeSections = [sections mutableCopy];
-                             [self choseParams];
-                             NSMutableDictionary *sectionsTemp = [NSMutableDictionary new];
-                             [sectionsTemp setValue:[NSMutableArray new] forKey:@""];
-                             for (id key in self.sectionArray) {
-                                 NSDictionary *tmp = self.sections[key];
-                                 for (NSDictionary *item in tmp) {
-                                     [sectionsTemp[@""] addObject:item];
-                                 }
-                             }
-                             self.sectionArray = @[@""];
-                             self.sections = [sectionsTemp mutableCopy];
-                             [self setFlowLayoutParams];
-                             [collectionView.collectionViewLayout invalidateLayout];
-                             [collectionView reloadData];
-                             [collectionView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
-                             [dataList setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
-                             NSDictionary *params = @{
-                                 @"hideToolbar": @NO,
-                                 @"duration": @(animDuration),
-                             };
-                             [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollFullScreenEnabled" object:self.view userInfo:params];
-                             [UIView animateWithDuration:0.2
-                                                   delay:0.0
-                                                 options:UIViewAnimationOptionCurveEaseInOut
-                                              animations:^{
-                                                  collectionView.alpha = 1;
-                                                  [fullscreenButton setImage:[UIImage imageNamed:@"button_exit_fullscreen"] forState:UIControlStateNormal];
-                                                  fullscreenButton.backgroundColor = [Utilities getGrayColor:0 alpha:0.5];
-                                              }
-                                              completion:^(BOOL finished) {
-                                                  [activityIndicatorView stopAnimating];
-                                              }
-                              ];
-                         }
-         ];
+            button6.hidden = YES;
+            moreItemsViewController.view.hidden = YES;
+            if (!enableCollectionView) {
+                forceCollection = YES;
+                [Utilities SetView:activeLayoutView Alpha:0.0 XPos:viewWidth];
+                enableCollectionView = YES;
+                [self configureLibraryView];
+                [Utilities SetView:activeLayoutView Alpha:0.0 XPos:0];
+            }
+            else {
+                forceCollection = NO;
+            }
+            storeSectionArray = [sectionArray copy];
+            storeSections = [sections mutableCopy];
+            [self choseParams];
+            NSMutableDictionary *sectionsTemp = [NSMutableDictionary new];
+            [sectionsTemp setValue:[NSMutableArray new] forKey:@""];
+            for (id key in self.sectionArray) {
+                NSDictionary *tmp = self.sections[key];
+                for (NSDictionary *item in tmp) {
+                    [sectionsTemp[@""] addObject:item];
+                }
+            }
+            self.sectionArray = @[@""];
+            self.sections = [sectionsTemp mutableCopy];
+            [self setFlowLayoutParams];
+            [collectionView.collectionViewLayout invalidateLayout];
+            [collectionView reloadData];
+            [collectionView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
+            [dataList setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
+            NSDictionary *params = @{
+                @"hideToolbar": @NO,
+                @"duration": @(animDuration),
+            };
+            [[NSNotificationCenter defaultCenter] postNotificationName: @"StackScrollFullScreenEnabled" object:self.view userInfo:params];
+            [UIView animateWithDuration:0.2
+                                  delay:0.0
+                                options:UIViewAnimationOptionCurveEaseInOut
+                             animations:^{
+                collectionView.alpha = 1;
+                [fullscreenButton setImage:[UIImage imageNamed:@"button_exit_fullscreen"] forState:UIControlStateNormal];
+                fullscreenButton.backgroundColor = [Utilities getGrayColor:0 alpha:0.5];
+            }
+                             completion:^(BOOL finished) {
+                [activityIndicatorView stopAnimating];
+            }
+            ];
+        }
+        ];
     }
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4011,6 +4011,7 @@
                              [collectionView.collectionViewLayout invalidateLayout];
                              [collectionView reloadData];
                              [collectionView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
+                             [dataList setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
                              NSDictionary *params = @{
                                  @"hideToolbar": @NO,
                                  @"duration": @(animDuration),
@@ -6258,6 +6259,7 @@
                              activeLayoutView.frame = frame;
                          }
                          completion:^(BOOL finished) {
+                             [activeLayoutView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
                              recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
                              enableCollectionView = [self collectionViewIsEnabled];
                              [self configureLibraryView];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -462,7 +462,7 @@
     }
     else {
         if (stackscrollFullscreen) {
-            [self toggleFullscreen:nil];
+            [self toggleFullscreen];
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.6f * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
                 DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:newMenuItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
                 [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:NO];
@@ -1490,7 +1490,7 @@
                 }
                 else {
                     if (stackscrollFullscreen) {
-                        [self toggleFullscreen:nil];
+                        [self toggleFullscreen];
                         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.6f * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
                             DetailViewController *iPadDetailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" withItem:newMenuItem withFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height) bundle:nil];
                             [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadDetailViewController invokeByController:self isStackStartView:NO];
@@ -1567,7 +1567,7 @@
         }
         else {
             if (stackscrollFullscreen) {
-                [self toggleFullscreen:nil];
+                [self toggleFullscreen];
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.6f * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
                     SettingsValuesViewController *iPadSettingsViewController = [[SettingsValuesViewController alloc] initWithFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.bounds.size.height) withItem:item];
                     [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:iPadSettingsViewController invokeByController:self isStackStartView:NO];
@@ -3911,11 +3911,11 @@
 
 - (void)leaveFullscreen {
     if (stackscrollFullscreen) {
-        [self toggleFullscreen:nil];
+        [self toggleFullscreen];
     }
 }
 
-- (void)toggleFullscreen:(id)sender {
+- (void)toggleFullscreen {
     if ([self doesShowSearchResults] || self.searchController.isActive) {
         [self.searchController setActive:NO];
     }
@@ -6180,7 +6180,7 @@
                 [fullscreenButton setImage:[UIImage imageNamed:@"button_fullscreen"] forState:UIControlStateNormal];
                 fullscreenButton.layer.cornerRadius = 2;
                 fullscreenButton.tintColor = UIColor.whiteColor;
-                [fullscreenButton addTarget:self action:@selector(toggleFullscreen:) forControlEvents:UIControlEventTouchUpInside];
+                [fullscreenButton addTarget:self action:@selector(toggleFullscreen) forControlEvents:UIControlEventTouchUpInside];
                 fullscreenButton.frame = CGRectMake(titleView.frame.size.width - fullscreenButton.frame.size.width - buttonPadding, titleView.frame.size.height / 2 - fullscreenButton.frame.size.height / 2, fullscreenButton.frame.size.width, fullscreenButton.frame.size.height);
                 [titleView addSubview:fullscreenButton];
             }
@@ -6205,7 +6205,7 @@
 - (void)twoFingerPinch:(UIPinchGestureRecognizer*)recognizer {
     if ([recognizer state] == UIGestureRecognizerStateEnded) {
         if ((recognizer.scale > 1 && !stackscrollFullscreen) || (recognizer.scale <= 1 && stackscrollFullscreen)) {
-            [self toggleFullscreen:nil];
+            [self toggleFullscreen];
         }
     }
     return;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1354,7 +1354,7 @@
     
     enableCollectionView = newEnableCollectionView;
     recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
-    [activeLayoutView setContentOffset:activeLayoutView.contentOffset animated:NO];
+    activeLayoutView.contentOffset = activeLayoutView.contentOffset;
     [self checkFullscreenButton:NO];
     [self addExtraProperties:mutableProperties newParams:mutableParameters params:parameters];
     if ([parameters[@"blackTableSeparator"] boolValue] && ![Utilities getPreferTvPosterMode]) {
@@ -5839,7 +5839,7 @@
             [collectionView.collectionViewLayout invalidateLayout];
             [collectionView reloadData];
         }
-        [activeLayoutView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
+        activeLayoutView.contentOffset = CGPointMake(0, iOSYDelta);
     }
                                  completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {}];
 }
@@ -6259,12 +6259,12 @@
                              activeLayoutView.frame = frame;
                          }
                          completion:^(BOOL finished) {
-                             [activeLayoutView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
+                             activeLayoutView.contentOffset = CGPointMake(0, iOSYDelta);
                              recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
                              enableCollectionView = [self collectionViewIsEnabled];
                              [self configureLibraryView];
                              [Utilities AnimView:activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:0];
-                             [activeLayoutView setContentOffset:CGPointMake(0, iOSYDelta) animated:NO];
+                             activeLayoutView.contentOffset = CGPointMake(0, iOSYDelta);
                          }];
     }
 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1218,6 +1218,7 @@
         collectionView.delegate = self;
         collectionView.dataSource = self;
         dataList.scrollsToTop = NO;
+        dataList.tableHeaderView.hidden = YES;
         collectionView.scrollsToTop = YES;
         activeLayoutView = (UITableView*)collectionView;
         
@@ -1229,6 +1230,7 @@
         collectionView.delegate = nil;
         collectionView.dataSource = nil;
         dataList.scrollsToTop = YES;
+        dataList.tableHeaderView.hidden = NO;
         collectionView.scrollsToTop = NO;
         activeLayoutView = dataList;
         


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR improves the animation behaviour of searchbar after leaving iPad fullscreen, and alongside makes some coding style changes.
1. Resolves an issue where list view's searchbar became shortly visible when animating from iPad fullscreen back to grid view by hiding the searchbar (`dataList.tableHeaderView`) once the list view is moved to invisible area. 
2. Avoids a distracting animation of the list view's searchbar when animating back from iPad fullscreen to list view by setting the inset to list view's top.
3. Coding style changes (`toggleFullscreen` re-indentation and removal of unneeded parameter)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Avoid glitches of searchbar animation when leaving iPad fullscreen