### PR TITLE
Maintenance: Remove non needed ivars and properties in iPhone MasterVC

### DIFF
--- a/XBMC Remote/MasterViewController.h
+++ b/XBMC Remote/MasterViewController.h
@@ -12,22 +12,8 @@
 #import "CustomNavigationController.h"
 #import "MessagesView.h"
 
-@class DetailViewController;
-@class NowPlaying;
-@class RemoteController;
-@class HostManagementViewController;
-@class AppInfoViewController;
-@class HostManagementViewController;
-
 @interface MasterViewController : UIViewController <UITableViewDataSource, UITableViewDelegate> {
     IBOutlet UITableView *menuList;
-    UIButton *xbmcInfo;
-    UIButton *xbmcLogo;
-    UIButton *powerButton;
-    NSDictionary *checkServerParams;
-    NSIndexPath *storeServerSelection;
-    AppInfoViewController *appInfoView;
-    HostManagementViewController *hostManagementViewController;
     BOOL itemIsActive;
     CustomNavigationController *navController;
     UIImageView *globalConnectionStatus;
@@ -35,10 +21,6 @@
 }
 
 @property (nonatomic, strong) NSMutableArray *mainMenu;
-@property (strong, nonatomic) DetailViewController *detailViewController;
-@property (strong, nonatomic) NowPlaying *nowPlaying;
-@property (strong, nonatomic) RemoteController *remoteController;
-@property (strong, nonatomic) HostManagementViewController *hostController;
 @property (strong, nonatomic) tcpJSONRPC *tcpJSONRPCconnection;
 
 @end

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -38,10 +38,6 @@
 
 @implementation MasterViewController
 
-@synthesize detailViewController = _detailViewController;
-@synthesize nowPlaying = _nowPlaying;
-@synthesize remoteController = _remoteController;
-@synthesize hostController = _hostController;
 @synthesize mainMenu;
 @synthesize tcpJSONRPCconnection;
 
@@ -153,26 +149,35 @@
     BOOL hideBottonLine = NO;
     switch (item.family) {
         case FamilyNowPlaying:
-            self.nowPlaying = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
-            self.nowPlaying.detailItem = item;
-            object = self.nowPlaying;
+        {
+            NowPlaying *nowPlayingController = [[NowPlaying alloc] initWithNibName:@"NowPlaying" bundle:nil];
+            nowPlayingController.detailItem = item;
+            object = nowPlayingController;
             break;
+        }
         case FamilyRemote:
-            [self.remoteController resetRemote];
-            self.remoteController = [[RemoteController alloc] initWithNibName:@"RemoteController" withEmbedded:NO bundle:nil];
-            self.remoteController.detailItem = item;
-            object = self.remoteController;
+        {
+            RemoteController *remoteController = [[RemoteController alloc] initWithNibName:@"RemoteController" withEmbedded:NO bundle:nil];
+            remoteController.detailItem = item;
+            object = remoteController;
             break;
+        }
         case FamilyServer:
-            self.hostController = [[HostManagementViewController alloc] initWithNibName:@"HostManagementViewController" bundle:nil];
-            object = self.hostController;
+        {
+            HostManagementViewController *hostController = [[HostManagementViewController alloc] initWithNibName:@"HostManagementViewController" bundle:nil];
+            object = hostController;
             hideBottonLine = YES;
             break;
+        }
         case FamilyDetailView:
-            self.detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
-            self.detailViewController.detailItem = item;
-            object = self.detailViewController;
+        {
+            DetailViewController *detailViewController = [[DetailViewController alloc] initWithNibName:@"DetailViewController" bundle:nil];
+            detailViewController.detailItem = item;
+            object = detailViewController;
             hideBottonLine = YES;
+            break;
+        }
+        default:
             break;
     }
     navController = [[CustomNavigationController alloc] initWithRootViewController:object];
@@ -341,7 +346,6 @@
     XBMCVirtualKeyboard *virtualKeyboard = [[XBMCVirtualKeyboard alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
     [self.view addSubview:virtualKeyboard];
     AppDelegate.instance.obj = [GlobalData getInstance];
-    checkServerParams = @{@"properties": @[@"version", @"volume"]};
     menuList.scrollsToTop = NO;
     
     // Add connection status icon to root view

--- a/XBMC Remote/RemoteController.h
+++ b/XBMC Remote/RemoteController.h
@@ -52,7 +52,6 @@ typedef NS_ENUM(NSInteger, RemotePositionType) {
 
 - (IBAction)startVibrate:(id)sender;
 - (void)setEmbeddedView;
-- (void)resetRemote;
 - (id)initWithNibName:(NSString*)nibNameOrNil withEmbedded:(BOOL)withEmbedded bundle:(NSBundle*)nibBundleOrNil;
 @property (strong, nonatomic) id detailItem;
 @property (nonatomic, strong) NSTimer *holdKeyTimer;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
`UIViewController` instances are generated fresh each time, there is no need to keep them as ivar or property. `RemoteController` does not need to expose `resetRemote` anymore.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Remove non needed ivars and properties in iPhone MasterVC