### PR TITLE
Rework volume change

### DIFF
--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -229,6 +229,10 @@
 }
 
 - (void)handleMute:(BOOL)mute {
+    if (!AppDelegate.instance.serverOnLine) {
+        return;
+    }
+    
     isMuted = mute;
     UIColor *buttonColor = isMuted ? UIColor.systemRedColor : muteIconColor;
     UIColor *sliderColor = isMuted ? UIColor.darkGrayColor : KODI_BLUE_COLOR;
@@ -299,6 +303,10 @@
 }
 
 - (void)changeVolume:(id)sender {
+    if (!AppDelegate.instance.serverOnLine) {
+        return;
+    }
+    
     // Process the volume change
     isChangingVolume = YES;
     NSInteger action = [sender tag];

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -19,7 +19,7 @@
 #define VOLUMESLIDER_HEIGHT 44
 #define SERVER_TIMEOUT 3.0
 #define VOLUME_HOLD_TIMEOUT 0.2
-#define VOLUME_REPEAT_TIMEOUT 0.05
+#define VOLUME_REPEAT_TIMEOUT 0.03
 #define VOLUME_INFO_TIMEOUT 1.0
 #define VOLUME_BUTTON_UP 1
 #define VOLUME_BUTTON_DOWN 2
@@ -312,13 +312,13 @@
     NSInteger action = [sender tag];
     switch (action) {
         case VOLUME_BUTTON_UP: // Volume Increase
-            volumeSlider.value += 2;
+            volumeSlider.value += 1;
             break;
         case VOLUME_BUTTON_DOWN: // Volume Decrease
-            volumeSlider.value -= 2;
+            volumeSlider.value -= 1;
             break;
-        case VOLUME_SLIDER: // Volume slider in 2-step resolution
-            volumeSlider.value = ((int)volumeSlider.value / 2) * 2;
+        case VOLUME_SLIDER: // Volume slider with 1% step resolution
+            volumeSlider.value = (int)volumeSlider.value;
             break;
         default:
             break;

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -207,7 +207,7 @@
     if (AppDelegate.instance.serverTCPConnectionOpen) {
         return;
     }
-    if (AppDelegate.instance.serverVolume > -1) {
+    if (AppDelegate.instance.serverOnLine && AppDelegate.instance.serverVolume > -1) {
         volumeLabel.text = [NSString stringWithFormat:@"%d", AppDelegate.instance.serverVolume];
         volumeSlider.value = AppDelegate.instance.serverVolume;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR does some small rework related to volume changes. 

First, volume changes are blocked when the server is not connected. Before this change users could change the volume, and by that also the displayed volume (on iPad), while the server was disconnected. This makes no sense.

Second, set volume to 0 (displayed value on iPad and volume slider) when no server is connected. Before this change the volume of the formerly connected server was still valid.

Third, the step size is now more fine granular and allows 1% steps.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Volume changes blocked when not connected
Improvement: Volume set to 0 when not connected
Improvement: 1% step size for volume changes