### PR TITLE
Bugfix: Avoid crash in colorizeImage:withColor:

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -202,7 +202,7 @@
 }
 
 + (UIImage*)colorizeImage:(UIImage*)image withColor:(UIColor*)color {
-    if (color == nil) {
+    if (color == nil || image.size.width == 0 || image.size.height == 0) {
         return image;
     }
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a crash reported via AppStore.

`UIGraphicsBeginImageContextWithOptions` cannot handle image sizes of width = 0 or height = 0.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid crash in colorizeImage:withColor: