### PR TITLE
Bugfix: Fix potential crash when renaming custom buttons

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -444,6 +444,9 @@
         textField.text = tableData[indexPath.row][@"label"];
     }];
     UIAlertAction *updateButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Update label") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+        if (indexPath.row >= tableData.count) {
+            return;
+        }
         tableData[indexPath.row][@"label"] = alertView.textFields[0].text;
         
         UITableViewCell *cell = [menuTableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:indexPath.row inSection:0]];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -445,17 +445,17 @@
     }];
     UIAlertAction *updateButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Update label") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
         tableData[indexPath.row][@"label"] = alertView.textFields[0].text;
-            
-            UITableViewCell *cell = [menuTableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:indexPath.row inSection:0]];
-            UILabel *title = (UILabel*)[cell viewWithTag:XIB_RIGHT_MENU_CELL_TITLE];
-            title.text = alertView.textFields[0].text;
-            
-            customButton *arrayButtons = [customButton new];
-            if ([arrayButtons.buttons[indexPath.row - editableRowStartAt] respondsToSelector:@selector(setObject:forKey:)]) {
-                arrayButtons.buttons[indexPath.row - editableRowStartAt][@"label"] = alertView.textFields[0].text;
-                [arrayButtons saveData];
-            }
-        }];
+        
+        UITableViewCell *cell = [menuTableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:indexPath.row inSection:0]];
+        UILabel *title = (UILabel*)[cell viewWithTag:XIB_RIGHT_MENU_CELL_TITLE];
+        title.text = alertView.textFields[0].text;
+        
+        customButton *arrayButtons = [customButton new];
+        if ([arrayButtons.buttons[indexPath.row - editableRowStartAt] respondsToSelector:@selector(setObject:forKey:)]) {
+            arrayButtons.buttons[indexPath.row - editableRowStartAt][@"label"] = alertView.textFields[0].text;
+            [arrayButtons saveData];
+        }
+    }];
     UIAlertAction *cancelButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:nil];
     [alertView addAction:updateButton];
     [alertView addAction:cancelButton];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a sporadic issue reported via AppStore by early return to avoid out-of-bounds-access.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix potential crash when renaming custom buttons