### PR TITLE
Bugfix: Fix crash after scrolling playlist

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2702,7 +2702,9 @@
 
 - (void)enableAutoscrollPlaylist {
     ignoreAutoscrollPlaylist = NO;
-    [playlistTableView selectRowAtIndexPath:storeSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
+    if (storeSelection && storeSelection.row < [playlistTableView numberOfRowsInSection:storeSelection.section]) {
+        [playlistTableView selectRowAtIndexPath:storeSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1135,7 +1135,7 @@
 
 - (void)updatePartyModePlaylist {
     lastSelected = SELECTED_NONE;
-    storeSelection = 0;
+    storeSelection = nil;
     // Do not update/switch to an updated Party playlist while the user watches another playlist.
     if (currentPlaylistID == PLAYERID_MUSIC) {
         [self createPlaylistAnimated:NO];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a crash report from AppStore by introducing a check for out-of-bounds before calling `selectRowAtIndexPath`. Also apply a minor coding style change to correctly assign `nil` to a variable of type `NSIndexPath`.

```
Last Exception Backtrace:
0   CoreFoundation                	0x19ab795ec __exceptionPreprocess + 164 (NSException.m:249)
1   libobjc.A.dylib               	0x1980f5244 objc_exception_throw + 88 (objc-exception.mm:356)
2   CoreFoundation                	0x19acc66e0 +[NSException raise:format:] + 128 (NSException.m:0)
3   UIKitCore                     	0x19e69d738 -[UITableView _contentOffsetForScrollingToRowAtIndexPath:atScrollPosition:usingPresentationValues:] + 364 (UITableView.m:0)
4   UIKitCore                     	0x19e69e1c8 -[UITableView _scrollToRowAtIndexPath:atScrollPosition:animated:usingPresentationValues:] + 140 (UITableView.m:8332)
5   UIKitCore                     	0x19e6a08d8 -[UITableView _selectRowAtIndexPath:animated:scrollPosition:notifyDelegate:isCellMultiSelect:deselectPrevious:performCustomSelectionAction:] + 924 (UITableView.m:9326)
6   UIKitCore                     	0x19e6a0f28 -[UITableView selectRowAtIndexPath:animated:scrollPosition:] + 136 (UITableView.m:9460)
7   Foundation                    	0x1999262b0 __NSFireTimer + 96 (NSTimer.m:280)
8   CoreFoundation                	0x19ac3c28c __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 32 (CFRunLoop.c:1810)
9   CoreFoundation                	0x19ac3bf30 __CFRunLoopDoTimer + 1012 (CFRunLoop.c:2417)
10  CoreFoundation                	0x19ac3ba84 __CFRunLoopDoTimers + 288 (CFRunLoop.c:2575)
11  CoreFoundation                	0x19abc2124 __CFRunLoopRun + 1856 (CFRunLoop.c:3136)
12  CoreFoundation                	0x19ac14274 CFRunLoopRunSpecific + 588 (CFRunLoop.c:3434)
13  GraphicsServices              	0x1e7d5d4c0 GSEventRunModal + 164 (GSEvent.c:2196)
14  UIKitCore                     	0x19d75677c -[UIApplication _run] + 816 (UIApplication.m:3846)
15  UIKitCore                     	0x19d37ce64 UIApplicationMain + 340 (UIApplication.m:5503)
16  Kodi Remote                   	0x102308c34 main + 80 (main.m:15)
17  dyld                          	0x1c0dd0de8 start + 2724 (dyldMain.cpp:1338)
```

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix crash after scrolling playlist