### PR TITLE
Maintenance: Rework iPhone main controller initialization

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -477,14 +477,6 @@
     self.preferredContentSize = size;
     [super viewWillAppear:animated];
     if (IS_IPHONE) {
-        if (![self.slidingViewController.underLeftViewController isKindOfClass:[MasterViewController class]]) {
-            MasterViewController *masterViewController = [[MasterViewController alloc] initWithNibName:@"MasterViewController" bundle:nil];
-            masterViewController.mainMenu = self.mainMenu;
-            self.slidingViewController.underLeftViewController = masterViewController;
-        }
-        self.slidingViewController.underRightViewController = nil;
-        self.slidingViewController.anchorLeftPeekAmount   = 0;
-        self.slidingViewController.anchorLeftRevealAmount = 0;
         self.slidingViewController.panGesture.delegate = self;
         [self.navigationController.view addGestureRecognizer:self.slidingViewController.panGesture];
     }

--- a/XBMC Remote/InitialSlidingViewController.h
+++ b/XBMC Remote/InitialSlidingViewController.h
@@ -9,9 +9,7 @@
 #import "ECSlidingViewController.h"
 #import "CustomNavigationController.h"
 
-@interface InitialSlidingViewController : ECSlidingViewController {
-    CustomNavigationController *navController;
-}
+@interface InitialSlidingViewController : ECSlidingViewController
 
 - (void)handleMenuButton;
 

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -24,22 +24,27 @@
     return self;
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-    [Utilities addShadowsToView:navController.view viewFrame:self.view.frame];
-}
-
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    MasterViewController *masterViewController = [[MasterViewController alloc] initWithNibName:@"MasterViewController" bundle:nil];
+    masterViewController.mainMenu = self.mainMenu;
+    self.underLeftViewController = masterViewController;
+    
     HostManagementViewController *hostManagementViewController = [[HostManagementViewController alloc] initWithNibName:@"HostManagementViewController" bundle:nil];
     navController = [[CustomNavigationController alloc] initWithRootViewController:hostManagementViewController];
     navController.navigationBar.barStyle = UIBarStyleBlack;
     navController.navigationBar.tintColor = ICON_TINT_COLOR;
+    [Utilities addShadowsToView:navController.view viewFrame:self.view.frame];
     
     self.view.tintColor = APP_TINT_COLOR;
     [navController hideNavBarBottomLine:YES];
     hostManagementViewController.mainMenu = self.mainMenu;
     self.topViewController = navController;
+    
+    self.slidingViewController.underRightViewController = nil;
+    self.slidingViewController.anchorLeftPeekAmount   = 0;
+    self.slidingViewController.anchorLeftRevealAmount = 0;
     
     // Hide the inital HostManagementVC in case the "start view" is not main menu to avoid disturbing
     // sliding out (this view) and in (the targeted view).

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -32,7 +32,7 @@
     self.underLeftViewController = masterViewController;
     
     HostManagementViewController *hostManagementViewController = [[HostManagementViewController alloc] initWithNibName:@"HostManagementViewController" bundle:nil];
-    navController = [[CustomNavigationController alloc] initWithRootViewController:hostManagementViewController];
+    CustomNavigationController *navController = [[CustomNavigationController alloc] initWithRootViewController:hostManagementViewController];
     navController.navigationBar.barStyle = UIBarStyleBlack;
     navController.navigationBar.tintColor = ICON_TINT_COLOR;
     [Utilities addShadowsToView:navController.view viewFrame:self.view.frame];

--- a/XBMC Remote/MasterViewController.h
+++ b/XBMC Remote/MasterViewController.h
@@ -15,7 +15,6 @@
 @interface MasterViewController : UIViewController <UITableViewDataSource, UITableViewDelegate> {
     IBOutlet UITableView *menuList;
     BOOL itemIsActive;
-    CustomNavigationController *navController;
     UIImageView *globalConnectionStatus;
     MessagesView *messagesView;
 }

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -313,7 +313,7 @@
     self.slidingViewController.underLeftWidthLayout = ECFullWidth;
     
     // Update dimension of message view
-    CGFloat deltaY = [Utilities getTopPaddingWithNavBar:self.navigationController];
+    CGFloat deltaY = [Utilities getTopPadding];
     [messagesView updateWithFrame:CGRectMake(0,
                                              0,
                                              UIScreen.mainScreen.bounds.size.width,

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -181,7 +181,7 @@
         default:
             break;
     }
-    navController = [[CustomNavigationController alloc] initWithRootViewController:object];
+    CustomNavigationController *navController = [[CustomNavigationController alloc] initWithRootViewController:object];
     navController.navigationBar.barStyle = UIBarStyleBlack;
     navController.navigationBar.tintColor = ICON_TINT_COLOR;
     UIImage *menuImg = [UIImage imageNamed:@"button_menu"];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
`InitialSlidingVC` is the main controller for iPhone. It has the top, the underleft and underright controller. When starting, the top controller is either the default `HostManagementVC` or any other menu controller defined by the user settings. The underleft controller is always the main menu (= `MasterVC`). These two controllers (top and underleft) should be created and assigned when `InitialSlidingVC` is initialized.

In addition apply a small refactoring to make `navController` a local variable instead of using ivar.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Rework iPhone main controller initialization