### PR TITLE
Bugfix: Early return to avoid crash in inet_pton

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1310,6 +1310,10 @@
 
 + (BOOL)isValidIP6Address:(NSString*)ip {
     const char *utf8 = [ip UTF8String];
+    
+    if (utf8 == NULL) {
+        return NO;
+    }
 
     // Check valid IPv6.
     struct in6_addr dst6;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a crash reported via AppStore. Perform early return in `isValidIP6Address` in case `utf8 == NULL` as otherwise `inet_pton` will crash.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Early return to avoid crash in inet_pton