### PR TITLE
Bugfix: Potentially hidden iPhone connection status icon in server list view

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -321,6 +321,8 @@
                            deltaY:deltaY
                            deltaX:0];
     [self addMessagesToRootView];
+    
+    [self addConnectionStatusToRootView];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
@@ -356,7 +358,6 @@
                                                                            [Utilities getTopPadding],
                                                                            CONNECTION_STATUS_SIZE,
                                                                            CONNECTION_STATUS_SIZE)];
-    [self addConnectionStatusToRootView];
     
     messagesView = [[MessagesView alloc] initWithFrame:CGRectZero deltaY:0 deltaX:0];
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1275. 

Call `addConnectionStatusToRootView` in `viewWillAppear`. Ensures the connection status icon is added on top the whole view hierarchy. This fixes an issue where the status icon was hidden behind the server list view when sliding to this view from main menu right after launch.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Potentially hidden iPhone connection status icon in server list view