### PR TITLE
Improvement: directly enter the TV Show details from iPad fullscreen

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3926,7 +3926,7 @@
     ];
     
     menu_TVShows.showInfo = @[
-        @NO,
+        @YES,
         @YES,
         @NO,
         @NO,


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
In iPad fullscreen the variable `showInfo` defines, if the detail info view is loaded on item selection. This avoids an additional step, as otherwise an action list with only a single entry ("TV Show Details") was shown, and the single action needed to be selected.

Screenshot showing the now removed single-action menu: https://ibb.co/DVC7FrL

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: directly enter the TV Show details from iPad fullscreen