### PR TITLE
Feature: support resume for PVR recordings

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -4530,6 +4530,7 @@
             @"row13": @"endtime",
             @"row14": @"playcount",
             @"row15": @"plot",
+            @"row16": @"resume",
             @"itemid_extra_info": @"recordingdetails",
         },
                       
@@ -5080,6 +5081,7 @@
             @"row13": @"endtime",
             @"row14": @"playcount",
             @"row15": @"plot",
+            @"row16": @"resume",
             @"itemid_extra_info": @"recordingdetails",
         },
                       


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The "resume" point was already requested from Kodi, but the response was not further processed. Now assign and process it as expected. This will bring up the "Resume from ..." option for recordings when playing via the ShowInfoVC.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: support resume for PVR recordings