### PR TITLE
Bugfix: Use full width for section header in fullscreen

### DIFF
--- a/XBMC Remote/PosterHeaderView.m
+++ b/XBMC Remote/PosterHeaderView.m
@@ -22,11 +22,7 @@
     if (self) {
         self.clipsToBounds = NO;
         self.restorationIdentifier = @"posterHeaderView";
-        
-        // Draw gray bar as section header background
-        UIView *sectionView = [[UIView alloc] initWithFrame:self.bounds];
-        sectionView.backgroundColor = [Utilities getGrayColor:44 alpha:1.0];
-        [self insertSubview: sectionView atIndex:0];
+        self.backgroundColor = [Utilities getGrayColor:44 alpha:1.0];
 
         // Draw text into section header
         if (self.frame.size.height > 20) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3217836#pid3217836).

`PosterHeaderView's` background needs to autoresize.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use full width for section header in fullscreen