### PR TITLE
Improvement: use Player.Open to resume

### DIFF
--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -60,7 +60,6 @@
     UIBarButtonItem *extraButton;
     int choosedTab;
     NSString *notificationName;
-    float resumePointPercentage;
     KenBurnsView *kenView;
     BOOL enableKenBurns;
     BOOL isFullscreenFanArt;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -418,7 +418,6 @@ double round(double d) {
     }
     else if ([actiontitle rangeOfString:LOCALIZED_STR(@"Resume from")].location != NSNotFound) {
         [self resumePlayback];
-        return;
     }
     else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Play Trailer")]) {
         NSDictionary *itemParams = @{

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -76,7 +76,6 @@ double round(double d) {
             float position = [Utilities getFloatValueFromItem:resumePointDict[@"position"]];
             float total = [Utilities getFloatValueFromItem:resumePointDict[@"total"]];
             if (position > 0 && total > 0) {
-                resumePointPercentage = (position * 100) / total;
                 [sheetActions addObject:LOCALIZED_STR_ARGS(@"Resume from %@", [Utilities convertTimeFromSeconds: @(position)])];
             }
         }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -418,7 +418,7 @@ double round(double d) {
         [self recordChannel];
     }
     else if ([actiontitle rangeOfString:LOCALIZED_STR(@"Resume from")].location != NSNotFound) {
-        [self addPlayback:resumePointPercentage];
+        [self resumePlayback];
         return;
     }
     else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Play Trailer")]) {
@@ -1719,6 +1719,43 @@ double round(double d) {
             self.navigationItem.rightBarButtonItem.enabled = YES;
         }];
     }
+}
+
+- (void)resumePlayback {
+   NSDictionary *item = self.detailItem;
+   if ([item[@"family"] isEqualToString:@"broadcastid"]) {
+       NSDictionary *itemParams = @{
+           @"item": [NSDictionary dictionaryWithObjectsAndKeys: item[@"pvrExtraInfo"][@"channelid"], @"channelid", nil],
+       };
+       [self openFile:itemParams];
+   }
+   else {
+       self.navigationItem.rightBarButtonItem.enabled = NO;
+       [activityIndicatorView startAnimating];
+       NSString *key = item[@"family"];
+       id value = item[key];
+       if (!value || !key) {
+           [activityIndicatorView stopAnimating];
+           return;
+       }
+       NSDictionary *params = @{
+           @"item": @{
+               key: value,
+           },
+           @"options": @{
+               @"resume": @YES,
+           },
+       };
+       [[Utilities getJsonRPC] callMethod:@"Player.Open" withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+           if (error == nil && methodError == nil) {
+               [[NSNotificationCenter defaultCenter] postNotificationName: @"XBMCPlaylistHasChanged" object: nil];
+               [self showNowPlaying];
+               [Utilities checkForReviewRequest];
+           }
+           [activityIndicatorView stopAnimating];
+           self.navigationItem.rightBarButtonItem.enabled = YES;
+       }];
+   }
 }
 
 - (void)addPlayback:(float)resumePointLocal {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This change takes care of issue reports regarding non-reliable resume functionality and at the same time addresses review comments in the nearly 4 years old https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/139.

#### Background

The remote app's playback is centered around playlists. When playing an item, the app first clears the playlist, then adds the item to the playlist and finally plays the playlist item. But when starting playback of a playlist index, `Player.Open` does not support the option to resume playback. Instead, the app added a seek to the desired position. Before seeking, the player needed to start playback, so a sleep of 1 second was added. This worked reasonably ok, but there were reports of unreliable resume or a glitchy user experience as users could see the playback start, followed by seek.

Old sequence:
1. `Playlist.Clear`
2. `Playlist.Add` -item-
3. `Player.Open` -playlist index- (does not support „resume“)
4. Wait
5. `Player.Seek` -position-

#### Updating the resume functionality

The new implementation does not use the playlist API at all. It directly calls `Player.Open` to resume playback for the desired item. As calling the playback directly also cleans the playlist and adds the resumed item, there is no loss of functionality.

1. `Playlist.Open` -item- -resume-

#### Low risk approach

As we are very near releasing 1.16, but this improvement is expected to make resume more reliable, I made the change without too much rework. A new method `resumePlayback` is introduced, which is a copy of the formerly used `addPlayback` and only changes the sequences as described before. An unused ivar is removed. 

In a dedicated future PR I will rework the other playback methods to respect the same logic.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: use Player.Open to resume