### PR TITLE
Improvement: Use both album and artist for Wikipedia search

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3756,11 +3756,16 @@
             }
         }
     }
-    NSString *searchString = item[@"label"];
+    NSString *phrase1 = item[@"label"];
     if (forceMusicAlbumMode) {
-        searchString = self.navigationItem.title;
+        phrase1 = self.navigationItem.title;
         forceMusicAlbumMode = NO;
     }
+    NSString *phrase2 = item[@"genre"];
+    NSString *searchString = [NSString stringWithFormat:@"%@%@%@",
+                              phrase1,
+                              (phrase1.length > 0 && phrase2.length > 0) ? @" " : @"",
+                              phrase2];
     NSString *query = [searchString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
     NSString *url = [NSString stringWithFormat:serviceURL, query];
     [Utilities SFloadURL:url fromctrl:self];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Implements an improvement suggested in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3229234#pid3229234).

This PR improves the search results by adding both the album name and artist to the search string. For albums with common names like Tailor Swift's "1989" this drastically improves the search result.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Use both album and artist for Wikipedia search