### PR TITLE
Bugfix: Kodi icon might not reflect disconnected state on iPhone

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -246,9 +246,10 @@
 
 - (void)setConnectionIcon:(UIImageView*)icon {
     // Load icon for top row in main menu
-    UIImage *image = [UIImage imageNamed:@"st_kodi_action"];
     UIColor *iconColor = AppDelegate.instance.serverOnLine ? KODI_BLUE_COLOR : UIColor.grayColor;
-    icon.highlightedImage = icon.image = [Utilities colorizeImage:image withColor:iconColor];
+    UIImage *image = [Utilities colorizeImage:[UIImage imageNamed:@"st_kodi_action"] withColor:iconColor];
+    icon.highlightedImage = image;
+    icon.image = image;
     
     // Load icon for global connection status
     NSString *statusIconName = [Utilities getConnectionStatusIconName];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
When assigning a recolored icon to `UIImageView's` `image` and `highlightedImage` the new icon might not be updated. This was observed with XCode 15.4 and 16.2.

Screenshot: https://ibb.co/WGBm26z

### Does not work:
`.highlightedImage = .image = icon`

### Working alternatives:
1. Changed order: `.image = .highlightedImage = icon`
2. `nil`'ing `highlightedImage` and `image` before assigning icon
3. Assigning icon separately to `highlightedImage` and `image`

Option 3 chosen to avoid any future problems by impact of order of assignment.

### How to get there on iPhone:
1. Successfully connect to a server
2. Enter the server list 
3. Disconnect from the server again
4. Go to main menu -> Still shows blue icon, but with "No connection" description
5. Scrolling the first menu entry (server list) out of the top of the menu also fixes this

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Kodi icon might not reflect disconnected state on iPhone