### PR TITLE
Maintenance: Remove unused string from localization

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2807,7 +2807,7 @@
     [ProgressSlider setThumbImage:[UIImage new] forState:UIControlStateNormal];
     [ProgressSlider setThumbImage:[UIImage new] forState:UIControlStateHighlighted];
     ProgressSlider.hidden = YES;
-    scrabbingMessage.text = LOCALIZED_STR(@"Slide your finger up to adjust the scrubbing rate.");
+    scrabbingMessage.text = LOCALIZED_STR(@"Slide your finger up or down to adjust the scrubbing rate.");
     scrabbingRate.text = LOCALIZED_STR(@"Scrubbing 1");
     sheetActions = [NSMutableArray new];
     currentPlaylistID = PLAYERID_UNKNOWN;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -388,6 +388,7 @@ double round(double d) {
 }
 
 - (void)actionSheetHandler:(NSString*)actiontitle {
+    NSString *resumeKey = [LOCALIZED_STR(@"Resume from %@") stringByReplacingOccurrencesOfString:@"%@" withString:@""];
     if ([actiontitle isEqualToString:LOCALIZED_STR(@"Queue after current")]) {
         [self addQueueAfterCurrent:YES];
     }
@@ -401,7 +402,7 @@ double round(double d) {
              [actiontitle isEqualToString:LOCALIZED_STR(@"Stop Recording")]) {
         [self recordChannel];
     }
-    else if ([actiontitle rangeOfString:LOCALIZED_STR(@"Resume from")].location != NSNotFound) {
+    else if ([actiontitle rangeOfString:resumeKey].location != NSNotFound) {
         [self resumePlayback];
     }
     else if ([actiontitle isEqualToString:LOCALIZED_STR(@"Play Trailer")]) {

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -160,7 +160,6 @@
 "vote" = "vote";
 "votes" = "votes";
 
-"Slide your finger up to adjust the scrubbing rate." = "Slide your finger up to adjust the scrubbing rate.";
 "Scrubbing 1" = "Hi-Speed Scrubbing";
 "Scrubbing 0.5" = "Half-Speed Scrubbing";
 "Scrubbing 0.25" = "Quarter-Speed Scrubbing";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -98,7 +98,6 @@
 "OK" = "OK";
 "Cancel" = "Cancel";
 "Resume from %@" = "Resume from %@";
-"Resume from" = "Resume from";
 "First aired on %@" = "First aired on %@";
 "Episodes: %@" = "Episodes: %@";
 "1 result" = "1 result";

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -56,20 +56,14 @@
 "Pictures Add-ons" = "Pictures Add-ons";
 
 "Power off System" = "Power off System";
-"Power off" = "Power off";
 "Hibernate" = "Hibernate";
 "Suspend" = "Suspend";
 "Reboot" = "Reboot";
 "Quit XBMC application" = "Quit Kodi application";
 "Update Audio Library" = "Update Audio Library";
-"Update Audio" = "Update Audio";
 "Clean Audio Library" = "Clean Audio Library";
-"Clean Audio" = "Clean Audio";
 "Update Video Library" = "Update Video Library";
-"Update Video" = "Update Video";
 "Clean Video Library" = "Clean Video Library";
-"Clean Video" = "Clean Video";
-"Quit" = "Quit";
 
 "Keyboard" = "Keyboard";
 "Gesture Zone" = "Gesture Zone";
@@ -100,7 +94,6 @@
 
 "Playlist" = "Playlist";
 "Details not found" = "Details not found";
-"Open in Safari" = "Open in Safari";
 "Error loading page" = "Error loading page";
 "OK" = "OK";
 "Cancel" = "Cancel";
@@ -129,15 +122,6 @@
 "Are you sure you want to clear the music playlist?" = "Are you sure you want to clear the music playlist?";
 "Are you sure you want to clear the video playlist?" = "Are you sure you want to clear the video playlist?";
 "Are you sure you want to clear the picture playlist?" = "Are you sure you want to clear the picture playlist?";
-"Are you sure you want to power off your XBMC system now?" = "Are you sure you want to power off your Kodi system now?";
-"Are you sure you want to hibernate your XBMC system now?" = "Are you sure you want to hibernate your Kodi system now?";
-"Are you sure you want to suspend your XBMC system now?" = "Are you sure you want to suspend your Kodi system now?";
-"Are you sure you want to reboot your XBMC system now?" = "Are you sure you want to reboot your Kodi system now?";
-"Are you sure you want to quit XBMC application now?" = "Are you sure you want to quit Kodi application now?";
-"Are you sure you want to update your audio library now?" = "Are you sure you want to update your audio library now?";
-"Are you sure you want to clean your audio library now?" = "Are you sure you want to clean your audio library now?";
-"Are you sure you want to update your video library now?" = "Are you sure you want to update your video library now?";
-"Are you sure you want to clean your video library now?" = "Are you sure you want to clean your video library now?";
 
 "DIRECTED BY" = "DIRECTED BY";
 "RUNTIME" = "RUNTIME";
@@ -162,11 +146,6 @@
 "BORN / FORMED" = "BORN / FORMED";
 "TRAILER" = "TRAILER";
 
-"codec" = "codec";
-"bit rate" = "bit rate";
-"sample rate" = "sample rate";
-"resolution" = "resolution";
-"aspect ratio" = "aspect ratio";
 "Subtitles not available" = "Subtitles not available";
 "Audiostream not available" = "Audio stream not available";
 "Audiostreams not available" = "Audio streams not available";
@@ -248,11 +227,9 @@
 "XBMC \"Gotham\" version 13 or superior is required to access XBMC settings" = "Kodi version 13 or superior is required to access Kodi settings";
 "-- WARNING --\nThis kind of setting cannot be configured remotely. Use the XBMC GUI for changing this setting.\nThank you." = "-- WARNING --\nThis kind of setting cannot be configured remotely. Use the Kodi GUI for changing this setting.\nThank you.";
 
-"Official Kodi Remote app uses artwork downloaded from your Kodi server or from the internet when your Kodi server refers to it. To unleash the beauty of artwork use Kodi's \"Universal Scraper\" or other scraper add-ons.\n\nKodi logo, Zappy mascot and Official Kodi Remote icons are property of Kodi Foundation.\nhttp://www.kodi.tv/contribute\n\n - Team Kodi" = "Official Kodi Remote app uses artwork downloaded from your Kodi server or from the internet when your Kodi server refers to it. To unleash the beauty of artwork use Kodi's \"Universal Scraper\" or other scraper add-ons.\n\nKodi logo, Zappy mascot and Official Kodi Remote icons are property of Kodi Foundation.\nhttp://www.kodi.tv/contribute\n\n - Team Kodi";
 "Official Kodi Remote app uses artwork downloaded from your Kodi server or from the internet when your Kodi server refers to it. To unleash the beauty of artwork use Kodi's \"Universal Scraper\" or other scraper add-ons.\n\nKodi logo and Official Kodi Remote icons are property of Kodi Foundation.\nhttp://www.kodi.tv/contribute\n\n - Team Kodi" = "Official Kodi Remote app uses artwork downloaded from your Kodi server or from the internet when your Kodi server refers to it. To unleash the beauty of artwork use Kodi's \"Universal Scraper\" or other scraper add-ons.\n\nKodi logo and Official Kodi Remote icons are property of Kodi Foundation.\nhttp://www.kodi.tv/contribute\n\n - Team Kodi";
 
 "No items found." = "No items found.";
-"Video" = "Video";
 "Party" = "Party";
 "Search" = "Search";
 
@@ -282,8 +259,6 @@
 "Password" = "Password";
 
 "Sort by" = "Sort by";
-"tap" = "tap";
-"the selection" = "the selection";
 "tap the selection\nto reverse the sort order" = "tap the selection\nto reverse the sort order";
 "Not listened" = "Not listened";
 "Listened one time" = "Listened one time";
@@ -300,7 +275,6 @@
 "Duration" = "Duration";
 "Date added" = "Date added";
 "Name" = "Name";
-"User rating" = "User rating";
 "The %@s decade" = "The %@s decade";
 "Year not available" = "Year not available";
 "Year %@" = "Year %@";
@@ -347,8 +321,6 @@
 
 "Last Updated: %@" = "Last Updated: %@";
 "Never" = "Never";
-
-"For search switch to list view" = "For search switch to list view";
 
 "Channel" = "Channel";
 "Date" = "Date";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1231.

One string was used in `AppInfoViewController` and replaced in https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1214. The content only changed in a very minor way, so it was kept for a while to allow translators have it as a reference in Kodi Weblate. Other obsolete strings were formerly used in former releases instead of icons or when user were asked to confirm power or library related actions. Also, there were two strings maintained around the scrubbing speed change, which I reduced the only valid one.

In one interesting case I found even a logical error around the resume function which made this _always_ fail when running the UI in Turkish. This is also fixed by a code change which now generates a `resumeKey` from the localized string `"Resume from %@"` and compares this with the user selected action's name, which always shows from which position to resume, e.g. `"Resume from 15:23"`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Remove unused string from localization
Bugfix: Make resume work when using Turkish localization