### PR TITLE
Bugfix: Add applicationWillEnterForeground after removing by fault

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -6285,6 +6285,10 @@
     }
 }
 
+- (void)applicationWillEnterForeground:(UIApplication*)application {
+    [self setIdleTimerFromUserDefaults];
+}
+
 - (void)applicationDidBecomeActive:(UIApplication*)application {
     // Trigger Local Network Privacy Alert once after app launch
     static dispatch_once_t once;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1281. Bring back `applicationWillEnterForeground` after removing by fault.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Add applicationWillEnterForeground after removing by fault