### PR TITLE
Improvement: better readability of fullscreen fanart close button

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1510,14 +1510,14 @@ double round(double d) {
             int cbWidth = clearLogoWidth / 2;
             int cbHeight = clearLogoHeight / 2;
             closeButton = [[UIButton alloc] initWithFrame:CGRectMake(self.view.bounds.size.width / 2 - cbWidth / 2, self.view.bounds.size.height - cbHeight - 20, cbWidth, cbHeight)];
-            closeButton.titleLabel.shadowColor = [Utilities getGrayColor:0 alpha:0.8];
-            closeButton.titleLabel.shadowOffset = CGSizeMake(0, 1);
             closeButton.autoresizingMask = UIViewAutoresizingFlexibleTopMargin |
                                            UIViewAutoresizingFlexibleRightMargin |
                                            UIViewAutoresizingFlexibleLeftMargin |
                                            UIViewAutoresizingFlexibleWidth;
             if (clearLogoImageView.frame.size.width == 0) {
                 [closeButton setTitle:clearlogoButton.titleLabel.text forState:UIControlStateNormal];
+                [closeButton setTitleShadowColor:[Utilities getGrayColor:0 alpha:0.8] forState:UIControlStateNormal];
+                closeButton.titleLabel.shadowOffset = CGSizeMake(1, 1);
                 closeButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
             }
             else {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Improve readability of close button in fullscreen fanart by adding text shadow.

Screenshots:
<a href="https://ibb.co/FVSnVc1"><img src="https://i.ibb.co/gV56VQ8/Bildschirmfoto-2024-11-27-um-20-35-42.png" alt="Bildschirmfoto-2024-11-27-um-20-35-42" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: better readability of fullscreen fanart close button