### PR TITLE
Maintenance: Small refactoring in DetailVC

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -92,8 +92,8 @@
 #define XIB_JSON_DATA_CELL_ACTIVTYINDICATOR SHARED_CELL_ACTIVTYINDICATOR
 #define ALBUM_VIEW_CELL_TRACKNUMBER 101
 #define SEASON_VIEW_CELL_TOGGLE 99
-#define DETAIL_VIEW_INFO_ALBUM 0
-#define DETAIL_VIEW_INFO_TVSHOW 1
+#define DETAIL_VIEW_INFO_ALBUM 104
+#define DETAIL_VIEW_INFO_TVSHOW 105
 #define EPG_VIEW_CELL_STARTTIME 102
 #define EPG_VIEW_CELL_PROGRESSVIEW 103
 #define EPG_VIEW_CELL_RECORDING_ICON SHARED_CELL_RECORDING_ICON
@@ -4475,7 +4475,7 @@
         }
     }
     menuItem = nil;
-    if ([sender tag] == DETAIL_VIEW_INFO_ALBUM) {
+    if (!sender || [sender tag] == DETAIL_VIEW_INFO_ALBUM) {
         menuItem = [AppDelegate.instance.playlistArtistAlbums copy];
     }
     else if ([sender tag] == DETAIL_VIEW_INFO_TVSHOW) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4142,7 +4142,7 @@
     mainMenu *menuItem = [self getMainMenu:item];
     NSDictionary *mainFields = menuItem.mainFields[choosedTab];
     if (forceMusicAlbumMode) {
-        mainFields = [AppDelegate.instance.playlistArtistAlbums mainFields][0];
+        mainFields = AppDelegate.instance.playlistArtistAlbums.mainFields[0];
         forceMusicAlbumMode = NO;
     }
     int playlistid = [mainFields[@"playlistid"] intValue];
@@ -4241,7 +4241,7 @@
     mainMenu *menuItem = [self getMainMenu:item];
     NSDictionary *mainFields = menuItem.mainFields[choosedTab];
     if (forceMusicAlbumMode) {
-        mainFields = [AppDelegate.instance.playlistArtistAlbums mainFields][0];
+        mainFields = AppDelegate.instance.playlistArtistAlbums.mainFields[0];
         forceMusicAlbumMode = NO;
     }
     if (mainFields.count == 0) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1361,8 +1361,6 @@
     mainMenu *menuItem = [self getMainMenu:item];
     NSMutableArray *sheetActions = menuItem.sheetActions[choosedTab];
     NSMutableDictionary *parameters = menuItem.subItem.mainParameters[choosedTab];
-    int rectOriginX = point.x;
-    int rectOriginY = point.y;
     NSDictionary *mainFields = menuItem.mainFields[choosedTab];
     
     NSNumber *libraryRowHeight = parameters[@"rowHeight"] ?: @(menuItem.subItem.rowHeight);
@@ -1487,7 +1485,7 @@
                      [item[@"filetype"] isEqualToString:@"file"]) {
                 NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
                 if (![userDefaults boolForKey:@"song_preference"]) {
-                    [self showActionSheet:indexPath sheetActions:sheetActions item:item rectOriginX:rectOriginX rectOriginY:rectOriginY];
+                    [self showActionSheet:indexPath sheetActions:sheetActions item:item origin:point];
                 }
                 else {
                     [self addPlayback:item indexPath:indexPath position:indexPath.row shuffle:NO];
@@ -1539,8 +1537,6 @@
     NSDictionary *methods = menuItem.subItem.mainMethod[choosedTab];
     NSMutableArray *sheetActions = [menuItem.sheetActions[choosedTab] mutableCopy];
     NSMutableDictionary *parameters = menuItem.subItem.mainParameters[choosedTab];
-    int rectOriginX = point.x;
-    int rectOriginY = point.y;
     if ([item[@"family"] isEqualToString:@"id"]) {
         if (IS_IPHONE) {
             SettingsValuesViewController *settingsViewController = [[SettingsValuesViewController alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, self.view.bounds.size.height) withItem:item];
@@ -1606,7 +1602,7 @@
             if (![userDefaults boolForKey:@"song_preference"] || [parameters[@"forceActionSheet"] boolValue]) {
                 sheetActions = [self getPlaylistActions:sheetActions item:item params:menuItem.mainParameters[choosedTab]];
                 selectedIndexPath = indexPath;
-                [self showActionSheet:indexPath sheetActions:sheetActions item:item rectOriginX:rectOriginX rectOriginY:rectOriginY];
+                [self showActionSheet:indexPath sheetActions:sheetActions item:item origin:point];
             }
             else {
                 [self addPlayback:item indexPath:indexPath position:indexPath.row shuffle:NO];
@@ -3214,7 +3210,7 @@
 
 #pragma mark - Long Press & Action sheet
 
-- (void)showActionSheet:(NSIndexPath*)indexPath sheetActions:(NSArray*)sheetActions item:(NSDictionary*)item rectOriginX:(int) rectOriginX rectOriginY:(int) rectOriginY {
+- (void)showActionSheet:(NSIndexPath*)indexPath sheetActions:(NSArray*)sheetActions item:(NSDictionary*)item origin:(CGPoint)sheetOrigin {
     NSInteger numActions = sheetActions.count;
     if (numActions) {
         NSString *title = [NSString stringWithFormat:@"%@%@%@", item[@"label"], [item[@"genre"] isEqualToString:@""] ? @"" : [NSString stringWithFormat:@"\n%@", item[@"genre"]], [item[@"family"] isEqualToString:@"songid"] ? [NSString stringWithFormat:@"\n%@", item[@"album"]] : @""];
@@ -3223,7 +3219,6 @@
             sheetActions = @[LOCALIZED_STR(@"Ok")];
         }
         BOOL isRecording = [self isTimerActiveForItem:item];
-        CGPoint sheetOrigin = CGPointMake(rectOriginX, rectOriginY);
         UIViewController *showFromCtrl = [Utilities topMostController];
         [self showActionSheetOptions:title options:sheetActions recording:isRecording origin:sheetOrigin fromcontroller:showFromCtrl fromview:self.view];
     }
@@ -4532,8 +4527,9 @@
     NSMutableDictionary *item = [sectionItem mutableCopy];
     item[@"label"] = self.navigationItem.title;
     forceMusicAlbumMode = YES;
-    int rectOrigin = (int)((albumViewHeight - albumViewPadding * 2) / 2);
-    [self showActionSheet:nil sheetActions:sheetActions item:item rectOriginX:rectOrigin + albumViewPadding rectOriginY:rectOrigin];
+    CGFloat rectOrigin = floor((albumViewHeight - albumViewPadding * 2) / 2);
+    CGPoint sheetOrigin = CGPointMake(rectOrigin + albumViewPadding, rectOrigin);
+    [self showActionSheet:nil sheetActions:sheetActions item:item origin:sheetOrigin];
 }
 
 # pragma mark - JSON DATA Management

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3219,8 +3219,7 @@
             sheetActions = @[LOCALIZED_STR(@"Ok")];
         }
         BOOL isRecording = [self isTimerActiveForItem:item];
-        UIViewController *showFromCtrl = [Utilities topMostController];
-        [self showActionSheetOptions:title options:sheetActions recording:isRecording origin:sheetOrigin fromcontroller:showFromCtrl fromview:self.view];
+        [self showActionSheetOptions:title options:sheetActions recording:isRecording origin:sheetOrigin fromview:self.view];
     }
     else if (indexPath != nil) { // No actions found, revert back to standard play action
         [self addPlayback:item indexPath:indexPath position:indexPath.row shuffle:NO];
@@ -3249,10 +3248,9 @@
                 title = [NSString stringWithFormat:@"%@\n%@", title, season];
             }
             
-            UIViewController *showFromCtrl = [Utilities topMostController];
             UIView *showFromView = self.view;
             CGPoint sheetOrigin = [sender locationInView:showFromView];
-            [self showActionSheetOptions:title options:sheetActions recording:NO origin:sheetOrigin fromcontroller:showFromCtrl fromview:showFromView];
+            [self showActionSheetOptions:title options:sheetActions recording:NO origin:sheetOrigin fromview:showFromView];
         }
     }
 }
@@ -3323,10 +3321,9 @@
                     [sheetActions removeObject:LOCALIZED_STR(@"Play using...")];
                 }
                 BOOL isRecording = [self isTimerActiveForItem:item];
-                UIViewController *showFromCtrl = [Utilities topMostController];
                 UIView *showFromView = self.view;
                 CGPoint sheetOrigin = [activeRecognizer locationInView:showFromView];
-                [self showActionSheetOptions:title options:sheetActions recording:isRecording origin:sheetOrigin fromcontroller:showFromCtrl fromview:showFromView];
+                [self showActionSheetOptions:title options:sheetActions recording:isRecording origin:sheetOrigin fromview:showFromView];
             }
             // In case of Global Search restore choosedTab after processing
             if (globalSearchView) {
@@ -3336,7 +3333,7 @@
     }
 }
 
-- (void)showActionSheetOptions:(NSString*)title options:(NSArray*)sheetActions recording:(BOOL)isRecording origin:(CGPoint)origin fromcontroller:(UIViewController*)fromctrl fromview:(UIView*)fromview {
+- (void)showActionSheetOptions:(NSString*)title options:(NSArray*)sheetActions recording:(BOOL)isRecording origin:(CGPoint)origin fromview:(UIView*)fromview {
     NSInteger numActions = sheetActions.count;
     if (numActions) {
         UIAlertController *actionTemp = [UIAlertController alertControllerWithTitle:title message:nil preferredStyle:UIAlertControllerStyleActionSheet];
@@ -3353,13 +3350,14 @@
                 actiontitle = LOCALIZED_STR(@"Stop Recording");
             }
             UIAlertAction *action = [UIAlertAction actionWithTitle:actiontitle style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-                [self actionSheetHandler:actiontitle origin:origin fromcontroller:fromctrl fromview:fromview];
+                [self actionSheetHandler:actiontitle origin:origin fromview:fromview];
             }];
             [actionView addAction:action];
         }
         [actionView addAction:action_cancel];
         actionView.modalPresentationStyle = UIModalPresentationPopover;
         
+        UIViewController *fromctrl = [Utilities topMostController];
         UIPopoverPresentationController *popPresenter = [actionView popoverPresentationController];
         if (popPresenter != nil) {
             popPresenter.sourceView = fromview;
@@ -3481,7 +3479,7 @@
     [userDefaults setObject:sortAscDescSave forKey:sortKey];
 }
 
-- (void)actionSheetHandler:(NSString*)actiontitle origin:(CGPoint)origin fromcontroller:(UIViewController*)fromctrl fromview:(UIView*)fromview {
+- (void)actionSheetHandler:(NSString*)actiontitle origin:(CGPoint)origin fromview:(UIView*)fromview {
     NSDictionary *item = nil;
     if (processAllItemsInSection) {
         selectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:[processAllItemsInSection longValue]];
@@ -3528,6 +3526,7 @@
                 [actionView addAction:action_cancel];
                 actionView.modalPresentationStyle = UIModalPresentationPopover;
                 
+                UIViewController *fromctrl = [Utilities topMostController];
                 UIPopoverPresentationController *popPresenter = [actionView popoverPresentationController];
                 if (popPresenter != nil) {
                     popPresenter.sourceView = fromview;
@@ -6290,13 +6289,12 @@
         sortOptions[sortMethodIndex] = [NSString stringWithFormat:@"\u2713 %@", sortOptions[sortMethodIndex]];
     }
     
-    UIViewController *showFromCtrl = [Utilities topMostController];
     CGPoint sheetOrigin = [button7 convertPoint:button7.center toView:buttonsView];
     sheetOrigin.y -= CGRectGetHeight(button7.frame) / 2;
     NSString *title = [NSString stringWithFormat:@"%@\n\n(%@)",
                        LOCALIZED_STR(@"Sort by"),
                        LOCALIZED_STR(@"tap the selection\nto reverse the sort order")];
-    [self showActionSheetOptions:title options:sortOptions recording:NO origin:sheetOrigin fromcontroller:showFromCtrl fromview:buttonsView];
+    [self showActionSheetOptions:title options:sortOptions recording:NO origin:sheetOrigin fromview:buttonsView];
 }
 
 - (BOOL)shouldAutorotate {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1949,7 +1949,7 @@
         }
     }
     else if ([item[@"type"] isEqualToString:@"movie"]) {
-        menuItem = AppDelegate.instance.playlistMovies;
+        menuItem = [AppDelegate.instance.playlistMovies copy];
         choosedTab = 0;
         menuItem.subItem.mainLabel = item[@"label"];
         notificationName = @"MainMenuDeselectSection";
@@ -1957,7 +1957,7 @@
     else if ([item[@"type"] isEqualToString:@"episode"]) {
         notificationName = @"MainMenuDeselectSection";
         if ([actiontitle isEqualToString:LOCALIZED_STR(@"Episode Details")]) {
-            menuItem = AppDelegate.instance.playlistTvShows.subItem;
+            menuItem = [AppDelegate.instance.playlistTvShows.subItem copy];
             choosedTab = 0;
             menuItem.subItem.mainLabel = item[@"label"];
         }
@@ -1969,13 +1969,13 @@
         }
     }
     else if ([item[@"type"] isEqualToString:@"musicvideo"]) {
-        menuItem = AppDelegate.instance.playlistMusicVideos;
+        menuItem = [AppDelegate.instance.playlistMusicVideos copy];
         choosedTab = 0;
         menuItem.subItem.mainLabel = item[@"label"];
         notificationName = @"MainMenuDeselectSection";
     }
     else if ([item[@"type"] isEqualToString:@"recording"]) {
-        menuItem = AppDelegate.instance.playlistPVR;
+        menuItem = [AppDelegate.instance.playlistPVR copy];
         choosedTab = 2;
         menuItem.subItem.mainLabel = item[@"label"];
         notificationName = @"MainMenuDeselectSection";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR does some small refactoring around method parameters.
- Replace origin's `x`/`y` parameters with `CGPoint`.
- Remove parameter `fromcontroller:` which anyway was always set to `[Utilities topMostController]`
- Improve checking `sender` in `prepareShowAlbumInfo` to not depend on `DETAIL_VIEW_INFO_ALBUM = 0`
- Ensure to use copies of `AppDelegate.instance.playlist`, when tailoring them, to avoid changing the origin by fault.


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Small refactoring in DetailVC