### PR TITLE
Maintenance: Minor refactoring around unused  swipes and NowPlaying in navigation bar

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -5639,28 +5639,18 @@
     
 #pragma mark - Playlist Artist Albums
     playlistArtistAlbums = [menu_Music copy];
-    playlistArtistAlbums.subItem.disableNowPlaying = YES;
-    playlistArtistAlbums.subItem.subItem.disableNowPlaying = YES;
     
 #pragma mark - Plalist Movies
     playlistMovies = [menu_Movies copy];
-    playlistMovies.subItem.disableNowPlaying = YES;
-    playlistMovies.subItem.subItem.disableNowPlaying = YES;
     
 #pragma mark - Plalist Movies
     playlistMusicVideos = [menu_Videos copy];
-    playlistMusicVideos.subItem.disableNowPlaying = YES;
-    playlistMusicVideos.subItem.subItem.disableNowPlaying = YES;
     
 #pragma mark - Playlist TV Shows
     playlistTvShows = [menu_TVShows copy];
-    playlistTvShows.subItem.disableNowPlaying = YES;
-    playlistTvShows.subItem.subItem.disableNowPlaying = YES;
 
 #pragma mark - Playlist PVR
     playlistPVR = [menu_LiveTV copy];
-    playlistPVR.subItem.disableNowPlaying = YES;
-    playlistPVR.subItem.subItem.disableNowPlaying = YES;
     
 #pragma mark - XBMC Settings 
     xbmcSettings = [mainMenu new];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -544,11 +544,6 @@
     if (!stringURL.length) {
         stringURL = [Utilities getItemIconFromDictionary:item];
     }
-    mainMenu *menuItem = self.detailItem;
-    BOOL disableNowPlaying = NO;
-    if (menuItem.disableNowPlaying) {
-        disableNowPlaying = YES;
-    }
     
     id row11 = item[mainFields[@"row11"]] ?: @0;
     NSString *row11key = mainFields[@"row11"] ?: @"";
@@ -557,7 +552,6 @@
     NSString *row7key = mainFields[@"row7"] ?: @"";
 
     NSDictionary *newItem = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                             @(disableNowPlaying), @"disableNowPlaying",
                              @(albumView), @"fromAlbumView",
                              @(episodesView), @"fromEpisodesView",
                              clearlogo, @"clearlogo",
@@ -3822,21 +3816,7 @@
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
-#pragma mark - Gestures
-
-- (void)handleSwipeFromLeft:(id)sender {
-    mainMenu *menuItem = self.detailItem;
-    if (!menuItem.disableNowPlaying) {
-        [self showNowPlaying];
-    }
-}
-
-- (void)handleSwipeFromRight:(id)sender {
-    if ([self.navigationController.viewControllers indexOfObject:self] == 0) {
-        [self revealMenu:nil];
-    }
-    [self.navigationController popViewControllerAnimated:YES];
-}
+#pragma mark - Keyboard
 
 - (void)hideKeyboard:(id)sender {
     [self.searchController.searchBar resignFirstResponder];
@@ -3874,20 +3854,6 @@
         topNavigationLabel.shadowOffset = CGSizeMake (0, -1);
         topNavigationLabel.highlightedTextColor = UIColor.blackColor;
         topNavigationLabel.opaque = YES;
-        
-        // Set up gestures
-        if (!menuItem.disableNowPlaying) {
-            UISwipeGestureRecognizer *leftSwipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFromLeft:)];
-            leftSwipe.numberOfTouchesRequired = 1;
-            leftSwipe.cancelsTouchesInView = NO;
-            leftSwipe.direction = UISwipeGestureRecognizerDirectionLeft;
-            [self.view addGestureRecognizer:leftSwipe];
-        }
-        UISwipeGestureRecognizer *rightSwipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFromRight:)];
-        rightSwipe.numberOfTouchesRequired = 1;
-        rightSwipe.cancelsTouchesInView = NO;
-        rightSwipe.direction = UISwipeGestureRecognizerDirectionRight;
-        [self.view addGestureRecognizer:rightSwipe];
         
         // Set up navigation bar items on upper right
         UIImage *remoteButtonImage = [UIImage imageNamed:@"icon_menu_remote"];

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -195,13 +195,6 @@
     return !(newLength > 2 && textField.tag >= XIB_FIRST_MAC_ADDRESS_FIELD && textField.tag <= XIB_LAST_MAC_ADDRESS_FIELD);
 }
 
-# pragma mark - Gestures
-
-- (void)handleSwipeFromRight:(id)sender {
-    [self.navigationController popViewControllerAnimated:YES];
-}
-
-
 # pragma mark - NSNetServiceBrowserDelegate Methods
 
 - (void)netServiceBrowserWillSearch:(NSNetServiceBrowser*)browser {
@@ -609,11 +602,6 @@
         textfield.tintColor = [Utilities get1stLabelColor];
     }
     discoveredInstancesTableView.backgroundColor = [Utilities getSystemGray6];
-    UISwipeGestureRecognizer *rightSwipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFromRight:)];
-    rightSwipe.numberOfTouchesRequired = 1;
-    rightSwipe.cancelsTouchesInView = NO;
-    rightSwipe.direction = UISwipeGestureRecognizerDirectionRight;
-    [self.view addGestureRecognizer:rightSwipe];
     
     CGFloat bottomPadding = [Utilities getBottomPadding];
     if (IS_IPAD) {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -96,17 +96,6 @@
     // Update the user interface for the detail item.
     if (self.detailItem) {
         self.navigationItem.title = LOCALIZED_STR(@"Now Playing"); // DA SISTEMARE COME PARAMETRO
-        UISwipeGestureRecognizer *rightSwipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFromRight:)];
-        rightSwipe.numberOfTouchesRequired = 1;
-        rightSwipe.cancelsTouchesInView = NO;
-        rightSwipe.direction = UISwipeGestureRecognizerDirectionRight;
-        [self.view addGestureRecognizer:rightSwipe];
-        
-        UISwipeGestureRecognizer *leftSwipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFromLeft:)];
-        leftSwipe.numberOfTouchesRequired = 1;
-        leftSwipe.cancelsTouchesInView = NO;
-        leftSwipe.direction = UISwipeGestureRecognizerDirectionLeft;
-        [self.view addGestureRecognizer:leftSwipe];
     }
 }
 
@@ -1446,14 +1435,12 @@
                  if (!stringURL.length) {
                      stringURL = [Utilities getItemIconFromDictionary:itemExtraDict];
                  }
-                 BOOL disableNowPlaying = YES;
                  NSObject *row11 = itemExtraDict[mainFields[@"row11"]];
                  if (row11 == nil) {
                      row11 = @(0);
                  }
                  NSDictionary *newItem =
                  [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                  @(disableNowPlaying), @"disableNowPlaying",
                   clearlogo, @"clearlogo",
                   clearart, @"clearart",
                   label, @"label",
@@ -2299,23 +2286,6 @@
         [self deselectPlaylistItem];
         [playlistTableView setEditing:YES animated:YES];
         editTableButton.selected = YES;
-    }
-}
-
-# pragma mark - Swipe Gestures
-
-- (void)handleSwipeFromRight:(id)sender {
-    if (updateProgressBar) {
-        if ([self.navigationController.viewControllers indexOfObject:self] == 0) {
-            [self revealMenu:nil];
-        }
-        [self.navigationController popViewControllerAnimated:YES];
-    }
-}
-
-- (void)handleSwipeFromLeft:(id)sender {
-    if (updateProgressBar) {
-        [self revealUnderRight:nil];
     }
 }
 

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -194,11 +194,6 @@ double round(double d) {
             else if (extraButton) {
                 self.navigationItem.rightBarButtonItems = @[extraButton];
             }
-            UISwipeGestureRecognizer *rightSwipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFromRight:)];
-            rightSwipe.numberOfTouchesRequired = 1;
-            rightSwipe.cancelsTouchesInView = NO;
-            rightSwipe.direction = UISwipeGestureRecognizerDirectionRight;
-            [self.view addGestureRecognizer:rightSwipe];
         }
         // Place the up and down arrows. Keep them invisible for now.
         CGFloat bottomPadding = [Utilities getBottomPadding];
@@ -210,13 +205,6 @@ double round(double d) {
         frame.origin.y += scrollView.contentInset.top;
         arrow_back_up.frame = frame;
         arrow_back_up.alpha = 0;
-    }
-    if (![self.detailItem[@"disableNowPlaying"] boolValue]) {
-        UISwipeGestureRecognizer *leftSwipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFromLeft:)];
-        leftSwipe.numberOfTouchesRequired = 1;
-        leftSwipe.cancelsTouchesInView = NO;
-        leftSwipe.direction = UISwipeGestureRecognizerDirectionLeft;
-        [self.view addGestureRecognizer:leftSwipe];
     }
 }
 
@@ -346,9 +334,6 @@ double round(double d) {
                                               nil];
         choosedMenuItem.mainParameters[choosedTab] = newParameters;
         choosedMenuItem.chooseTab = choosedTab;
-        if (![item[@"disableNowPlaying"] boolValue]) {
-            choosedMenuItem.disableNowPlaying = NO;
-        }
         if (IS_IPHONE) {
             DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
             detailViewController.detailItem = choosedMenuItem;
@@ -1639,15 +1624,6 @@ double round(double d) {
     [trailerWebView loadRequest:urlrequest];
 }
 
-#pragma mark - Gestures
-
-- (void)handleSwipeFromLeft:(id)sender {
-    if (![self.detailItem[@"disableNowPlaying"] boolValue]) {
-        [self showNowPlaying];
-        [self.navigationController setNavigationBarHidden:NO animated:YES];
-    }
-}
-
 # pragma mark - JSON Data
 
 - (void)addQueueAfterCurrent:(BOOL)afterCurrent {
@@ -1840,12 +1816,6 @@ double round(double d) {
     [[Utilities getJsonRPC] callMethod:action withParameters:parameters];
 }
 
-# pragma mark - Gestures
-
-- (void)handleSwipeFromRight:(id)sender {
-    [self.navigationController popViewControllerAnimated:YES];
-}
-
 # pragma mark - Utility
 
 - (void)elabKenBurns:(UIImage*)image {
@@ -1887,12 +1857,6 @@ double round(double d) {
     self.slidingViewController.underRightViewController = nil;
     self.slidingViewController.anchorLeftPeekAmount   = 0;
     self.slidingViewController.anchorLeftRevealAmount = 0;
-    // TRICK WHEN CHILDREN WAS FORCED TO PORTRAIT
-//    if (![self.detailItem[@"disableNowPlaying"] boolValue]) {
-//        UIViewController *c = [[UIViewController alloc]init];
-//        [self presentViewController:c animated:NO completion:nil];
-//        [self dismissViewControllerAnimated:NO completion:nil];
-//    }
     [actorsTable deselectRowAtIndexPath:[actorsTable indexPathForSelectedRow] animated:YES];
     if ([self isModal]) {
         if (doneButton == nil) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Minor refactoring:
- Swipes are consumed by either iPad's StackVC or iPhone's SlidingVC. 
- Only use menu config's `disableNowPlaying` to not show the NowPlaying button in the settings's navigation bar.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Minor refactoring around unused swipes and NowPlaying in navigation bar