### PR TITLE
Bugfix: use correct default thumbs for recordings and timers in grid view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1769,6 +1769,7 @@
 
 - (UICollectionViewCell*)collectionView:(UICollectionView*)cView cellForItemAtIndexPath:(NSIndexPath*)indexPath {
     NSDictionary *item = [self getItemFromIndexPath:indexPath];
+    defaultThumb = [self getTimerDefaultThumb:item];
     NSString *stringURL = item[@"thumbnail"];
     NSString *fanartURL = item[@"fanart"];
     NSString *displayThumb = [NSString stringWithFormat:@"%@_wall", defaultThumb];
@@ -1798,7 +1799,6 @@
             cell.posterLabelFullscreen.hidden = YES;
         }
         
-        defaultThumb = displayThumb = [self getTimerDefaultThumb:item];
         if (tvshowsView && choosedTab == 0) {
             defaultThumb = displayThumb = @"nocover_tvshows";
         }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Update the `defaultThumb` before attaching `"_wall"`. This ensures the default thumb with correct dimension is chosen for recordings and timers.

Screenshots:
<a href="https://ibb.co/5LqbBY7"><img src="https://i.ibb.co/jD7ngVp/Bildschirmfoto-2024-11-23-um-10-50-22.png" alt="Bildschirmfoto-2024-11-23-um-10-50-22" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: use correct default thumbs for recordings and timers in grid view