### PR TITLE
Music playlist items shall only show song title and artist

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2076,10 +2076,7 @@
     }
     else if ([item[@"type"] isEqualToString:@"song"] ||
              [item[@"type"] isEqualToString:@"musicvideo"]) {
-        NSString *album = item[@"album"];
-        NSString *artist = item[@"artist"];
-        NSString *dash = album.length && artist.length ? @" - " : @"";
-        subLabel.text = [NSString stringWithFormat:@"%@%@%@", album, dash, artist];
+        subLabel.text = item[@"artist"];
     }
     else if ([item[@"type"] isEqualToString:@"movie"]) {
         subLabel.text = item[@"genre"];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Picks up a suggestion from [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3227084#pid3227084).

Let the 2nd row show "artist" only, not "album - artist" which often made the artist non-readable as the album name took all the available space.

Screenshots:
https://ibb.co/5gH1nnt1

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Music playlist items shall only show song title and artist