### PR TITLE
Rework PosterCell and RecentlyAddedCell

### DIFF
--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -32,6 +32,7 @@
 /*
  * Dimension and layout macros
  */
+#define GET_PIXEL_EXACT_SIZE(x) (floor(x * UIScreen.mainScreen.scale) / UIScreen.mainScreen.scale);
 #define GET_MAINSCREEN_HEIGHT CGRectGetHeight(UIScreen.mainScreen.fixedCoordinateSpace.bounds)
 #define GET_MAINSCREEN_WIDTH CGRectGetWidth(UIScreen.mainScreen.fixedCoordinateSpace.bounds)
 #define STACKSCROLL_WIDTH (GET_MAINSCREEN_WIDTH - PAD_MENU_TABLE_WIDTH)

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1038,17 +1038,8 @@
         [item[@"family"] isEqualToString:@"type"]) {
         imgView.contentMode = UIViewContentModeScaleAspectFit;
     }
-    BOOL showBorder = !([item[@"family"] isEqualToString:@"channelid"] ||
-                        [item[@"family"] isEqualToString:@"recordingid"] ||
-                        [item[@"family"] isEqualToString:@"channelgroupid"] ||
-                        [item[@"family"] isEqualToString:@"timerid"] ||
-                        [item[@"family"] isEqualToString:@"genreid"] ||
-                        [item[@"family"] isEqualToString:@"sectionid"] ||
-                        [item[@"family"] isEqualToString:@"categoryid"] ||
-                        [item[@"family"] isEqualToString:@"type"] ||
-                        [item[@"family"] isEqualToString:@"file"]) && !enableCollectionView;
     BOOL isOnPVR = [item[@"path"] hasPrefix:@"pvr:"];
-    [Utilities applyRoundedEdgesView:imgView drawBorder:showBorder];
+    [Utilities applyRoundedEdgesView:imgView];
     // In few cases stringURL does not hold an URL path but a loadable icon name. In this case
     // ensure sd_setImageWithURL falls back to this icon.
     if (stringURL.length) {
@@ -3051,7 +3042,7 @@
     
     // Load the thumb image and set the colors for the labels
     NSString *displayThumb = episodesView ? @"coverbox_back_section" : @"coverbox_back";
-    [Utilities applyRoundedEdgesView:thumbImageView drawBorder:YES];
+    [Utilities applyRoundedEdgesView:thumbImageView];
     if (stringURL.length) {
         // In few cases stringURL does not hold an URL path but a loadable icon name. In this case
         // ensure setImageWithURL falls back to this icon.

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -79,7 +79,7 @@
 #define INDICATOR_SIZE 16
 #define FLOWLAYOUT_FULLSCREEN_INSET 8
 #define FLOWLAYOUT_FULLSCREEN_MIN_SPACE 4
-#define FLOWLAYOUT_FULLSCREEN_LABEL (FULLSCREEN_LABEL_HEIGHT * [Utilities getTransformX] + 8)
+#define FLOWLAYOUT_FULLSCREEN_LABEL (FULLSCREEN_LABEL_HEIGHT + 8)
 #define TOGGLE_BUTTON_SIZE 11
 #define INFO_BUTTON_SIZE 30
 #define LABEL_HEIGHT(font) ceil(font.lineHeight)
@@ -1670,9 +1670,11 @@
         CGFloat screenwidth = IS_PORTRAIT ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT;
         CGFloat numItemsPerRow = screenwidth / fullscreenCellGridWidth;
         int num = round(numItemsPerRow);
-        CGFloat newWidth = (screenwidth - num * FLOWLAYOUT_FULLSCREEN_MIN_SPACE - 2 * FLOWLAYOUT_FULLSCREEN_INSET) / num;
+        CGFloat newWidth = (screenwidth - (num - 1) * FLOWLAYOUT_FULLSCREEN_MIN_SPACE - 2 * FLOWLAYOUT_FULLSCREEN_INSET) / num;
         
-        flowLayout.itemSize = CGSizeMake(newWidth, fullscreenCellGridHeight * newWidth / fullscreenCellGridWidth);
+        CGFloat pixelExactWidth = GET_PIXEL_EXACT_SIZE(newWidth);
+        CGFloat pixelExactHeight = GET_PIXEL_EXACT_SIZE(fullscreenCellGridHeight * newWidth / fullscreenCellGridWidth);
+        flowLayout.itemSize = CGSizeMake(pixelExactWidth, pixelExactHeight);
         if (!recentlyAddedView && !hiddenLabel) {
             flowLayout.minimumLineSpacing = FLOWLAYOUT_FULLSCREEN_LABEL;
         }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1785,6 +1785,7 @@
     if (!recentlyAddedView) {
         static NSString *identifier = @"posterCell";
         PosterCell *cell = [cView dequeueReusableCellWithReuseIdentifier:identifier forIndexPath:indexPath];
+        [Utilities applyRoundedEdgesView:cell.contentView];
         cell.posterLabel.text = @"";
         cell.posterLabelFullscreen.text = @"";
         cell.posterLabel.font = [UIFont boldSystemFontOfSize:posterFontSize];
@@ -1836,6 +1837,7 @@
     else {
         static NSString *identifier = @"recentlyAddedCell";
         RecentlyAddedCell *cell = [cView dequeueReusableCellWithReuseIdentifier:identifier forIndexPath:indexPath];
+        [Utilities roundedCornerView:cell.contentView];
 
         if (stringURL.length) {
             [cell.posterThumbnail sd_setImageWithURL:[NSURL URLWithString:stringURL]

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2062,7 +2062,15 @@
     // Get the indicator view and place it in the middle of the thumb (if no thumb keep it at least fully visible)
     id cell = [self getCell:indexPath];
     UIActivityIndicatorView *cellActivityIndicator = (UIActivityIndicatorView*)[cell viewWithTag:XIB_JSON_DATA_CELL_ACTIVTYINDICATOR];
-    cellActivityIndicator.center = CGPointMake(MAX(thumbWidth / 2, cellActivityIndicator.frame.size.width / 2), cellHeight / 2);
+    if (!enableCollectionView) {
+        cellActivityIndicator.center = CGPointMake(MAX(thumbWidth / 2, cellActivityIndicator.frame.size.width / 2), cellHeight / 2);
+    }
+    else if (recentlyAddedView) {
+        cellActivityIndicator.center = ((RecentlyAddedCell*)cell).posterThumbnail.center;
+    }
+    else {
+        cellActivityIndicator.center = ((PosterCell*)cell).posterThumbnail.center;
+    }
     return cellActivityIndicator;
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1808,7 +1808,7 @@
         if (channelListView) {
             [cell setIsRecording:[item[@"isrecording"] boolValue]];
         }
-        cell.posterThumbnail.frame = cell.bounds;
+        [cell setPosterCellLayoutManually:cell.bounds];
         [self setCellImageView:cell.posterThumbnail cell:cell dictItem:item url:stringURL size:CGSizeMake(cellthumbWidth, cellthumbHeight) defaultImg:displayThumb];
         if (!stringURL.length) {
             cell.posterThumbnail.backgroundColor = [Utilities getGrayColor:28 alpha:1.0];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1046,7 +1046,7 @@
                         [item[@"family"] isEqualToString:@"sectionid"] ||
                         [item[@"family"] isEqualToString:@"categoryid"] ||
                         [item[@"family"] isEqualToString:@"type"] ||
-                        [item[@"family"] isEqualToString:@"file"]);
+                        [item[@"family"] isEqualToString:@"file"]) && !enableCollectionView;
     BOOL isOnPVR = [item[@"path"] hasPrefix:@"pvr:"];
     [Utilities applyRoundedEdgesView:imgView drawBorder:showBorder];
     // In few cases stringURL does not hold an URL path but a loadable icon name. In this case

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -298,7 +298,7 @@
 }
 
 - (UIImage*)imageWithBorderFromImage:(UIImage*)source {
-    return [Utilities applyRoundedEdgesImage:source drawBorder:YES];
+    return [Utilities applyRoundedEdgesImage:source];
 }
 
 - (void)updateRepeatButton:(NSString*)mode {
@@ -2132,7 +2132,7 @@
     [thumb sd_setImageWithURL:[NSURL URLWithString:stringURL]
              placeholderImage:defaultThumb
                       options:SDWebImageScaleToNativeSize];
-    [Utilities applyRoundedEdgesView:thumb drawBorder:YES];
+    [Utilities applyRoundedEdgesView:thumb];
     BOOL active = indexPath.row == lastSelected;
     [self setPlaylistCellProgressBar:cell hidden:!active];
     

--- a/XBMC Remote/PosterCell.h
+++ b/XBMC Remote/PosterCell.h
@@ -16,6 +16,7 @@
 
 - (void)setIsRecording:(BOOL)enable;
 - (void)setOverlayWatched:(BOOL)enable;
+- (void)setPosterCellLayoutManually:(CGRect)frame;
 
 @property (nonatomic, readonly) UIImageView *posterThumbnail;
 @property (nonatomic, readonly) UIImageView *labelImageView;

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -126,4 +126,19 @@
     }
 }
 
+- (void)setPosterCellLayoutManually:(CGRect)frame {
+    CGFloat borderWidth = 1.0 / UIScreen.mainScreen.scale;
+    _posterThumbnail.autoresizingMask = 0;
+    _posterThumbnail.frame = CGRectMake(borderWidth,
+                                        borderWidth,
+                                        frame.size.width - borderWidth * 2,
+                                        frame.size.height - borderWidth * 2);
+    
+    _posterLabelFullscreen.autoresizingMask = 0;
+    _posterLabelFullscreen.frame = CGRectMake(0,
+                                              frame.size.height,
+                                              frame.size.width,
+                                              FULLSCREEN_LABEL_HEIGHT);
+}
+
 @end

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -33,13 +33,18 @@
         self.contentView.backgroundColor = UIColor.clearColor;
         [self.contentView addSubview:_posterThumbnail];
         
-        _labelImageView = [[UIImageView alloc] initWithFrame:CGRectMake(borderWidth, frame.size.height - labelHeight, frame.size.width - borderWidth * 2, labelHeight - borderWidth)];
+        _labelImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0,
+                                                                        _posterThumbnail.frame.size.height - labelHeight,
+                                                                        _posterThumbnail.frame.size.width,
+                                                                        labelHeight)];
         _labelImageView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _labelImageView.image = [UIImage imageNamed:@"cell_bg"];
         _labelImageView.highlightedImage = [UIImage imageNamed:@"cell_bg_selected"];
-        [Utilities applyRoundedEdgesView:_labelImageView drawBorder:NO];
 
-        _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(0, 0, frame.size.width - borderWidth * 2, labelHeight - borderWidth)];
+        _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(0,
+                                                                     0,
+                                                                     _labelImageView.frame.size.width,
+                                                                     _labelImageView.frame.size.height)];
         _posterLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterLabel.backgroundColor = UIColor.clearColor;
         _posterLabel.textAlignment = NSTextAlignmentCenter;
@@ -49,10 +54,9 @@
         _posterLabel.numberOfLines = 2;
         _posterLabel.adjustsFontSizeToFitWidth = YES;
         _posterLabel.minimumScaleFactor = FONT_SCALING_NONE;
-        [Utilities applyRoundedEdgesView:_posterLabel drawBorder:NO];
 
         [_labelImageView addSubview:_posterLabel];
-        [self.contentView addSubview:_labelImageView];
+        [_posterThumbnail addSubview:_labelImageView];
         
         if (IS_IPAD) {
             _posterLabelFullscreen = [[PosterLabel alloc] initWithFrame:CGRectMake(0, frame.size.height, frame.size.width - borderWidth * 2, FULLSCREEN_LABEL_HEIGHT)];

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -25,7 +25,7 @@
     self = [super initWithFrame:frame];
     if (self) {
         CGFloat labelHeight = ceil(frame.size.height * 0.19);
-        CGFloat borderWidth = [self halfSizeIfRetina:1.0];
+        CGFloat borderWidth = 1.0 / UIScreen.mainScreen.scale;
         self.restorationIdentifier = @"posterCell";
         _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectMake(borderWidth, borderWidth, frame.size.width - borderWidth * 2, frame.size.height - borderWidth * 2)];
         _posterThumbnail.clipsToBounds = YES;
@@ -78,10 +78,6 @@
         self.selectedBackgroundView = bgView;
     }
     return self;
-}
-
-- (CGFloat)halfSizeIfRetina:(CGFloat)size {
-    return size / UIScreen.mainScreen.scale;
 }
 
 - (void)setIsRecording:(BOOL)enable {

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -25,12 +25,11 @@
     self = [super initWithFrame:frame];
     if (self) {
         CGFloat labelHeight = ceil(frame.size.height * 0.19);
-        CGFloat borderWidth = 1.0 / UIScreen.mainScreen.scale;
         self.restorationIdentifier = @"posterCell";
-        _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectMake(borderWidth,
-                                                                         borderWidth,
-                                                                         frame.size.width - borderWidth * 2,
-                                                                         frame.size.height - borderWidth * 2)];
+        _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectMake(0,
+                                                                         0,
+                                                                         frame.size.width,
+                                                                         frame.size.height)];
         _posterThumbnail.clipsToBounds = YES;
         _posterThumbnail.contentMode = UIViewContentModeScaleAspectFill;
         self.contentView.backgroundColor = UIColor.clearColor;
@@ -81,13 +80,15 @@
         _busyView.center = _posterThumbnail.center;
         _busyView.tag = POSTER_CELL_ACTIVTYINDICATOR;
         [self.contentView addSubview:_busyView];
-
-        UIView *bgView = [[UIView alloc] initWithFrame:frame];
-        bgView.layer.borderWidth = borderWidth;
-        bgView.layer.borderColor = [Utilities getSystemBlue].CGColor;
-        self.selectedBackgroundView = bgView;
     }
     return self;
+}
+
+- (void)setSelected:(BOOL)selected {
+    [super setSelected:selected];
+    CALayer *layer = self.contentView.layer;
+    layer.borderColor = [Utilities getSystemBlue].CGColor;
+    layer.borderWidth = selected ? 1.0 / UIScreen.mainScreen.scale : 0;
 }
 
 - (void)setIsRecording:(BOOL)enable {
@@ -127,12 +128,11 @@
 }
 
 - (void)setPosterCellLayoutManually:(CGRect)frame {
-    CGFloat borderWidth = 1.0 / UIScreen.mainScreen.scale;
     _posterThumbnail.autoresizingMask = 0;
-    _posterThumbnail.frame = CGRectMake(borderWidth,
-                                        borderWidth,
-                                        frame.size.width - borderWidth * 2,
-                                        frame.size.height - borderWidth * 2);
+    _posterThumbnail.frame = CGRectMake(0,
+                                        0,
+                                        frame.size.width,
+                                        frame.size.height);
     
     _posterLabelFullscreen.autoresizingMask = 0;
     _posterLabelFullscreen.frame = CGRectMake(0,

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -66,7 +66,7 @@
                                                                                    frame.size.height,
                                                                                    frame.size.width,
                                                                                    FULLSCREEN_LABEL_HEIGHT)];
-            _posterLabelFullscreen.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
+            _posterLabelFullscreen.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
             _posterLabelFullscreen.backgroundColor = UIColor.clearColor;
             _posterLabelFullscreen.textColor = UIColor.lightGrayColor;
             _posterLabelFullscreen.textAlignment = NSTextAlignmentCenter;

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -62,7 +62,10 @@
         [_posterThumbnail addSubview:_labelImageView];
         
         if (IS_IPAD) {
-            _posterLabelFullscreen = [[PosterLabel alloc] initWithFrame:CGRectMake(0, frame.size.height, frame.size.width - borderWidth * 2, FULLSCREEN_LABEL_HEIGHT)];
+            _posterLabelFullscreen = [[PosterLabel alloc] initWithFrame:CGRectMake(0,
+                                                                                   frame.size.height,
+                                                                                   frame.size.width,
+                                                                                   FULLSCREEN_LABEL_HEIGHT)];
             _posterLabelFullscreen.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
             _posterLabelFullscreen.backgroundColor = UIColor.clearColor;
             _posterLabelFullscreen.textColor = UIColor.lightGrayColor;

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -75,7 +75,7 @@
 
         _busyView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
         _busyView.hidesWhenStopped = YES;
-        _busyView.center = CGPointMake(frame.size.width / 2, (frame.size.height / 2) - borderWidth);
+        _busyView.center = _posterThumbnail.center;
         _busyView.tag = POSTER_CELL_ACTIVTYINDICATOR;
         [self.contentView addSubview:_busyView];
 

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -27,7 +27,10 @@
         CGFloat labelHeight = ceil(frame.size.height * 0.19);
         CGFloat borderWidth = 1.0 / UIScreen.mainScreen.scale;
         self.restorationIdentifier = @"posterCell";
-        _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectMake(borderWidth, borderWidth, frame.size.width - borderWidth * 2, frame.size.height - borderWidth * 2)];
+        _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectMake(borderWidth,
+                                                                         borderWidth,
+                                                                         frame.size.width - borderWidth * 2,
+                                                                         frame.size.height - borderWidth * 2)];
         _posterThumbnail.clipsToBounds = YES;
         _posterThumbnail.contentMode = UIViewContentModeScaleAspectFill;
         self.contentView.backgroundColor = UIColor.clearColor;

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -19,30 +19,28 @@
     if (self) {
         self.restorationIdentifier = @"recentlyAddedCell";
         self.backgroundColor = UIColor.clearColor;
+        self.contentView.clipsToBounds = YES;
         CGFloat labelHeight = (floor)(frame.size.height * 0.18);
         CGFloat genreHeight = (floor)(frame.size.height * 0.11);
         CGFloat yearHeight = (floor)(frame.size.height * 0.11);
-        CGFloat borderWidth = 1.0 / UIScreen.mainScreen.scale;
         CGFloat posterWidth = (ceil)(frame.size.height * 0.67);
         CGFloat fanartWidth = frame.size.width - posterWidth;
-        CGFloat posterStartX = borderWidth;
-        CGFloat startX = borderWidth * 2 + posterWidth;
 
-        _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectMake(posterStartX, borderWidth, posterWidth, frame.size.height - borderWidth * 2)];
+        _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, posterWidth, frame.size.height)];
         _posterThumbnail.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterThumbnail.clipsToBounds = YES;
         _posterThumbnail.contentMode = UIViewContentModeScaleAspectFill;
         [self.contentView addSubview:_posterThumbnail];
         
-        _posterFanart = [[UIImageView alloc] initWithFrame:CGRectMake(startX, borderWidth, fanartWidth - borderWidth * 3, frame.size.height - borderWidth * 2)];
+        _posterFanart = [[UIImageView alloc] initWithFrame:CGRectMake(posterWidth, 0, fanartWidth, frame.size.height)];
         _posterFanart.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterFanart.clipsToBounds = YES;
         _posterFanart.contentMode = UIViewContentModeScaleAspectFill;
         _posterFanart.alpha = 0.9;
         [self.contentView addSubview:_posterFanart];
 
-        int frameHeight = labelHeight + genreHeight + yearHeight - borderWidth * 2;
-        UIImageView *labelImageView = [[UIImageView alloc] initWithFrame:CGRectMake(startX, frame.size.height - genreHeight - yearHeight - labelHeight + borderWidth * 2, fanartWidth - borderWidth * 3, labelHeight + genreHeight + yearHeight - borderWidth * 3)];
+        int frameHeight = labelHeight + genreHeight + yearHeight;
+        UIImageView *labelImageView = [[UIImageView alloc] initWithFrame:CGRectMake(posterWidth, frame.size.height - genreHeight - yearHeight - labelHeight, fanartWidth, labelHeight + genreHeight + yearHeight)];
         labelImageView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
 
         labelImageView.image = [UIImage imageNamed:@"cell_bg"];
@@ -50,7 +48,7 @@
         
         CGFloat posterYOffset = IS_IPAD ? 4 : 0;
         CGFloat labelPadding = 4;
-         _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, posterYOffset, fanartWidth - labelPadding - borderWidth * 4, labelHeight - borderWidth)];
+         _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, posterYOffset, fanartWidth - labelPadding, labelHeight)];
         _posterLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterLabel.backgroundColor = UIColor.clearColor;
         _posterLabel.textColor = UIColor.whiteColor;
@@ -61,7 +59,7 @@
         _posterLabel.adjustsFontSizeToFitWidth = YES;
         [labelImageView addSubview:_posterLabel];
         
-        _posterGenre = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, frameHeight - genreHeight - yearHeight + borderWidth, fanartWidth - labelPadding - borderWidth * 4, genreHeight - borderWidth)];
+        _posterGenre = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, frameHeight - genreHeight - yearHeight, fanartWidth - labelPadding, genreHeight)];
         _posterGenre.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterGenre.backgroundColor = UIColor.clearColor;
         _posterGenre.textColor = UIColor.whiteColor;
@@ -72,7 +70,7 @@
         _posterGenre.adjustsFontSizeToFitWidth = YES;
         [labelImageView addSubview:_posterGenre];
         
-        _posterYear = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, frameHeight - yearHeight, fanartWidth - labelPadding - borderWidth * 4, yearHeight - borderWidth)];
+        _posterYear = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, frameHeight - yearHeight, fanartWidth - labelPadding, yearHeight)];
         _posterYear.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterYear.backgroundColor = UIColor.clearColor;
         _posterYear.textColor = UIColor.whiteColor;
@@ -89,11 +87,6 @@
         _busyView.center = _posterThumbnail.center;
         _busyView.tag = RECENTLY_ADDED_CELL_ACTIVTYINDICATOR;
         [self.contentView addSubview:_busyView];
-        
-        UIView *bgView = [[UIView alloc] initWithFrame:frame];
-        bgView.layer.borderWidth = borderWidth;
-        bgView.layer.borderColor = [Utilities getSystemBlue].CGColor;
-        self.selectedBackgroundView = bgView;
     }
     return self;
 }
@@ -114,6 +107,13 @@
     else {
         overlayWatched.hidden = YES;
     }
+}
+
+- (void)setSelected:(BOOL)selected {
+    [super setSelected:selected];
+    CALayer *layer = self.contentView.layer;
+    layer.borderColor = [Utilities getSystemBlue].CGColor;
+    layer.borderWidth = selected ? 1.0 / UIScreen.mainScreen.scale : 0;
 }
 
 @end

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -86,7 +86,7 @@
 
         _busyView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
         _busyView.hidesWhenStopped = YES;
-        _busyView.center = CGPointMake(frame.size.width / 2 + _posterThumbnail.frame.size.width / 2 + borderWidth / 2, frame.size.height / 2 - borderWidth);
+        _busyView.center = _posterThumbnail.center;
         _busyView.tag = RECENTLY_ADDED_CELL_ACTIVTYINDICATOR;
         [self.contentView addSubview:_busyView];
         

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -557,7 +557,7 @@ double round(double d) {
         
         // Ensure we draw the rounded edges around TV station logo view
         coverView.image = imageToShow;
-        [Utilities applyRoundedEdgesView:coverView drawBorder:YES];
+        [Utilities applyRoundedEdgesView:coverView];
         
         // Choose correct background color for station logos
         if (image != nil) {
@@ -566,7 +566,7 @@ double round(double d) {
     }
     else {
         // Ensure we draw the rounded edges around thumbnail images
-        coverView.image = [Utilities applyRoundedEdgesImage:imageToShow drawBorder:YES];
+        coverView.image = [Utilities applyRoundedEdgesImage:imageToShow];
     }
     [Utilities alphaView:coverView AnimDuration:0.1 Alpha:1.0];
 }
@@ -1328,7 +1328,7 @@ double round(double d) {
             trailerWebView.opaque = NO;
             trailerWebView.backgroundColor = UIColor.blackColor;
             trailerWebView.UIDelegate = self;
-            [Utilities applyRoundedEdgesView:trailerWebView drawBorder:YES];
+            [Utilities applyRoundedEdgesView:trailerWebView];
             [scrollView addSubview:trailerWebView];
             
             trailerComponents = [NSURLComponents componentsWithURL:embedVideoURL resolvingAgainstBaseURL:YES];
@@ -1601,7 +1601,7 @@ double round(double d) {
         [cell.actorThumbnail sd_setImageWithURL:[NSURL URLWithString:stringURL]
                                placeholderImage:[UIImage imageNamed:@"person"]
                                         options:SDWebImageScaleToNativeSize];
-        [Utilities applyRoundedEdgesView:cell.actorThumbnail drawBorder:YES];
+        [Utilities applyRoundedEdgesView:cell.actorThumbnail];
         cell.actorName.text = castMember[@"name"] ?: self.detailItem[@"label"];
         cell.actorRole.text = castMember[@"role"];
         [cell.actorRole sizeToFit];

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -84,10 +84,10 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (NSString*)getImageServerURL;
 + (NSString*)formatStringURL:(NSString*)path serverURL:(NSString*)serverURL;
 + (CGSize)getSizeOfLabel:(UILabel*)label;
-+ (UIImage*)roundedCornerImage:(UIImage*)image drawBorder:(BOOL)drawBorder;
-+ (void)roundedCornerView:(UIView*)view drawBorder:(BOOL)drawBorder;
-+ (UIImage*)applyRoundedEdgesImage:(UIImage*)image drawBorder:(BOOL)drawBorder;
-+ (void)applyRoundedEdgesView:(UIView*)view drawBorder:(BOOL)drawBorder;
++ (UIImage*)roundedCornerImage:(UIImage*)image;
++ (void)roundedCornerView:(UIView*)view;
++ (UIImage*)applyRoundedEdgesImage:(UIImage*)image;
++ (void)applyRoundedEdgesView:(UIView*)view;
 + (void)turnTorchOn:(id)sender on:(BOOL)torchOn;
 + (BOOL)hasTorch;
 + (BOOL)isTorchOn;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -920,7 +920,7 @@
     CGFloat radius = GET_ROUNDED_EDGES_RADIUS(imageLayer.frame.size);
     // Create a mask layer
     CAShapeLayer *maskLayer = [CAShapeLayer new];
-    CGFloat freeAreaWidth = 1.0 / UIScreen.mainScreen.scale;
+    CGFloat freeAreaWidth = drawBorder ? 1.0 / UIScreen.mainScreen.scale : 0;
     CGRect maskFrame = CGRectInset(imageLayer.bounds, freeAreaWidth, freeAreaWidth);
     maskFrame.origin.x /= 2;
     maskFrame.origin.y /= 2;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -886,7 +886,7 @@
     return [label sizeThatFits:CGSizeMake(label.frame.size.width, CGFLOAT_MAX)];
 }
 
-+ (UIImage*)roundedCornerImage:(UIImage*)image drawBorder:(BOOL)drawBorder {
++ (UIImage*)roundedCornerImage:(UIImage*)image {
     CGRect imageRect = CGRectMake(0, 0, image.size.width, image.size.height);
     UIGraphicsBeginImageContextWithOptions(image.size, NO, 0);
 
@@ -899,13 +899,6 @@
 
     // Draw the image into the implicit context
     [image drawInRect:imageRect];
-    
-    if (drawBorder) {
-        // Draw border with shape of path
-        path.lineWidth = 1.0 / UIScreen.mainScreen.scale;
-        [UIColor.blackColor setStroke];
-        [path stroke];
-    }
      
     // Get image and cleanup
     UIImage *roundedCornerImage = UIGraphicsGetImageFromCurrentImageContext();
@@ -913,48 +906,24 @@
     return roundedCornerImage;
 }
 
-+ (void)roundedCornerView:(UIView*)view drawBorder:(BOOL)drawBorder {
-    CALayer *imageLayer = view.layer;
-    
-    // Set radius for corners
-    CGFloat radius = GET_ROUNDED_EDGES_RADIUS(imageLayer.frame.size);
-    // Create a mask layer
-    CAShapeLayer *maskLayer = [CAShapeLayer new];
-    CGFloat freeAreaWidth = drawBorder ? 1.0 / UIScreen.mainScreen.scale : 0;
-    CGRect maskFrame = CGRectInset(imageLayer.bounds, freeAreaWidth, freeAreaWidth);
-    maskFrame.origin.x /= 2;
-    maskFrame.origin.y /= 2;
-    maskLayer.frame = maskFrame;
-    // Define our path, capitalizing on UIKit's corner rounding magic
-    UIBezierPath *newPath = GET_ROUNDED_EDGES_PATH(maskLayer.frame, radius);
-    maskLayer.path = newPath.CGPath;
-    // Apply the mask
-    imageLayer.mask = maskLayer;
-    
-    // Apply border
-    if (drawBorder) {
-        imageLayer.borderWidth = 1.0 / UIScreen.mainScreen.scale;
-        imageLayer.borderColor = UIColor.blackColor.CGColor;
-    }
-    else {
-        imageLayer.borderWidth = 0;
-    }
++ (void)roundedCornerView:(UIView*)view {
+    view.layer.cornerRadius = GET_ROUNDED_EDGES_RADIUS(view.layer.frame.size);
 }
 
-+ (UIImage*)applyRoundedEdgesImage:(UIImage*)image drawBorder:(BOOL)drawBorder {
++ (UIImage*)applyRoundedEdgesImage:(UIImage*)image {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     BOOL corner_preference = [userDefaults boolForKey:@"rounded_corner_preference"];
     if (corner_preference) {
-        image = [Utilities roundedCornerImage:image drawBorder:drawBorder];
+        image = [Utilities roundedCornerImage:image];
     }
     return image;
 }
 
-+ (void)applyRoundedEdgesView:(UIView*)view drawBorder:(BOOL)drawBorder {
++ (void)applyRoundedEdgesView:(UIView*)view {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     BOOL corner_preference = [userDefaults boolForKey:@"rounded_corner_preference"];
     if (corner_preference) {
-        [Utilities roundedCornerView:view drawBorder:drawBorder];
+        [Utilities roundedCornerView:view];
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
#### Simplification of label layout in `PosterCell`
This PR simplifies the layout of `posterLabel` and `labelImageView` by adding both as subviews to `posterThumbnail` instead of `self.contentView`. This way calling `applyRoundedEdgesView` can be removed for both as the new parent view has this applied already.

#### Activity indicator position for `PosterCell` and `RecentlyAddedCell`
Correctly place the activity indicators for collection view. As the cell layout might change after rotation, the center must be updated before starting the animation.

#### Rework fullscreen grid view
Use pixel exact dimension for the item sizes (based on `UIScreen.mainScreen.scale`). Use fixed height for `posterLabelFullscreen`(keeping flexible width) and place it relative to the bottom of the cell.

#### Bring back blue frame for selected items (step 1)
The blue frame for selected items in collection view now works again when having "rounded edges" disabled. To make this happen, the cell's `posterThumbnail` is scaled down to unveil `selectedBackgroundView` again. To compensate for loss of thumb size caused by drawing borders in "rounded edges" mode, borders are not drawn anymore in collection view. This has no visible downside as the background is anyway dark and does not allow see the borders.

#### Bring back blue frame for selected items (step 2)
Instead of using `selectedBackgroundView` draw a border for `contentView` in the newly implemented framework method `setSelected:` and even follow the "rounded corners" setting. This also allows to increase the size of the thumbnail image views.

#### Simplify implementation of "rounded corners" for views
Only apply `layer.cornerRadius` to view, which is expected to give performance improvements and will resolve "purple" warnings by XCode. Also remove support for drawing borders which are not used when having rounded corners disabled.

#### Manual layout of `PosterCell` content
The auto-layout of iOS causes erratic changes of cell dimensions when using the collection view's flow layout (use case: enter a library view in grid view, then enter fullscreen view and start/end search). To avoid this, a manual override of the `posterThumbnail` and `posterLabelFullscreen` layout is introduced.

**Remark:** This PR causes some image view sizes to update, which in consequence will force re-building the image cache.

#### Additional minor changes
- Fullscreen labels can use full cell width
- Remove unneeded method `halfSizeIfRetina` (1-liner only called in single place)
- Coding style change when calling `CGRectMake`

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: simplified collection view cell layout (potential performance improvement)
Improvement: simplified "rounded corners" for views (potential performance improvement) 
Bugfix: correct position of activity indicators in grid view
Bugfix: bring back blue frame on selected grid view items
Bugfix: avoid erratic layout change of labels or thumbnails in grid view