### PR TITLE
Bugfix: Hide resume option for Kodi 11 or earlier

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -75,7 +75,7 @@ double round(double d) {
         if (resumePointDict && [resumePointDict isKindOfClass:[NSDictionary class]]) {
             float position = [Utilities getFloatValueFromItem:resumePointDict[@"position"]];
             float total = [Utilities getFloatValueFromItem:resumePointDict[@"total"]];
-            if (position > 0 && total > 0) {
+            if (position > 0 && total > 0 && [VersionCheck hasPlayerOpenOptions]) {
                 [sheetActions addObject:LOCALIZED_STR_ARGS(@"Resume from %@", [Utilities convertTimeFromSeconds: @(position)])];
             }
         }

--- a/XBMC Remote/VersionCheck.h
+++ b/XBMC Remote/VersionCheck.h
@@ -19,5 +19,6 @@
 + (BOOL)hasAlbumArtistOnlySupport;
 + (BOOL)hasInputButtonEventSupport;
 + (BOOL)hasPlayUsingSupport;
++ (BOOL)hasPlayerOpenOptions;
 
 @end

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -60,4 +60,9 @@
     return AppDelegate.instance.serverVersion >= 21;
 }
 
++ (BOOL)hasPlayerOpenOptions {
+    // "options" for Player.Open were introduced with Kodi 12. This is required to support resume.
+    return AppDelegate.instance.serverVersion > 11;
+}
+
 @end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
`Player.Open` requires at least Kodi 12 to support `resume` in `options`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Hide resume option for Kodi 11 or earlier