### PR TITLE
Bugfix: iPad stack not movable after leaving fullscreen with toolbar's nowplaying button

### DIFF
--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -196,6 +196,8 @@
 }
 
 - (void)offView {
+    stackScrollIsFullscreen = NO;
+    
     CGFloat posX = (IS_PORTRAIT ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT) - PAD_MENU_TABLE_WIDTH;
     
     [UIView transitionWithView:self.view


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fullscreen mode ends when moving all stack views off screen. This fixes an issue where stack views were immovable after leaving fullscreen via the NowPlaying button in the toolbar.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: iPad stack not movable after leaving fullscreen with toolbar's nowplaying button