### PR TITLE
Improvement: Faster connect to Kodi server

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -6150,6 +6150,23 @@
         @[menu_Music,   [self getGlobalSearchTab:menu_Music   label:LOCALIZED_STR(@"All songs")]], // Songs
     ];
     
+    // Load last Kodi server. Will be taken up by tcpJSONRPC heartbeat when controllers are initialized
+    if ([userDefaults objectForKey:@"lastServer"] != nil) {
+        NSInteger lastServer = [userDefaults integerForKey:@"lastServer"];
+        if (lastServer > -1 && lastServer < AppDelegate.instance.arrayServerList.count) {
+            NSIndexPath *lastServerIndexPath = [NSIndexPath indexPathForRow:lastServer inSection:0];
+            NSDictionary *item = AppDelegate.instance.arrayServerList[lastServerIndexPath.row];
+            AppDelegate.instance.obj.serverDescription = item[@"serverDescription"];
+            AppDelegate.instance.obj.serverUser = item[@"serverUser"];
+            AppDelegate.instance.obj.serverPass = item[@"serverPass"];
+            AppDelegate.instance.obj.serverRawIP = item[@"serverIP"];
+            AppDelegate.instance.obj.serverIP = [Utilities getUrlStyleAddress:item[@"serverIP"]];
+            AppDelegate.instance.obj.serverPort = item[@"serverPort"];
+            AppDelegate.instance.obj.serverHWAddr = item[@"serverMacAddress"];
+            AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue];
+        }
+    }
+    
     // Initialize controllers
     self.serverName = LOCALIZED_STR(@"No connection");
     if (IS_IPHONE) {

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -40,6 +40,22 @@
     [navController hideNavBarBottomLine:YES];
     hostManagementViewController.mainMenu = self.mainMenu;
     self.topViewController = navController;
+    
+    // Hide the inital HostManagementVC in case the "start view" is not main menu to avoid disturbing
+    // sliding out (this view) and in (the targeted view).
+    self.topViewController.view.hidden = [Utilities getIndexPathForDefaultController:self.mainMenu];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleTcpJSONRPCShowSetup:)
+                                                 name:@"TcpJSONRPCShowSetup"
+                                               object:nil];
+}
+
+- (void)handleTcpJSONRPCShowSetup:(NSNotification*)sender {
+    // If showSetup is requested, unhide this view in any case. This ensures this view is brought up
+    // in case of problems connecting to a server in combination with entering a different "start view".
+    BOOL showValue = [[sender.userInfo objectForKey:@"showSetup"] boolValue];
+    self.topViewController.view.hidden = !showValue;
 }
 
 - (void)revealMenu:(id)sender {

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -59,6 +59,8 @@
     if (status) {
         [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
         notificationName = @"XBMCServerConnectionSuccess";
+        NSString *message = [NSString stringWithFormat:LOCALIZED_STR(@"Connected to %@"), AppDelegate.instance.obj.serverDescription];
+        [Utilities showMessage:message color:[Utilities getSystemGreen:0.95]];
     }
     else {
         [self.tcpJSONRPCconnection stopNetworkCommunication];

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -102,6 +102,7 @@ typedef enum {
 + (void)addShadowsToView:(UIView*)view viewFrame:(CGRect)frame;
 + (void)setStyleOfMenuItemCell:(UITableViewCell*)cell active:(BOOL)active;
 + (void)setStyleOfMenuItems:(UITableView*)tableView active:(BOOL)active;
++ (NSIndexPath*)getIndexPathForDefaultController:(NSArray*)menuItems;
 + (void)enableDefaultController:(id<UITableViewDelegate>)viewController tableView:(UITableView*)tableView menuItems:(NSArray*)menuItems;
 + (id)unarchivePath:(NSString*)path file:(NSString*)filename;
 + (void)archivePath:(NSString*)path file:(NSString*)filename data:(id)data;

--- a/XBMC Remote/ViewControllerIPad.h
+++ b/XBMC Remote/ViewControllerIPad.h
@@ -35,7 +35,6 @@
     UIButton *powerButton;
     UIImageView *connectionStatus;
     VolumeSliderView *volumeSliderView;
-    BOOL firstRun;
     BOOL didTouchLeftMenu;
     NSTimer *extraTimer;
     HostManagementViewController *_hostPickerViewController;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -91,18 +91,6 @@
 
 #pragma mark - ServerManagement
 
-- (void)selectServerAtIndexPath:(NSIndexPath*)indexPath {
-    storeServerSelection = indexPath;
-    NSDictionary *item = AppDelegate.instance.arrayServerList[indexPath.row];
-    AppDelegate.instance.obj.serverDescription = item[@"serverDescription"];
-    AppDelegate.instance.obj.serverUser = item[@"serverUser"];
-    AppDelegate.instance.obj.serverPass = item[@"serverPass"];
-    AppDelegate.instance.obj.serverRawIP = item[@"serverIP"];
-    AppDelegate.instance.obj.serverIP = [Utilities getUrlStyleAddress:item[@"serverIP"]];
-    AppDelegate.instance.obj.serverPort = item[@"serverPort"];
-    AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue];
-}
-
 - (void)connectionStatus:(NSNotification*)note {
     NSDictionary *theData = note.userInfo;
     NSString *icon_connection = theData[@"icon_connection"];

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -111,6 +111,8 @@
     if (status) {
         [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
         notificationName = @"XBMCServerConnectionSuccess";
+        NSString *message = [NSString stringWithFormat:LOCALIZED_STR(@"Connected to %@"), AppDelegate.instance.obj.serverDescription];
+        [Utilities showMessage:message color:[Utilities getSystemGreen:0.95]];
         [volumeSliderView startTimer];
     }
     else {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -161,7 +161,6 @@
 }
 
 - (void)showSetup:(BOOL)show {
-    firstRun = NO;
     if ([self.hostPickerViewController isViewLoaded]) {
         if (!show) {
             [self.hostPickerViewController dismissViewControllerAnimated:NO completion:nil];
@@ -372,10 +371,8 @@
     int deltaY = [Utilities getTopPadding];
     [self setNeedsStatusBarAppearanceUpdate];
     self.view.tintColor = APP_TINT_COLOR;
-    self.tcpJSONRPCconnection = [tcpJSONRPC new];
     XBMCVirtualKeyboard *virtualKeyboard = [[XBMCVirtualKeyboard alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
     [self.view addSubview:virtualKeyboard];
-    firstRun = YES;
     AppDelegate.instance.obj = [GlobalData getInstance];
     
     // Create the left menu
@@ -615,6 +612,13 @@
                                                object: nil];
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    // Only start tcpJSONRPC after view did appear. This ensures the HostManagement popover can be shown in case needed.
+    // This required, if the server csnnot connect or no server has been selected.
+    self.tcpJSONRPCconnection = [tcpJSONRPC new];
+}
+
 - (void)handleLibraryNotification:(NSNotification*)note {
     [Utilities showMessage:note.name color:[Utilities getSystemGreen:0.95]];
 }
@@ -682,9 +686,7 @@
 
 - (void)handleTcpJSONRPCShowSetup:(NSNotification*)sender {
     BOOL showValue = [[sender.userInfo objectForKey:@"showSetup"] boolValue];
-    if ((showValue && firstRun) || !showValue) {
-        [self showSetup:showValue];
-    }
+    [self showSetup:showValue];
 }
 
 - (void)handleTcpJSONRPCChangeServerStatus:(NSNotification*)sender {

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -123,6 +123,7 @@
 "Cannot do that" = "Cannot do that";
 "Send Wake-On-LAN" = "Send Wake-On-LAN";
 "No saved hosts found" = "No saved hosts found";
+"Connected to %@" = "Connected to %@";
 
 "Are you sure you want to clear the playlist?" = "Are you sure you want to clear the playlist?";
 "Are you sure you want to clear the music playlist?" = "Are you sure you want to clear the music playlist?";

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -24,7 +24,7 @@ NSInputStream	*inStream;
 - (id)init {
     if (self = [super init]) {
         infoTitle = @"";
-        heartbeatTimer = [NSTimer scheduledTimerWithTimeInterval:SERVER_CHECK_TIMER target:self selector:@selector(checkServer) userInfo:nil repeats:YES];
+        [self startServerHeartbeat];
         [[NSNotificationCenter defaultCenter] addObserver: self
                                                  selector: @selector(handleSystemOnSleep:)
                                                      name: @"System.OnSleep"
@@ -37,6 +37,11 @@ NSInputStream	*inStream;
         [[NSNotificationCenter defaultCenter] addObserver: self
                                                  selector: @selector(handleDidEnterBackground:)
                                                      name: @"UIApplicationDidEnterBackgroundNotification"
+                                                   object: nil];
+        
+        [[NSNotificationCenter defaultCenter] addObserver: self
+                                                 selector: @selector(startServerHeartbeat)
+                                                     name: @"XBMCServerHasChanged"
                                                    object: nil];
     }
     return self;
@@ -51,6 +56,12 @@ NSInputStream	*inStream;
 }
 
 - (void)handleEnterForeground:(NSNotification*)sender {
+    [self startServerHeartbeat];
+}
+
+- (void)startServerHeartbeat {
+    [heartbeatTimer invalidate];
+    [self checkServer];
     heartbeatTimer = [NSTimer scheduledTimerWithTimeInterval:SERVER_CHECK_TIMER target:self selector:@selector(checkServer) userInfo:nil repeats:YES];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR improves the time from App start or from manual server selection until the server is connected. Basically, this is done by two core changes:
1. Loading the last server in `AppDelegates's` `didFinishLaunchingWithOptions` before initializing the main controllers for iPad and iPhone.
2. Calling the heartbeat check method `checkServer` immediately before starting the repeating timer which calls `checkServer`.
3. Trigger restart of timer by notification once a new server was selected.

To be able to show the `HostManagement` popover on iPad (e.g. no last server is defined or last server cannot be connected) the `tcpJSONRPC` is started in `viewDidAppear`.

As we are now connecting faster, the heartbeat timer can use a lower frequency. The timer was increased 5 seconds, and the connection timeout error kicks in after 4 seconds. This gives more time to the server to deal with potential high load situations, before the App is throwing error messages and signals a disconnect.

The videos show start to connect, followed by selecting a new server.
- [iPhone 14 Pro](https://www.dropbox.com/scl/fi/8v17k8ruipcqk5adnsdfx/iPhone14Pro_fast_connect_2.mp4?rlkey=zazh0tpa2i2pd3wwt2mtkvce2&st=976frarl&dl=0)
- [iPad 8G](https://www.dropbox.com/scl/fi/1u05g0hf4zuo53ns8kfvu/iPad8G_fast_connect_2.mov?rlkey=hjxzv4nwr9gk0ifbaijgeaqfu&st=vw1k7s42&dl=0)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Faster connect to Kodi server
Improvement: More robust against connection loss in load situations on Kodi server