### PR TITLE
Bugfix: Bring back Queue/Play for addon content

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -1758,7 +1758,7 @@
         [self action_queue_to_play],
         @[],
         @[],
-        @[],
+        [self action_queue_to_play],
         [self action_queue_to_play],
         [self action_artist],
     ];
@@ -3022,7 +3022,7 @@
         @[],
         [self action_movie],
         [self action_queue_to_play],
-        @[],
+        [self action_queue_to_play],
         [self action_queue_to_play],
     ];
     
@@ -3583,7 +3583,7 @@
         @[],
         @[],
         [self action_queue_to_play],
-        @[],
+        [self action_queue_to_play],
         [self action_queue_to_play],
     ];
     
@@ -4176,7 +4176,7 @@
         [self action_episode],
         @[],
         [self action_queue_to_play],
-        @[],
+        [self action_queue_to_play],
         [self action_queue_to_play],
     ];
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves an issue reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=379921&pid=3220043#pid3220043).

Queue/Play cannot be disabled as this removes used functionality. Kodi itself handles attempts to queue/play non-supported directories without major problems. Only problem persisting is that Kodi does not respond with success or failure in such case. The iOS App therefore keeps the activity indicator active. But it is possible to just continue with using the App and Kodi.

From a user perspective the iOS App behaves same as the Chorus web interface, except for the activity indicator (which Chorus does not have).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Bring back Queue/Play for addon content