### PR TITLE
Bugfix: Avoid potential crash in "Play using..."

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4321,6 +4321,9 @@
         if ([item[@"filetype"] isEqualToString:@"directory"]) {
             key = @"directory";
         }
+        if (!value || !key) {
+            return;
+        }
         NSDictionary *itemParams = @{
             @"item": @{key: value},
             @"options": @{


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a crash reported via AppStore by applying early return in case of `nil` for `value` or `key` when building `item` while processing "Play using...".

```
Last Exception Backtrace:
0   CoreFoundation                	0x19fc4d5ec __exceptionPreprocess + 164 (NSException.m:249)
1   libobjc.A.dylib               	0x19d1c9244 objc_exception_throw + 88 (objc-exception.mm:356)
2   CoreFoundation                	0x19fc61398 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 728 (:-1)
3   CoreFoundation                	0x19fc60734 +[NSDictionary dictionaryWithObjects:forKeys:count:] + 52 (NSDictionary.m:614)
4   Kodi Remote                   	0x102674468 -[DetailViewController addPlayback:indexPath:using:position:shuffle:] + 1336 (DetailViewController.m:4325)
5   UIKitCore                     	0x1a2c12874 -[UIAlertController _invokeHandlersForAction:] + 88 (UIAlertController.m:1218)
6   UIKitCore                     	0x1a2c130a4 __103-[UIAlertController _dismissAnimated:triggeringAction:triggeredByPopoverDimmingView:dismissCompletion:]_block_invoke_2 + 36 (UIAlertController.m:1383)
7   UIKitCore                     	0x1a27aadb0 -[UIPresentationController transitionDidFinish:] + 840 (UIPresentationController.m:677)
8   UIKitCore                     	0x1a2689944 __77-[UIPresentationController runTransitionForCurrentStateAnimated:handoffData:]_block_invoke.112 + 344 (UIPresentationController.m:1423)
9   UIKitCore                     	0x1a2686e00 -[_UIViewControllerTransitionContext completeTransition:] + 192 (UIViewControllerTransitioning.m:353)
10  UIKitCore                     	0x1a24d177c __UIVIEW_IS_EXECUTING_ANIMATION_COMPLETION_BLOCK__ + 36 (UIView.m:16552)
11  UIKitCore                     	0x1a24d1718 -[UIViewAnimationBlockDelegate _didEndBlockAnimation:finished:context:] + 624 (UIView.m:16585)
12  UIKitCore                     	0x1a24d0434 -[UIViewAnimationState sendDelegateAnimationDidStop:finished:] + 436 (UIView.m:0)
13  UIKitCore                     	0x1a244e350 -[UIViewAnimationState animationDidStop:finished:] + 192 (UIView.m:2417)
14  UIKitCore                     	0x1a244e3c0 -[UIViewAnimationState animationDidStop:finished:] + 304 (UIView.m:2439)
15  QuartzCore                    	0x1a180b008 run_animation_callbacks(void*) + 132 (CALayer.mm:7841)
16  libdispatch.dylib             	0x1a79d3fa8 _dispatch_client_callout + 20 (object.m:576)
17  libdispatch.dylib             	0x1a79e2a34 _dispatch_main_queue_drain + 984 (queue.c:8093)
18  libdispatch.dylib             	0x1a79e264c _dispatch_main_queue_callback_4CF + 44 (queue.c:8253)
19  CoreFoundation                	0x19fc99bbc __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 16 (CFRunLoop.c:1793)
20  CoreFoundation                	0x19fc961b0 __CFRunLoopRun + 1996 (CFRunLoop.c:3163)
21  CoreFoundation                	0x19fce8274 CFRunLoopRunSpecific + 588 (CFRunLoop.c:3434)
22  GraphicsServices              	0x1ece614c0 GSEventRunModal + 164 (GSEvent.c:2196)
23  UIKitCore                     	0x1a282e77c -[UIApplication _run] + 816 (UIApplication.m:3846)
24  UIKitCore                     	0x1a2454e64 UIApplicationMain + 340 (UIApplication.m:5503)
25  Kodi Remote                   	0x10262cc34 main + 80 (main.m:15)
26  dyld                          	0x1c5ebcde8 start + 2724 (dyldMain.cpp:1338)
```

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid potential crash in "Play using..."