### PR TITLE
Rework handling default server port and tcp port

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -6161,9 +6161,9 @@
             AppDelegate.instance.obj.serverPass = item[@"serverPass"];
             AppDelegate.instance.obj.serverRawIP = item[@"serverIP"];
             AppDelegate.instance.obj.serverIP = [Utilities getUrlStyleAddress:item[@"serverIP"]];
-            AppDelegate.instance.obj.serverPort = item[@"serverPort"];
+            AppDelegate.instance.obj.serverPort = [item[@"serverPort"] intValue] ? item[@"serverPort"] : @"8080";
             AppDelegate.instance.obj.serverHWAddr = item[@"serverMacAddress"];
-            AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue];
+            AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue] ?: 9090;
         }
     }
     

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -6161,9 +6161,9 @@
             AppDelegate.instance.obj.serverPass = item[@"serverPass"];
             AppDelegate.instance.obj.serverRawIP = item[@"serverIP"];
             AppDelegate.instance.obj.serverIP = [Utilities getUrlStyleAddress:item[@"serverIP"]];
-            AppDelegate.instance.obj.serverPort = [item[@"serverPort"] intValue] ? item[@"serverPort"] : @"8080";
+            AppDelegate.instance.obj.serverPort = [Utilities getServerPort:item[@"serverPort"]];
             AppDelegate.instance.obj.serverHWAddr = item[@"serverMacAddress"];
-            AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue] ?: 9090;
+            AppDelegate.instance.obj.tcpPort = [Utilities getTcpPort:item[@"tcpPort"]];
         }
     }
     

--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -54,4 +54,10 @@
 #define FONT_SCALING_DEFAULT 0.9
 #define FONT_SCALING_NONE 1.0
 
+/*
+ * Port defaults
+ */
+#define DEFAULT_SERVER_PORT 8080
+#define DEFAULT_TCP_PORT 9090
+
 #endif /* ConvenienceMacros_h */

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -64,6 +64,7 @@
         AppDelegate.instance.obj.serverIP = @"";
         AppDelegate.instance.obj.serverPort = @"";
         AppDelegate.instance.obj.serverHWAddr = @"";
+        AppDelegate.instance.obj.tcpPort = 0;
         [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCServerHasChanged" object: nil];
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
         [userDefaults setObject: @(-1) forKey:@"lastServer"];
@@ -157,9 +158,9 @@
     AppDelegate.instance.obj.serverPass = item[@"serverPass"];
     AppDelegate.instance.obj.serverRawIP = item[@"serverIP"];
     AppDelegate.instance.obj.serverIP = [Utilities getUrlStyleAddress:item[@"serverIP"]];
-    AppDelegate.instance.obj.serverPort = item[@"serverPort"];
+    AppDelegate.instance.obj.serverPort = [item[@"serverPort"] intValue] ? item[@"serverPort"] : @"8080";
     AppDelegate.instance.obj.serverHWAddr = item[@"serverMacAddress"];
-    AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue];
+    AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue] ?: 9090;
 }
 
 - (void)deselectServerAtIndexPath:(NSIndexPath*)indexPath {

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -158,9 +158,9 @@
     AppDelegate.instance.obj.serverPass = item[@"serverPass"];
     AppDelegate.instance.obj.serverRawIP = item[@"serverIP"];
     AppDelegate.instance.obj.serverIP = [Utilities getUrlStyleAddress:item[@"serverIP"]];
-    AppDelegate.instance.obj.serverPort = [item[@"serverPort"] intValue] ? item[@"serverPort"] : @"8080";
+    AppDelegate.instance.obj.serverPort = [Utilities getServerPort:item[@"serverPort"]];
     AppDelegate.instance.obj.serverHWAddr = item[@"serverMacAddress"];
-    AppDelegate.instance.obj.tcpPort = [item[@"tcpPort"] intValue] ?: 9090;
+    AppDelegate.instance.obj.tcpPort = [Utilities getTcpPort:item[@"tcpPort"]];
 }
 
 - (void)deselectServerAtIndexPath:(NSIndexPath*)indexPath {

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -598,6 +598,8 @@
     ipUI.placeholder = LOCALIZED_STR(@"e.g. 192.168.0.8");
     usernameUI.placeholder = LOCALIZED_STR(@"Username");
     passwordUI.placeholder = LOCALIZED_STR(@"Password");
+    tcpPortUI.placeholder = [NSString stringWithFormat:@"%d", 9090];
+    portUI.placeholder = @"8080";
     self.edgesForExtendedLayout = 0;
     
     for (UITextField *textfield in [self getAllEntryMaskLabels]) {

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -598,8 +598,8 @@
     ipUI.placeholder = LOCALIZED_STR(@"e.g. 192.168.0.8");
     usernameUI.placeholder = LOCALIZED_STR(@"Username");
     passwordUI.placeholder = LOCALIZED_STR(@"Password");
-    tcpPortUI.placeholder = [NSString stringWithFormat:@"%d", 9090];
-    portUI.placeholder = @"8080";
+    tcpPortUI.placeholder = [NSString stringWithFormat:@"%d", DEFAULT_TCP_PORT];
+    portUI.placeholder = [NSString stringWithFormat:@"%d", DEFAULT_SERVER_PORT];
     self.edgesForExtendedLayout = 0;
     
     for (UITextField *textfield in [self getAllEntryMaskLabels]) {

--- a/XBMC Remote/HostViewController.xib
+++ b/XBMC Remote/HostViewController.xib
@@ -278,7 +278,7 @@ TCP port</string>
                                 <outlet property="delegate" destination="-1" id="33"/>
                             </connections>
                         </textField>
-                        <textField tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="9090" placeholder="9090" textAlignment="center" adjustsFontSizeToFit="NO" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="93">
+                        <textField tag="4" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="9090" textAlignment="center" adjustsFontSizeToFit="NO" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="93">
                             <rect key="frame" x="277" y="34" width="32" height="26"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -123,6 +123,8 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (BOOL)isValidMacAddress:(NSString*)macAddress;
 + (void)wakeUp:(NSString*)macAddress;
 + (NSString*)getUrlStyleAddress:(NSString*)address;
++ (NSString*)getServerPort:(NSString*)serverPort;
++ (int)getTcpPort:(NSNumber*)tcpPort;
 + (int)getActivePlayerID:(NSArray*)activePlayerList;
 + (UIViewController*)topMostController;
 + (UIViewController*)topMostControllerIgnoringClass:(Class)ignoredClass;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1378,11 +1378,11 @@
 }
 
 + (NSString*)getServerPort:(NSString*)serverPort {
-    return serverPort.length ? serverPort : @"8080";
+    return serverPort.length ? serverPort : [NSString stringWithFormat:@"%d", DEFAULT_SERVER_PORT];;
 }
 
 + (int)getTcpPort:(NSNumber*)tcpPort {
-    return [tcpPort intValue] ?: 9090;
+    return [tcpPort intValue] ?: DEFAULT_TCP_PORT;
 }
 
 + (int)getActivePlayerID:(NSArray*)activePlayerList {

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1377,6 +1377,14 @@
     return URLaddress;
 }
 
++ (NSString*)getServerPort:(NSString*)serverPort {
+    return serverPort.length ? serverPort : @"8080";
+}
+
++ (int)getTcpPort:(NSNumber*)tcpPort {
+    return [tcpPort intValue] ?: 9090;
+}
+
 + (int)getActivePlayerID:(NSArray*)activePlayerList {
     if (!activePlayerList.count) {
         return PLAYERID_UNKNOWN;

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -70,9 +70,6 @@ NSInputStream	*inStream;
 }
 
 - (void)startNetworkCommunicationWithServer:(NSString*)server serverPort:(int)port {
-    if (port == 0) {
-        port = 9090;
-    }
     if (!server.length) {
         return;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves an issue reported via TestFlight. The App shows default values for server port (8080) and tcp port (9090) in the placeholders of the text fields. If the values are not set explicitly, these defaults should be used automatically. This was not done for the server port, which resulted in connection errors in this case.

This PR now changes few things to improve the behaviour and maintainability:
- Set the default for server / tcp port via newly introduced helper methods
- Use app-wide macros for the default values and show these value as placeholders in the UI

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Use port defaults if not explicitly set
Maintenance: Centralized definition of port defaults