### PR TITLE
Fixes for connection issues after wakeup

### DIFF
--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -55,7 +55,9 @@
     // If showSetup is requested, unhide this view in any case. This ensures this view is brought up
     // in case of problems connecting to a server in combination with entering a different "start view".
     BOOL showValue = [[sender.userInfo objectForKey:@"showSetup"] boolValue];
-    self.topViewController.view.hidden = !showValue;
+    if (showValue) {
+        self.topViewController.view.hidden = NO;
+    }
 }
 
 - (void)handleMenuButton {

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -43,7 +43,7 @@
     
     // Hide the inital HostManagementVC in case the "start view" is not main menu to avoid disturbing
     // sliding out (this view) and in (the targeted view).
-    self.topViewController.view.hidden = [Utilities getIndexPathForDefaultController:self.mainMenu];
+    self.topViewController.view.hidden = [Utilities getIndexPathForDefaultController:self.mainMenu] != nil;
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleTcpJSONRPCShowSetup:)

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -56,7 +56,9 @@ NSInputStream	*inStream;
 }
 
 - (void)handleEnterForeground:(NSNotification*)sender {
-    [self startServerHeartbeat];
+    // Start the JSON heartbeat only with a little delay to ensure iOS provides all services.
+    // See https://stackoverflow.com/questions/63621039/
+    [self performSelector:@selector(startServerHeartbeat) withObject:nil afterDelay:0.1];
 }
 
 - (void)startServerHeartbeat {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes two issues reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3212625#pid3212625).

### Connection error after wakeup
iOS does obviously cause errors when issuing JSON commands right after `applicationWillEnterForeground`, see also https://stackoverflow.com/questions/63621039/. Solution is to add a minor delay of 0.1 seconds before starting the heartbeat timer which will issue the JSON commands to re-connect to the Kodi server.

### Missing top view controller on iPhone after wakeup
Root cause was a logic error, which caused `topViewController.view.hidden` to _follow_ the connection state. The desired behaviour is to unhide the view only on an error, and to leave it unchanged else. This error caused the `topViewController`, which is the active controller on an iPhone (e.g. Music or Remote), to be hidden on each successful connection attempt. This  could result in users being stuck in views like the custom buttons view.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: iPhone had no top view on successful reconnect after wakeup
Bugfix: Avoid connection error after device wakeup