### PR TITLE
Improvement: Add error messages when items cannot be played/queued/streamed

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3501,6 +3501,7 @@
             if (error == nil && methodError == nil) {
                 NSArray *sheetActions = [self getSupportedPlayers:methodResult forItem:item];
                 if (!sheetActions.count) {
+                    [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
                     return;
                 }
                 UIAlertController *alertCtrl = [UIAlertController alertControllerWithTitle:LOCALIZED_STR(@"Play using...") message:nil preferredStyle:UIAlertControllerStyleActionSheet];
@@ -4145,6 +4146,7 @@
     id playlistItems = [self buildPlaylistItems:item key:mainFields[@"row9"]];
     if (!playlistItems) {
         [cellActivityIndicator stopAnimating];
+        [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
         return;
     }
     NSDictionary *playlistParams = @{
@@ -4298,6 +4300,7 @@
     id playlistItems = [self buildPlaylistItems:item key:mainFields[@"row9"]];
     if (!playlistItems) {
         [cellActivityIndicator stopAnimating];
+        [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
         return;
     }
     NSDictionary *playbackParams = [NSDictionary dictionaryWithObjectsAndKeys:
@@ -4334,6 +4337,7 @@
     }
     if (!value || !key) {
         [cellActivityIndicator stopAnimating];
+        [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
         return;
     }
     NSDictionary *playbackParams = @{@"item": @{key: value}};

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1629,6 +1629,7 @@
     }
     if (!value || !param) {
         [activityIndicatorView stopAnimating];
+        [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
         return;
     }
     if (afterCurrent) {
@@ -1704,6 +1705,7 @@
         id value = item[key];
         if (!value || !key) {
             [activityIndicatorView stopAnimating];
+            [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
             return;
         }
         NSDictionary *params = @{


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1230.

This PR adds the error message "Cannot do that", if the actions "Play" (also covering slideshows), "Play using...", "Queue" or "Queue after" cannot be processed further for a selected item.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Add error messages when items cannot be played/queued/streamed