### PR TITLE
Bugfix: Apply rounded edges to grid view thumb's bottom

### DIFF
--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -37,6 +37,7 @@
         _labelImageView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _labelImageView.image = [UIImage imageNamed:@"cell_bg"];
         _labelImageView.highlightedImage = [UIImage imageNamed:@"cell_bg_selected"];
+        [Utilities applyRoundedEdgesView:_labelImageView drawBorder:NO];
 
         _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(0, 0, frame.size.width - borderWidth * 2, labelHeight - borderWidth)];
         _posterLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Apply rounded edges to grid view's `labelImageView`. Resolves layout glitch at bottom of grid view thumbs, which caused missing rounded edges.

Screenshots:
<a href="https://ibb.co/fSZ5v9H"><img src="https://i.ibb.co/1nB56MT/Bildschirmfoto-2024-10-27-um-12-09-31.png" alt="Bildschirmfoto-2024-10-27-um-12-09-31" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Apply rounded edges to grid view thumb's bottom