### PR TITLE
Maintenance: Use long type for database IDs

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -157,11 +157,11 @@
 #pragma mark - live tv epg management
 
 - (void)getChannelEpgInfo:(NSDictionary*)parameters {
-    NSNumber *channelid = parameters[@"channelid"];
+    NSNumber *channelid = [Utilities getNumberFromItem:parameters[@"channelid"]];
     NSIndexPath *indexPath = parameters[@"indexPath"];
     UITableView *tableView = parameters[@"tableView"];
     NSMutableDictionary *item = parameters[@"item"];
-    if ([channelid isKindOfClass:[NSNumber class]] && [channelid longValue] > 0) {
+    if ([channelid longValue] > 0) {
         NSMutableArray *retrievedEPG = [self loadEPGFromMemory:channelid];
         NSMutableDictionary *channelEPG = [self parseEpgData:retrievedEPG];
         NSDictionary *epgparams = [NSDictionary dictionaryWithObjectsAndKeys:
@@ -574,7 +574,7 @@
                              rating, @"rating",
                              mainFields[@"playlistid"], @"playlistid",
                              mainFields[@"row8"], @"family",
-                             @([[NSString stringWithFormat:@"%@", item[mainFields[@"row9"]]] intValue]), mainFields[@"row9"],
+                             [Utilities getNumberFromItem:item[mainFields[@"row9"]]], mainFields[@"row9"],
                              item[mainFields[@"row10"]], mainFields[@"row10"],
                              row11, row11key,
                              item[mainFields[@"row12"]], mainFields[@"row12"],
@@ -2624,7 +2624,7 @@
             UIImageView *isRecordingImageView = (UIImageView*)[cell viewWithTag:EPG_VIEW_CELL_RECORDING_ICON];
             isRecordingImageView.hidden = ![item[@"isrecording"] boolValue];
             NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
-                                    @([item[@"channelid"] longValue]), @"channelid",
+                                    [Utilities getNumberFromItem:item[@"channelid"]], @"channelid",
                                     tableView, @"tableView",
                                     indexPath, @"indexPath",
                                     item, @"item",
@@ -4101,7 +4101,7 @@
 }
 
 - (void)deleteTimer:(NSDictionary*)item indexPath:(NSIndexPath*)indexPath {
-    NSNumber *itemid = @([item[@"timerid"] longValue]);
+    NSNumber *itemid = [Utilities getNumberFromItem:item[@"timerid"]];
     if ([itemid longValue] == 0) {
         return;
     }
@@ -4134,11 +4134,11 @@
 - (void)recordChannel:(NSDictionary*)item indexPath:(NSIndexPath*)indexPath {
     NSString *methodToCall = @"PVR.Record";
     NSString *parameterName = @"channel";
-    NSNumber *itemid = @([item[@"channelid"] longValue]);
+    NSNumber *itemid = [Utilities getNumberFromItem:item[@"channelid"]];
     NSNumber *storeChannelid = itemid;
-    NSNumber *storeBroadcastid = @([item[@"broadcastid"] longValue]);
+    NSNumber *storeBroadcastid = [Utilities getNumberFromItem:item[@"broadcastid"]];
     if ([itemid longValue] == 0) {
-        itemid = @([item[@"pvrExtraInfo"][@"channelid"] longValue]);
+        itemid = [Utilities getNumberFromItem:item[@"pvrExtraInfo"][@"channelid"]];
         if ([itemid longValue] == 0) {
             return;
         }
@@ -4147,7 +4147,7 @@
         NSDate *endtime = [xbmcDateFormatter dateFromString:item[@"endtime"]];
         float percent_elapsed = [Utilities getPercentElapsed:starttime EndDate:endtime];
         if (percent_elapsed < 0) {
-            itemid = @([item[@"broadcastid"] longValue]);
+            itemid = [Utilities getNumberFromItem:item[@"broadcastid"]];
             storeBroadcastid = itemid;
             storeChannelid = @(0);
             methodToCall = @"PVR.ToggleTimer";
@@ -4978,7 +4978,7 @@
                              // Postprocessing of movie sets lists to ignore 1-movie-sets
                              if (ignoreSingleMovieSets) {
                                  NSString *newMethodToCall = @"VideoLibrary.GetMovieSetDetails";
-                                 NSDictionary *newParameter = @{@"setid": @([item[@"setid"] longValue])};
+                                 NSDictionary *newParameter = @{@"setid": [Utilities getNumberFromItem:item[@"setid"]]};
                                  dispatch_group_enter(group);
                                  [[Utilities getJsonRPC]
                                   callMethod:newMethodToCall

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4167,7 +4167,7 @@
                    UIImageView *isRecordingImageView = (UIImageView*)[cell viewWithTag:EPG_VIEW_CELL_RECORDING_ICON];
                    isRecordingImageView.hidden = !isRecordingImageView.hidden;
                    NSNumber *status = @(![item[@"isrecording"] boolValue]);
-                   if ([item[@"broadcastid"] longValue] > 0) {
+                   if ([item[@"broadcastid"] longLongValue] > 0) {
                        status = @(![item[@"hastimer"] boolValue]);
                    }
                    NSDictionary *params = @{

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2624,7 +2624,7 @@
             UIImageView *isRecordingImageView = (UIImageView*)[cell viewWithTag:EPG_VIEW_CELL_RECORDING_ICON];
             isRecordingImageView.hidden = ![item[@"isrecording"] boolValue];
             NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
-                                    @([item[@"channelid"] integerValue]), @"channelid",
+                                    @([item[@"channelid"] longValue]), @"channelid",
                                     tableView, @"tableView",
                                     indexPath, @"indexPath",
                                     item, @"item",

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1392,8 +1392,8 @@
         if (item[mainFields[@"row15"]] != nil) {
             key = mainFields[@"row15"];
         }
-        id obj = item[mainFields[@"row6"]];
         id objKey = mainFields[@"row6"];
+        id obj = item[objKey];
         if (AppDelegate.instance.serverVersion > 11 && ![parameters[@"disableFilterParameter"] boolValue]) {
             NSDictionary *currentParams = menuItem.mainParameters[choosedTab];
             obj = [NSDictionary dictionaryWithObjectsAndKeys:

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1242,10 +1242,10 @@
                            NSString *episode = [Utilities getStringFromItem:item[@"episode"]];
                            NSString *type = [Utilities getStringFromItem:item[@"type"]];
                            NSString *idType = [NSString stringWithFormat:@"%@id", type];
-                           NSNumber *idItem = @([item[@"id"] longValue]);
-                           NSNumber *artistid = @([[Utilities getStringFromItem:item[@"artistid"]] longLongValue]);
-                           NSNumber *albumid = @([item[@"albumid"] longValue]);
-                           NSNumber *tvshowid = @([item[@"tvshowid"] longValue]);
+                           NSNumber *idItem = [Utilities getNumberFromItem:item[@"id"]];
+                           NSNumber *artistid = [Utilities getNumberFromItem:item[@"artistid"]];
+                           NSNumber *albumid = [Utilities getNumberFromItem:item[@"albumid"]];
+                           NSNumber *tvshowid = [Utilities getNumberFromItem:item[@"tvshowid"]];
                            NSString *channel = [Utilities getStringFromItem:item[@"channel"]];
                            NSString *genre = [Utilities getStringFromItem:item[@"genre"]];
                            NSString *durationTime = [Utilities convertTimeFromSeconds:item[@"duration"]];
@@ -1406,11 +1406,11 @@
 - (void)retrieveExtraInfoData:(NSString*)methodToCall parameters:(NSDictionary*)parameters index:(NSIndexPath*)indexPath item:(NSDictionary*)item menuItem:(mainMenu*)menuItem {
     NSDictionary *mainFields = menuItem.mainFields[choosedTab];
     NSString *itemid = mainFields[@"row6"] ?: @"";
-    id object = @([item[itemid] longValue]);
+    id object = [Utilities getNumberFromItem:item[itemid]];
     if (AppDelegate.instance.serverVersion > 11 && [methodToCall isEqualToString:@"AudioLibrary.GetArtistDetails"]) {
         // WORKAROUND due to the lack of the artistid with Playlist.GetItems
         methodToCall = @"AudioLibrary.GetArtists";
-        object = @{@"songid": @([item[@"idItem"] longValue])};
+        object = @{@"songid": [Utilities getNumberFromItem:item[@"idItem"]]};
         itemid = @"filter";
     }
     UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:indexPath];
@@ -1495,7 +1495,7 @@
                   rating, @"rating",
                   mainFields[@"playlistid"], @"playlistid",
                   mainFields[@"row8"], @"family",
-                  @([itemExtraDict[mainFields[@"row9"]] longValue]), mainFields[@"row9"],
+                  [Utilities getNumberFromItem:itemExtraDict[mainFields[@"row9"]]], mainFields[@"row9"],
                   itemExtraDict[mainFields[@"row10"]], mainFields[@"row10"],
                   row11, mainFields[@"row11"],
                   itemExtraDict[mainFields[@"row12"]], mainFields[@"row12"],
@@ -2016,7 +2016,7 @@
             key = mainFields[@"row15"];
         }
         id objKey = mainFields[@"row6"];
-        id obj = @([item[objKey] longValue]);
+        id obj = [Utilities getNumberFromItem:item[objKey]];
         if (AppDelegate.instance.serverVersion > 11 && ![parameters[@"disableFilterParameter"] boolValue]) {
             if ([objKey isEqualToString:@"artistid"]) {
                 // WORKAROUND due to the lack of the artistid with Playlist.GetItems
@@ -2194,9 +2194,9 @@
     NSDictionary *objSource = playlistData[sourceIndexPath.row];
     NSDictionary *itemToMove;
     
-    long idItem = [objSource[@"idItem"] longValue];
-    if (idItem) {
-        itemToMove = @{[NSString stringWithFormat:@"%@id", objSource[@"type"]]: @(idItem)};
+    NSNumber *idItem = [Utilities getNumberFromItem:objSource[@"idItem"]];
+    if ([idItem longValue] > 0) {
+        itemToMove = @{[NSString stringWithFormat:@"%@id", objSource[@"type"]]: idItem};
     }
     else {
         itemToMove = [NSDictionary dictionaryWithObjectsAndKeys:

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1859,7 +1859,7 @@
             }
             NSInteger numActions = sheetActions.count;
             if (numActions) {
-                 NSString *title = item[@"label"];
+                NSString *title = item[@"label"];
                 if ([item[@"type"] isEqualToString:@"song"]) {
                     title = [NSString stringWithFormat:@"%@\n%@\n%@", item[@"label"], item[@"album"], item[@"artist"]];
                 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1406,18 +1406,15 @@
 - (void)retrieveExtraInfoData:(NSString*)methodToCall parameters:(NSDictionary*)parameters index:(NSIndexPath*)indexPath item:(NSDictionary*)item menuItem:(mainMenu*)menuItem {
     NSDictionary *mainFields = menuItem.mainFields[choosedTab];
     NSString *itemid = mainFields[@"row6"] ?: @"";
-    UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:indexPath];
-    UIActivityIndicatorView *activityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:XIB_PLAYLIST_CELL_ACTIVTYINDICATOR];
-    id object;
+    id object = @([item[itemid] longValue]);
     if (AppDelegate.instance.serverVersion > 11 && [methodToCall isEqualToString:@"AudioLibrary.GetArtistDetails"]) {
         // WORKAROUND due to the lack of the artistid with Playlist.GetItems
         methodToCall = @"AudioLibrary.GetArtists";
         object = @{@"songid": @([item[@"idItem"] longValue])};
         itemid = @"filter";
     }
-    else {
-        object = @([item[itemid] longValue]);
-    }
+    UITableViewCell *cell = [playlistTableView cellForRowAtIndexPath:indexPath];
+    UIActivityIndicatorView *activityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:XIB_PLAYLIST_CELL_ACTIVTYINDICATOR];
     if (!object) {
         return; // something goes wrong
     }
@@ -2018,16 +2015,16 @@
         if (item[mainFields[@"row15"]] != nil) {
             key = mainFields[@"row15"];
         }
-        id obj = @([item[mainFields[@"row6"]] longValue]);
         id objKey = mainFields[@"row6"];
+        id obj = @([item[objKey] longValue]);
         if (AppDelegate.instance.serverVersion > 11 && ![parameters[@"disableFilterParameter"] boolValue]) {
-            if ([mainFields[@"row6"] isEqualToString:@"artistid"]) {
+            if ([objKey isEqualToString:@"artistid"]) {
                 // WORKAROUND due to the lack of the artistid with Playlist.GetItems
                 NSString *artistFrodoWorkaround = [NSString stringWithFormat:@"%@", [item[@"artist"] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
                 obj = @{@"artist": artistFrodoWorkaround};
             }
             else {
-                obj = [NSDictionary dictionaryWithObjectsAndKeys: @([item[mainFields[@"row6"]] longValue]), mainFields[@"row6"], nil];
+                obj = [NSDictionary dictionaryWithObjectsAndKeys: obj, objKey, nil];
             }
             objKey = @"filter";
         }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -169,7 +169,7 @@
 
 - (NSString*)getNowPlayingThumbnailPath:(NSDictionary*)item {
     // If a recording is played, we can use the iocn (typically the station logo)
-    BOOL useIcon = [item[@"type"] isEqualToString:@"recording"] || [item[@"recordingid"] longValue] > 0;
+    BOOL useIcon = [item[@"type"] isEqualToString:@"recording"] || [item[@"recordingid"] longLongValue] > 0;
     return [Utilities getThumbnailFromDictionary:item useBanner:NO useIcon:useIcon];
 }
 
@@ -675,7 +675,7 @@
     storePosSeconds = posSeconds;
     
     // Update the playlist position and time when a new item plays, else update progress only
-    long playlistPosition = [item[@"position"] longValue];
+    long playlistPosition = [item[@"position"] longLongValue];
     if (playlistPosition != lastSelected && playlistPosition != SELECTED_NONE) {
         [self setPlaylistPosition:playlistPosition forPlayer:currentPlayerID];
         [self updatePlaylistProgressbar:0.0f actual:@"00:00"];
@@ -787,8 +787,8 @@
                  if (![nowPlayingInfo isKindOfClass:[NSDictionary class]]) {
                      return;
                  }
-                 long currentItemID = nowPlayingInfo[@"id"] ? [nowPlayingInfo[@"id"] longValue] : ID_INVALID;
-                 if ((nowPlayingInfo.count && currentItemID != storedItemID) || 
+                 long currentItemID = nowPlayingInfo[@"id"] ? [nowPlayingInfo[@"id"] longLongValue] : ID_INVALID;
+                 if ((nowPlayingInfo.count && currentItemID != storedItemID) ||
                      nowPlayingInfo[@"id"] == nil ||
                      ([nowPlayingInfo[@"type"] isEqualToString:@"channel"] && ![nowPlayingInfo[@"title"] isEqualToString:storeLiveTVTitle])) {
                      storedItemID = currentItemID;
@@ -858,7 +858,7 @@
              if ([methodResult isKindOfClass:[NSDictionary class]]) {
                  if ([methodResult count]) {
                      // Update the playlist position
-                     [self setPlaylistPosition:[methodResult[@"position"] longValue] forPlayer:PLAYERID_PICTURES];
+                     [self setPlaylistPosition:[methodResult[@"position"] longLongValue] forPlayer:PLAYERID_PICTURES];
                  }
              }
          }
@@ -1831,22 +1831,22 @@
             NSDictionary *item = (playlistData.count > indexPath.row) ? playlistData[indexPath.row] : nil;
             selectedIndexPath = indexPath;
             CGPoint selectedPoint = [gestureRecognizer locationInView:self.view];
-            if ([item[@"albumid"] longValue] > 0) {
+            if ([item[@"albumid"] longLongValue] > 0) {
                 [sheetActions addObjectsFromArray:@[LOCALIZED_STR(@"Album Details"), LOCALIZED_STR(@"Album Tracks")]];
             }
-            if ([item[@"artistid"] longValue] > 0 || ([item[@"type"] isEqualToString:@"song"] && AppDelegate.instance.serverVersion > 11)) {
+            if ([item[@"artistid"] longLongValue] > 0 || ([item[@"type"] isEqualToString:@"song"] && AppDelegate.instance.serverVersion > 11)) {
                 [sheetActions addObjectsFromArray:@[LOCALIZED_STR(@"Artist Details"), LOCALIZED_STR(@"Artist Albums")]];
             }
-            if ([item[@"movieid"] longValue] > 0) {
+            if ([item[@"movieid"] longLongValue] > 0) {
                 [sheetActions addObjectsFromArray:@[LOCALIZED_STR(@"Movie Details")]];
             }
-            else if ([item[@"episodeid"] longValue] > 0) {
+            else if ([item[@"episodeid"] longLongValue] > 0) {
                 [sheetActions addObjectsFromArray:@[LOCALIZED_STR(@"TV Show Details"), LOCALIZED_STR(@"Episode Details")]];
             }
-            else if ([item[@"musicvideoid"] longValue] > 0) {
+            else if ([item[@"musicvideoid"] longLongValue] > 0) {
                 [sheetActions addObjectsFromArray:@[LOCALIZED_STR(@"Music Video Details")]];
             }
-            else if ([item[@"recordingid"] longValue] > 0) {
+            else if ([item[@"recordingid"] longLongValue] > 0) {
                 [sheetActions addObjectsFromArray:@[LOCALIZED_STR(@"Recording Details")]];
             }
             NSInteger numActions = sheetActions.count;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -790,7 +790,7 @@
                      isFullscreen = [methodResult[@"fullscreen"] boolValue];
                  }
                  if (methodResult[@"currentwindow"] != [NSNull null]) {
-                     winID = [methodResult[@"currentwindow"][@"id"] longValue];
+                     winID = [methodResult[@"currentwindow"][@"id"] longLongValue];
                  }
                  if (isFullscreen && (winID == WINDOW_FULLSCREEN_VIDEO || winID == WINDOW_VISUALISATION)) {
                      [[Utilities getJsonRPC]

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -309,14 +309,14 @@ double round(double d) {
     if (methods[@"method"] != nil) { // THERE IS A CHILD
         NSDictionary *mainFields = menuItem.mainFields[choosedTab];
         NSMutableDictionary *parameters = choosedMenuItem.mainParameters[choosedTab];
-        id obj = @([item[mainFields[@"row6"]] longValue]);
         id objKey = mainFields[@"row6"];
+        id obj = @([item[objKey] longValue]);
         if (movieObj != nil && movieObjKey != nil) {
             obj = movieObj;
             objKey = movieObjKey;
         }
         else if (AppDelegate.instance.serverVersion > 11 && ![parameters[@"disableFilterParameter"] boolValue]) {
-            obj = [NSDictionary dictionaryWithObjectsAndKeys: @([item[mainFields[@"row6"]] longValue]), mainFields[@"row6"], nil];
+            obj = [NSDictionary dictionaryWithObjectsAndKeys: obj, objKey, nil];
             objKey = @"filter";
         }
         NSMutableDictionary *newSectionParameters = nil;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -310,7 +310,7 @@ double round(double d) {
         NSDictionary *mainFields = menuItem.mainFields[choosedTab];
         NSMutableDictionary *parameters = choosedMenuItem.mainParameters[choosedTab];
         id objKey = mainFields[@"row6"];
-        id obj = @([item[objKey] longValue]);
+        id obj = [Utilities getNumberFromItem:item[objKey]];
         if (movieObj != nil && movieObjKey != nil) {
             obj = movieObj;
             objKey = movieObjKey;
@@ -455,17 +455,17 @@ double round(double d) {
 
 - (void)recordChannel {
     NSDictionary *item = self.detailItem;
-    NSNumber *channelid = @([item[@"pvrExtraInfo"][@"channelid"] longValue]);
+    NSNumber *channelid = [Utilities getNumberFromItem:item[@"pvrExtraInfo"][@"channelid"]];
     if ([channelid longValue] == 0) {
         return;
     }
     NSString *methodToCall = @"PVR.Record";
     NSString *parameterName = @"channel";
-    NSNumber *itemid = @([item[@"channelid"] longValue]);
+    NSNumber *itemid = [Utilities getNumberFromItem:item[@"channelid"]];
     NSNumber *storeChannelid = itemid;
-    NSNumber *storeBroadcastid = @([item[@"broadcastid"] longValue]);
+    NSNumber *storeBroadcastid = [Utilities getNumberFromItem:item[@"broadcastid"]];
     if ([itemid longValue] == 0) {
-        itemid = @([item[@"pvrExtraInfo"][@"channelid"] longValue]);
+        itemid = [Utilities getNumberFromItem:item[@"pvrExtraInfo"][@"channelid"]];
         if ([itemid longValue] == 0) {
             return;
         }
@@ -474,7 +474,7 @@ double round(double d) {
         NSDate *endtime = [xbmcDateFormatter dateFromString:item[@"endtime"]];
         float percent_elapsed = [Utilities getPercentElapsed:starttime EndDate:endtime];
         if (percent_elapsed < 0) {
-            itemid = @([item[@"broadcastid"] longValue]);
+            itemid = [Utilities getNumberFromItem:item[@"broadcastid"]];
             storeBroadcastid = itemid;
             storeChannelid = @(0);
             methodToCall = @"PVR.ToggleTimer";

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -309,14 +309,14 @@ double round(double d) {
     if (methods[@"method"] != nil) { // THERE IS A CHILD
         NSDictionary *mainFields = menuItem.mainFields[choosedTab];
         NSMutableDictionary *parameters = choosedMenuItem.mainParameters[choosedTab];
-        id obj = @([item[mainFields[@"row6"]] intValue]);
+        id obj = @([item[mainFields[@"row6"]] longValue]);
         id objKey = mainFields[@"row6"];
         if (movieObj != nil && movieObjKey != nil) {
             obj = movieObj;
             objKey = movieObjKey;
         }
         else if (AppDelegate.instance.serverVersion > 11 && ![parameters[@"disableFilterParameter"] boolValue]) {
-            obj = [NSDictionary dictionaryWithObjectsAndKeys: @([item[mainFields[@"row6"]] intValue]), mainFields[@"row6"], nil];
+            obj = [NSDictionary dictionaryWithObjectsAndKeys: @([item[mainFields[@"row6"]] longValue]), mainFields[@"row6"], nil];
             objKey = @"filter";
         }
         NSMutableDictionary *newSectionParameters = nil;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -492,7 +492,7 @@ double round(double d) {
                if (error == nil && methodError == nil) {
                    [self animateRecordAction];
                    NSNumber *status = @(![item[@"isrecording"] boolValue]);
-                   if ([item[@"broadcastid"] longValue] > 0) {
+                   if ([item[@"broadcastid"] longLongValue] > 0) {
                        status = @(![item[@"hastimer"] boolValue]);
                    }
                    NSDictionary *params = [NSMutableDictionary dictionaryWithObjectsAndKeys:

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -72,6 +72,7 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (NSString*)convertTimeFromSeconds:(NSNumber*)seconds;
 + (NSString*)getItemIconFromDictionary:(NSDictionary*)dict;
 + (NSString*)getStringFromItem:(id)item;
++ (NSNumber*)getNumberFromItem:(id)item;
 + (NSString*)getTimeFromItem:(id)item sec2min:(int)secondsToMinute;
 + (NSString*)getYearFromItem:(id)item;
 + (float)getFloatValueFromItem:(id)item;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -736,6 +736,22 @@
     return text;
 }
 
++ (NSNumber*)getNumberFromItem:(id)item {
+    NSNumber *value = @(0);
+    if (!item) {
+        return value;
+    }
+    // Check for longLongValue as this is supported by both NSNumber and NSString.
+    // If longLongValue value is not supported, convert via NSString.
+    if ([item respondsToSelector:@selector(longLongValue)]) {
+        value = @([item longLongValue]);
+    }
+    else {
+        value = @([[Utilities getStringFromItem:item] longLongValue]);
+    }
+    return value;
+}
+
 + (NSString*)getTimeFromItem:(id)item sec2min:(int)secondsToMinute {
     NSString *runtime = @"";
     if (item == nil || [item isKindOfClass:[NSNull class]]) {

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -101,7 +101,7 @@
          onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
              if (error == nil && methodError == nil && [methodResult isKindOfClass: [NSDictionary class]]) {
                  if (methodResult[@"currentwindow"] != [NSNull null]) {
-                     if ([methodResult[@"currentwindow"][@"id"] longValue] == WINDOW_VIRTUAL_KEYBOARD) {
+                     if ([methodResult[@"currentwindow"][@"id"] longLongValue] == WINDOW_VIRTUAL_KEYBOARD) {
                          [self GUIAction:@"Input.Back" params:@{} httpAPIcallback:nil];
                      }
                  }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/570.

Migrated places where database IDs are processed to use `long` precision. Major area was `NowPlaying`, but also one more situation in `DetailViewController` was identified. In addition, some minor refactoring was done to improve code readability.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Use long type for database IDs