### PR TITLE
Improvement: change logic for playlist updates in Party Mode

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2913,11 +2913,6 @@
 }
 
 - (void)handleXBMCPlaylistHasChanged:(NSNotification*)sender {
-    // Party mode will cause playlist updates for each new song, if TCP is enabled. Just ignore here and
-    // let this be handled by the updatePartyModePlaylist which is called for each new song in Party Mode.
-    if (musicPartyMode) {
-        return;
-    }
     NSDictionary *theData = sender.userInfo;
     if ([theData isKindOfClass:[NSDictionary class]]) {
         currentPlaylistID = [theData[@"params"][@"data"][@"playlistid"] intValue];
@@ -2939,7 +2934,14 @@
 }
 
 - (void)clearAndReloadPlaylist {
-    [self createPlaylistAnimated:YES];
+    // While in Party Mode only reload playlist via updatePartyModePlaylist. This does not animate the playlist
+    // to avoid flickering and it blocks moving the focus to music playlist.
+    if (musicPartyMode) {
+        [self updatePartyModePlaylist];
+    }
+    else {
+        [self createPlaylistAnimated:YES];
+    }
 }
 
 - (BOOL)shouldAutorotate {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3217268#pid3217268).

Current logic ignored playlist updates in Party Mode to avoid flickering. Playlist reloads are handled by `updatePartyModePlaylist` which are only called for each new song in Party Mode. This causes also _user_ triggered playlist changes, e.g. by adding an item, to be ignored as well. With this PR _any_ playlist update again triggers a playlist reload by also calling `updatePartyModePlaylist` while in Party Mode.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: change logic for playlist updates in Party Mode