### PR TITLE
Bugfix: Use correct method to start playback

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1603,7 +1603,7 @@
         [self deselectAtIndexPath:indexPath];
     }
     else if ([parameters[@"forcePlayback"] boolValue]) {
-        [self addPlayback:item indexPath:indexPath position:indexPath.row shuffle:NO];
+        [self startPlayback:item indexPath:indexPath shuffle:NO];
     }
     else if (methods[@"method"] != nil && ![parameters[@"forceActionSheet"] boolValue] && !stackscrollFullscreen) {
         // There is a child and we want to show it (only when not in fullscreen)


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Sorry for this. Did not do a compile check after rebasing https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1248. The new method `startPlayback` must be used.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use correct method to start playback