### PR TITLE
Rework strategy to select/deselect items

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2851,7 +2851,6 @@
     int rectOriginX = cell.frame.origin.x + cell.frame.size.width / 2;
     int rectOriginY = cell.frame.origin.y + cell.frame.size.height / 2 - offsetPoint.y;
     [self didSelectItemAtIndexPath:indexPath item:item displayPoint:CGPointMake(rectOriginX, rectOriginY)];
-    return;
 }
 
 - (NSUInteger)indexOfObjectWithSeason:(NSString*)seasonNumber inArray:(NSArray*)array {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1507,6 +1507,7 @@
                 else {
                     [self addPlayback:item indexPath:indexPath position:indexPath.row shuffle:NO];
                 }
+                [self deselectAtIndexPath:indexPath];
                 return;
             }
             else {
@@ -1550,6 +1551,7 @@
 }
 
 - (void)didSelectItemAtIndexPath:(NSIndexPath*)indexPath item:(NSDictionary*)item displayPoint:(CGPoint)point {
+    [self selectAtIndexPath:indexPath];
     mainMenu *menuItem = [self getMainMenu:item];
     int activeTab = [self getActiveTab:item];
     NSDictionary *methods = menuItem.subItem.mainMethod[activeTab];
@@ -1606,6 +1608,7 @@
             NSString *message = [NSString stringWithFormat:@"%@ (type = '%@')", LOCALIZED_STR(@"Cannot do that"), item[@"type"]];
             [Utilities showMessage:message color:[Utilities getSystemRed:0.95]];
         }
+        [self deselectAtIndexPath:indexPath];
     }
     else if (methods[@"method"] != nil && ![parameters[@"forceActionSheet"] boolValue] && !stackscrollFullscreen) {
         // There is a child and we want to show it (only when not in fullscreen)
@@ -1625,6 +1628,7 @@
             else {
                 [self addPlayback:item indexPath:indexPath position:indexPath.row shuffle:NO];
             }
+            [self deselectAtIndexPath:indexPath];
         }
     }
 }
@@ -3213,6 +3217,15 @@
     return cell;
 }
 
+- (void)selectAtIndexPath:(NSIndexPath*)indexPath {
+    if (enableCollectionView) {
+        [collectionView selectItemAtIndexPath:indexPath animated:NO scrollPosition:UICollectionViewScrollPositionNone];
+    }
+    else {
+        [dataList selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
+    }
+}
+
 - (void)deselectAtIndexPath:(NSIndexPath*)indexPath {
     if (enableCollectionView) {
         [collectionView deselectItemAtIndexPath:indexPath animated:NO];
@@ -3284,18 +3297,6 @@
             selectedIndexPath = indexPath;
             
             NSDictionary *item = [self getItemFromIndexPath:indexPath];
-            
-            if ([self doesShowSearchResults]) {
-                [dataList selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
-            }
-            else {
-                if (enableCollectionView) {
-                    [collectionView selectItemAtIndexPath:indexPath animated:NO scrollPosition:UICollectionViewScrollPositionNone];
-                }
-                else {
-                    [dataList selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
-                }
-            }
             mainMenu *menuItem = [self getMainMenu:item];
             int activeTab = [self getActiveTab:item];
             NSMutableArray *sheetActions = [menuItem.sheetActions[activeTab] mutableCopy];
@@ -3351,7 +3352,6 @@
         
         UIAlertAction *action_cancel = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
             forceMusicAlbumMode = NO;
-            [self deselectAtIndexPath:selectedIndexPath];
         }];
         
         for (NSString *actionName in sheetActions) {
@@ -3525,7 +3525,6 @@
                 
                 UIAlertAction *action_cancel = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:^(UIAlertAction *action) {
                     forceMusicAlbumMode = NO;
-                    [self deselectAtIndexPath:selectedIndexPath];
                 }];
                 
                 for (NSString *actiontitle in sheetActions) {
@@ -4071,7 +4070,6 @@
          withParameters:parameters
            onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
                [cellActivityIndicator stopAnimating];
-               [self deselectAtIndexPath:indexPath];
                if (error == nil && methodError == nil) {
                    [self.searchController setActive:NO];
                    [Utilities AnimView:activeLayoutView AnimDuration:0.3 Alpha:1.0 XPos:viewWidth];
@@ -4118,7 +4116,6 @@
          withParameters:parameters
            onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
                [cellActivityIndicator stopAnimating];
-               [self deselectAtIndexPath:indexPath];
                if (error == nil && methodError == nil) {
                    id cell = [self getCell:indexPath];
                    UIImageView *timerView = (UIImageView*)[cell viewWithTag:EPG_VIEW_CELL_RECORDING_ICON];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5470,14 +5470,9 @@
         self.slidingViewController.anchorLeftRevealAmount = 0;
     }
     NSIndexPath *selection = [dataList indexPathForSelectedRow];
-	if (selection) {
-		[dataList deselectRowAtIndexPath:selection animated:NO];
-    }
-    selection = [dataList indexPathForSelectedRow];
     if (selection) {
-		[dataList deselectRowAtIndexPath:selection animated:YES];
+        [dataList deselectRowAtIndexPath:selection animated:NO];
     }
-    
     for (selection in [collectionView indexPathsForSelectedItems]) {
         [collectionView deselectItemAtIndexPath:selection animated:YES];
     }

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -77,8 +77,6 @@
         UIPanGestureRecognizer *panRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePanFrom:)];
         panRecognizer.delegate = self;
         panRecognizer.maximumNumberOfTouches = 1;
-        panRecognizer.delaysTouchesBegan = YES;
-        panRecognizer.delaysTouchesEnded = YES;
         panRecognizer.cancelsTouchesInView = YES;
         [self.view addGestureRecognizer:panRecognizer];
         [self.view addSubview:slideViews];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
PR is motivated by a discussion [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3222637#pid3222637).

This PR unifies the selection/deselection behaviour for iPad and iPhone by not setting
```
panRecognizer.delaysTouchesBegan = YES;
panRecognizer.delaysTouchesEnded = YES;
```
in iPad's StackViewController. This is not required as sliding the views is not impacted, but an unwanted side effect of non-visible selections is gone.

Generally this PR reworks the strategy to show the selection of items. The selection is removed when showing an action sheet. The details for the selected item are anyway shown on top of the action sheet, on iPad there is a pointer to the touched origin and on iPhone the selection is most cases hidden behind the action sheet. Now, a selection is shown on tap and kept when entering a next level view, e.g. selecting a movie and entering the movie details. This visually emphasizes the selected item when showing two views side-by-side as it is done on iPad.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Unify selection/deselection for iPad/iPhone