### PR TITLE
Maintenance: Cleanup colors

### DIFF
--- a/XBMC Remote/ActorCell.m
+++ b/XBMC Remote/ActorCell.m
@@ -32,7 +32,7 @@ int offsetY = 5;
         UIView *actorContainer = [[UIView alloc] initWithFrame:CGRectMake(offsetX, offsetY, castWidth, castHeight)];
         actorContainer.clipsToBounds = NO;
         actorContainer.backgroundColor = UIColor.clearColor;
-        actorContainer.layer.shadowColor = [Utilities getGrayColor:0 alpha:0.8].CGColor;
+        actorContainer.layer.shadowColor = FONT_SHADOW_STRONG.CGColor;
         actorContainer.layer.shadowOpacity = 0.7f;
         actorContainer.layer.shadowOffset = CGSizeZero;
         actorContainer.layer.shadowRadius = 2.0;
@@ -53,7 +53,7 @@ int offsetY = 5;
         _actorName.backgroundColor = UIColor.clearColor;
         _actorName.textColor = UIColor.whiteColor;
         _actorName.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleWidth;
-        _actorName.shadowColor = UIColor.blackColor;
+        _actorName.shadowColor = FONT_SHADOW_WEAK;
         _actorName.shadowOffset = CGSizeMake(1, 1);
         [self addSubview:_actorName];
         
@@ -62,13 +62,13 @@ int offsetY = 5;
         _actorRole.font = [UIFont systemFontOfSize:castFontSize - 2];
         _actorRole.backgroundColor = UIColor.clearColor;
         _actorRole.textColor = UIColor.lightGrayColor;
-        _actorRole.shadowColor = UIColor.blackColor;
+        _actorRole.shadowColor = FONT_SHADOW_STRONG;
         _actorRole.shadowOffset = CGSizeMake(1, 1);
         _actorRole.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleWidth;
         [self addSubview:_actorRole];
         
         UIView *myBackView = [[UIView alloc] initWithFrame:self.frame];
-        myBackView.backgroundColor = [Utilities getGrayColor:128 alpha:0.5];
+        myBackView.backgroundColor = ACTOR_SELECTED_COLOR;
         self.selectedBackgroundView = myBackView;
     }
     return self;

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -416,7 +416,7 @@
         UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
         [appearance configureWithOpaqueBackground];
         appearance.titleTextAttributes = @{NSForegroundColorAttributeName : UIColor.whiteColor};
-        appearance.backgroundColor = [Utilities getGrayColor:38 alpha:1.0];
+        appearance.backgroundColor = NAVBAR_TINT_COLOR;
         [UINavigationBar appearance].standardAppearance = appearance;
         [UINavigationBar appearance].scrollEdgeAppearance = appearance;
     }

--- a/XBMC Remote/ClearCacheView.m
+++ b/XBMC Remote/ClearCacheView.m
@@ -21,12 +21,12 @@
     self = [super initWithFrame:frame];
     if (self) {
         self.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-        self.backgroundColor = [Utilities getGrayColor:0 alpha:0.7];
+        self.backgroundColor = INFO_POPOVER_COLOR;
         CGFloat labelHeight = 300.0;
         PosterLabel *label = [[PosterLabel alloc] initWithFrame:CGRectMake(0, CGRectGetHeight(self.frame) / 2 - labelHeight / 2, CGRectGetWidth(self.frame) - borderWidth, labelHeight)];
         label.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         label.text = LOCALIZED_STR(@"Clearing app disk cache...\n\nPlease wait, since this may take a while");
-        label.shadowColor = UIColor.blackColor;
+        label.shadowColor = FONT_SHADOW_STRONG;
         label.shadowOffset = CGSizeMake(1, 1);
         label.textAlignment = NSTextAlignmentCenter;
         label.numberOfLines = 0;

--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -23,7 +23,6 @@
 #define APP_TINT_COLOR [Utilities getGrayColor:0 alpha:0.3]
 #define ICON_TINT_COLOR UIColor.lightGrayColor
 #define ICON_TINT_COLOR_ACTIVE UIColor.systemBlueColor
-#define BAR_TINT_COLOR [Utilities getGrayColor:26 alpha:1]
 #define REMOTE_CONTROL_BAR_TINT_COLOR [Utilities getGrayColor:12 alpha:1]
 #define SLIDER_DEFAULT_COLOR UIColor.lightGrayColor
 #define TOOLBAR_TINT_COLOR [Utilities getGrayColor:38 alpha:0.95]

--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -26,7 +26,23 @@
 #define REMOTE_CONTROL_BAR_TINT_COLOR [Utilities getGrayColor:12 alpha:1]
 #define SLIDER_DEFAULT_COLOR UIColor.lightGrayColor
 #define TOOLBAR_TINT_COLOR [Utilities getGrayColor:38 alpha:0.95]
+#define NAVBAR_TINT_COLOR [Utilities getGrayColor:38 alpha:1.0]
 #define KODI_BLUE_COLOR [Utilities getKodiBlue]
+#define CUSTOM_BUTTON_BACKGROUND [Utilities getGrayColor:36 alpha:1]
+#define GRIDVIEW_SECTION_COLOR [Utilities getGrayColor:44 alpha:1.0]
+#define SYSTEMGRAY6_DARKMODE [Utilities getGrayColor:28 alpha:1] // Gray:28 is similar to systemGray6 in Dark Mode
+#define SYSTEMGRAY6_LIGHTMODE [Utilities getGrayColor:242 alpha:1] // Gray:242 is similar to systemGray6 in Light Mode
+#define MAINMENU_SELECTED_COLOR [Utilities getGrayColor:8 alpha:1]
+#define MAINMENU_SERVER_COLOR [Utilities getGrayColor:53 alpha:1]
+#define ACTOR_SELECTED_COLOR [Utilities getGrayColor:128 alpha:0.5]
+#define INFO_POPOVER_COLOR [Utilities getGrayColor:0 alpha:0.8]
+#define IPAD_MENU_SEPARATOR [Utilities getGrayColor:77 alpha:0.6]
+#define PLAYLIST_PROGRESSBAR_BACKGROUND_COLOR [Utilities getGrayColor:96 alpha:1.0]
+#define PLAYLIST_PROGRESSBAR_TRACK_COLOR [Utilities getGrayColor:28 alpha:1.0]
+#define FONT_SHADOW_WEAK [Utilities getGrayColor:0 alpha:0.6]
+#define FONT_SHADOW_STRONG [Utilities getGrayColor:0 alpha:0.8]
+#define ERROR_MESSAGE_COLOR [Utilities getSystemRed:0.95]
+#define SUCCESS_MESSAGE_COLOR [Utilities getSystemGreen:0.95]
 
 /*
  * Dimension and layout macros

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -998,8 +998,7 @@
             if (!enableCollectionView && !stackscrollFullscreen) {
                 // If loaded, we use a dark background
                 if (!useFallback) {
-                    // Gray:28 is similar to systemGray6 in Dark Mode
-                    cell.backgroundColor = [Utilities getGrayColor:28 alpha:1.0];
+                    cell.backgroundColor = SYSTEMGRAY6_DARKMODE;
                 }
                 // If not loaded, use default background color and poster dimensions for default thumb
                 else {
@@ -1008,15 +1007,13 @@
             }
             // When in grid or fullscreen view
             else {
-                // Gray:28 is similar to systemGray6 in Dark Mode
-                cell.backgroundColor = [Utilities getGrayColor:28 alpha:1.0];
+                cell.backgroundColor = SYSTEMGRAY6_DARKMODE;
             }
         }
         // Other tabs (e.g. list of episodes) use default layout
         else {
             if (enableCollectionView) {
-                // Gray:28 is similar to systemGray6 in Dark Mode
-                cell.backgroundColor = [Utilities getGrayColor:28 alpha:1.0];
+                cell.backgroundColor = SYSTEMGRAY6_DARKMODE;
             }
             else {
                 cell.backgroundColor = [Utilities getSystemGray6];
@@ -1593,7 +1590,7 @@
         // Selected favourite item is an unknown type -> throw an error
         else {
             NSString *message = [NSString stringWithFormat:@"%@ (type = '%@')", LOCALIZED_STR(@"Cannot do that"), item[@"type"]];
-            [Utilities showMessage:message color:[Utilities getSystemRed:0.95]];
+            [Utilities showMessage:message color:ERROR_MESSAGE_COLOR];
         }
         [self deselectAtIndexPath:indexPath];
     }
@@ -1803,7 +1800,7 @@
         [cell setPosterCellLayoutManually:cell.bounds];
         [self setCellImageView:cell.posterThumbnail cell:cell dictItem:item url:stringURL size:CGSizeMake(cellthumbWidth, cellthumbHeight) defaultImg:displayThumb];
         if (!stringURL.length) {
-            cell.posterThumbnail.backgroundColor = [Utilities getGrayColor:28 alpha:1.0];
+            cell.posterThumbnail.backgroundColor = SYSTEMGRAY6_DARKMODE;
         }
         // Set label visibility based on setting and current view
         if (hiddenLabel || stackscrollFullscreen) {
@@ -1902,7 +1899,7 @@
                                                                       overlayWidth,
                                                                       overlayHeight)];
     sectionNameOverlayView.autoresizingMask = (UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleTopMargin);
-    sectionNameOverlayView.backgroundColor = [Utilities getGrayColor:0 alpha:0.8];
+    sectionNameOverlayView.backgroundColor = INFO_POPOVER_COLOR;
     sectionNameOverlayView.layer.cornerRadius = 12;
     [sectionNameOverlayView addSubview:sectionNameLabel];
     [self.view addSubview:sectionNameOverlayView];
@@ -2177,7 +2174,7 @@
 
 - (void)setSearchBar:(UISearchBar*)searchBar toDark:(BOOL)isDark {
     if (isDark) {
-        searchBar.backgroundColor = [Utilities getGrayColor:22 alpha:1];
+        searchBar.backgroundColor = SYSTEMGRAY6_DARKMODE;
         searchBar.tintColor = ICON_TINT_COLOR;
     }
     else {
@@ -3735,7 +3732,7 @@
     customButton *arrayButtons = [customButton new];
     [arrayButtons.buttons addObject:button];
     [arrayButtons saveData];
-    [Utilities showMessage:LOCALIZED_STR(@"Button added") color:[Utilities getSystemGreen:0.95]];
+    [Utilities showMessage:LOCALIZED_STR(@"Button added") color:SUCCESS_MESSAGE_COLOR];
     if (IS_IPAD) {
         [[NSNotificationCenter defaultCenter] postNotificationName:@"UIInterfaceCustomButtonAdded" object:nil];
     }
@@ -3840,7 +3837,7 @@
         topNavigationLabel.adjustsFontSizeToFitWidth = YES;
         topNavigationLabel.textAlignment = NSTextAlignmentLeft;
         topNavigationLabel.textColor = UIColor.whiteColor;
-        topNavigationLabel.shadowColor = [Utilities getGrayColor:0 alpha:0.5];
+        topNavigationLabel.shadowColor = FONT_SHADOW_WEAK;
         topNavigationLabel.shadowOffset = CGSizeMake (0, -1);
         topNavigationLabel.highlightedTextColor = UIColor.blackColor;
         topNavigationLabel.opaque = YES;
@@ -4408,10 +4405,10 @@
 - (void)SimpleAction:(NSString*)action params:(NSDictionary*)parameters success:(NSString*)successMessage failure:(NSString*)failureMessage {
     [[Utilities getJsonRPC] callMethod:action withParameters:parameters onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (error == nil && methodError == nil) {
-            [Utilities showMessage:successMessage color:[Utilities getSystemGreen:0.95]];
+            [Utilities showMessage:successMessage color:SUCCESS_MESSAGE_COLOR];
         }
         else {
-            [Utilities showMessage:failureMessage color:[Utilities getSystemRed:0.95]];
+            [Utilities showMessage:failureMessage color:ERROR_MESSAGE_COLOR];
         }
     }];
 }

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -766,7 +766,7 @@
 
 - (void)connectionError:(NSNotification*)note {
     NSDictionary *theData = note.userInfo;
-    [Utilities showMessage:theData[@"error_message"] color:[Utilities getSystemRed:0.95]];
+    [Utilities showMessage:theData[@"error_message"] color:ERROR_MESSAGE_COLOR];
 }
 
 - (void)authFailed:(NSNotification*)note {

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -572,7 +572,6 @@
     
     if (IS_IPAD) {
         self.edgesForExtendedLayout = 0;
-        self.view.tintColor = APP_TINT_COLOR;
         CGRect frame = backgroundImageView.frame;
         frame.size.height = frame.size.height + 8;
         backgroundImageView.frame = frame;

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -62,7 +62,7 @@
         [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
         notificationName = @"XBMCServerConnectionSuccess";
         NSString *message = [NSString stringWithFormat:LOCALIZED_STR(@"Connected to %@"), AppDelegate.instance.obj.serverDescription];
-        [Utilities showMessage:message color:[Utilities getSystemGreen:0.95]];
+        [Utilities showMessage:message color:SUCCESS_MESSAGE_COLOR];
     }
     else {
         [self.tcpJSONRPCconnection stopNetworkCommunication];
@@ -99,7 +99,7 @@
         
         // Set background view
         UIView *backgroundView = [[UIView alloc] initWithFrame:cell.frame];
-        backgroundView.backgroundColor = [Utilities getGrayColor:22 alpha:1];
+        backgroundView.backgroundColor = MAINMENU_SELECTED_COLOR;
         cell.selectedBackgroundView = backgroundView;
     }
     mainMenu *item = self.mainMenu[indexPath.row];
@@ -115,7 +115,7 @@
         title.numberOfLines = 2;
         title.text = [Utilities getConnectionStatusServerName];
         [self setConnectionIcon:icon];
-        cell.backgroundColor = [Utilities getGrayColor:53 alpha:1];
+        cell.backgroundColor = MAINMENU_SERVER_COLOR;
     }
     else {
         // Adapt layout for main menu cells
@@ -429,7 +429,7 @@
 }
 
 - (void)handleLibraryNotification:(NSNotification*)note {
-    [Utilities showMessage:note.name color:[Utilities getSystemGreen:0.95]];
+    [Utilities showMessage:note.name color:SUCCESS_MESSAGE_COLOR];
 }
 
 - (void)showNotificationMessage:(NSNotification*)note {

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -425,7 +425,6 @@
                                                  name:@"UIShowMessage"
                                                object:nil];
     
-    self.view.backgroundColor = [Utilities getGrayColor:36 alpha:1];
     [menuList selectRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] animated:YES scrollPosition:UITableViewScrollPositionNone];
 }
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2213,7 +2213,7 @@
         else {
             [playlistTableView reloadData];
             [playlistTableView selectRowAtIndexPath:storeSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
-            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
+            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
         }
     }];
 }
@@ -2243,7 +2243,7 @@
             else {
                 [playlistTableView reloadData];
                 [playlistTableView selectRowAtIndexPath:storeSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
-                [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
+                [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
             }
         }];
     }
@@ -2739,6 +2739,8 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    scrabbingView.backgroundColor = INFO_POPOVER_COLOR;
+    songDetailsView.backgroundColor = INFO_POPOVER_COLOR;
     itemDescription.selectable = NO;
     itemLogoImage.layer.minificationFilter = kCAFilterTrilinear;
     songCodecImage.layer.minificationFilter = kCAFilterTrilinear;

--- a/XBMC Remote/PlaylistProgressView.m
+++ b/XBMC Remote/PlaylistProgressView.m
@@ -25,7 +25,7 @@
 }
 
 - (void)createProgressView {
-    self.backgroundColor = [Utilities getGrayColor:96 alpha:1.0];
+    self.backgroundColor = PLAYLIST_PROGRESSBAR_BACKGROUND_COLOR;
     
     timeLabel = [UILabel new];
     timeLabel.font = [UIFont systemFontOfSize:FONT_SIZE];
@@ -39,7 +39,7 @@
     progressBarView = [ProgressBarView new];
     [self addSubview:progressBarView];
     
-    [progressBarView setTrackColor:[Utilities getGrayColor:28 alpha:1.0]];
+    [progressBarView setTrackColor:PLAYLIST_PROGRESSBAR_TRACK_COLOR];
 }
 
 - (void)setProgress:(CGFloat)progress {

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -41,7 +41,7 @@
         _posterLabel.backgroundColor = UIColor.clearColor;
         _posterLabel.textAlignment = NSTextAlignmentCenter;
         _posterLabel.textColor = UIColor.whiteColor;
-        _posterLabel.shadowColor = [Utilities getGrayColor:0 alpha:0.6];
+        _posterLabel.shadowColor = FONT_SHADOW_WEAK;
         _posterLabel.shadowOffset = CGSizeMake(0, 1);
         _posterLabel.numberOfLines = 2;
         _posterLabel.adjustsFontSizeToFitWidth = YES;

--- a/XBMC Remote/PosterHeaderView.m
+++ b/XBMC Remote/PosterHeaderView.m
@@ -22,7 +22,7 @@
     if (self) {
         self.clipsToBounds = NO;
         self.restorationIdentifier = @"posterHeaderView";
-        self.backgroundColor = [Utilities getGrayColor:44 alpha:1.0];
+        self.backgroundColor = GRIDVIEW_SECTION_COLOR;
 
         // Draw text into section header
         if (self.frame.size.height > 20) {

--- a/XBMC Remote/PosterHeaderView.m
+++ b/XBMC Remote/PosterHeaderView.m
@@ -29,7 +29,7 @@
             _headerLabel = [[PosterLabel alloc] initWithFrame:CGRectMake(10, 0, self.frame.size.width - 20, self.frame.size.height)];
             _headerLabel.backgroundColor = UIColor.clearColor;
             _headerLabel.font = [UIFont boldSystemFontOfSize:self.frame.size.height - 10];
-            _headerLabel.textColor = [Utilities getGrayColor:235 alpha:0.6];
+            _headerLabel.textColor = UIColor.lightGrayColor;
             _headerLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight |
                                             UIViewAutoresizingFlexibleWidth |
                                             UIViewAutoresizingFlexibleLeftMargin |

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -45,7 +45,7 @@
         _posterLabel.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterLabel.backgroundColor = UIColor.clearColor;
         _posterLabel.textColor = UIColor.whiteColor;
-        _posterLabel.shadowColor = [Utilities getGrayColor:0 alpha:0.6];
+        _posterLabel.shadowColor = FONT_SHADOW_WEAK;
         _posterLabel.shadowOffset = CGSizeMake(0, 1);
         _posterLabel.numberOfLines = 1;
         _posterLabel.minimumScaleFactor = FONT_SCALING_MIN;
@@ -56,7 +56,7 @@
         _posterGenre.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterGenre.backgroundColor = UIColor.clearColor;
         _posterGenre.textColor = UIColor.whiteColor;
-        _posterGenre.shadowColor = [Utilities getGrayColor:0 alpha:0.6];
+        _posterGenre.shadowColor = FONT_SHADOW_WEAK;
         _posterGenre.shadowOffset = CGSizeMake(0, 1);
         _posterGenre.numberOfLines = 1;
         _posterGenre.minimumScaleFactor = FONT_SCALING_MIN;
@@ -67,7 +67,7 @@
         _posterYear.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         _posterYear.backgroundColor = UIColor.clearColor;
         _posterYear.textColor = UIColor.whiteColor;
-        _posterYear.shadowColor = [Utilities getGrayColor:0 alpha:0.6];
+        _posterYear.shadowColor = FONT_SHADOW_WEAK;
         _posterYear.shadowOffset = CGSizeMake(0, 1);
         _posterYear.numberOfLines = 1;
         _posterYear.minimumScaleFactor = FONT_SCALING_MIN;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -531,7 +531,7 @@
                                      [self showActionSubtitles:actionSheetTitles];
                                  }
                                  else {
-                                     [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") color:[Utilities getSystemRed:0.95]];
+                                     [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") color:ERROR_MESSAGE_COLOR];
                                  }
                              }
                          }
@@ -539,7 +539,7 @@
                  }];
             }
             else {
-                [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") color:[Utilities getSystemRed:0.95]];
+                [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") color:ERROR_MESSAGE_COLOR];
             }
         }
     }];
@@ -574,7 +574,7 @@
                                      [self showActionAudiostreams:actionSheetTitles];
                                  }
                                  else {
-                                     [self showSubInfo:LOCALIZED_STR(@"Audiostreams not available") color:[Utilities getSystemRed:0.95]];
+                                     [self showSubInfo:LOCALIZED_STR(@"Audiostreams not available") color:ERROR_MESSAGE_COLOR];
                                  }
                              }
                         }
@@ -582,7 +582,7 @@
                  }];
             }
             else {
-                [self showSubInfo:LOCALIZED_STR(@"Audiostream not available") color:[Utilities getSystemRed:0.95]];
+                [self showSubInfo:LOCALIZED_STR(@"Audiostream not available") color:ERROR_MESSAGE_COLOR];
             }
         }
     }];
@@ -650,7 +650,7 @@
                             id audiostreamIndex = audiostreamsDictionary[@"audiostreams"][i][@"index"];
                             if (audiostreamIndex) {
                                 [self playbackAction:@"Player.SetAudioStream" params:@{@"stream": audiostreamIndex}];
-                                [self showSubInfo:actiontitle color:[Utilities getSystemGreen:0.95]];
+                                [self showSubInfo:actiontitle color:SUCCESS_MESSAGE_COLOR];
                             }
                         }
                     }
@@ -678,7 +678,7 @@
         UIAlertAction *action_cancel = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:nil];
 
         UIAlertAction *action_disable = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Disable subtitles") style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
-            [self showSubInfo:LOCALIZED_STR(@"Subtitles disabled") color:[Utilities getSystemGreen:0.95]];
+            [self showSubInfo:LOCALIZED_STR(@"Subtitles disabled") color:SUCCESS_MESSAGE_COLOR];
             [self playbackAction:@"Player.SetSubtitle" params:@{@"subtitle": @"off"}];
         }];
         if ([subsDictionary[@"subtitleenabled"] boolValue]) {
@@ -696,7 +696,7 @@
                             if (subsIndex) {
                                 [self playbackAction:@"Player.SetSubtitle" params:@{@"subtitle": subsIndex}];
                                 [self playbackAction:@"Player.SetSubtitle" params:@{@"subtitle": @"on"}];
-                                [self showSubInfo:actiontitle color:[Utilities getSystemGreen:0.95]];
+                                [self showSubInfo:actiontitle color:SUCCESS_MESSAGE_COLOR];
                             }
                         }
                     }

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1343,7 +1343,6 @@
     [super viewDidLoad];
 
     self.edgesForExtendedLayout = 0;
-    self.view.tintColor = APP_TINT_COLOR;
     
     quickHelpImageView.image = [UIImage imageNamed:@"remote_quick_help"];
     [self loadRemoteMode];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -83,22 +83,12 @@
     if (cell == nil) {
         NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"rightCellView" owner:self options:nil];
         cell = nib[0];
-        
-        // Set background view
-        UIView *backView = [[UIView alloc] initWithFrame:cell.frame];
-        backView.backgroundColor = [Utilities getGrayColor:22 alpha:1];
-        cell.selectedBackgroundView = backView;
     }
     */
     // WORKAROUND BEGIN
     // Load nib each time as otherwise the layout of the cells is not properly handled after sleep / resume.
     NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"rightCellView" owner:self options:nil];
     UITableViewCell *cell = nib[0];
-    
-    // Set background view
-    UIView *backView = [[UIView alloc] initWithFrame:cell.frame];
-    backView.backgroundColor = [Utilities getGrayColor:22 alpha:1];
-    cell.selectedBackgroundView = backView;
     // WROKAROUND END
     
     // Reset to default for each cell to allow dequeuing

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -173,7 +173,7 @@
         iconName = tableData[indexPath.row][@"icon"];
     }
     
-    UIColor *fontColor = [Utilities getGrayColor:125 alpha:1];
+    UIColor *fontColor = UIColor.grayColor;
     title.textColor = fontColor;
     title.highlightedTextColor = fontColor;
     

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -199,7 +199,7 @@
     CGRect frame = self.view.bounds;
     UIView *newView = [[UIView alloc] initWithFrame:CGRectMake(0, frame.size.height - footerHeight, frame.size.width, footerHeight)];
     newView.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleWidth;
-    newView.backgroundColor = [Utilities getGrayColor:36 alpha:1];
+    newView.backgroundColor = TOOLBAR_TINT_COLOR;
     
     // ...more button
     CGFloat originX = self.peekLeftAmount + BUTTON_SPACING;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -73,7 +73,7 @@
         cell.backgroundColor = UIColor.clearColor;
     }
     else {
-        cell.backgroundColor = [Utilities getGrayColor:36 alpha:1];
+        cell.backgroundColor = CUSTOM_BUTTON_BACKGROUND;
     }
 }
 
@@ -514,10 +514,10 @@
     }
     [[Utilities getJsonRPC] callMethod:action withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (methodError == nil && error == nil) {
-            [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:[Utilities getSystemGreen:0.95]];
+            [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:SUCCESS_MESSAGE_COLOR];
         }
         else {
-            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
+            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
         }
         if ([sender respondsToSelector:@selector(setUserInteractionEnabled:)]) {
             [sender setUserInteractionEnabled:YES];

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -160,11 +160,11 @@
         longPressGesture.delegate = self;
         [_tableView addGestureRecognizer:longPressGesture];
         
-        scrubbingView = [[UIView alloc] initWithFrame:CGRectMake(0, 
+        scrubbingView = [[UIView alloc] initWithFrame:CGRectMake(0,
                                                                  0,
                                                                  frame.size.width,
                                                                  SCRUBBINGVIEW_HEIGHT)];
-        scrubbingView.backgroundColor = [Utilities getGrayColor:0 alpha:0.8];
+        scrubbingView.backgroundColor = INFO_POPOVER_COLOR;
         scrubbingView.alpha = 0.0;
         
         scrubbingMessage = [[UILabel alloc] initWithFrame:CGRectMake(SCRUBBINGTEXT_PADDING,
@@ -295,7 +295,7 @@
     customButton *arrayButtons = [customButton new];
     [arrayButtons.buttons addObject:button];
     [arrayButtons saveData];
-    [Utilities showMessage:LOCALIZED_STR(@"Button added") color:[Utilities getSystemGreen:0.95]];
+    [Utilities showMessage:LOCALIZED_STR(@"Button added") color:SUCCESS_MESSAGE_COLOR];
     if (IS_IPAD) {
         [[NSNotificationCenter defaultCenter] postNotificationName:@"UIInterfaceCustomButtonAdded" object:nil];
     }
@@ -311,10 +311,10 @@
     [[Utilities getJsonRPC] callMethod:action withParameters:params onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         [activityIndicator stopAnimating];
         if (methodError == nil && error == nil) {
-            [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:[Utilities getSystemGreen:0.95]];
+            [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:SUCCESS_MESSAGE_COLOR];
         }
         else {
-            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
+            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
         }
         if ([sender respondsToSelector:@selector(setUserInteractionEnabled:)]) {
             [sender setUserInteractionEnabled:YES];
@@ -753,7 +753,7 @@
 - (UIView*)tableView:(UITableView*)tableView viewForFooterInSection:(NSInteger)section {
     UIView *helpView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, footerHeight)];
     if (xbmcSetting == SettingTypeUnsupported) {
-        helpView.backgroundColor = [Utilities getSystemRed:0.95];
+        helpView.backgroundColor = ERROR_MESSAGE_COLOR;
     }
     else {
         helpView.backgroundColor = TOOLBAR_TINT_COLOR;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -136,7 +136,7 @@
             viewTitle.minimumScaleFactor = FONT_SCALING_DEFAULT;
             viewTitle.adjustsFontSizeToFitWidth = YES;
             viewTitle.shadowOffset = CGSizeMake(1, 1);
-            viewTitle.shadowColor = [Utilities getGrayColor:0 alpha:0.7];
+            viewTitle.shadowColor = FONT_SHADOW_WEAK;
             viewTitle.autoresizingMask = UIViewAutoresizingNone;
             viewTitle.contentMode = UIViewContentModeScaleAspectFill;
             [viewTitle sizeThatFits:viewTitle.frame.size];
@@ -1038,7 +1038,7 @@
     UILabel *label = [[UILabel alloc] initWithFrame:defaultFrame];
     label.hidden = NO;
     label.textColor = UIColor.lightGrayColor;
-    label.shadowColor = UIColor.blackColor;
+    label.shadowColor = FONT_SHADOW_STRONG;
     label.font = [UIFont systemFontOfSize:12];
     label.textAlignment = NSTextAlignmentLeft;
     label.lineBreakMode = NSLineBreakByTruncatingTail;
@@ -1052,7 +1052,7 @@
     UILabel *label = [[UILabel alloc] initWithFrame:defaultFrame];
     label.hidden = NO;
     label.textColor = UIColor.whiteColor;
-    label.shadowColor = UIColor.blackColor;
+    label.shadowColor = FONT_SHADOW_WEAK;
     label.font = [UIFont systemFontOfSize:15];
     label.textAlignment = NSTextAlignmentJustified;
     label.lineBreakMode = NSLineBreakByWordWrapping;
@@ -1329,7 +1329,7 @@
 - (void)processClearlogoFromDictionary:(NSDictionary*)item {
     clearlogoButton = [UIButton buttonWithType:UIButtonTypeCustom];
     clearlogoButton.frame = CGRectMake(LEFT_RIGHT_PADDING, 0, clearLogoWidth, clearLogoHeight);
-    clearlogoButton.titleLabel.shadowColor = [Utilities getGrayColor:0 alpha:0.8];
+    clearlogoButton.titleLabel.shadowColor = FONT_SHADOW_STRONG;
     clearlogoButton.titleLabel.shadowOffset = CGSizeMake(0, 1);
     clearlogoButton.titleLabel.font = [UIFont systemFontOfSize:16];
     [clearlogoButton addTarget:self action:@selector(showBackground:) forControlEvents:UIControlEventTouchUpInside];
@@ -1489,7 +1489,7 @@
                                            UIViewAutoresizingFlexibleWidth;
             if (clearLogoImageView.frame.size.width == 0) {
                 [closeButton setTitle:clearlogoButton.titleLabel.text forState:UIControlStateNormal];
-                [closeButton setTitleShadowColor:[Utilities getGrayColor:0 alpha:0.8] forState:UIControlStateNormal];
+                [closeButton setTitleShadowColor:FONT_SHADOW_STRONG forState:UIControlStateNormal];
                 closeButton.titleLabel.shadowOffset = CGSizeMake(1, 1);
                 closeButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentCenter;
             }

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -248,8 +248,8 @@
 + (void)setLogoBackgroundColor:(UIImageView*)imageview mode:(LogoBackgroundType)mode {
     UIColor *bgcolor = UIColor.clearColor;
     UIColor *imgcolor = nil;
-    UIColor *bglight = [Utilities getGrayColor:242 alpha:1.0];
-    UIColor *bgdark = [Utilities getGrayColor:28 alpha:1.0];
+    UIColor *bglight = SYSTEMGRAY6_LIGHTMODE;
+    UIColor *bgdark = SYSTEMGRAY6_DARKMODE;
     switch (mode) {
         case LogoBackgroundAuto:
             // get background color and colorize the image background
@@ -511,10 +511,10 @@
     [[Utilities getJsonRPC] callMethod:command withParameters:@{} onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         // User already confirmed, so we only show a short-lived message.
         if (methodError == nil && error == nil) {
-            [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:[Utilities getSystemGreen:0.95]];
+            [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:SUCCESS_MESSAGE_COLOR];
         }
         else {
-            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:[Utilities getSystemRed:0.95]];
+            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
         }
     }];
 }
@@ -528,10 +528,10 @@
             // In this case we want to have a user interaction popup instead of a short-lived message.
             if ([Utilities isValidMacAddress:AppDelegate.instance.obj.serverHWAddr]) {
                 [Utilities wakeUp:AppDelegate.instance.obj.serverHWAddr];
-                [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:[Utilities getSystemGreen:0.95]];
+                [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:SUCCESS_MESSAGE_COLOR];
             }
             else {
-                [Utilities showMessage:LOCALIZED_STR(@"No server MAC address defined") color:[Utilities getSystemRed:0.95]];
+                [Utilities showMessage:LOCALIZED_STR(@"No server MAC address defined") color:ERROR_MESSAGE_COLOR];
             }
         }];
         [alertCtrl addAction:action_wake];

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -110,7 +110,7 @@
         [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
         notificationName = @"XBMCServerConnectionSuccess";
         NSString *message = [NSString stringWithFormat:LOCALIZED_STR(@"Connected to %@"), AppDelegate.instance.obj.serverDescription];
-        [Utilities showMessage:message color:[Utilities getSystemGreen:0.95]];
+        [Utilities showMessage:message color:SUCCESS_MESSAGE_COLOR];
         [volumeSliderView startTimer];
     }
     else {
@@ -351,7 +351,7 @@
     playlistHeader.textColor = UIColor.lightGrayColor;
     playlistHeader.text = LOCALIZED_STR(@"Playlist");
     playlistHeader.textAlignment = NSTextAlignmentCenter;
-    playlistHeader.layer.borderColor = [Utilities getGrayColor:77 alpha:0.6].CGColor;
+    playlistHeader.layer.borderColor = IPAD_MENU_SEPARATOR.CGColor;
     playlistHeader.layer.borderWidth = 1.0;
     [leftMenuView addSubview:playlistHeader];
     
@@ -486,7 +486,7 @@
     xbmcInfo.titleLabel.numberOfLines = 2;
     xbmcInfo.titleLabel.textAlignment = NSTextAlignmentCenter;
     xbmcInfo.titleEdgeInsets = UIEdgeInsetsZero;
-    xbmcInfo.titleLabel.shadowColor = UIColor.blackColor;
+    xbmcInfo.titleLabel.shadowColor = FONT_SHADOW_STRONG;
     xbmcInfo.titleLabel.shadowOffset = CGSizeZero;
     xbmcInfo.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
     [xbmcInfo addTarget:self action:@selector(toggleSetup) forControlEvents:UIControlEventTouchUpInside];
@@ -631,7 +631,7 @@
 }
 
 - (void)handleLibraryNotification:(NSNotification*)note {
-    [Utilities showMessage:note.name color:[Utilities getSystemGreen:0.95]];
+    [Utilities showMessage:note.name color:SUCCESS_MESSAGE_COLOR];
 }
 
 - (void)showNotificationMessage:(NSNotification*)note {

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -65,7 +65,7 @@
         
         UIView *verticalLineView = [[UIView alloc] initWithFrame:CGRectMake(self.view.frame.size.width, 0, IPAD_MENU_SEPARATOR_WIDTH, self.view.frame.size.height)];
         verticalLineView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
-        verticalLineView.backgroundColor = [Utilities getGrayColor:77 alpha:0.6];
+        verticalLineView.backgroundColor = IPAD_MENU_SEPARATOR;
         [self.view addSubview:verticalLineView];
         [self.view bringSubviewToFront:verticalLineView];
 	}
@@ -153,7 +153,7 @@
         
         // Set background view
         UIView *backgroundView = [[UIView alloc] initWithFrame:cell.frame];
-        backgroundView.backgroundColor = [Utilities getGrayColor:0 alpha:0.4];
+        backgroundView.backgroundColor = MAINMENU_SELECTED_COLOR;
         cell.selectedBackgroundView = backgroundView;
     }
     mainMenu *item = mainMenuItems[indexPath.row];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR does some color cleanup. It removes some unused color definitions and background views. It introduced the new macros for color at a central place and it partially unifies colors between certain UI elements.

I keep this non-squashed for easier review. Once approved I plan to squash the introduction of the new defines into a single commit.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Cleanup colors