### PR TITLE
Maintenance: clean up dealloc

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6349,9 +6349,6 @@
     [self.sections removeAllObjects];
     [channelListUpdateTimer invalidate];
     [[NSNotificationCenter defaultCenter] removeObserver: self];
-    self.searchController.searchResultsUpdater = nil;
-    self.searchController.searchBar.delegate = nil;
-    self.searchController.delegate = nil;
 }
 
 - (BOOL)shouldAutorotate {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6347,7 +6347,6 @@
     [self.richResults removeAllObjects];
     [self.filteredListContent removeAllObjects];
     [self.sections removeAllObjects];
-    [channelListUpdateTimer invalidate];
     [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6343,12 +6343,6 @@
     [self showActionSheet:nil sheetActions:sortOptions item:item rectOriginX:[button7 convertPoint:button7.center toView:buttonsView.superview].x rectOriginY:buttonsView.center.y - button7.frame.size.height / 2];
 }
 
-- (void)dealloc {
-    [self.richResults removeAllObjects];
-    [self.filteredListContent removeAllObjects];
-    [self.sections removeAllObjects];
-}
-
 - (BOOL)shouldAutorotate {
     return YES;
 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6347,7 +6347,6 @@
     [self.richResults removeAllObjects];
     [self.filteredListContent removeAllObjects];
     [self.sections removeAllObjects];
-    [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 
 - (BOOL)shouldAutorotate {

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -799,8 +799,4 @@
     return YES;
 }
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 @end

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -636,6 +636,13 @@
     [segmentServerType addTarget:self action:@selector(segmentValueChanged:) forControlEvents: UIControlEventValueChanged];
 }
 
+- (void)dealloc {
+    // NSNetService delegate uses "assign" in XCode 15.4 SDK. So we nil it.
+    remoteService.delegate = nil;
+    // NSNetServiceBrowser delegate uses "assign" in XCode 15.4 SDK. So we nil it.
+    netServiceBrowser.delegate = nil;
+}
+
 - (BOOL)shouldAutorotate {
     return YES;
 }

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -467,10 +467,6 @@
     [Utilities enableDefaultController:self tableView:menuList menuItems:self.mainMenu];
 }
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver: self];
-}
-
 - (BOOL)shouldAutorotate {
     return YES;
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2942,10 +2942,6 @@
     [self createPlaylistAnimated:YES];
 }
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver: self];
-}
-
 - (BOOL)shouldAutorotate {
     return YES;
 }

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1403,10 +1403,6 @@
     }
 }
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (BOOL)shouldAutorotate {
     return YES;
 }

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -702,8 +702,4 @@
     [super didReceiveMemoryWarning];
 }
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 @end

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -2001,7 +2001,6 @@ double round(double d) {
 - (void)dealloc {
     [kenView removeFromSuperview];
     [self.kenView removeFromSuperview];
-    [[NSNotificationCenter defaultCenter] removeObserver: self];
 }
 
 - (BOOL)shouldAutorotate {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1998,11 +1998,6 @@ double round(double d) {
     [super didReceiveMemoryWarning];
 }
 
-- (void)dealloc {
-    [kenView removeFromSuperview];
-    [self.kenView removeFromSuperview];
-}
-
 - (BOOL)shouldAutorotate {
     return YES;
 }

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -737,10 +737,6 @@
     }
 }
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver: self];
-}
-
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -327,8 +327,4 @@
     }
 }
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver: self];
-}
-
 @end

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -229,10 +229,4 @@
     }];
 }
 
-#pragma mark - lifecycle
-
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 @end

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -68,9 +68,6 @@
     return self;
 }
 
-- (void)dealloc {
-}
-
 #pragma mark - Web Service Invocation Methods
 
 - (NSInteger)callMethod:(NSString*)methodName {

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPCError.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPCError.m
@@ -58,9 +58,6 @@
     return error;
 }
 
-- (void)dealloc {
-}
-
 - (NSString*)description {
     return [NSString stringWithFormat:@"XBMC JSON-RPC Error: %@\n(Code: %li)\nData: %@", self.message, (long)self.code, self.data];
 }

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -740,8 +740,4 @@
     }];
 }
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver: self];
-}
-
 @end

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -363,7 +363,6 @@ NSInputStream	*inStream;
 }
 
 - (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver: self];
     // NSStream delegate uses "assign" in XCode 15.4 SDK. So we nil it.
     inStream.delegate = nil;
 }

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -364,6 +364,8 @@ NSInputStream	*inStream;
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver: self];
+    // NSStream delegate uses "assign" in XCode 15.4 SDK. So we nil it.
+    inStream.delegate = nil;
 }
 
 @end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR cleans up several actions in `dealloc` when deallocating objects.

- `delegates` which are _not_ `weak` must be `nil`'ed (`NSStream`, `NSNetService` and `NSNetServiceBrowser`)
- `delegates` which _are_ `weak` do not need to be `nil`'ed
- No need to `invalidate` timers
- No need to `removeObserver`
- No need to clean up properties (`removeAllObjects` or `nil`'ing)
- No need for `removeFromSuperview`
- Removing empty `dealloc`

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: clean up dealloc