### PR TITLE
Bugfix: restore GlobalSearch sort method and sort order

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5764,12 +5764,10 @@
 
 - (NSString*)getCurrentSortMethod:(NSDictionary*)methods withParameters:(NSDictionary*)parameters {
     NSString *sortMethod = parameters[@"parameters"][@"sort"][@"method"];
-    if (methods != nil) {
-        NSString *sortKey = [NSString stringWithFormat:@"%@_sort_method", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
-        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-        if ([userDefaults objectForKey:sortKey] != nil) {
-            sortMethod = [userDefaults objectForKey:sortKey];
-        }
+    NSString *sortKey = [NSString stringWithFormat:@"%@_sort_method", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    if ([userDefaults objectForKey:sortKey] != nil) {
+        sortMethod = [userDefaults objectForKey:sortKey];
     }
     return sortMethod;
 }
@@ -5930,12 +5928,10 @@
 
 - (NSString*)getCurrentSortAscDesc:(NSDictionary*)methods withParameters:(NSDictionary*)parameters {
     NSString *sortAscDescSaved = parameters[@"parameters"][@"sort"][@"order"];
-    if (methods != nil) {
-        NSString *sortKey = [NSString stringWithFormat:@"%@_sort_ascdesc", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
-        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-        if ([userDefaults objectForKey:sortKey] != nil) {
-            sortAscDescSaved = [userDefaults objectForKey:sortKey];
-        }
+    NSString *sortKey = [NSString stringWithFormat:@"%@_sort_ascdesc", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    if ([userDefaults objectForKey:sortKey] != nil) {
+        sortAscDescSaved = [userDefaults objectForKey:sortKey];
     }
     return sortAscDescSaved;
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes and issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3214668#pid3214668).

The issue was caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1145, which resulted in GlobalSearch having `method` equal to `nil` instead of `@[@{}]`. This in consequence resulted in sort method and sort order not being restored anymore. This PR fixes this by removing the check for nil when restoring, as it is not required for robustness or function.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: restore GlobalSearch sort method and sort order