### PR TITLE
Bugfix: Update playlist after coming back from full screen remote on iPhone

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2638,6 +2638,7 @@
 }
 
 - (void)showRemote {
+    fromItself = YES;
     RemoteController *remote = [[RemoteController alloc] initWithNibName:@"RemoteController" bundle:nil];
     [self.navigationController pushViewController:remote animated:YES];
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3222438#pid3222438).

When entering the full screen remote from NowPlaying view, the ivar `fromItself` must be set. This will trigger reloading the playlist once NowPlaying is again entering `viewDidAppear`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Update playlist after coming back from full screen remote on iPhone