### PR TITLE
Improvement: Allow font scaling for MoreItemsVC

### DIFF
--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -71,6 +71,8 @@
     cellLabel.font = [UIFont systemFontOfSize:18];
     cellLabel.textColor = [Utilities get1stLabelColor];
     cellLabel.highlightedTextColor = [Utilities get1stLabelColor];
+    cellLabel.adjustsFontSizeToFitWidth = YES;
+    cellLabel.minimumScaleFactor = FONT_SCALING_MIN;
     NSDictionary *item = mainMenuItems[indexPath.row];
     cellLabel.text = item[@"label"];
     [cell.contentView addSubview:cellLabel];


### PR DESCRIPTION
This improves user experience on small screen devices like iPod Touch.

## Description
<!--- Detailed info for reviewers and developers -->
In `MoreItemsViewController`, which is loaded when pressing "..." in menus, there was no font scaling used at all. This PR enables this to improve the user experience on small screen devices.

Screenshots (taken from iPod Touch simulator):
<a href="https://ibb.co/PGGc5F3"><img src="https://i.ibb.co/233vjWm/Bildschirmfoto-2024-10-19-um-17-05-48.png" alt="Bildschirmfoto-2024-10-19-um-17-05-48" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Allow font scaling for MoreItemsVC