### PR TITLE
Improvement: Simplified actionsheet title for playlist items

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1851,15 +1851,32 @@
             }
             NSInteger numActions = sheetActions.count;
             if (numActions) {
-                NSString *title = item[@"label"];
+                NSString *title = item[@"title"];
+                NSString *label = item[@"label"];
+                NSString *sheetTitle = title.length ? title : label;
                 if ([item[@"type"] isEqualToString:@"song"]) {
-                    title = [NSString stringWithFormat:@"%@\n%@\n%@", item[@"label"], item[@"album"], item[@"artist"]];
+                    NSString *album = item[@"album"];
+                    NSString *artist = item[@"artist"];
+                    NSString *newLine1 = album.length ? @"\n" : @"";
+                    NSString *newLine2 = artist.length ? @"\n" : @"";
+                    sheetTitle = [NSString stringWithFormat:@"%@%@%@%@%@", sheetTitle, newLine1, album, newLine2, artist];
+                }
+                else if ([item[@"type"] isEqualToString:@"musicvideo"]) {
+                    NSString *artist = item[@"artist"];
+                    NSString *newLine = artist.length ? @"\n" : @"";
+                    sheetTitle = [NSString stringWithFormat:@"%@%@%@", sheetTitle, newLine, artist];
+                }
+                else if ([item[@"type"] isEqualToString:@"recording"]) {
+                    NSString *channel = item[@"channel"];
+                    NSString *newLine = channel.length ? @"\n" : @"";
+                    sheetTitle = [NSString stringWithFormat:@"%@%@%@", sheetTitle, newLine, channel];
                 }
                 else if ([item[@"type"] isEqualToString:@"episode"]) {
                     NSString *tvshowText = [Utilities formatTVShowStringForSeasonTrailing:item[@"season"] episode:item[@"episode"] title:item[@"showtitle"]];
-                    title = [NSString stringWithFormat:@"%@%@%@", item[@"label"], tvshowText.length ? @"\n" : @"", tvshowText];
+                    NSString *newLine = tvshowText.length ? @"\n" : @"";
+                    sheetTitle = [NSString stringWithFormat:@"%@%@%@", sheetTitle, newLine, tvshowText];
                 }
-                [self showActionNowPlaying:sheetActions title:title point:selectedPoint];
+                [self showActionNowPlaying:sheetActions title:sheetTitle point:selectedPoint];
             }
         }
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR improves the titles of actionsheets for playlist items (reachable via longpress on a playlist item).
- Prefer title over label, if present
- Show artist for musicvideos
- Show channel for recordings
- Avoid empty rows by adding newline strings

Screenshots: https://ibb.co/GHgT0f6

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Simplified actionsheet title for playlist items