### PR TITLE
Bugfix: Remove local cache for PVR recordings

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -4388,7 +4388,6 @@
             @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
             @"thumbWidth": @LIVETV_THUMB_WIDTH_SMALL,
             @"enableCollectionView": @YES,
-            @"enableLibraryCache": @YES,
             @"itemSizes": [self itemSizes_Music],
         },
                           
@@ -4939,7 +4938,6 @@
             @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
             @"thumbWidth": @LIVETV_THUMB_WIDTH_SMALL,
             @"enableCollectionView": @YES,
-            @"enableLibraryCache": @YES,
             @"itemSizes": [self itemSizes_Music],
         },
                           


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
As clarified with Kodi development team ([link to thread](https://forum.kodi.tv/showthread.php?tid=380235)), the recording ids are recreated each time the recording list build inside Kodi. Mapping of ids to recordings is therefor volatile and caching not possible. This PR removes local cache for PVR recordings.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Remove local cache for PVR recordings
Bugfix: Avoid mismatching recording IDs between Remote App and Kodi