### PR TITLE
Bugfix: Fix avoids never-ending activity indicator in movie sets

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5050,6 +5050,9 @@
 //                 NSLog(@"RICH RESULTS %@", resultStoreArray);
                  // Single Movie Sets are handled seperately
                  if (ignoreSingleMovieSets) {
+                     if (!itemDict){
+                         [self showNoResultsFound:resultStoreArray refresh:forceRefresh];
+                     }
                      return;
                  }
                  if (!extraSectionCallBool) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Call `showNoResultsFound` in case no movie sets are found. This avoids never-ending activity indicator when no movie sets are found, as movie sets use an early return.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix avoids never-ending activity indicator in movie sets