### PR TITLE
Remove blackTableSeparator special handling

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -3715,7 +3715,6 @@
                 ],
             },
             @"label": LOCALIZED_STR(@"TV Shows"),
-            @"blackTableSeparator": @YES,
             @"FrodoExtraArt": @YES,
             @"enableLibraryCache": @YES,
             @"enableCollectionView": @YES,

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1345,12 +1345,8 @@
     activeLayoutView.contentOffset = activeLayoutView.contentOffset;
     [self checkFullscreenButton:NO];
     [self addExtraProperties:mutableProperties newParams:mutableParameters params:parameters];
-    if ([parameters[@"blackTableSeparator"] boolValue] && ![Utilities getPreferTvPosterMode]) {
-        dataList.separatorColor = [Utilities getGrayColor:38 alpha:1];
-    }
-    else {
+    if (!tvshowsView || [Utilities getPreferTvPosterMode]) {
         [self setSearchBar:self.searchController.searchBar toDark:NO];
-        dataList.separatorColor = [Utilities getGrayColor:191 alpha:1];
     }
     if (methods[@"method"] != nil) {
         [self retrieveData:methods[@"method"] parameters:mutableParameters sectionMethod:methods[@"extra_section_method"] sectionParameters:parameters[@"extra_section_parameters"] resultStore:self.richResults extraSectionCall:NO refresh:refresh];
@@ -1427,7 +1423,6 @@
                                               @([parameters[@"forcePlayback"] boolValue]), @"forcePlayback",
                                               @([parameters[@"forceActionSheet"] boolValue]), @"forceActionSheet",
                                               @([parameters[@"collectionViewRecentlyAdded"] boolValue]), @"collectionViewRecentlyAdded",
-                                              @([parameters[@"blackTableSeparator"] boolValue]), @"blackTableSeparator",
                                               pvrExtraInfo, @"pvrExtraInfo",
                                               kodiExtrasPropertiesMinimumVersion, @"kodiExtrasPropertiesMinimumVersion",
                                               parameters[@"extra_info_parameters"], @"extra_info_parameters",
@@ -5902,9 +5897,8 @@
         globalSearchView = YES;
     }
     
-    if ([parameters[@"blackTableSeparator"] boolValue] && ![Utilities getPreferTvPosterMode]) {
+    if (tvshowsView && ![Utilities getPreferTvPosterMode]) {
         dataList.separatorInset = UIEdgeInsetsZero;
-        dataList.separatorColor = [Utilities getGrayColor:38 alpha:1];
     }
     bottomPadding = [Utilities getBottomPadding];
     if (IS_IPHONE) {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -234,7 +234,6 @@
     int activeTab = 0;
     id movieObj = nil;
     id movieObjKey = nil;
-    BOOL blackTableSeparator = NO;
     if ([item[@"family"] isEqualToString:@"albumid"]) {
         notificationName = @"MainMenuDeselectSection";
         menuItem = [AppDelegate.instance.playlistArtistAlbums copy];
@@ -282,7 +281,6 @@
             }
             menuItem.thumbWidth = thumbWidth;
             menuItem.rowHeight = tvshowHeight;
-            blackTableSeparator = YES;
         }
     }
     else {
@@ -317,7 +315,6 @@
                                                parameters[@"parameters"][@"properties"], @"properties",
                                                parameters[@"parameters"][@"sort"], @"sort",
                                                nil], @"parameters",
-                                              @(blackTableSeparator), @"blackTableSeparator",
                                               parameters[@"label"], @"label",
                                               @YES, @"fromShowInfo",
                                               @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
First, this can be derived from being in TV Show banner mode (when in `tvshowsView` and not preferring posters). Second, the separators are anyway not visible as covered by banners.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Remove blackTableSeparator special handling