### PR TITLE
Rework wakeup of tcpJSONRPC

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -6241,11 +6241,11 @@
 - (void)handleProximityChangeNotification:(id)sender {
     if ([[UIDevice currentDevice] proximityState]) {
         UIApplication.sharedApplication.idleTimerDisabled = YES;
-        [[NSNotificationCenter defaultCenter] postNotificationName: @"UIApplicationDidEnterBackgroundNotification" object: nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil];
     }
     else {
         [self setIdleTimerFromUserDefaults];
-        [[NSNotificationCenter defaultCenter] postNotificationName: @"UIApplicationWillEnterForegroundNotification" object: nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
         [UIDevice currentDevice].proximityMonitoringEnabled = NO;
         [UIDevice currentDevice].proximityMonitoringEnabled = YES;
     }
@@ -6415,7 +6415,7 @@
 - (void)applicationWillEnterForeground:(UIApplication*)application {
     // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     [self setIdleTimerFromUserDefaults];
-//    [[NSNotificationCenter defaultCenter] postNotificationName: @"UIApplicationWillEnterForegroundNotification" object: nil];
+//    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
 }
 
 - (void)applicationDidBecomeActive:(UIApplication*)application {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6135,7 +6135,7 @@
     
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleEnterForeground:)
-                                                 name: @"UIApplicationWillEnterForegroundNotification"
+                                                 name: UIApplicationWillEnterForegroundNotification
                                                object: nil];
     
     [[NSNotificationCenter defaultCenter] addObserver: self

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -745,7 +745,7 @@
          withParameters: parameters
            onCompletion: ^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
                if (error == nil && methodError == nil) {
-                   [[NSNotificationCenter defaultCenter] postNotificationName:@"UIApplicationWillEnterForegroundNotification" object:nil userInfo:nil];
+                   [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil userInfo:nil];
                }
                else {
                    UIAlertController *alertView = [Utilities createAlertOK:LOCALIZED_STR(@"Cannot do that") message:nil];

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -46,6 +46,9 @@
 
 - (id)initWithNibName:(NSString*)nibNameOrNil bundle:(NSBundle*)nibBundleOrNil {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self) {
+        self.tcpJSONRPCconnection = [tcpJSONRPC new];
+    }
     return self;
 }
 	
@@ -333,7 +336,6 @@
         [self.view addSubview:clearView];
         [NSThread detachNewThreadSelector:@selector(startClearAppDiskCache:) toTarget:self withObject:clearView];
     }
-    self.tcpJSONRPCconnection = [tcpJSONRPC new];
     XBMCVirtualKeyboard *virtualKeyboard = [[XBMCVirtualKeyboard alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
     [self.view addSubview:virtualKeyboard];
     AppDelegate.instance.obj = [GlobalData getInstance];
@@ -453,9 +455,6 @@
 
 - (void)handleEnterForeground:(NSNotification*)sender {
     if (AppDelegate.instance.serverOnLine) {
-        if (self.tcpJSONRPCconnection == nil) {
-            self.tcpJSONRPCconnection = [tcpJSONRPC new];
-        }
         [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
     }
 }

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -353,15 +353,15 @@
     
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleWillResignActive:)
-                                                 name: @"UIApplicationWillResignActiveNotification"
+                                                 name: UIApplicationWillResignActiveNotification
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleDidEnterBackground:)
-                                                 name: @"UIApplicationDidEnterBackgroundNotification"
+                                                 name: UIApplicationDidEnterBackgroundNotification
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleEnterForeground:)
-                                                 name: @"UIApplicationWillEnterForegroundNotification"
+                                                 name: UIApplicationWillEnterForegroundNotification
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleXBMCServerHasChanged:)

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2603,12 +2603,12 @@
     
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleEnterForeground:)
-                                                 name: @"UIApplicationWillEnterForegroundNotification"
+                                                 name: UIApplicationWillEnterForegroundNotification
                                                object: nil];
     
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleDidEnterBackground:)
-                                                 name: @"UIApplicationDidEnterBackgroundNotification"
+                                                 name: UIApplicationDidEnterBackgroundNotification
                                                object: nil];
     
     [[NSNotificationCenter defaultCenter] addObserver: self

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -617,8 +617,8 @@
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     // Only start tcpJSONRPC after view did appear. This ensures the HostManagement popover can be shown in case needed.
-    // This required, if the server csnnot connect or no server has been selected.
     self.tcpJSONRPCconnection = [tcpJSONRPC new];
+    // This required, if the server cannot connect or no server has been selected.
 }
 
 - (void)handleLibraryNotification:(NSNotification*)note {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -84,7 +84,7 @@
 - (id)initWithNibName:(NSString*)nibNameOrNil bundle:(NSBundle*)nibBundleOrNil {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
-        // Custom initialization
+        self.tcpJSONRPCconnection = [tcpJSONRPC new];
     }
     return self;
 }
@@ -614,13 +614,6 @@
                                                object: nil];
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-    [super viewDidAppear:animated];
-    // Only start tcpJSONRPC after view did appear. This ensures the HostManagement popover can be shown in case needed.
-    self.tcpJSONRPCconnection = [tcpJSONRPC new];
-    // This required, if the server cannot connect or no server has been selected.
-}
-
 - (void)handleLibraryNotification:(NSNotification*)note {
     [Utilities showMessage:note.name color:[Utilities getSystemGreen:0.95]];
 }
@@ -734,9 +727,6 @@
 
 - (void)handleEnterForeground:(NSNotification*)sender {
     if (AppDelegate.instance.serverOnLine) {
-        if (self.tcpJSONRPCconnection == nil) {
-            self.tcpJSONRPCconnection = [tcpJSONRPC new];
-        }
         [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
     }
 }

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -614,6 +614,12 @@
                                                object: nil];
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    BOOL showSetup = AppDelegate.instance.obj.serverIP.length == 0;
+    [self showSetup:showSetup];
+}
+
 - (void)handleLibraryNotification:(NSNotification*)note {
     [Utilities showMessage:note.name color:[Utilities getSystemGreen:0.95]];
 }

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -549,15 +549,15 @@
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleWillResignActive:)
-                                                 name: @"UIApplicationWillResignActiveNotification"
+                                                 name: UIApplicationWillResignActiveNotification
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleDidEnterBackground:)
-                                                 name: @"UIApplicationDidEnterBackgroundNotification"
+                                                 name: UIApplicationDidEnterBackgroundNotification
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleEnterForeground:)
-                                                 name: @"UIApplicationWillEnterForegroundNotification"
+                                                 name: UIApplicationWillEnterForegroundNotification
                                                object: nil];
     [[NSNotificationCenter defaultCenter] addObserver: self
                                              selector: @selector(handleTcpJSONRPCShowSetup:)

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -147,12 +147,12 @@
         
         [[NSNotificationCenter defaultCenter] addObserver: self
                                                  selector: @selector(handleEnterForeground:)
-                                                     name: @"UIApplicationWillEnterForegroundNotification"
+                                                     name: UIApplicationWillEnterForegroundNotification
                                                    object: nil];
         
         [[NSNotificationCenter defaultCenter] addObserver: self
                                                  selector: @selector(handleDidEnterBackground:)
-                                                     name: @"UIApplicationDidEnterBackgroundNotification"
+                                                     name: UIApplicationDidEnterBackgroundNotification
                                                    object: nil];
     }
     return self;

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -30,12 +30,12 @@ NSInputStream	*inStream;
                                                    object: nil];
         [[NSNotificationCenter defaultCenter] addObserver: self
                                                  selector: @selector(handleDidBecomeActive:)
-                                                     name: @"UIApplicationDidBecomeActiveNotification"
+                                                     name: UIApplicationDidBecomeActiveNotification
                                                    object: nil];
         
         [[NSNotificationCenter defaultCenter] addObserver: self
                                                  selector: @selector(handleDidEnterBackground:)
-                                                     name: @"UIApplicationDidEnterBackgroundNotification"
+                                                     name: UIApplicationDidEnterBackgroundNotification
                                                    object: nil];
         
         [[NSNotificationCenter defaultCenter] addObserver: self

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -24,14 +24,13 @@ NSInputStream	*inStream;
 - (id)init {
     if (self = [super init]) {
         infoTitle = @"";
-        [self startServerHeartbeat];
         [[NSNotificationCenter defaultCenter] addObserver: self
                                                  selector: @selector(handleSystemOnSleep:)
                                                      name: @"System.OnSleep"
                                                    object: nil];
         [[NSNotificationCenter defaultCenter] addObserver: self
-                                                 selector: @selector(handleEnterForeground:)
-                                                     name: @"UIApplicationWillEnterForegroundNotification"
+                                                 selector: @selector(handleDidBecomeActive:)
+                                                     name: @"UIApplicationDidBecomeActiveNotification"
                                                    object: nil];
         
         [[NSNotificationCenter defaultCenter] addObserver: self
@@ -55,10 +54,8 @@ NSInputStream	*inStream;
     [heartbeatTimer invalidate];
 }
 
-- (void)handleEnterForeground:(NSNotification*)sender {
-    // Start the JSON heartbeat only with a little delay to ensure iOS provides all services.
-    // See https://stackoverflow.com/questions/63621039/
-    [self performSelector:@selector(startServerHeartbeat) withObject:nil afterDelay:0.1];
+- (void)handleDidBecomeActive:(NSNotification*)sender {
+    [self startServerHeartbeat];
 }
 
 - (void)startServerHeartbeat {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1175.

Move `init` of `tcpJSONRPC` to `init` of main iPad/iPhone controllers and do not start the heartbeat in the `init` anymore. Generally hook up starting the heartbeat timer with `applicationDidBecomeActive` instead of `applicationWillEnterForeground` as the socket will be available at this time and no additional timeout is needed.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Rework wakeup of tcpJSONRPC
Improvement: Avoid loss of connection during wakeup