### PR TITLE
Maintenance: rightMenuItems do not need to be mutable

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -103,8 +103,8 @@
 @property (nonatomic, strong) mainMenu *playlistPVR;
 @property (nonatomic, strong) mainMenu *xbmcSettings;
 @property (nonatomic, strong) NSArray *globalSearchMenuLookup;
-@property (nonatomic, strong) NSMutableArray *nowPlayingMenuItems;
-@property (nonatomic, strong) NSMutableArray *remoteControlMenuItems;
+@property (nonatomic, strong) NSArray *nowPlayingMenuItems;
+@property (nonatomic, strong) NSArray *remoteControlMenuItems;
 @property (nonatomic, assign) BOOL serverOnLine;
 @property (nonatomic, assign) BOOL serverTCPConnectionOpen;
 @property (nonatomic, assign) int serverVersion;

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -5994,7 +5994,6 @@
     xbmcSettings.subItem.subItem.thumbWidth = SETTINGS_THUMB_WIDTH;
     
 #pragma mark - Now Playing Right Menu
-    nowPlayingMenuItems = [NSMutableArray arrayWithCapacity:1];
     __auto_type nowPlayingItem1 = [mainMenu new];
     nowPlayingItem1.mainLabel = @"EmbeddedRemote";
     nowPlayingItem1.family = FamilyNowPlaying;
@@ -6018,10 +6017,9 @@
         },
     ];
     
-    [nowPlayingMenuItems addObject:nowPlayingItem1];
+    nowPlayingMenuItems = @[nowPlayingItem1];
     
 #pragma mark - Remote Control Right Menu
-    remoteControlMenuItems = [NSMutableArray arrayWithCapacity:1];
     __auto_type remoteControlItem1 = [mainMenu new];
     remoteControlItem1.mainLabel = @"RemoteControl";
     remoteControlItem1.family = FamilyRemote;
@@ -6062,7 +6060,7 @@
         },
     ];
     
-    [remoteControlMenuItems addObject:remoteControlItem1];
+    remoteControlMenuItems = @[remoteControlItem1];
 
 #pragma mark - Build and Initialize menu structure
     

--- a/XBMC Remote/RightMenuViewController.h
+++ b/XBMC Remote/RightMenuViewController.h
@@ -23,6 +23,6 @@
     NSDictionary *infoCustomButton;
 }
 
-@property (strong, nonatomic) NSMutableArray *rightMenuItems;
+@property (strong, nonatomic) NSArray *rightMenuItems;
 
 @end

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -605,7 +605,7 @@
     menuTableView.dataSource = self;
     menuTableView.backgroundColor = UIColor.clearColor;
     menuTableView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
-    [menuTableView setScrollEnabled:[self.rightMenuItems[0] enableSection]];
+    [menuTableView setScrollEnabled:menuItems.enableSection];
     menuTableView.separatorInset = UIEdgeInsetsMake(0, 0, 0, 0);
     menuTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
     [self.view addSubview:menuTableView];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Both `nowPlayingMenuItems` and `remoteControlMenuItems` properties do not need to be mutable. They are also only assigned to the non-mutable property `rightMenuItems` of class `RightMenuViewController`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: rightMenuItems do not need to be mutable