### PR TITLE
Feature: Share URL of item

### DIFF
--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		C76594B72C5E8A5B00B93A2A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = C70F41D02BA4D98E00847C75 /* PrivacyInfo.xcprivacy */; };
 		C78C30F528F877870055CD95 /* VersionCheck.m in Sources */ = {isa = PBXBuildFile; fileRef = C78C30F428F877870055CD95 /* VersionCheck.m */; };
 		C78C30FA28F8AADA0055CD95 /* SharingActivityItemSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C78C30F928F89A3E0055CD95 /* SharingActivityItemSource.m */; };
+		C795123F2DC95A7E00A8CEE5 /* LinkPresentation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C795123E2DC95A7E00A8CEE5 /* LinkPresentation.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -318,6 +319,7 @@
 		C79F6B332CBBF981009A785C /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C78C30F828F89A1E0055CD95 /* SharingActivityItemSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SharingActivityItemSource.h; sourceTree = "<group>"; };
 		C78C30F928F89A3E0055CD95 /* SharingActivityItemSource.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SharingActivityItemSource.m; sourceTree = "<group>"; };
+		C795123E2DC95A7E00A8CEE5 /* LinkPresentation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LinkPresentation.framework; path = System/Library/Frameworks/LinkPresentation.framework; sourceTree = SDKROOT; };
 		C7A030F128B60DB200B27764 /* ca-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ca-ES"; path = "ca-ES.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C7A030F228B60DB200B27764 /* ca-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ca-ES"; path = "ca-ES.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C7A030F328B60EB900B27764 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -334,6 +336,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C795123F2DC95A7E00A8CEE5 /* LinkPresentation.framework in Frameworks */,
 				0F5548FB151D1187007E633F /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -516,6 +519,7 @@
 		0F5548F9151D1187007E633F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C795123E2DC95A7E00A8CEE5 /* LinkPresentation.framework */,
 				C7432A6D2B12195600100E83 /* WebKit.framework */,
 				C703692827148CEF0049F9BF /* StoreKit.framework */,
 				C718444525FFD06300F5A060 /* SafariServices.framework */,

--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		C76594B62C5E885B00B93A2A /* Roboto-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0FE6087E164B3094009CA3A9 /* Roboto-Regular.ttf */; };
 		C76594B72C5E8A5B00B93A2A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = C70F41D02BA4D98E00847C75 /* PrivacyInfo.xcprivacy */; };
 		C78C30F528F877870055CD95 /* VersionCheck.m in Sources */ = {isa = PBXBuildFile; fileRef = C78C30F428F877870055CD95 /* VersionCheck.m */; };
+		C78C30FA28F8AADA0055CD95 /* SharingActivityItemSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C78C30F928F89A3E0055CD95 /* SharingActivityItemSource.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -315,6 +316,8 @@
 		C78C30F628F8779A0055CD95 /* VersionCheck.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VersionCheck.h; sourceTree = "<group>"; };
 		C79F6B322CBBF981009A785C /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C79F6B332CBBF981009A785C /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		C78C30F828F89A1E0055CD95 /* SharingActivityItemSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SharingActivityItemSource.h; sourceTree = "<group>"; };
+		C78C30F928F89A3E0055CD95 /* SharingActivityItemSource.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SharingActivityItemSource.m; sourceTree = "<group>"; };
 		C7A030F128B60DB200B27764 /* ca-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ca-ES"; path = "ca-ES.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C7A030F228B60DB200B27764 /* ca-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ca-ES"; path = "ca-ES.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C7A030F328B60EB900B27764 /* es-MX */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-MX"; path = "es-MX.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -598,6 +601,7 @@
 				0F7F0DC71703490A0098FF75 /* BDKCollectionIndexView */,
 				0F05FB66170D79B000BBA833 /* NSString+MD5 */,
 				0FDC8917170DCAEA00419F58 /* SVPullToRefresh */,
+				C78C30F728F899DF0055CD95 /* SharingActivityItemSource */,
 				0F7983891C26ABBD002863D0 /* Network */,
 			);
 			name = classes;
@@ -700,6 +704,15 @@
 				0FDC8919170DCAEA00419F58 /* UIScrollView+SVPullToRefresh.m */,
 			);
 			path = SVPullToRefresh;
+			sourceTree = "<group>";
+		};
+		C78C30F728F899DF0055CD95 /* SharingActivityItemSource */ = {
+			isa = PBXGroup;
+			children = (
+				C78C30F828F89A1E0055CD95 /* SharingActivityItemSource.h */,
+				C78C30F928F89A3E0055CD95 /* SharingActivityItemSource.m */,
+			);
+			path = SharingActivityItemSource;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -857,6 +870,7 @@
 				0FB133AA165EC1E5003756C1 /* tcpJSONRPC.m in Sources */,
 				C76451DB29C51221000AE949 /* UIImageView+WebCache.m in Sources */,
 				0FEA79FC165FBBED00BB281F /* XBMCVirtualKeyboard.m in Sources */,
+				C78C30FA28F8AADA0055CD95 /* SharingActivityItemSource.m in Sources */,
 				0F90904516E53C590021EFA9 /* Utilities.m in Sources */,
 				0FEAE76816EA632800387DED /* ActorCell.m in Sources */,
 				0F00207816EE247A003822B5 /* OBSlider.m in Sources */,

--- a/XBMC Remote/SharingActivityItemSource/SharingActivityItemSource.h
+++ b/XBMC Remote/SharingActivityItemSource/SharingActivityItemSource.h
@@ -1,0 +1,13 @@
+//
+//  SharingActivityItemSource.h
+//  Kodi Remote
+//
+//  Created by Buschmann on 09.03.25.
+//  Copyright © 2025 Team Kodi. All rights reserved.
+//
+
+@interface SharingActivityItemSource : NSObject <UIActivityItemSource>
+
+- (instancetype)initWithUrlString:(NSString*)urlString label:(NSString*)label image:(UIImage*)image;
+
+@end

--- a/XBMC Remote/SharingActivityItemSource/SharingActivityItemSource.m
+++ b/XBMC Remote/SharingActivityItemSource/SharingActivityItemSource.m
@@ -1,0 +1,50 @@
+//
+//  SharingActivityItemSource.m
+//  Kodi Remote
+//
+//  Created by Buschmann on 09.03.25.
+//  Copyright © 2025 Team Kodi. All rights reserved.
+//
+
+#import "SharingActivityItemSource.h"
+
+@import UIKit;
+@import LinkPresentation;
+
+@interface SharingActivityItemSource ()
+
+@property (nonatomic, copy) NSURL *url;
+@property (nonatomic, copy) NSString *label;
+@property (nonatomic, copy) UIImage *thumbnail;
+
+@end
+
+@implementation SharingActivityItemSource
+
+- (instancetype)initWithUrlString:(NSString*)urlString label:(NSString*)label image:(UIImage*)image {
+    if (self = [super init]) {
+        self.url = [NSURL URLWithString:urlString];
+        self.label = label;
+        self.thumbnail = image ?: [UIImage imageNamed:@"app_logo"];
+    }
+    return self;
+}
+
+- (id)activityViewControllerPlaceholderItem:(UIActivityViewController*)activityViewController {
+    return self.url;
+}
+
+- (id)activityViewController:(UIActivityViewController*)activityViewController itemForActivityType:(NSString*)activityType {
+    return self.url;
+}
+
+- (LPLinkMetadata*)activityViewControllerLinkMetadata:(UIActivityViewController*)activityViewController API_AVAILABLE(ios(13.0)) {
+    __auto_type meta = [LPLinkMetadata new];
+    meta.originalURL = self.url;
+    meta.URL = meta.originalURL;
+    meta.title = self.label;
+    meta.imageProvider = [[NSItemProvider alloc] initWithObject:self.thumbnail];
+    return meta;
+}
+
+@end

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -91,6 +91,7 @@
 "Recording Details" = "Recording Details";
 "Details" = "Details";
 "Play Trailer" = "Play Trailer";
+"Share" = "Share";
 
 "Playlist" = "Playlist";
 "Details not found" = "Details not found";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/702.

This PR adds the option to share an item's URL with other applications or copying it to clipboard. This URL can be used as download link to play/download the selected item through another application on your iOS device, e.g. by pasting the URL to VLC. The item must be a downloadable file, the Remote App will not offer the option in other cases. The Share menu will show the item's label and a thumbnail (in case no item thumbnail is available the Remote App's logo is shown).

Screenshots: https://ibb.co/zhLMyWHx

Important: The iOS Remote App will not implement local playback itself as the iOS `AVPlayer` has *very* limited support for audio and video formats.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Share URL of item