### PR TITLE
Rework handling of active tab

### DIFF
--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -30,7 +30,6 @@
     IBOutlet UIActivityIndicatorView *activityIndicatorView;
     NSMutableDictionary *sections;
     int choosedTab;
-    int numTabs;
     int filterModeIndex;
     ViewModes filterModeType;
     UILabel *topNavigationLabel;

--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -29,7 +29,7 @@
     NSMutableArray *storeRichResults;
     IBOutlet UIActivityIndicatorView *activityIndicatorView;
     NSMutableDictionary *sections;
-    int choosedTab;
+    int chosenTab;
     int filterModeIndex;
     ViewModes filterModeType;
     UILabel *topNavigationLabel;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1272,7 +1272,7 @@
     BOOL refresh = NO;
     
     // Read new tab index
-    numTabs = (int)menuItem.mainMethod.count;
+    int numTabs = (int)menuItem.mainMethod.count;
     newChoosedTab = newChoosedTab % numTabs;
     
     // Bring up MoreItemsViewContoller
@@ -5959,7 +5959,7 @@
     }
     self.view.userInteractionEnabled = YES;
     mainMenu *menuItem = self.detailItem;
-    numTabs = (int)menuItem.mainMethod.count;
+    int numTabs = (int)menuItem.mainMethod.count;
     choosedTab = menuItem.chooseTab;
     if (choosedTab >= numTabs) {
         choosedTab = 0;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -363,7 +363,7 @@
     }
     if (mutableParameters != nil) {
         mainMenu *menuItem = self.detailItem;
-        NSDictionary *methods = menuItem.mainMethod[choosedTab];
+        NSDictionary *methods = menuItem.mainMethod[chosenTab];
         NSString *viewKey = [self getCacheKey:methods[@"method"] parameters:mutableParameters];
         
         NSString *filename = [NSString stringWithFormat:@"%@.richResults.dat", viewKey];
@@ -729,7 +729,7 @@
 }
 
 - (int)getActiveTab:(id)item {
-    int activeTab = choosedTab;
+    int activeTab = chosenTab;
     if (globalSearchView) {
         NSArray *lookup = [self getGlobalSearchLookup:item];
         if (lookup.count > 1) {
@@ -897,8 +897,8 @@
 
 - (void)setButtonViewContent:(int)activeTab {
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *methods = menuItem.mainMethod[choosedTab];
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
+    NSDictionary *methods = menuItem.mainMethod[chosenTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     
     // Build basic button list
     [self buildButtons:activeTab];
@@ -1001,7 +1001,7 @@
     // Exception handling for TVShow banner view
     if (tvshowsView) {
         // First tab shows the banner
-        if (choosedTab == 0) {
+        if (chosenTab == 0) {
             // When not in grid and not in fullscreen view
             if (!enableCollectionView && !stackscrollFullscreen) {
                 // If loaded, we use a dark background
@@ -1098,11 +1098,11 @@
     [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
     [activityIndicatorView startAnimating];
     NSArray *buttonsIB = @[button1, button2, button3, button4, button5];
-    if (choosedTab < buttonsIB.count) {
-        [buttonsIB[choosedTab] setSelected:NO];
+    if (chosenTab < buttonsIB.count) {
+        [buttonsIB[chosenTab] setSelected:NO];
     }
-    choosedTab = MAX_NORMAL_BUTTONS;
-    [buttonsIB[choosedTab] setSelected:YES];
+    chosenTab = MAX_NORMAL_BUTTONS;
+    [buttonsIB[chosenTab] setSelected:YES];
     [Utilities AnimView:activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
     int i;
     NSInteger count = menuItem.mainParameters.count;
@@ -1282,23 +1282,23 @@
     }
     
     // Handle modes (pressing same tab) or changed tabs
-    if (newChoosedTab == choosedTab && !fromMoreItems) {
+    if (newChoosedTab == chosenTab && !fromMoreItems) {
         // Read relevant data from configuration
-        methods = menuItem.mainMethod[choosedTab];
-        parameters = menuItem.mainParameters[choosedTab];
+        methods = menuItem.mainMethod[chosenTab];
+        parameters = menuItem.mainParameters[chosenTab];
         mutableParameters = [parameters[@"parameters"] mutableCopy];
         mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
         
-        NSInteger num_modes = [menuItem.filterModes[choosedTab][@"modes"] count];
+        NSInteger num_modes = [menuItem.filterModes[chosenTab][@"modes"] count];
         if (!num_modes) {
             return;
         }
         filterModeIndex = (filterModeIndex + 1) % num_modes;
         NSArray *buttonsIB = @[button1, button2, button3, button4, button5];
-        [buttonsIB[choosedTab] setImage:[UIImage imageNamed:menuItem.filterModes[choosedTab][@"icons"][filterModeIndex]] forState:UIControlStateSelected];
+        [buttonsIB[chosenTab] setImage:[UIImage imageNamed:menuItem.filterModes[chosenTab][@"icons"][filterModeIndex]] forState:UIControlStateSelected];
         
         // Artist filter is inactive. We simply filter results via helper function changeViewMode and return.
-        filterModeType = [menuItem.filterModes[choosedTab][@"modes"][filterModeIndex] intValue];
+        filterModeType = [menuItem.filterModes[chosenTab][@"modes"][filterModeIndex] intValue];
         if (!(filterModeType == ViewModeAlbumArtists ||
               filterModeType == ViewModeSongArtists ||
               filterModeType == ViewModeDefaultArtists)) {
@@ -1310,20 +1310,20 @@
         filterModeIndex = 0;
         filterModeType = ViewModeDefault;
         NSArray *buttonsIB = @[button1, button2, button3, button4, button5];
-        if (choosedTab < buttonsIB.count) {
-            [buttonsIB[choosedTab] setImage:[UIImage imageNamed:@"blank"] forState:UIControlStateSelected];
-            [buttonsIB[choosedTab] setSelected:NO];
+        if (chosenTab < buttonsIB.count) {
+            [buttonsIB[chosenTab] setImage:[UIImage imageNamed:@"blank"] forState:UIControlStateSelected];
+            [buttonsIB[chosenTab] setSelected:NO];
         }
         else {
             [buttonsIB.lastObject setSelected:NO];
         }
-        choosedTab = newChoosedTab;
-        if (choosedTab < buttonsIB.count) {
-            [buttonsIB[choosedTab] setSelected:YES];
+        chosenTab = newChoosedTab;
+        if (chosenTab < buttonsIB.count) {
+            [buttonsIB[chosenTab] setSelected:YES];
         }
-        // Read relevant data from configuration (important: new value for choosedTab)
-        methods = menuItem.mainMethod[choosedTab];
-        parameters = menuItem.mainParameters[choosedTab];
+        // Read relevant data from configuration (important: new value for chosenTab)
+        methods = menuItem.mainMethod[chosenTab];
+        parameters = menuItem.mainParameters[chosenTab];
         mutableParameters = [parameters[@"parameters"] mutableCopy];
         mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
     }
@@ -1344,7 +1344,7 @@
     }
 
     BOOL newEnableCollectionView = [self collectionViewIsEnabled];
-    [self setButtonViewContent:choosedTab];
+    [self setButtonViewContent:chosenTab];
     [self checkDiskCache];
     
     [Utilities SetView:activeLayoutView Alpha:1.0 XPos:viewWidth];
@@ -1793,7 +1793,7 @@
             cell.posterLabelFullscreen.hidden = YES;
         }
         
-        if (tvshowsView && choosedTab == 0) {
+        if (tvshowsView && chosenTab == 0) {
             defaultThumb = displayThumb = @"nocover_tvshows";
         }
         
@@ -2108,7 +2108,7 @@
 
 - (void)choseParams { // DA OTTIMIZZARE TROPPI IF!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     if ([parameters[@"defaultThumb"] length] != 0 && ![parameters[@"defaultThumb"] isEqualToString:@"(null)"]) {
         defaultThumb = parameters[@"defaultThumb"];
     }
@@ -2148,7 +2148,7 @@
     dataList.separatorInset = UIEdgeInsetsMake(0, thumbWidth + LABEL_PADDING, 0, 0);
     
     // label position for TVShow banner view needs to be tailored to match the default thumb size
-    if (tvshowsView && choosedTab == 0) {
+    if (tvshowsView && chosenTab == 0) {
         CGFloat targetHeight = IS_IPAD ? PAD_TV_SHOWS_BANNER_HEIGHT : PHONE_TV_SHOWS_BANNER_HEIGHT;
         CGFloat factor = targetHeight / PHONE_TV_SHOWS_POSTER_HEIGHT * [Utilities getTransformX];
         labelPosition = PAD_TV_SHOWS_POSTER_WIDTH * factor + LABEL_PADDING;
@@ -2543,7 +2543,7 @@
     }
     
     // In case no thumbs are shown and there is a child view or we are showing a setting, display disclosure indicator and adapt width.
-    NSDictionary *method = menuItem.subItem.mainMethod[choosedTab];
+    NSDictionary *method = menuItem.subItem.mainMethod[chosenTab];
     BOOL hasChild = method.count > 0;
     BOOL isSettingID = [item[@"family"] isEqualToString:@"id"];
     if (!thumbWidth && self.indexView.hidden && (hasChild || isSettingID)) {
@@ -2571,7 +2571,7 @@
     frame.origin.x = menuItem.originYearDuration;
     runtimeyear.frame = frame;
 
-    if ([menuItem.showRuntime[choosedTab] boolValue]) {
+    if ([menuItem.showRuntime[chosenTab] boolValue]) {
         NSString *duration = @"";
         if (!menuItem.noConvertTime) {
             duration = [Utilities convertTimeFromSeconds:item[@"runtime"]];
@@ -2642,7 +2642,7 @@
         }
         NSString *stringURL = tvshowsView ? item[@"banner"] : item[@"thumbnail"];
         NSString *displayThumb = globalSearchView ? [self getGlobalSearchThumb:item] : defaultThumb;
-        if (tvshowsView && choosedTab == 0) {
+        if (tvshowsView && chosenTab == 0) {
             displayThumb = defaultThumb = @"nocover_tvshows_banner";
         }
         if ([item[@"filetype"] length] != 0 ||
@@ -3476,7 +3476,7 @@
 
 - (void)saveSortMethod:(NSString*)sortMethod parameters:(NSDictionary*)parameters {
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *methods = menuItem.mainMethod[choosedTab];
+    NSDictionary *methods = menuItem.mainMethod[chosenTab];
     NSString *sortKey = [NSString stringWithFormat:@"%@_sort_method", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [userDefaults setObject:sortMethod forKey:sortKey];
@@ -3484,7 +3484,7 @@
 
 - (void)saveSortAscDesc:(NSString*)sortAscDescSave parameters:(NSDictionary*)parameters {
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *methods = menuItem.mainMethod[choosedTab];
+    NSDictionary *methods = menuItem.mainMethod[chosenTab];
     NSString *sortKey = [NSString stringWithFormat:@"%@_sort_ascdesc", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [userDefaults setObject:sortAscDescSave forKey:sortKey];
@@ -4635,11 +4635,11 @@
         [activeLayoutView setUserInteractionEnabled:NO];
     }
     mainMenu *menuItem = self.detailItem;
-    if (choosedTab >= menuItem.mainParameters.count) {
+    if (chosenTab >= menuItem.mainParameters.count) {
         return;
     }
-    NSDictionary *methods = menuItem.mainMethod[choosedTab];
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
+    NSDictionary *methods = menuItem.mainMethod[chosenTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
     NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
     [self addExtraProperties:mutableProperties newParams:mutableParameters params:parameters];
@@ -4663,7 +4663,7 @@
     NSArray *itemsAndTabs = AppDelegate.instance.globalSearchMenuLookup;
     
     mainMenu *menuItem = self.detailItem;
-    NSMutableDictionary *parameters = [menuItem.mainParameters[choosedTab] mutableCopy];
+    NSMutableDictionary *parameters = [menuItem.mainParameters[chosenTab] mutableCopy];
     if ([self loadedDataFromDisk:nil parameters:parameters refresh:forceRefresh]) {
         return;
     }
@@ -4714,7 +4714,7 @@
         
         // Save and display
         mainMenu *menuItem = self.detailItem;
-        NSMutableDictionary *parameters = [menuItem.mainParameters[choosedTab] mutableCopy];
+        NSMutableDictionary *parameters = [menuItem.mainParameters[chosenTab] mutableCopy];
         [self saveData:parameters];
         [self indexAndDisplayData];
         return;
@@ -4884,7 +4884,7 @@
          // If we are reading PVR timer, we need to filter them for the current mode in postprocessing. Ignore
          // scheduled recordings, if we are in timer rules mode. Or ignore timer rules, if scheduled recordings
          // are listed.
-         NSDictionary *menuParam = menuItem.mainParameters[choosedTab];
+         NSDictionary *menuParam = menuItem.mainParameters[chosenTab];
          BOOL isTimerMethod = [methodToCall isEqualToString:@"PVR.GetTimers"];
          BOOL ignoreTimerRulesItems = isTimerMethod && [menuParam[@"label"] isEqualToString:LOCALIZED_STR(@"Timers")];
          BOOL ignoreTimerItems = isTimerMethod && [menuParam[@"label"] isEqualToString:LOCALIZED_STR(@"Timer rules")];
@@ -4900,7 +4900,7 @@
              [self.sections removeAllObjects];
              [activeLayoutView reloadData];
              if ([methodResult isKindOfClass:[NSDictionary class]]) {
-                 NSMutableDictionary *mainFields = [[self.detailItem mainFields][choosedTab] mutableCopy];
+                 NSMutableDictionary *mainFields = [[self.detailItem mainFields][chosenTab] mutableCopy];
                  NSString *itemid = extraSectionCallBool ? mainFields[@"itemid_extra_section"] : mainFields[@"itemid"];
                  id itemDict = methodResult[itemid];
                  if ([itemDict isKindOfClass:[NSArray class]]) {
@@ -4988,7 +4988,7 @@
                      if ([itemType isKindOfClass:[NSDictionary class]]) {
                          itemDict = itemType[itemField];
                          if ([itemDict isKindOfClass:[NSArray class]]) {
-                             NSString *sublabel = menuItem.mainParameters[choosedTab][@"morelabel"] ?: @"";
+                             NSString *sublabel = menuItem.mainParameters[chosenTab][@"morelabel"] ?: @"";
                              for (id item in itemDict) {
                                  if ([item isKindOfClass:[NSString class]]) {
                                      NSDictionary *listEntry = @{
@@ -5135,7 +5135,7 @@
 - (BOOL)isSortDifferentToDefault {
     BOOL isDifferent = NO;
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     NSString *defaultSortMethod = parameters[@"parameters"][@"sort"][@"method"];
     NSString *defaultSortOrder = parameters[@"parameters"][@"sort"][@"order"];
     if (sortMethodName != nil && ![sortMethodName isEqualToString:defaultSortMethod]) {
@@ -5154,8 +5154,8 @@
 
 - (void)indexAndDisplayData {
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
-    NSDictionary *methods = menuItem.mainMethod[choosedTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
+    NSDictionary *methods = menuItem.mainMethod[chosenTab];
     NSArray *copyRichResults = [self.richResults copy];
     BOOL addUITableViewIndexSearch = NO;
     BOOL isFileBrowsing = [methods[@"method"] isEqualToString:@"Files.GetDirectory"];
@@ -5271,7 +5271,7 @@
             [self.richResults removeAllObjects];
         }
         NSDictionary *epgparams = [NSDictionary dictionaryWithObjectsAndKeys:
-                                   menuItem.mainParameters[choosedTab][@"parameters"][@"channelid"], @"channelid",
+                                   menuItem.mainParameters[chosenTab][@"parameters"][@"channelid"], @"channelid",
                                    retrievedEPG, @"epgArray",
                                    nil];
         [NSThread detachNewThreadSelector:@selector(backgroundSaveEPGToDisk:) toTarget:self withObject:epgparams];
@@ -5390,7 +5390,7 @@
     [self choseParams];
     NSUInteger numResults = self.richResults.count;
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     
     BOOL useMainLabel = ![menuItem.mainLabel isEqualToString:menuItem.rootLabel] && ![menuItem.mainLabel isEqualToString:LOCALIZED_STR(@"XBMC Settings")];
     NSString *labelText = useMainLabel ? menuItem.mainLabel : parameters[@"label"];
@@ -5537,7 +5537,7 @@
     if (showkeyboard) {
         [[self getSearchTextField] performSelector:@selector(becomeFirstResponder) withObject:nil afterDelay:0.1];
     }
-    [self setButtonViewContent:choosedTab];
+    [self setButtonViewContent:chosenTab];
 }
 
 - (void)didReceiveMemoryWarning {
@@ -5680,7 +5680,7 @@
 
 - (BOOL)collectionViewCanBeEnabled {
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     return ([parameters[@"enableCollectionView"] boolValue]);
 }
 
@@ -5690,8 +5690,8 @@
     }
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
-    NSDictionary *methods = menuItem.mainMethod[choosedTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
+    NSDictionary *methods = menuItem.mainMethod[chosenTab];
     NSMutableDictionary *tempDict = [NSMutableDictionary dictionaryWithDictionary:parameters[@"parameters"]];
     if (AppDelegate.instance.serverVersion > 11) {
         if (tempDict[@"filter"] != nil) {
@@ -5960,13 +5960,13 @@
     self.view.userInteractionEnabled = YES;
     mainMenu *menuItem = self.detailItem;
     int numTabs = (int)menuItem.mainMethod.count;
-    choosedTab = menuItem.chooseTab;
-    if (choosedTab >= numTabs) {
-        choosedTab = 0;
+    chosenTab = menuItem.chooseTab;
+    if (chosenTab >= numTabs) {
+        chosenTab = 0;
     }
     filterModeType = ViewModeDefault;
-    NSDictionary *methods = menuItem.mainMethod[choosedTab];
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
+    NSDictionary *methods = menuItem.mainMethod[chosenTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     watchedListenedStrings = parameters[@"watchedListenedStrings"];
     [self checkDiskCache];
     numberOfStars = 10;
@@ -6182,7 +6182,7 @@
 - (void)checkFullscreenButton:(BOOL)forceHide {
     mainMenu *menuItem = self.detailItem;
     if (IS_IPAD && menuItem.enableSection) {
-        NSDictionary *parameters = menuItem.mainParameters[choosedTab];
+        NSDictionary *parameters = menuItem.mainParameters[chosenTab];
         if ([self collectionViewCanBeEnabled] && ([parameters[@"enableLibraryFullScreen"] boolValue] && !forceHide)) {
             int buttonPadding = 1;
             if (fullscreenButton == nil) {
@@ -6227,7 +6227,7 @@
 
 - (void)checkDiskCache {
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     BOOL diskcache_preference = [userDefaults boolForKey:@"diskcache_preference"];
     enableDiskCache = diskcache_preference && [parameters[@"enableLibraryCache"] boolValue];
@@ -6243,8 +6243,8 @@
         [self.searchController setActive:NO];
     }
     mainMenu *menuItem = self.detailItem;
-    NSDictionary *methods = menuItem.mainMethod[choosedTab];
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
+    NSDictionary *methods = menuItem.mainMethod[chosenTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     if ([self collectionViewCanBeEnabled] && self.view.superview != nil && ![methods[@"method"] isEqualToString:@""]) {
         NSMutableDictionary *tempDict = [NSMutableDictionary dictionaryWithDictionary:parameters[@"parameters"]];
         if (AppDelegate.instance.serverVersion > 11) {
@@ -6289,10 +6289,10 @@
     }
     selectedIndexPath = nil;
     mainMenu *menuItem = self.detailItem;
-    if (choosedTab >= menuItem.mainParameters.count) {
+    if (chosenTab >= menuItem.mainParameters.count) {
         return;
     }
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     NSDictionary *sortDictionary = parameters[@"available_sort_methods"];
     NSMutableArray *sortOptions = [sortDictionary[@"label"] mutableCopy];
     if (sortMethodIndex != -1) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1143,7 +1143,6 @@
         return;
     }
     NSIndexPath *choice = notification.object;
-    choosedTab = 0;
     NSInteger selectedIdx = MAX_NORMAL_BUTTONS + choice.row;
     [self handleChangeTab:(int)selectedIdx fromMoreItems:YES];
 }
@@ -1281,7 +1280,7 @@
     }
     
     // Handle modes (pressing same tab) or changed tabs
-    if (newChoosedTab == choosedTab) {
+    if (newChoosedTab == choosedTab && !fromMoreItems) {
         // Read relevant data from configuration
         methods = menuItem.mainMethod[choosedTab];
         parameters = menuItem.mainParameters[choosedTab];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -446,11 +446,13 @@
     return [item[@"hastimer"] boolValue] || [item[@"isrecording"] boolValue];
 }
 
-- (void)enterSubmenuOfMenu:(mainMenu*)menuItem label:(NSString*)label params:(NSDictionary*)parameters {
-    menuItem.subItem.mainLabel = label;
+- (void)enterSubmenuForItem:(id)item params:(NSDictionary*)parameters {
+    mainMenu *menuItem = [self getMainMenu:item];
+    int activeTab = [self getActiveTab:item];
+    menuItem.subItem.mainLabel = item[@"label"];
     mainMenu *newMenuItem = [menuItem.subItem copy];
-    newMenuItem.mainParameters[choosedTab] = parameters;
-    newMenuItem.chooseTab = choosedTab;
+    newMenuItem.mainParameters[activeTab] = parameters;
+    newMenuItem.chooseTab = activeTab;
     if (IS_IPHONE) {
         DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
         detailViewController.detailItem = newMenuItem;
@@ -1450,7 +1452,7 @@
         if (parameters[@"parameters"][@"albumartistsonly"]) {
             newParameters[@"parameters"][@"albumartistsonly"] = parameters[@"parameters"][@"albumartistsonly"];
         }
-        [self enterSubmenuOfMenu:menuItem label:item[@"label"] params:newParameters];
+        [self enterSubmenuForItem:item params:newParameters];
     }
     else { // CHILD IS FILEMODE
         NSNumber *filemodeRowHeight = parameters[@"rowHeight"] ?: @44;
@@ -1542,7 +1544,7 @@
             if ([item[@"family"] isEqualToString:@"sectionid"] || [item[@"family"] isEqualToString:@"categoryid"]) {
                 newParameters[@"parameters"][@"level"] = @"expert";
             }
-            [self enterSubmenuOfMenu:menuItem label:item[@"label"] params:newParameters];
+            [self enterSubmenuForItem:item params:newParameters];
         }
     }
 }
@@ -4052,7 +4054,7 @@
                                           @"Files.GetDirectory", @"exploreCommand",
                                           @([parameters[@"disableFilterParameter"] boolValue]), @"disableFilterParameter",
                                           nil];
-    [self enterSubmenuOfMenu:menuItem label:item[@"label"] params:newParameters];
+    [self enterSubmenuForItem:item params:newParameters];
 }
 
 - (void)deleteTimer:(NSDictionary*)item indexPath:(NSIndexPath*)indexPath {

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -74,7 +74,6 @@
     BOOL updateProgressBar;
     int totalSeconds;
     NSString *lastThumbnail;
-    int choosedTab;
     NSString *notificationName;
     __weak IBOutlet UILabel *scrabbingMessage;
     __weak IBOutlet UILabel *scrabbingRate;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1311,9 +1311,10 @@
     }];
 }
 
-- (void)showInfo:(NSDictionary*)item menuItem:(mainMenu*)menuItem indexPath:(NSIndexPath*)indexPath {
-    NSDictionary *methods = menuItem.mainMethod[choosedTab];
-    NSDictionary *parameters = menuItem.mainParameters[choosedTab];
+- (void)showInfo:(NSDictionary*)item menuItem:(mainMenu*)menuItem activeTab:(int)activeTab indexPath:(NSIndexPath*)indexPath {
+    NSDictionary *methods = menuItem.mainMethod[activeTab];
+    NSDictionary *parameters = menuItem.mainParameters[activeTab];
+    NSDictionary *mainFields = menuItem.mainFields[activeTab];
     
     NSMutableDictionary *mutableParameters = [parameters[@"extra_info_parameters"] mutableCopy];
     NSMutableArray *mutableProperties = [parameters[@"extra_info_parameters"][@"properties"] mutableCopy];
@@ -1324,7 +1325,7 @@
     }
 
     if (parameters[@"extra_info_parameters"] != nil && methods[@"extra_info_method"] != nil) {
-        [self retrieveExtraInfoData:methods[@"extra_info_method"] parameters:mutableParameters index:indexPath item:item menuItem:menuItem];
+        [self retrieveExtraInfoData:methods[@"extra_info_method"] parameters:mutableParameters mainFields:mainFields index:indexPath item:item];
     }
     else {
         [self displayInfoView:item];
@@ -1346,8 +1347,7 @@
     }
 }
 
-- (void)retrieveExtraInfoData:(NSString*)methodToCall parameters:(NSDictionary*)parameters index:(NSIndexPath*)indexPath item:(NSDictionary*)item menuItem:(mainMenu*)menuItem {
-    NSDictionary *mainFields = menuItem.mainFields[choosedTab];
+- (void)retrieveExtraInfoData:(NSString*)methodToCall parameters:(NSDictionary*)parameters mainFields:(NSDictionary*)mainFields index:(NSIndexPath*)indexPath item:(NSDictionary*)item {
     NSString *itemid = mainFields[@"row6"] ?: @"";
     id object = [Utilities getNumberFromItem:item[itemid]];
     if (AppDelegate.instance.serverVersion > 11 && [methodToCall isEqualToString:@"AudioLibrary.GetArtistDetails"]) {
@@ -1902,28 +1902,28 @@
     else {
         return;
     }
-    choosedTab = -1;
+    int activeTab = -1;
     mainMenu *menuItem = nil;
     notificationName = @"";
     if ([item[@"type"] isEqualToString:@"song"]) {
         notificationName = @"MainMenuDeselectSection";
         menuItem = [AppDelegate.instance.playlistArtistAlbums copy];
         if ([actiontitle isEqualToString:LOCALIZED_STR(@"Album Details")]) {
-            choosedTab = 0;
+            activeTab = 0;
             menuItem.subItem.mainLabel = item[@"album"];
             menuItem.subItem.mainMethod = nil;
         }
         else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Album Tracks")]) {
-            choosedTab = 0;
+            activeTab = 0;
             menuItem.subItem.mainLabel = item[@"album"];
         }
         else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Artist Details")]) {
-            choosedTab = 1;
+            activeTab = 1;
             menuItem.subItem.mainLabel = item[@"artist"];
             menuItem.subItem.mainMethod = nil;
         }
         else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Artist Albums")]) {
-            choosedTab = 1;
+            activeTab = 1;
             menuItem.subItem.mainLabel = item[@"artist"];
         }
         else {
@@ -1932,7 +1932,7 @@
     }
     else if ([item[@"type"] isEqualToString:@"movie"]) {
         menuItem = [AppDelegate.instance.playlistMovies copy];
-        choosedTab = 0;
+        activeTab = 0;
         menuItem.subItem.mainLabel = item[@"label"];
         notificationName = @"MainMenuDeselectSection";
     }
@@ -1940,35 +1940,35 @@
         notificationName = @"MainMenuDeselectSection";
         if ([actiontitle isEqualToString:LOCALIZED_STR(@"Episode Details")]) {
             menuItem = [AppDelegate.instance.playlistTvShows.subItem copy];
-            choosedTab = 0;
+            activeTab = 0;
             menuItem.subItem.mainLabel = item[@"label"];
         }
         else if ([actiontitle isEqualToString:LOCALIZED_STR(@"TV Show Details")]) {
             menuItem = [AppDelegate.instance.playlistTvShows copy];
             menuItem.subItem.mainMethod = nil;
-            choosedTab = 0;
+            activeTab = 0;
             menuItem.subItem.mainLabel = item[@"label"];
         }
     }
     else if ([item[@"type"] isEqualToString:@"musicvideo"]) {
         menuItem = [AppDelegate.instance.playlistMusicVideos copy];
-        choosedTab = 0;
+        activeTab = 0;
         menuItem.subItem.mainLabel = item[@"label"];
         notificationName = @"MainMenuDeselectSection";
     }
     else if ([item[@"type"] isEqualToString:@"recording"]) {
         menuItem = [AppDelegate.instance.playlistPVR copy];
-        choosedTab = 2;
+        activeTab = 2;
         menuItem.subItem.mainLabel = item[@"label"];
         notificationName = @"MainMenuDeselectSection";
     }
     else {
         return;
     }
-    NSDictionary *methods = menuItem.subItem.mainMethod[choosedTab];
+    NSDictionary *methods = menuItem.subItem.mainMethod[activeTab];
     if (methods[@"method"] != nil) { // THERE IS A CHILD
-        NSDictionary *mainFields = menuItem.mainFields[choosedTab];
-        NSMutableDictionary *parameters = menuItem.subItem.mainParameters[choosedTab];
+        NSDictionary *mainFields = menuItem.mainFields[activeTab];
+        NSMutableDictionary *parameters = menuItem.subItem.mainParameters[activeTab];
         NSString *key = @"null";
         if (item[mainFields[@"row15"]] != nil) {
             key = mainFields[@"row15"];
@@ -1997,8 +1997,8 @@
                                               [NSDictionary dictionaryWithDictionary:parameters[@"itemSizes"]], @"itemSizes",
                                               @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
                                               nil];
-        menuItem.subItem.mainParameters[choosedTab] = newParameters;
-        menuItem.subItem.chooseTab = choosedTab;
+        menuItem.subItem.mainParameters[activeTab] = newParameters;
+        menuItem.subItem.chooseTab = activeTab;
         fromItself = YES;
         if (IS_IPHONE) {
             DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
@@ -2013,7 +2013,7 @@
         }
     }
     else {
-        [self showInfo:item menuItem:menuItem indexPath:selectedIndexPath];
+        [self showInfo:item menuItem:menuItem activeTab:activeTab indexPath:selectedIndexPath];
     }
 }
 

--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -58,7 +58,6 @@
     NSMutableArray *sheetActions;
     UIBarButtonItem *actionSheetButtonItem;
     UIBarButtonItem *extraButton;
-    int choosedTab;
     NSString *notificationName;
     KenBurnsView *kenView;
     BOOL enableKenBurns;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -235,7 +235,7 @@ double round(double d) {
     NSDictionary *item = self.detailItem;
     mainMenu *menuItem = nil;
     mainMenu *choosedMenuItem = nil;
-    choosedTab = 0;
+    int activeTab = 0;
     id movieObj = nil;
     id movieObjKey = nil;
     BOOL blackTableSeparator = NO;
@@ -253,7 +253,7 @@ double round(double d) {
     }
     else if ([item[@"family"] isEqualToString:@"artistid"]) {
         notificationName = @"MainMenuDeselectSection";
-        choosedTab = 1;
+        activeTab = 1;
         menuItem = [AppDelegate.instance.playlistArtistAlbums copy];
         choosedMenuItem = menuItem.subItem;
         choosedMenuItem.mainLabel = [NSString stringWithFormat:@"%@", item[@"label"]];
@@ -261,7 +261,7 @@ double round(double d) {
     else if ([item[@"family"] isEqualToString:@"movieid"] && AppDelegate.instance.serverVersion > 11) {
         if ([sender isKindOfClass:[NSString class]]) {
             NSString *actorName = (NSString*)sender;
-            choosedTab = 2;
+            activeTab = 2;
             menuItem = [AppDelegate.instance.playlistMovies copy];
             movieObj = [NSDictionary dictionaryWithObjectsAndKeys:actorName, @"actor", nil];
             movieObjKey = @"filter";
@@ -272,7 +272,7 @@ double round(double d) {
     else if (([item[@"family"] isEqualToString:@"episodeid"] || [item[@"family"] isEqualToString:@"tvshowid"]) && AppDelegate.instance.serverVersion > 11) {
         if ([sender isKindOfClass:[NSString class]]) {
             NSString *actorName = (NSString*)sender;
-            choosedTab = 0;
+            activeTab = 0;
             menuItem = [AppDelegate.instance.playlistTvShows copy];
             movieObj = [NSDictionary dictionaryWithObjectsAndKeys:actorName, @"actor", nil];
             movieObjKey = @"filter";
@@ -292,10 +292,10 @@ double round(double d) {
     else {
         return;
     }
-    NSDictionary *methods = choosedMenuItem.mainMethod[choosedTab];
+    NSDictionary *methods = choosedMenuItem.mainMethod[activeTab];
     if (methods[@"method"] != nil) { // THERE IS A CHILD
-        NSDictionary *mainFields = menuItem.mainFields[choosedTab];
-        NSMutableDictionary *parameters = choosedMenuItem.mainParameters[choosedTab];
+        NSDictionary *mainFields = menuItem.mainFields[activeTab];
+        NSMutableDictionary *parameters = choosedMenuItem.mainParameters[activeTab];
         id objKey = mainFields[@"row6"];
         id obj = [Utilities getNumberFromItem:item[objKey]];
         if (movieObj != nil && movieObjKey != nil) {
@@ -332,8 +332,8 @@ double round(double d) {
                                               @([parameters[@"collectionViewRecentlyAdded"] boolValue]), @"collectionViewRecentlyAdded",
                                               newSectionParameters, @"extra_section_parameters",
                                               nil];
-        choosedMenuItem.mainParameters[choosedTab] = newParameters;
-        choosedMenuItem.chooseTab = choosedTab;
+        choosedMenuItem.mainParameters[activeTab] = newParameters;
+        choosedMenuItem.chooseTab = activeTab;
         if (IS_IPHONE) {
             DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
             detailViewController.detailItem = choosedMenuItem;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR resolves a long-standing concept problem, which also is expected to cause some sporadically reported crashes in via AppStore while using Global Search. 

#### Background
`choosedTab` represents the selected view in a menu, e.g. Albums, Artists or Genre. The variable is used to read key data, like JSON methods/parameters or sort options, from the menu structure array. The implementation for now did change this ivar while processing actions for Global Search items (like entering next menu level or processing action sheets). This could result in the current Global Search view (always `choosedTab = 0`) temporarily using wrong values of `choosedTab` just to process an item related action. In worst case this could end up in an out-of-bounds access crash.

#### Main Change 
Instead of changing the ivar `choosedTab`, when processing actions in Global Search, it is better to use a local variable  -- `activeTab` was introduced. This avoids race conditions and allows to remove special handling when coming back to Global Search from a child view or after processing an action in Global Search. This requires the implementation of `getActiveTab` which returns the targeted `activeTab` for a given item.

#### Further Improvements
After this main rework similar changes were done to `NowPlaying` and `ShowInfoViewController`, replacing ivar with local variables, following the same naming convention as in `DetailViewController`.

#### Crash Log
One of AppStore's crash logs points to an out-of-bounds access in `NSDictionary *parameters = [Utilities indexKeyedDictionaryFromArray:menuItem.mainParameters[choosedTab]];` which is likely to be caused by `choosedTab` having been altered for Global Search.
```
Last Exception Backtrace:
0   CoreFoundation                	0x183152180 __exceptionPreprocess + 228 (NSException.m:172)
1   libobjc.A.dylib               	0x18232a9f8 objc_exception_throw + 56 (objc-exception.mm:557)
2   CoreFoundation                	0x1830cbbec _CFThrowFormattedException + 112 (CFObject.m:1958)
3   CoreFoundation                	0x183050bec -[__NSArrayM objectAtIndexedSubscript:] + 220 (NSArrayM.m:291)
4   Kodi Remote                   	0x1009dbfc8 -[DetailViewController indexAndDisplayData] + 108 (DetailViewController.m:4993)
5   Kodi Remote                   	0x1009d2c98 __43-[DetailViewController actionSheetHandler:]_block_invoke_2 + 324 (DetailViewController.m:3648)
6   UIKitCore                     	0x1afc59d1c -[UIViewAnimationBlockDelegate _didEndBlockAnimation:finished:context:] + 752 (UIView.m:12852)
7   UIKitCore                     	0x1afc30a74 -[UIViewAnimationState sendDelegateAnimationDidStop:finished:] + 312 (UIView.m:0)
8   UIKitCore                     	0x1afc31048 -[UIViewAnimationState animationDidStop:finished:] + 296 (UIView.m:2111)
9   QuartzCore                    	0x1876a23c8 CA::Layer::run_animation_callbacks(void*) + 284 (CALayer.mm:6680)
10  libdispatch.dylib             	0x182b907d4 _dispatch_client_callout + 16 (object.m:511)
11  libdispatch.dylib             	0x182b3e008 _dispatch_main_queue_callback_4CF$VARIANT$mp + 1068 (inline_internal.h:2441)
12  CoreFoundation                	0x1830e3b20 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12 (CFRunLoop.c:1813)
13  CoreFoundation                	0x1830dea58 __CFRunLoopRun + 1924 (CFRunLoop.c:3113)
14  CoreFoundation                	0x1830ddfb4 CFRunLoopRunSpecific + 436 (CFRunLoop.c:3247)
15  GraphicsServices              	0x1852e079c GSEventRunModal + 104 (GSEvent.c:2245)
16  UIKitCore                     	0x1af7cec38 UIApplicationMain + 212 (UIApplication.m:4353)
17  Kodi Remote                   	0x100990c34 main + 80 (main.m:15)
18  libdyld.dylib                 	0x182ba18e0 start + 4 (:-1)
```

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid potential crash in Global Search
Maintenance: Rework handling of active tab with focus on the library view