### PR TITLE
Bugfix: Make Swedish InfoPlist compiling again

### DIFF
--- a/XBMC Remote/sv.lproj/InfoPlist.strings
+++ b/XBMC Remote/sv.lproj/InfoPlist.strings
@@ -1,1 +1,1 @@
-NSLocalNetworkUsageDescription=”Kodi Remote App använder lokalt nätverk för att hitta och kommunicera med Kodi-instanser i nätverket.”;
+NSLocalNetworkUsageDescription="Kodi Remote App använder lokalt nätverk för att hitta och kommunicera med Kodi-instanser i nätverket.";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes issue caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1263.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Make Swedish InfoPlist compiling again