### PR TITLE
Play TV/Radio channels on selection

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -4622,7 +4622,7 @@
             @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
             @"thumbWidth": @LIVETV_THUMB_WIDTH,
             @"itemSizes": [self itemSizes_Music],
-            @"forceActionSheet": @YES,
+            @"forcePlayback": @YES,
         },
                                   
         @{
@@ -4747,7 +4747,7 @@
             @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
             @"thumbWidth": @LIVETV_THUMB_WIDTH,
             @"itemSizes": [self itemSizes_Music],
-            @"forceActionSheet": @YES,
+            @"forcePlayback": @YES,
         },
                                             
         @{},
@@ -5175,7 +5175,7 @@
             @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
             @"thumbWidth": @LIVETV_THUMB_WIDTH,
             @"itemSizes": [self itemSizes_Music],
-            @"forceActionSheet": @YES,
+            @"forcePlayback": @YES,
         },
                                   
         @{
@@ -5300,7 +5300,7 @@
             @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
             @"thumbWidth": @LIVETV_THUMB_WIDTH,
             @"itemSizes": [self itemSizes_Music],
-            @"forceActionSheet": @YES,
+            @"forcePlayback": @YES,
         },
                                             
         @{},

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -4296,6 +4296,7 @@
             @"thumbWidth": @LIVETV_THUMB_WIDTH_SMALL,
             @"enableCollectionView": @YES,
             @"itemSizes": [self itemSizes_Music],
+            @"forcePlayback": @YES,
         },
                           
         @{
@@ -4622,7 +4623,6 @@
             @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
             @"thumbWidth": @LIVETV_THUMB_WIDTH,
             @"itemSizes": [self itemSizes_Music],
-            @"forcePlayback": @YES,
         },
                                   
         @{
@@ -4645,6 +4645,7 @@
             @"thumbWidth": @LIVETV_THUMB_WIDTH_SMALL,
             @"enableCollectionView": @YES,
             @"itemSizes": [self itemSizes_Music],
+            @"forcePlayback": @YES,
         },
                                   
         @{},
@@ -4747,7 +4748,6 @@
             @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
             @"thumbWidth": @LIVETV_THUMB_WIDTH,
             @"itemSizes": [self itemSizes_Music],
-            @"forcePlayback": @YES,
         },
                                             
         @{},
@@ -4851,6 +4851,7 @@
             @"thumbWidth": @LIVETV_THUMB_WIDTH_SMALL,
             @"enableCollectionView": @YES,
             @"itemSizes": [self itemSizes_Music],
+            @"forcePlayback": @YES,
         },
                           
         @{
@@ -5175,7 +5176,6 @@
             @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
             @"thumbWidth": @LIVETV_THUMB_WIDTH,
             @"itemSizes": [self itemSizes_Music],
-            @"forcePlayback": @YES,
         },
                                   
         @{
@@ -5198,6 +5198,7 @@
             @"thumbWidth": @LIVETV_THUMB_WIDTH_SMALL,
             @"enableCollectionView": @YES,
             @"itemSizes": [self itemSizes_Music],
+            @"forcePlayback": @YES,
         },
                                   
         @{},
@@ -5300,7 +5301,6 @@
             @"rowHeight": @CHANNEL_EPG_ROW_HEIGHT,
             @"thumbWidth": @LIVETV_THUMB_WIDTH,
             @"itemSizes": [self itemSizes_Music],
-            @"forcePlayback": @YES,
         },
                                             
         @{},
@@ -5715,6 +5715,7 @@
             @"thumbWidth": @SETTINGS_THUMB_WIDTH_BIG,
             @"itemSizes": [self itemSizes_Music],
             @"enableCollectionView": @YES,
+            @"forceActionSheet": @YES,
         },
                                    
         @{
@@ -5734,6 +5735,7 @@
             @"thumbWidth": @SETTINGS_THUMB_WIDTH_BIG,
             @"itemSizes": [self itemSizes_Music],
             @"enableCollectionView": @YES,
+            @"forceActionSheet": @YES,
         },
                                    
         @{
@@ -5753,6 +5755,7 @@
             @"thumbWidth": @SETTINGS_THUMB_WIDTH_BIG,
             @"itemSizes": [self itemSizes_Music],
             @"enableCollectionView": @YES,
+            @"forceActionSheet": @YES,
         },
                                    
         @{
@@ -5767,6 +5770,7 @@
             @"rowHeight": @FILEMODE_ROW_HEIGHT,
             @"thumbWidth": @0,
             @"morelabel": LOCALIZED_STR(@"Execute a specific action"),
+            @"forceActionSheet": @YES,
         },
                                    
         @{
@@ -5781,6 +5785,7 @@
             @"rowHeight": @FILEMODE_ROW_HEIGHT,
             @"thumbWidth": @0,
             @"morelabel": LOCALIZED_STR(@"Activate a specific window"),
+            @"forceActionSheet": @YES,
         },
     ] mutableCopy];
     
@@ -5911,26 +5916,11 @@
             @"rowHeight": @SETTINGS_ROW_HEIGHT,
             @"thumbWidth": @0,
         },
-
-        @{
-            @"forceActionSheet": @YES,
-        },
-
-        @{
-            @"forceActionSheet": @YES,
-        },
-
-        @{
-            @"forceActionSheet": @YES,
-        },
-
-        @{
-            @"forceActionSheet": @YES,
-        },
-
-        @{
-            @"forceActionSheet": @YES,
-        },
+        @{},
+        @{},
+        @{},
+        @{},
+        @{},
     ] mutableCopy];
     
     xbmcSettings.subItem.mainFields = @[

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1424,6 +1424,7 @@
                                               @([parameters[@"FrodoExtraArt"] boolValue]), @"FrodoExtraArt",
                                               @([parameters[@"enableLibraryCache"] boolValue]), @"enableLibraryCache",
                                               @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
+                                              @([parameters[@"forcePlayback"] boolValue]), @"forcePlayback",
                                               @([parameters[@"forceActionSheet"] boolValue]), @"forceActionSheet",
                                               @([parameters[@"collectionViewRecentlyAdded"] boolValue]), @"collectionViewRecentlyAdded",
                                               @([parameters[@"blackTableSeparator"] boolValue]), @"blackTableSeparator",
@@ -1600,6 +1601,9 @@
             [Utilities showMessage:message color:[Utilities getSystemRed:0.95]];
         }
         [self deselectAtIndexPath:indexPath];
+    }
+    else if ([parameters[@"forcePlayback"] boolValue]) {
+        [self addPlayback:item indexPath:indexPath position:indexPath.row shuffle:NO];
     }
     else if (methods[@"method"] != nil && ![parameters[@"forceActionSheet"] boolValue] && !stackscrollFullscreen) {
         // There is a child and we want to show it (only when not in fullscreen)

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1548,7 +1548,7 @@
     int activeTab = [self getActiveTab:item];
     NSDictionary *methods = menuItem.subItem.mainMethod[activeTab];
     NSMutableArray *sheetActions = [menuItem.sheetActions[activeTab] mutableCopy];
-    NSMutableDictionary *parameters = menuItem.subItem.mainParameters[activeTab];
+    NSMutableDictionary *parameters = menuItem.mainParameters[activeTab];
     if ([item[@"family"] isEqualToString:@"id"]) {
         if (IS_IPHONE) {
             SettingsValuesViewController *settingsViewController = [[SettingsValuesViewController alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, self.view.bounds.size.height) withItem:item];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR adds an improvement suggested via AppStore: Directly play TV/Radio channels on selection, instead of always bringing up the action sheet with all options. The action sheet can still be brought up by long press. This updated behaviour is aligned with Kodi UI.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Play TV/Radio channels on selection
Maintenance: Rework menu parameters forcePlayback and forceActionsheet
