### PR TITLE
Bugfix: Fix Broadcast Details while recording is active

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1197,6 +1197,7 @@ double round(double d) {
     [scrollView addSubview:isRecording];
     if ([item[@"hastimer"] boolValue]) {
         isRecording.alpha = 1.0;
+        frame = voteLabel.frame;
         frame.origin.x += REC_DOT_SIZE + REC_DOT_PADDING;
         frame.size.width -= REC_DOT_SIZE + REC_DOT_PADDING;
         voteLabel.frame = frame;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The Broadcast Details where not showing the title correctly while recording is active. This was caused by using a wrong `CGRect` when manipulating the frame dimensions.

Screenshots:
<a href="https://ibb.co/4Tssdg4"><img src="https://i.ibb.co/hWXXf12/Bildschirmfoto-2024-12-27-um-19-03-09.png" alt="Bildschirmfoto-2024-12-27-um-19-03-09" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix Broadcast Details while recording is active