### PR TITLE
Improvement: do not show toast message while in AppInfoView on iPhone

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -17,6 +17,7 @@
 #import "AppDelegate.h"
 #import "HostManagementViewController.h"
 #import "InitialSlidingViewController.h"
+#import "AppInfoViewController.h"
 #import "tcpJSONRPC.h"
 #import "XBMCVirtualKeyboard.h"
 #import "ClearCacheView.h"
@@ -419,7 +420,8 @@
 
 - (void)showNotificationMessage:(NSNotification*)note {
     NSDictionary *params = note.userInfo;
-    if (!params || self.slidingViewController.underLeftShowing) {
+    UIViewController *activeVC = [Utilities topMostControllerIgnoringClass:[UIAlertController class]];
+    if (!params || self.slidingViewController.underLeftShowing || [activeVC isKindOfClass:[AppInfoViewController class]]) {
         return;
     }
     [self addMessagesToRootView];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Do not show toast messages while in `AppInfoView` on iPhone. The toast message is not placed correctly in this case.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: do not show toast message while in AppInfoView on iPhone