### PR TITLE
Show "clearing cache" popover at least for two seconds

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -24,6 +24,7 @@
 #import "Utilities.h"
 
 #define SERVER_TIMEOUT 2.0
+#define CLEARCACHE_TIMEOUT 2.0
 #define CONNECTION_ICON_SIZE 18
 #define MENU_ICON_SIZE 30
 #define ICON_MARGIN 10
@@ -285,7 +286,9 @@
 
 - (void)startClearAppDiskCache:(ClearCacheView*)clearView {
     [AppDelegate.instance clearAppDiskCache];
-    [self performSelectorOnMainThread:@selector(clearAppDiskCacheFinished:) withObject:clearView waitUntilDone:YES];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, CLEARCACHE_TIMEOUT * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        [self clearAppDiskCacheFinished:clearView];
+    });
 }
 
 - (void)clearAppDiskCacheFinished:(ClearCacheView*)clearView {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -22,6 +22,7 @@
 
 #define CONNECTION_TIMEOUT 240.0
 #define SERVER_TIMEOUT 2.0
+#define CLEARCACHE_TIMEOUT 2.0
 #define VIEW_PADDING 10 /* separation between toolbar views */
 #define TOOLBAR_HEIGHT 44
 #define XBMCLOGO_WIDTH 30
@@ -262,7 +263,9 @@
 
 - (void)startClearAppDiskCache:(ClearCacheView*)clearView {
     [AppDelegate.instance clearAppDiskCache];
-    [self performSelectorOnMainThread:@selector(clearAppDiskCacheFinished:) withObject:clearView waitUntilDone:YES];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, CLEARCACHE_TIMEOUT * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        [self clearAppDiskCacheFinished:clearView];
+    });
 }
 
 - (void)clearAppDiskCacheFinished:(ClearCacheView*)clearView {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR improves usability as the "clearing cache" popover is for sure readable by the user and does not just look like an unwanted glitch because clearing the cache is usually finished really quick.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Show "clearing cache" popover at least for two seconds