### PR TITLE
Feature: Support language af-za

### DIFF
--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -261,6 +261,8 @@
 		8ED18E7B16B572D700CA03F4 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B1FF37DE1709D1EB005473FF /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		B1FF37DF1709D1ED005473FF /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+                C7106D752D2FC9BC00A96C93 /* af-ZA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "af-ZA"; path = "af-ZA.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		C7106D762D2FC9BC00A96C93 /* af-ZA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "af-ZA"; path = "af-ZA.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C703692827148CEF0049F9BF /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		C70F41D02BA4D98E00847C75 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		C7106D772D33C25400A96C93 /* BroadcastProgressView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BroadcastProgressView.h; sourceTree = "<group>"; };
@@ -753,6 +755,7 @@
 				"es-MX",
 				"hr-HR",
 				"pt-BR",
+				"af-ZA",
 			);
 			mainGroup = 0F5548EB151D1187007E633F;
 			productRefGroup = 0F5548F7151D1187007E633F /* Products */;
@@ -899,6 +902,7 @@
 				C7A030F328B60EB900B27764 /* es-MX */,
 				C7A1381F296AF0B500D84A72 /* hr-HR */,
 				C79F6B322CBBF981009A785C /* pt-BR */,
+				C7106D752D2FC9BC00A96C93 /* af-ZA */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -925,6 +929,7 @@
 				C7A030F428B60EB900B27764 /* es-MX */,
 				C7A13820296AF0B500D84A72 /* hr-HR */,
 				C79F6B332CBBF981009A785C /* pt-BR */,
+				C7106D762D2FC9BC00A96C93 /* af-ZA */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The translation for Afrikaans (South Africa) reached >70% and is enabled now.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Support language af-za