### PR TITLE
Bugfix: do not have "rounded corners" always on for "recently added" grid view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1828,7 +1828,7 @@
     else {
         static NSString *identifier = @"recentlyAddedCell";
         RecentlyAddedCell *cell = [cView dequeueReusableCellWithReuseIdentifier:identifier forIndexPath:indexPath];
-        [Utilities roundedCornerView:cell.contentView];
+        [Utilities applyRoundedEdgesView:cell.contentView];
 
         if (stringURL.length) {
             [cell.posterThumbnail sd_setImageWithURL:[NSURL URLWithString:stringURL]

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -84,8 +84,6 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (NSString*)getImageServerURL;
 + (NSString*)formatStringURL:(NSString*)path serverURL:(NSString*)serverURL;
 + (CGSize)getSizeOfLabel:(UILabel*)label;
-+ (UIImage*)roundedCornerImage:(UIImage*)image;
-+ (void)roundedCornerView:(UIView*)view;
 + (UIImage*)applyRoundedEdgesImage:(UIImage*)image;
 + (void)applyRoundedEdgesView:(UIView*)view;
 + (void)turnTorchOn:(id)sender on:(BOOL)torchOn;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Call `applyRoundedEdgesView` to process the "rounded corner" setting before applying it to "recently added" view. Do not make `roundedCornerImage` and `roundedCornerView` public to avoid calling these methods outside of `Utilities`. This forces using the methods which check for the "rounded corner" setting.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: do not have "rounded corners" always on for "recently added" grid view