### PR TITLE
Improvement: Use max resolution and correct aspect ratio for iPhone's playlist toggle button

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -123,7 +123,10 @@
 # pragma mark - toolbar management
 
 - (UIImage*)resizeToolbarThumb:(UIImage*)img {
-    return [self resizeImage:img width:34 height:34 padding:0];
+    return [self resizeImage:img 
+                       width:CGRectGetWidth(playlistButton.frame) * UIScreen.mainScreen.scale
+                      height:CGRectGetHeight(playlistButton.frame) * UIScreen.mainScreen.scale
+                     padding:0];
 }
 
 #pragma mark - utility

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -297,23 +297,13 @@
 }
 
 - (UIImage*)resizeImage:(UIImage*)image width:(int)destWidth height:(int)destHeight {
-	int w = image.size.width;
-    int h = image.size.height;
-    if (!w || !h) {
-        return image;
-    }
-    CGImageRef imageRef = [image CGImage];
-	
-	int width, height;
+    CGImageRef imageRef = image.CGImage;
+    CGFloat horizontalRatio = destWidth / image.size.width;
+    CGFloat verticalRatio = destHeight / image.size.height;
+    CGFloat ratio = MIN(horizontalRatio, verticalRatio); // UIViewContentModeScaleAspectFit
+    CGFloat width = floor(image.size.width * ratio);
+    CGFloat height = floor(image.size.height * ratio);
     
-	if (w > h) {
-		width = destWidth;
-		height = h * destWidth / w;
-	}
-    else {
-		height = destHeight;
-		width = w * destHeight / h;
-	}
 	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     
 	CGContextRef bitmap;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -314,7 +314,7 @@
                                                 colorSpace,
                                                 kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast);
     
-    CGContextDrawImage(bitmap, CGRectMake(destWidth / 2 - width / 2, destHeight / 2 - height / 2, width, height), imageRef);
+    CGContextDrawImage(bitmap, CGRectMake(floor((destWidth - width) / 2), floor((destHeight - height) / 2), width, height), imageRef);
     CGImageRef ref = CGBitmapContextCreateImage(bitmap);
     UIImage *result = [UIImage imageWithCGImage:ref scale:image.scale orientation:image.imageOrientation];
     

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -304,20 +304,20 @@
     CGFloat width = floor(image.size.width * ratio);
     CGFloat height = floor(image.size.height * ratio);
     
-	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     
-	CGContextRef bitmap;
-	bitmap = CGBitmapContextCreate(NULL, destWidth, destHeight, 8, 4 * destWidth, colorSpace, kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast);
-	
-	CGContextDrawImage(bitmap, CGRectMake(destWidth / 2 - width / 2, destHeight / 2 - height / 2, width, height), imageRef);
-	CGImageRef ref = CGBitmapContextCreateImage(bitmap);
+    CGContextRef bitmap;
+    bitmap = CGBitmapContextCreate(NULL, destWidth, destHeight, 8, 4 * destWidth, colorSpace, kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast);
+    
+    CGContextDrawImage(bitmap, CGRectMake(destWidth / 2 - width / 2, destHeight / 2 - height / 2, width, height), imageRef);
+    CGImageRef ref = CGBitmapContextCreateImage(bitmap);
     UIImage *result = [UIImage imageWithCGImage:ref scale:image.scale orientation:image.imageOrientation];
-	
-	CGContextRelease(bitmap);
+    
+    CGContextRelease(bitmap);
     CGColorSpaceRelease(colorSpace);
-	CGImageRelease(ref);
-	
-	return result;
+    CGImageRelease(ref);
+    
+    return result;
 }
 
 - (UIImage*)imageWithBorderFromImage:(UIImage*)source {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -125,8 +125,7 @@
 - (UIImage*)resizeToolbarThumb:(UIImage*)img {
     return [self resizeImage:img 
                        width:CGRectGetWidth(playlistButton.frame) * UIScreen.mainScreen.scale
-                      height:CGRectGetHeight(playlistButton.frame) * UIScreen.mainScreen.scale
-                     padding:0];
+                      height:CGRectGetHeight(playlistButton.frame) * UIScreen.mainScreen.scale];
 }
 
 #pragma mark - utility
@@ -297,24 +296,23 @@
     view.hidden = hidden;
 }
 
-- (UIImage*)resizeImage:(UIImage*)image width:(int)destWidth height:(int)destHeight padding:(int)destPadding {
+- (UIImage*)resizeImage:(UIImage*)image width:(int)destWidth height:(int)destHeight {
 	int w = image.size.width;
     int h = image.size.height;
     if (!w || !h) {
         return image;
     }
-    destPadding = 0;
     CGImageRef imageRef = [image CGImage];
 	
 	int width, height;
     
 	if (w > h) {
-		width = destWidth - destPadding;
-		height = h * (destWidth - destPadding) / w;
+		width = destWidth;
+		height = h * destWidth / w;
 	}
     else {
-		height = destHeight - destPadding;
-		width = w * (destHeight - destPadding) / h;
+		height = destHeight;
+		width = w * destHeight / h;
 	}
 	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -309,26 +309,9 @@
 	CGContextRef bitmap;
 	bitmap = CGBitmapContextCreate(NULL, destWidth, destHeight, 8, 4 * destWidth, colorSpace, kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast);
 	
-	if (image.imageOrientation == UIImageOrientationLeft) {
-		CGContextRotateCTM (bitmap, M_PI / 2);
-		CGContextTranslateCTM (bitmap, 0, -height);
-	}
-    else if (image.imageOrientation == UIImageOrientationRight) {
-		CGContextRotateCTM (bitmap, -M_PI / 2);
-		CGContextTranslateCTM (bitmap, -width, 0);
-	}
-    else if (image.imageOrientation == UIImageOrientationUp) {
-		
-	}
-    else if (image.imageOrientation == UIImageOrientationDown) {
-		CGContextTranslateCTM (bitmap, width, height);
-		CGContextRotateCTM (bitmap, -M_PI);
-		
-	}
-	
 	CGContextDrawImage(bitmap, CGRectMake(destWidth / 2 - width / 2, destHeight / 2 - height / 2, width, height), imageRef);
 	CGImageRef ref = CGBitmapContextCreateImage(bitmap);
-	UIImage *result = [UIImage imageWithCGImage:ref];
+    UIImage *result = [UIImage imageWithCGImage:ref scale:image.scale orientation:image.imageOrientation];
 	
 	CGContextRelease(bitmap);
     CGColorSpaceRelease(colorSpace);

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -306,8 +306,13 @@
     
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     
-    CGContextRef bitmap;
-    bitmap = CGBitmapContextCreate(NULL, destWidth, destHeight, 8, 4 * destWidth, colorSpace, kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast);
+    CGContextRef bitmap = CGBitmapContextCreate(NULL,
+                                                destWidth,
+                                                destHeight,
+                                                8,
+                                                4 * destWidth,
+                                                colorSpace,
+                                                kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast);
     
     CGContextDrawImage(bitmap, CGRectMake(destWidth / 2 - width / 2, destHeight / 2 - height / 2, width, height), imageRef);
     CGImageRef ref = CGBitmapContextCreateImage(bitmap);


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The cover thumb used for iPhone's playlist toggle button was not using the maximum (native) pixel resolution of the display and a wrong aspect ratio.

Screenshots (white background for debugging):
<a href="https://ibb.co/QnCHwZG"><img src="https://i.ibb.co/K7LsvYH/Bildschirmfoto-2024-10-12-um-21-49-01.png" alt="Bildschirmfoto-2024-10-12-um-21-49-01" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Use max resolution and correct aspect ratio for iPhone's playlist toggle button