### PR TITLE
Bugfix: Make menu button in server list work again on iPhone

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -597,8 +597,6 @@
         xbmcLogo.showsTouchWhenHighlighted = NO;
         [xbmcLogo addTarget:self action:@selector(infoView) forControlEvents:UIControlEventTouchUpInside];
         self.navigationItem.titleView = xbmcLogo;
-        UIImage *menuImg = [UIImage imageNamed:@"button_menu"];
-        self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:menuImg style:UIBarButtonItemStylePlain target:nil action:@selector(revealMenu:)];
         UIImage *powerImg = [UIImage imageNamed:@"icon_power"];
         self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithImage:powerImg style:UIBarButtonItemStylePlain target:self action:@selector(powerControl)];
     }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2607,10 +2607,6 @@
         if (self.slidingViewController.panGesture != nil) {
             [self.navigationController.view addGestureRecognizer:self.slidingViewController.panGesture];
         }
-        if ([self.navigationController.viewControllers indexOfObject:self] == 0) {
-            UIImage *menuImg = [UIImage imageNamed:@"button_menu"];
-            self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:menuImg style:UIBarButtonItemStylePlain target:nil action:@selector(revealMenu:)];
-        }
         UIImage *remoteImg = [UIImage imageNamed:@"icon_menu_remote"];
         UIImage *powerImg = [UIImage imageNamed:@"icon_power"];
         self.navigationItem.rightBarButtonItems = @[


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes regression of https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1150.

Do not overwrite `leftBarButtonItem` in `NowPlaying` and `HostManagementViewController`. The `leftBarButtonItem` is already defined in `MasterViewController`. This ensures the correct method `handleMenuButton` is called on pressing the menu button.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Make menu button in server list work again on iPhone