### PR TITLE
Bugfix: Avoid crash in roundedCornerImage

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -866,6 +866,10 @@
 }
 
 + (UIImage*)roundedCornerImage:(UIImage*)image {
+    if (image.size.width == 0 || image.size.height == 0) {
+        return image;
+    }
+    
     CGRect imageRect = CGRectMake(0, 0, image.size.width, image.size.height);
     UIGraphicsBeginImageContextWithOptions(image.size, NO, 0);
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
`UIGraphicsBeginImageContextWithOptions` crashes when called with an image size of zero width or height. Perform an early return in this case.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid crash in for roundedCornerImage