### PR TITLE
Bugfix: GlobalSearch by type respects user sort order for section during search

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5912,9 +5912,10 @@
         }
         
         // Build sections and sectionsArray for the filtered list
+        BOOL sortAscending = [sortAscDesc isEqualToString:@"descending"] ? NO : YES;
         self.sections = [NSMutableDictionary new];
         [self buildSectionsForList:self.filteredListContent sortMethod:sortMethodName];
-        [self buildSectionsArraySortedAscending:YES withIndexSearch:self.filteredListContent.count > 0];
+        [self buildSectionsArraySortedAscending:sortAscending withIndexSearch:self.filteredListContent.count > 0];
     }
     else {
         self.filteredListContent = [self sortfilteredList:[self.richResults filteredArrayUsingPredicate:pred]];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Reads the configured sort order and uses it when building the section array in case of GlobalSearch sort-by-type. Keeps sorting ascending inside each section.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: GlobalSearch by type respects user sort order for section during search