### PR TITLE
Rework image cache

### DIFF
--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -44,6 +44,7 @@
 #define LOCALIZED_STR(string) NSLocalizedString(string, nil)
 #define LOCALIZED_STR_ARGS(string, ...) [NSString stringWithFormat:LOCALIZED_STR(string), __VA_ARGS__]
 #define SD_NATIVESIZE_KEY @"nativeSize"
+#define SD_ASPECTMODE_KEY @"aspectMode"
 #define FLOAT_EQUAL_ZERO(x) (fabs(x) < FLT_EPSILON)
 
 /*

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -9,6 +9,7 @@
 #import "NowPlaying.h"
 #import "mainMenu.h"
 #import "UIImageView+WebCache.h"
+#import "UIImage+Resize.h"
 #import <QuartzCore/QuartzCore.h>
 #import "GlobalData.h"
 #import "SDImageCache.h"
@@ -123,9 +124,9 @@
 # pragma mark - toolbar management
 
 - (UIImage*)resizeToolbarThumb:(UIImage*)img {
-    return [self resizeImage:img 
-                       width:CGRectGetWidth(playlistButton.frame) * UIScreen.mainScreen.scale
-                      height:CGRectGetHeight(playlistButton.frame) * UIScreen.mainScreen.scale];
+    CGSize thumbSize = CGSizeMake(CGRectGetWidth(playlistButton.frame) * UIScreen.mainScreen.scale,
+                                  CGRectGetHeight(playlistButton.frame) * UIScreen.mainScreen.scale);
+    return [img resizedImageSize:thumbSize aspectMode:UIViewContentModeScaleAspectFit];
 }
 
 #pragma mark - utility
@@ -294,35 +295,6 @@
         hidden = YES;
     }
     view.hidden = hidden;
-}
-
-- (UIImage*)resizeImage:(UIImage*)image width:(int)destWidth height:(int)destHeight {
-    CGImageRef imageRef = image.CGImage;
-    CGFloat horizontalRatio = destWidth / image.size.width;
-    CGFloat verticalRatio = destHeight / image.size.height;
-    CGFloat ratio = MIN(horizontalRatio, verticalRatio); // UIViewContentModeScaleAspectFit
-    CGFloat width = floor(image.size.width * ratio);
-    CGFloat height = floor(image.size.height * ratio);
-    
-    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    
-    CGContextRef bitmap = CGBitmapContextCreate(NULL,
-                                                destWidth,
-                                                destHeight,
-                                                8,
-                                                4 * destWidth,
-                                                colorSpace,
-                                                kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast);
-    
-    CGContextDrawImage(bitmap, CGRectMake(floor((destWidth - width) / 2), floor((destHeight - height) / 2), width, height), imageRef);
-    CGImageRef ref = CGBitmapContextCreateImage(bitmap);
-    UIImage *result = [UIImage imageWithCGImage:ref scale:image.scale orientation:image.imageOrientation];
-    
-    CGContextRelease(bitmap);
-    CGColorSpaceRelease(colorSpace);
-    CGImageRelease(ref);
-    
-    return result;
 }
 
 - (UIImage*)imageWithBorderFromImage:(UIImage*)source {

--- a/XBMC Remote/SDWebImage/SDImageCache.m
+++ b/XBMC Remote/SDWebImage/SDImageCache.m
@@ -115,7 +115,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         }
 
         // Set decompression to YES
-        _shouldDecompressImages = YES;
+        _shouldDecompressImages = NO;
 
         // memory cache enabled
         _shouldCacheImagesInMemory = YES;

--- a/XBMC Remote/SDWebImage/SDWebImageDecoder.m
+++ b/XBMC Remote/SDWebImage/SDWebImageDecoder.m
@@ -55,8 +55,6 @@
         
         size_t width = CGImageGetWidth(imageRef);
         size_t height = CGImageGetHeight(imageRef);
-        NSUInteger bytesPerPixel = 4;
-        NSUInteger bytesPerRow = bytesPerPixel * width;
         NSUInteger bitsPerComponent = 8;
 
 
@@ -67,7 +65,7 @@
                                                      width,
                                                      height,
                                                      bitsPerComponent,
-                                                     bytesPerRow,
+                                                     0,
                                                      colorspaceRef,
                                                      kCGBitmapByteOrderDefault|kCGImageAlphaNoneSkipLast);
         

--- a/XBMC Remote/SDWebImage/SDWebImageDownloader.m
+++ b/XBMC Remote/SDWebImage/SDWebImageDownloader.m
@@ -66,7 +66,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
 - (id)init {
     if ((self = [super init])) {
         _operationClass = [SDWebImageDownloaderOperation class];
-        _shouldDecompressImages = YES;
+        _shouldDecompressImages = NO;
         _executionOrder = SDWebImageDownloaderFIFOExecutionOrder;
         _downloadQueue = [NSOperationQueue new];
         _downloadQueue.maxConcurrentOperationCount = 6;

--- a/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.m
@@ -79,7 +79,7 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
             cancelled:(SDWebImageNoParamsBlock)cancelBlock {
     if ((self = [super init])) {
         _request = [request copy];
-        _shouldDecompressImages = YES;
+        _shouldDecompressImages = NO;
         _options = options;
         _progressBlock = [progressBlock copy];
         _completedBlock = [completedBlock copy];

--- a/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.m
@@ -427,7 +427,7 @@ didReceiveResponse:(NSURLResponse *)response
                 
                 if (self.userInfo[SD_NATIVESIZE_KEY]) {
                     CGSize size = CGSizeFromString(self.userInfo[SD_NATIVESIZE_KEY]);
-                    image = [image resizedImage:image.CGImage size:size interpolationQuality:kCGInterpolationHigh];
+                    image = [image resizedImageSize:size aspectMode:UIViewContentModeScaleAspectFill];
                     self.imageData = [UIImagePNGRepresentation(image) mutableCopy];
                 }
                 

--- a/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/XBMC Remote/SDWebImage/SDWebImageDownloaderOperation.m
@@ -426,8 +426,9 @@ didReceiveResponse:(NSURLResponse *)response
                 image = [self scaledImageForKey:key image:image];
                 
                 if (self.userInfo[SD_NATIVESIZE_KEY]) {
+                    UIViewContentMode aspectMode = [self.userInfo[SD_ASPECTMODE_KEY] intValue];
                     CGSize size = CGSizeFromString(self.userInfo[SD_NATIVESIZE_KEY]);
-                    image = [image resizedImageSize:size aspectMode:UIViewContentModeScaleAspectFill];
+                    image = [image resizedImageSize:size aspectMode:aspectMode];
                     self.imageData = [UIImagePNGRepresentation(image) mutableCopy];
                 }
                 

--- a/XBMC Remote/SDWebImage/UIImageView+WebCache.m
+++ b/XBMC Remote/SDWebImage/UIImageView+WebCache.m
@@ -9,6 +9,7 @@
 #import "UIImageView+WebCache.h"
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
+#import "UIImage+Resize.h"
 
 static char imageURLKey;
 static char TAG_ACTIVITY_INDICATOR;
@@ -56,12 +57,13 @@ static char TAG_ACTIVITY_SHOW;
     }
     
     if (url) {
-        // We want to fill the cache with images the size of the native views to reduce scaling load
+        // We want to fill the cache with images the size of the native views and follow the content mode to reduce scaling load
         CGSize nativeViewSize = [self doubleSizeRetina:self.bounds.size];
         NSDictionary *userInfo = nil;
         if ((options & SDWebImageScaleToNativeSize) && nativeViewSize.width && nativeViewSize.height) {
             userInfo = @{
                 SD_NATIVESIZE_KEY: NSStringFromCGSize(nativeViewSize),
+                SD_ASPECTMODE_KEY: @(self.contentMode),
             };
         }
 

--- a/XBMC Remote/SDWebImage/UIImageView+WebCache.m
+++ b/XBMC Remote/SDWebImage/UIImageView+WebCache.m
@@ -57,7 +57,7 @@ static char TAG_ACTIVITY_SHOW;
     
     if (url) {
         // We want to fill the cache with images the size of the native views to reduce scaling load
-        CGSize nativeViewSize = [self doubleSizeRetina:self.frame.size];
+        CGSize nativeViewSize = [self doubleSizeRetina:self.bounds.size];
         NSDictionary *userInfo = nil;
         if ((options & SDWebImageScaleToNativeSize) && nativeViewSize.width && nativeViewSize.height) {
             userInfo = @{

--- a/XBMC Remote/UIImage+Resize/UIImage+Resize.h
+++ b/XBMC Remote/UIImage+Resize/UIImage+Resize.h
@@ -9,6 +9,6 @@
 
 @interface UIImage (Resize)
 
-- (UIImage*)resizedImage:(CGImageRef)imageRef size:(CGSize)newSize interpolationQuality:(CGInterpolationQuality)quality;
+- (UIImage*)resizedImageSize:(CGSize)newSize aspectMode:(UIViewContentMode)contentMode;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -205,22 +205,17 @@
     if (color == nil) {
         return image;
     }
-    UIGraphicsBeginImageContextWithOptions(image.size, YES, 0);
     
     CGRect contextRect = (CGRect) {.origin = CGPointZero, .size = image.size};
-    
-    CGSize itemImageSize = image.size;
-    CGPoint itemImagePosition;
-    itemImagePosition.x = ceilf((contextRect.size.width - itemImageSize.width) / 2);
-    itemImagePosition.y = ceilf(contextRect.size.height - itemImageSize.height);
     
     UIGraphicsBeginImageContextWithOptions(contextRect.size, NO, 0);
     
     CGContextRef c = UIGraphicsGetCurrentContext();
     
     CGContextBeginTransparencyLayer(c, NULL);
+    CGContextTranslateCTM(c, 0, contextRect.size.height);
     CGContextScaleCTM(c, 1.0, -1.0);
-    CGContextClipToMask(c, CGRectMake(itemImagePosition.x, -itemImagePosition.y, itemImageSize.width, -itemImageSize.height), [image CGImage]);
+    CGContextClipToMask(c, contextRect, [image CGImage]);
 
     CGColorSpaceRef colorSpace = CGColorGetColorSpace(color.CGColor);
     CGColorSpaceModel model = CGColorSpaceGetModel(colorSpace);
@@ -233,8 +228,6 @@
         CGContextSetRGBFillColor(c, colors[0], colors[1], colors[2], colors[3]);
     }
     
-    contextRect.size.height = -contextRect.size.height;
-    contextRect.size.height -= 15;
     CGContextFillRect(c, contextRect);
     CGContextEndTransparencyLayer(c);
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1176.

This PR does another major improvement to the `SDWebImage` cache implementation.

#### Memory improvement with `shouldDecompressImages`

When enabling the `SDWebImage`-setting `shouldDecompressImages`, any `UIImage` loaded from flash to in-memory retained the CG context of the decompressed image. This PR applies a change to the decompression which results in not retaining this copy anymore. The memory consumption for the image cache is reduced to 50%.

#### Memory improvement without `shouldDecompressImages`

When disabling the `SDWebImage`-setting `shouldDecompressImages`, any `UIImage` loaded from flash to in-memory retains the (PNG) data loaded from flash. In this case the memory consumption is reduced to about 60%.

#### Pre-scaling to target resolution and aspect ratio

After reviewing the implementation in-depth, it became clear that thumb images are not really fully scaled to the target resolution, which would require content fill method to be taken into account at this stage. In fact, the image's aspect ratio was kept, and the thumbs were only scaled half-way to meet to minimum resolution requirements. Examples:
- Target (300x300), image (600x900) -> scaled to 300x450
- Target (300x300), image (900x600) -> scaled to 450x300

This caused some scaling do be processed by `UIImageView`, if target and image have different aspect ratios. In addition, the PNG image saved to flash used more pixels and therefore size. This is prominent especially when target and image aspect ratio mismatch a lot, like for TV station logos in grid view.

This PR now scales images to the exact target resolution and aspect ratio before writing them to flash. The implementation takes into account the `UIViewContentMode` used by the targeted `UIImageView` to avoid any image scaling after this initial image caching.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Reduce memory consumption of image cache
Improvement: Image cache pre-scales to target resolution and aspect ratio
Improvement: Reduce load by avoiding unwanted image scaling / processing