### PR TITLE
Improvement: Add timers to RunLoopCommonModes to avoid blockage by dragging a view

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -431,7 +431,9 @@
     if (!serverInfoView.hidden) {
         [self updateServerInfo];
         // Start timer to update the server info view
-        serverInfoTimer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(updateServerInfo) userInfo:nil repeats:YES];
+        // Add timer to RunLoopCommonModes to decouple the timer from touch events like dragging
+        serverInfoTimer = [NSTimer timerWithTimeInterval:1.0 target:self selector:@selector(updateServerInfo) userInfo:nil repeats:YES];
+        [[NSRunLoop currentRunLoop] addTimer:serverInfoTimer forMode:NSRunLoopCommonModes];
     }
 }
 

--- a/XBMC Remote/MessagesView.m
+++ b/XBMC Remote/MessagesView.m
@@ -67,8 +67,10 @@
                      }
                      completion:^(BOOL finished) {}];
     // then slide out again after timeout seconds
+    // Add timer to RunLoopCommonModes to decouple the timer from touch events like dragging
     [fadeoutTimer invalidate];
-    fadeoutTimer = [NSTimer scheduledTimerWithTimeInterval:timeout target:self selector:@selector(fadeoutMessage:) userInfo:nil repeats:NO];
+    fadeoutTimer = [NSTimer timerWithTimeInterval:timeout target:self selector:@selector(fadeoutMessage:) userInfo:nil repeats:NO];
+    [[NSRunLoop currentRunLoop] addTimer:fadeoutTimer forMode:NSRunLoopCommonModes];
 }
 
 - (void)fadeoutMessage:(NSTimer*)timer {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2740,8 +2740,10 @@
     storedItemID = SELECTED_NONE;
     [self playbackInfo];
     updateProgressBar = YES;
+    // Add timer to RunLoopCommonModes to decouple the timer from touch events like dragging
     [updateInfoTimer invalidate];
-    updateInfoTimer = [NSTimer scheduledTimerWithTimeInterval:UPDATE_INFO_TIMEOUT target:self selector:@selector(updateInfo) userInfo:nil repeats:YES];
+    updateInfoTimer = [NSTimer timerWithTimeInterval:UPDATE_INFO_TIMEOUT target:self selector:@selector(updateInfo) userInfo:nil repeats:YES];
+    [[NSRunLoop currentRunLoop] addTimer:updateInfoTimer forMode:NSRunLoopCommonModes];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -64,7 +64,9 @@ NSInputStream	*inStream;
 - (void)startServerHeartbeat {
     [heartbeatTimer invalidate];
     [self checkServer];
-    heartbeatTimer = [NSTimer scheduledTimerWithTimeInterval:SERVER_CHECK_TIMER target:self selector:@selector(checkServer) userInfo:nil repeats:YES];
+    // Add timer to RunLoopCommonModes to decouple the timer from touch events like dragging
+    heartbeatTimer = [NSTimer timerWithTimeInterval:SERVER_CHECK_TIMER target:self selector:@selector(checkServer) userInfo:nil repeats:YES];
+    [[NSRunLoop currentRunLoop] addTimer:heartbeatTimer forMode:NSRunLoopCommonModes];
 }
 
 - (void)startNetworkCommunicationWithServer:(NSString*)server serverPort:(int)port {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Several timers should independent of ongoing dragging / touching events, especially the toast animation, the heartbeat and the NowPlaying updates. This change avoids that toast messages are not disappearing while touching / dragging., that the heartbeat checks and NowPlaying updates continue while dragging.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Add timers to RunLoopCommonModes to avoid blockage by dragging a view
Improvement: Continue toast message, NowPlaying and heartbeat while dragging a view