### PR TITLE
Bugfix: Use exact Kodi blue color in sRGB color space

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -366,7 +366,7 @@
 }
 
 + (UIColor*)getKodiBlue {
-    return RGBA(50, 174, 225, 1.0);
+    return RGBA(20, 178, 231, 1.0);
 }
 
 + (UIColor*)getSystemBlue {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
By fault the RGB values were taken from P3 color space, but applied to sRGB. The updated values are using the correct sRGB color space and are taken from official Kodi logos provided on kodi.tv.

Link to logos:
https://kodi.wiki/view/Official:Media_center_logos

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use exact Kodi blue color in sRGB color space