### PR TITLE
Bugfix: avoid visual glitch on iPad when closing stack while bounce animation is active

### DIFF
--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -203,6 +203,7 @@
                        options:UIViewAnimationOptionBeginFromCurrentState | UIViewAnimationOptionTransitionNone
                     animations:^{
         for (UIView *subview in slideViews.subviews) {
+            [subview.layer removeAllAnimations];
             subview.frame = CGRectMake(posX,
                                        viewAtLeft.frame.origin.y,
                                        viewAtLeft.frame.size.width,


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3216270#pid3216270).

Stop all animations before moving stack views off screen. This avoids visual glitches when starting an new animation while another one (bounce) is still active.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: avoid visual glitch on iPad when closing stack while bounce animation is active