### PR TITLE
Rework RecentlyAddedCell and PosterCell

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1829,6 +1829,7 @@
         static NSString *identifier = @"recentlyAddedCell";
         RecentlyAddedCell *cell = [cView dequeueReusableCellWithReuseIdentifier:identifier forIndexPath:indexPath];
         [Utilities applyRoundedEdgesView:cell.contentView];
+        [cell setRecentlyAddedCellLayoutManually:cell.bounds];
 
         if (stringURL.length) {
             [cell.posterThumbnail sd_setImageWithURL:[NSURL URLWithString:stringURL]

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -24,29 +24,19 @@
 - (id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        CGFloat labelHeight = ceil(frame.size.height * 0.19);
         self.restorationIdentifier = @"posterCell";
-        _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectMake(0,
-                                                                         0,
-                                                                         frame.size.width,
-                                                                         frame.size.height)];
+        _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectZero];
         _posterThumbnail.clipsToBounds = YES;
         _posterThumbnail.contentMode = UIViewContentModeScaleAspectFill;
         self.contentView.backgroundColor = UIColor.clearColor;
         [self.contentView addSubview:_posterThumbnail];
         
-        _labelImageView = [[UIImageView alloc] initWithFrame:CGRectMake(0,
-                                                                        _posterThumbnail.frame.size.height - labelHeight,
-                                                                        _posterThumbnail.frame.size.width,
-                                                                        labelHeight)];
+        _labelImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
         _labelImageView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _labelImageView.image = [UIImage imageNamed:@"cell_bg"];
         _labelImageView.highlightedImage = [UIImage imageNamed:@"cell_bg_selected"];
 
-        _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(0,
-                                                                     0,
-                                                                     _labelImageView.frame.size.width,
-                                                                     _labelImageView.frame.size.height)];
+        _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectZero];
         _posterLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterLabel.backgroundColor = UIColor.clearColor;
         _posterLabel.textAlignment = NSTextAlignmentCenter;
@@ -61,10 +51,7 @@
         [_posterThumbnail addSubview:_labelImageView];
         
         if (IS_IPAD) {
-            _posterLabelFullscreen = [[PosterLabel alloc] initWithFrame:CGRectMake(0,
-                                                                                   frame.size.height,
-                                                                                   frame.size.width,
-                                                                                   FULLSCREEN_LABEL_HEIGHT)];
+            _posterLabelFullscreen = [[PosterLabel alloc] initWithFrame:CGRectZero];
             _posterLabelFullscreen.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
             _posterLabelFullscreen.backgroundColor = UIColor.clearColor;
             _posterLabelFullscreen.textColor = UIColor.lightGrayColor;
@@ -74,6 +61,8 @@
             _posterLabelFullscreen.minimumScaleFactor = FONT_SCALING_NONE;
             [self.contentView addSubview:_posterLabelFullscreen];
         }
+        
+        [self setPosterCellLayout:frame];
 
         _busyView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
         _busyView.hidesWhenStopped = YES;
@@ -127,18 +116,36 @@
     }
 }
 
-- (void)setPosterCellLayoutManually:(CGRect)frame {
-    _posterThumbnail.autoresizingMask = 0;
+- (void)setPosterCellLayout:(CGRect)frame {
+    CGFloat labelHeight = ceil(frame.size.height * 0.19);
+    
     _posterThumbnail.frame = CGRectMake(0,
                                         0,
                                         frame.size.width,
                                         frame.size.height);
     
-    _posterLabelFullscreen.autoresizingMask = 0;
+    _labelImageView.frame = CGRectMake(0,
+                                       _posterThumbnail.frame.size.height - labelHeight,
+                                       _posterThumbnail.frame.size.width,
+                                       labelHeight);
+    
+    _posterLabel.frame = CGRectMake(0,
+                                    0,
+                                    _labelImageView.frame.size.width,
+                                    _labelImageView.frame.size.height);
+    
     _posterLabelFullscreen.frame = CGRectMake(0,
                                               frame.size.height,
                                               frame.size.width,
                                               FULLSCREEN_LABEL_HEIGHT);
+}
+
+- (void)setPosterCellLayoutManually:(CGRect)frame {
+    _posterThumbnail.autoresizingMask = UIViewAutoresizingNone;
+    _labelImageView.autoresizingMask = UIViewAutoresizingNone;
+    _posterLabel.autoresizingMask = UIViewAutoresizingNone;
+    _posterLabelFullscreen.autoresizingMask = UIViewAutoresizingNone;
+    [self setPosterCellLayout:frame];
 }
 
 @end

--- a/XBMC Remote/RecentlyAddedCell.h
+++ b/XBMC Remote/RecentlyAddedCell.h
@@ -14,9 +14,11 @@
 }
 
 - (void)setOverlayWatched:(BOOL)enable;
+- (void)setRecentlyAddedCellLayoutManually:(CGRect)frame;
 
 @property (nonatomic, readonly) UIImageView *posterThumbnail;
 @property (nonatomic, readonly) UIImageView *posterFanart;
+@property (nonatomic, readonly) UIImageView *labelImageView;
 @property (nonatomic, readonly) PosterLabel *posterLabel;
 @property (nonatomic, readonly) PosterLabel *posterGenre;
 @property (nonatomic, readonly) PosterLabel *posterYear;

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -11,6 +11,7 @@
 #import "AppDelegate.h"
 
 #define RECENTLY_ADDED_CELL_ACTIVTYINDICATOR SHARED_CELL_ACTIVTYINDICATOR
+#define LABEL_PADDING 4
 
 @implementation RecentlyAddedCell
 
@@ -20,35 +21,26 @@
         self.restorationIdentifier = @"recentlyAddedCell";
         self.backgroundColor = UIColor.clearColor;
         self.contentView.clipsToBounds = YES;
-        CGFloat labelHeight = (floor)(frame.size.height * 0.18);
-        CGFloat genreHeight = (floor)(frame.size.height * 0.11);
-        CGFloat yearHeight = (floor)(frame.size.height * 0.11);
-        CGFloat posterWidth = (ceil)(frame.size.height * 0.67);
-        CGFloat fanartWidth = frame.size.width - posterWidth;
 
-        _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, posterWidth, frame.size.height)];
+        _posterThumbnail = [[UIImageView alloc] initWithFrame:CGRectZero];
         _posterThumbnail.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterThumbnail.clipsToBounds = YES;
         _posterThumbnail.contentMode = UIViewContentModeScaleAspectFill;
         [self.contentView addSubview:_posterThumbnail];
         
-        _posterFanart = [[UIImageView alloc] initWithFrame:CGRectMake(posterWidth, 0, fanartWidth, frame.size.height)];
+        _posterFanart = [[UIImageView alloc] initWithFrame:CGRectZero];
         _posterFanart.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterFanart.clipsToBounds = YES;
         _posterFanart.contentMode = UIViewContentModeScaleAspectFill;
         _posterFanart.alpha = 0.9;
         [self.contentView addSubview:_posterFanart];
 
-        int frameHeight = labelHeight + genreHeight + yearHeight;
-        UIImageView *labelImageView = [[UIImageView alloc] initWithFrame:CGRectMake(posterWidth, frame.size.height - genreHeight - yearHeight - labelHeight, fanartWidth, labelHeight + genreHeight + yearHeight)];
-        labelImageView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
-
-        labelImageView.image = [UIImage imageNamed:@"cell_bg"];
-        labelImageView.highlightedImage = [UIImage imageNamed:@"cell_bg_selected"];
+        _labelImageView = [[UIImageView alloc] initWithFrame:CGRectZero];
+        _labelImageView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
+        _labelImageView.image = [UIImage imageNamed:@"cell_bg"];
+        _labelImageView.highlightedImage = [UIImage imageNamed:@"cell_bg_selected"];
         
-        CGFloat posterYOffset = IS_IPAD ? 4 : 0;
-        CGFloat labelPadding = 4;
-         _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, posterYOffset, fanartWidth - labelPadding, labelHeight)];
+        _posterLabel = [[PosterLabel alloc] initWithFrame:CGRectZero];
         _posterLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterLabel.backgroundColor = UIColor.clearColor;
         _posterLabel.textColor = UIColor.whiteColor;
@@ -57,9 +49,9 @@
         _posterLabel.numberOfLines = 1;
         _posterLabel.minimumScaleFactor = FONT_SCALING_MIN;
         _posterLabel.adjustsFontSizeToFitWidth = YES;
-        [labelImageView addSubview:_posterLabel];
+        [_labelImageView addSubview:_posterLabel];
         
-        _posterGenre = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, frameHeight - genreHeight - yearHeight, fanartWidth - labelPadding, genreHeight)];
+        _posterGenre = [[PosterLabel alloc] initWithFrame:CGRectZero];
         _posterGenre.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterGenre.backgroundColor = UIColor.clearColor;
         _posterGenre.textColor = UIColor.whiteColor;
@@ -68,9 +60,9 @@
         _posterGenre.numberOfLines = 1;
         _posterGenre.minimumScaleFactor = FONT_SCALING_MIN;
         _posterGenre.adjustsFontSizeToFitWidth = YES;
-        [labelImageView addSubview:_posterGenre];
+        [_labelImageView addSubview:_posterGenre];
         
-        _posterYear = [[PosterLabel alloc] initWithFrame:CGRectMake(labelPadding, frameHeight - yearHeight, fanartWidth - labelPadding, yearHeight)];
+        _posterYear = [[PosterLabel alloc] initWithFrame:CGRectZero];
         _posterYear.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterYear.backgroundColor = UIColor.clearColor;
         _posterYear.textColor = UIColor.whiteColor;
@@ -79,8 +71,10 @@
         _posterYear.numberOfLines = 1;
         _posterYear.minimumScaleFactor = FONT_SCALING_MIN;
         _posterYear.adjustsFontSizeToFitWidth = YES;
-        [labelImageView addSubview:_posterYear];
-        [self.contentView addSubview:labelImageView];
+        [_labelImageView addSubview:_posterYear];
+        [self.contentView addSubview:_labelImageView];
+        
+        [self setRecentlyAddedCellLayout:frame];
 
         _busyView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
         _busyView.hidesWhenStopped = YES;
@@ -114,6 +108,49 @@
     CALayer *layer = self.contentView.layer;
     layer.borderColor = [Utilities getSystemBlue].CGColor;
     layer.borderWidth = selected ? 1.0 / UIScreen.mainScreen.scale : 0;
+}
+
+- (void)setRecentlyAddedCellLayout:(CGRect)frame {
+    CGFloat labelHeight = (floor)(frame.size.height * 0.18);
+    CGFloat genreHeight = (floor)(frame.size.height * 0.12);
+    CGFloat yearHeight = (floor)(frame.size.height * 0.10);
+    CGFloat posterWidth = (ceil)(frame.size.height * 0.67);
+    CGFloat fanartWidth = frame.size.width - posterWidth;
+    CGFloat labelImageHeight = labelHeight + genreHeight + yearHeight;
+    
+    _posterThumbnail.frame = CGRectMake(0, 0, posterWidth, frame.size.height);
+    
+    _posterFanart.frame = CGRectMake(posterWidth, 0, fanartWidth, frame.size.height);
+    
+    _labelImageView.frame = CGRectMake(posterWidth,
+                                       frame.size.height - labelImageHeight,
+                                       fanartWidth,
+                                       labelImageHeight);
+    
+    _posterLabel.frame = CGRectMake(LABEL_PADDING,
+                                    0,
+                                    fanartWidth - 2 * LABEL_PADDING,
+                                    labelHeight);
+    
+    _posterGenre.frame = CGRectMake(LABEL_PADDING,
+                                    CGRectGetMaxY(_posterLabel.frame),
+                                    CGRectGetWidth(_posterLabel.frame),
+                                    genreHeight);
+    
+    _posterYear.frame = CGRectMake(LABEL_PADDING,
+                                   CGRectGetMaxY(_posterGenre.frame),
+                                   CGRectGetWidth(_posterGenre.frame),
+                                   yearHeight);
+}
+
+- (void)setRecentlyAddedCellLayoutManually:(CGRect)frame {
+    _posterThumbnail.autoresizingMask = UIViewAutoresizingNone;
+    _posterFanart.autoresizingMask = UIViewAutoresizingNone;
+    _labelImageView.autoresizingMask = UIViewAutoresizingNone;
+    _posterLabel.autoresizingMask = UIViewAutoresizingNone;
+    _posterGenre.autoresizingMask = UIViewAutoresizingNone;
+    _posterYear.autoresizingMask = UIViewAutoresizingNone;
+    [self setRecentlyAddedCellLayout:frame];
 }
 
 @end

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -12,6 +12,7 @@
 
 #define RECENTLY_ADDED_CELL_ACTIVTYINDICATOR SHARED_CELL_ACTIVTYINDICATOR
 #define LABEL_PADDING 4
+#define VERTICAL_PADDING 10
 
 @implementation RecentlyAddedCell
 
@@ -116,7 +117,7 @@
     CGFloat yearHeight = (floor)(frame.size.height * 0.10);
     CGFloat posterWidth = (ceil)(frame.size.height * 0.67);
     CGFloat fanartWidth = frame.size.width - posterWidth;
-    CGFloat labelImageHeight = labelHeight + genreHeight + yearHeight;
+    CGFloat labelImageHeight = labelHeight + genreHeight + yearHeight + VERTICAL_PADDING;
     
     _posterThumbnail.frame = CGRectMake(0, 0, posterWidth, frame.size.height);
     
@@ -128,7 +129,7 @@
                                        labelImageHeight);
     
     _posterLabel.frame = CGRectMake(LABEL_PADDING,
-                                    0,
+                                    VERTICAL_PADDING,
                                     fanartWidth - 2 * LABEL_PADDING,
                                     labelHeight);
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
#### Manual layout of `RecentlyAddedCell` to avoid erratic auto-layout changes
Introduce method `setRecentlyAddedCellLayout` to manually set object dimensions to avoid erratic change of cell dimensions by auto-layout. Introduce helper method which calculates the frame sizes for all objects to avoid code duplication. The helper is called from init and the manual layout method.

#### Improve readability
Let the background gradient shadow overlap more with labels. This increases the contrast for the the top row's text.
Screenshots: https://ibb.co/9nZ1k4B (left = new, right = before)

#### Avoid code duplication in `PosterCell`
Introduce helper method `setPosterCellLayout` which calculates the frame sizes for all objects to avoid code duplication. The helper is called from init and the manual layout method.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: avoid erratic layout change of labels or thumbnails in "recently added" grid view
Improvement: better readability of labels in "recently added" grid view
Maintenance: avoid code duplication in PosterCell and RecentlyAddedCell