### PR TITLE
Bugfix: Show menu icon on iPhone server list after launch

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -12,6 +12,7 @@
 #import "mainMenu.h"
 #import "AppInfoViewController.h"
 #import "Utilities.h"
+#import "InitialSlidingViewController.h"
 
 // + 2 to cover two single-line separators
 #define HOSTMANAGERVC_MSG_HEIGHT (supportedVersionView.frame.size.height + 2)
@@ -597,6 +598,8 @@
         xbmcLogo.showsTouchWhenHighlighted = NO;
         [xbmcLogo addTarget:self action:@selector(infoView) forControlEvents:UIControlEventTouchUpInside];
         self.navigationItem.titleView = xbmcLogo;
+        UIImage *menuImg = [UIImage imageNamed:@"button_menu"];
+        self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:menuImg style:UIBarButtonItemStylePlain target:nil action:@selector(handleMenuButton)];
         UIImage *powerImg = [UIImage imageNamed:@"icon_power"];
         self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithImage:powerImg style:UIBarButtonItemStylePlain target:self action:@selector(powerControl)];
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Explicitly add the menu icon for HostManagementVC. This is needed as the server list is shown on iPhone as default and without selecting a menu item, which usually adds the menu icon to the next upcoming controller.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Show menu icon on iPhone server list after launch