### PR TITLE
Maintenance: Introduce a base class for the iPhone and iPad main controller

### DIFF
--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		C78C30F528F877870055CD95 /* VersionCheck.m in Sources */ = {isa = PBXBuildFile; fileRef = C78C30F428F877870055CD95 /* VersionCheck.m */; };
 		C78C30FA28F8AADA0055CD95 /* SharingActivityItemSource.m in Sources */ = {isa = PBXBuildFile; fileRef = C78C30F928F89A3E0055CD95 /* SharingActivityItemSource.m */; };
 		C795123F2DC95A7E00A8CEE5 /* LinkPresentation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C795123E2DC95A7E00A8CEE5 /* LinkPresentation.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C79B0EA52DF0CF6900046334 /* BaseMasterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C79B0EA42DF0CF6900046334 /* BaseMasterViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -324,6 +325,8 @@
 		C78C30F828F89A1E0055CD95 /* SharingActivityItemSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SharingActivityItemSource.h; sourceTree = "<group>"; };
 		C78C30F928F89A3E0055CD95 /* SharingActivityItemSource.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SharingActivityItemSource.m; sourceTree = "<group>"; };
 		C795123E2DC95A7E00A8CEE5 /* LinkPresentation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LinkPresentation.framework; path = System/Library/Frameworks/LinkPresentation.framework; sourceTree = SDKROOT; };
+		C79B0EA42DF0CF6900046334 /* BaseMasterViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BaseMasterViewController.m; sourceTree = "<group>"; };
+		C79B0EA62DF0CF8C00046334 /* BaseMasterViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BaseMasterViewController.h; sourceTree = "<group>"; };
 		C79F6B322CBBF981009A785C /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C79F6B332CBBF981009A785C /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C7A030F128B60DB200B27764 /* ca-ES */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ca-ES"; path = "ca-ES.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -547,6 +550,8 @@
 				0FDFC67C15377CE9000BE837 /* Settings.bundle */,
 				0F554909151D1187007E633F /* AppDelegate.h */,
 				0F55490A151D1187007E633F /* AppDelegate.m */,
+				C79B0EA62DF0CF8C00046334 /* BaseMasterViewController.h */,
+				C79B0EA42DF0CF6900046334 /* BaseMasterViewController.m */,
 				0F554C1E151D14DA007E633F /* mainMenu.h */,
 				0F554C1F151D14DA007E633F /* mainMenu.m */,
 				0F4883C21521B3D400883243 /* GlobalData.h */,
@@ -891,6 +896,7 @@
 				0F4156451646D810009E6DD4 /* JBKenBurnsView.m in Sources */,
 				C76451CF29C51221000AE949 /* UIImage+WebP.m in Sources */,
 				0F7F3DA5164A6D730080A14A /* ECSlidingViewController.m in Sources */,
+				C79B0EA52DF0CF6900046334 /* BaseMasterViewController.m in Sources */,
 				0F7F3DA6164A6D730080A14A /* UIImage+ImageWithUIView.m in Sources */,
 				0F7F3DAB164AAD0F0080A14A /* InitialSlidingViewController.m in Sources */,
 				0F40F5A7164D5FA000AF9DE9 /* RightMenuViewController.m in Sources */,

--- a/XBMC Remote/BaseMasterViewController.h
+++ b/XBMC Remote/BaseMasterViewController.h
@@ -13,6 +13,7 @@
 @interface BaseMasterViewController : UIViewController
 
 - (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName;
+- (void)handleXBMCServerHasChanged:(NSNotification*)sender;
 
 @property (strong, nonatomic) tcpJSONRPC *tcpJSONRPCconnection;
 

--- a/XBMC Remote/BaseMasterViewController.h
+++ b/XBMC Remote/BaseMasterViewController.h
@@ -7,6 +7,7 @@
 //
 
 #import "tcpJSONRPC.h"
+#import "ClearCacheView.h"
 
 @import UIKit;
 
@@ -14,6 +15,7 @@
 
 - (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName;
 - (void)handleXBMCServerHasChanged:(NSNotification*)sender;
+- (void)startClearAppDiskCache:(ClearCacheView*)clearView;
 
 @property (strong, nonatomic) tcpJSONRPC *tcpJSONRPCconnection;
 

--- a/XBMC Remote/BaseMasterViewController.h
+++ b/XBMC Remote/BaseMasterViewController.h
@@ -6,8 +6,12 @@
 //  Copyright © 2025 Team Kodi. All rights reserved.
 //
 
+#import "tcpJSONRPC.h"
+
 @import UIKit;
 
 @interface BaseMasterViewController : UIViewController
+
+@property (strong, nonatomic) tcpJSONRPC *tcpJSONRPCconnection;
 
 @end

--- a/XBMC Remote/BaseMasterViewController.h
+++ b/XBMC Remote/BaseMasterViewController.h
@@ -16,7 +16,6 @@
 - (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName;
 - (void)handleXBMCServerHasChanged:(NSNotification*)sender;
 - (void)startClearAppDiskCache:(ClearCacheView*)clearView;
-- (void)addClearCacheMessage;
 
 @property (strong, nonatomic) tcpJSONRPC *tcpJSONRPCconnection;
 

--- a/XBMC Remote/BaseMasterViewController.h
+++ b/XBMC Remote/BaseMasterViewController.h
@@ -15,6 +15,7 @@
 
 - (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName;
 - (void)handleXBMCServerHasChanged:(NSNotification*)sender;
+- (void)connectionStatus:(NSNotification*)note;
 - (void)startClearAppDiskCache:(ClearCacheView*)clearView;
 
 @property (strong, nonatomic) tcpJSONRPC *tcpJSONRPCconnection;

--- a/XBMC Remote/BaseMasterViewController.h
+++ b/XBMC Remote/BaseMasterViewController.h
@@ -16,6 +16,7 @@
 - (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName;
 - (void)handleXBMCServerHasChanged:(NSNotification*)sender;
 - (void)startClearAppDiskCache:(ClearCacheView*)clearView;
+- (void)addClearCacheMessage;
 
 @property (strong, nonatomic) tcpJSONRPC *tcpJSONRPCconnection;
 

--- a/XBMC Remote/BaseMasterViewController.h
+++ b/XBMC Remote/BaseMasterViewController.h
@@ -12,6 +12,8 @@
 
 @interface BaseMasterViewController : UIViewController
 
+- (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName;
+
 @property (strong, nonatomic) tcpJSONRPC *tcpJSONRPCconnection;
 
 @end

--- a/XBMC Remote/BaseMasterViewController.h
+++ b/XBMC Remote/BaseMasterViewController.h
@@ -1,0 +1,13 @@
+//
+//  BaseMasterViewController.h
+//  Kodi Remote
+//
+//  Created by Buschmann on 04.06.25.
+//  Copyright © 2025 Team Kodi. All rights reserved.
+//
+
+@import UIKit;
+
+@interface BaseMasterViewController : UIViewController
+
+@end

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "BaseMasterViewController.h"
+#import "AppDelegate.h"
 
 @implementation BaseMasterViewController
 
@@ -17,10 +18,21 @@
                                              selector:@selector(handleDidEnterBackground:)
                                                  name:UIApplicationDidEnterBackgroundNotification
                                                object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleEnterForeground:)
+                                                 name:UIApplicationWillEnterForegroundNotification
+                                               object:nil];
 }
 
 - (void)handleDidEnterBackground:(NSNotification*)sender {
     [self.tcpJSONRPCconnection stopNetworkCommunication];
+}
+
+- (void)handleEnterForeground:(NSNotification*)sender {
+    if (AppDelegate.instance.serverOnLine) {
+        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
+    }
 }
 
 @end

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -10,4 +10,17 @@
 
 @implementation BaseMasterViewController
 
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleDidEnterBackground:)
+                                                 name:UIApplicationDidEnterBackgroundNotification
+                                               object:nil];
+}
+
+- (void)handleDidEnterBackground:(NSNotification*)sender {
+    [self.tcpJSONRPCconnection stopNetworkCommunication];
+}
+
 @end

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -140,4 +140,16 @@
     }];
 }
 
+- (void)addClearCacheMessage {
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    BOOL clearCacheEnabled = [userDefaults boolForKey:@"clearcache_preference"];
+    if (clearCacheEnabled) {
+        UIView *view = IS_IPHONE ? self.parentViewController.view : self.view;
+        ClearCacheView *clearView = [[ClearCacheView alloc] initWithFrame:view.bounds];
+        [clearView startActivityIndicator];
+        [view addSubview:clearView];
+        [NSThread detachNewThreadSelector:@selector(startClearAppDiskCache:) toTarget:self withObject:clearView];
+    }
+}
+
 @end

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -43,6 +43,16 @@
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(connectionStatus:)
+                                                 name:@"XBMCServerConnectionSuccess"
+                                               object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(connectionStatus:)
+                                                 name:@"XBMCServerConnectionFailed"
+                                               object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleLibraryNotification:)
                                                  name:@"AudioLibrary.OnScanFinished"
                                                object:nil];
@@ -120,6 +130,11 @@
 
 - (void)handleLocalNetworkAccessError:(NSNotification*)sender {
     [Utilities showLocalNetworkAccessError:self];
+}
+
+- (void)connectionStatus:(NSNotification*)note {
+    // We are connected to server, we now need to share credentials with SDWebImageManager
+    [Utilities setWebImageAuthorizationOnSuccessNotification:note];
 }
 
 #pragma mark - App clear disk cache methods

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -54,6 +54,11 @@
                                              selector:@selector(handleLibraryNotification:)
                                                  name:@"VideoLibrary.OnCleanFinished"
                                                object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleLocalNetworkAccessError:)
+                                                 name:@"LocalNetworkAccessError"
+                                               object:nil];
 }
 
 - (void)handleDidEnterBackground:(NSNotification*)sender {
@@ -104,6 +109,10 @@
 
 - (void)handleLibraryNotification:(NSNotification*)note {
     [Utilities showMessage:note.name color:SUCCESS_MESSAGE_COLOR];
+}
+
+- (void)handleLocalNetworkAccessError:(NSNotification*)sender {
+    [Utilities showLocalNetworkAccessError:self];
 }
 
 @end

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -10,6 +10,8 @@
 #import "AppDelegate.h"
 #import "Utilities.h"
 
+#define CLEARCACHE_TIMEOUT 2.0
+
 @implementation BaseMasterViewController
 
 - (void)viewDidLoad {
@@ -113,6 +115,29 @@
 
 - (void)handleLocalNetworkAccessError:(NSNotification*)sender {
     [Utilities showLocalNetworkAccessError:self];
+}
+
+#pragma mark - App clear disk cache methods
+
+- (void)startClearAppDiskCache:(ClearCacheView*)clearView {
+    [AppDelegate.instance clearAppDiskCache];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, CLEARCACHE_TIMEOUT * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        [self clearAppDiskCacheFinished:clearView];
+    });
+}
+
+- (void)clearAppDiskCacheFinished:(ClearCacheView*)clearView {
+    [UIView animateWithDuration:0.3
+                     animations:^{
+        [clearView stopActivityIndicator];
+        clearView.alpha = 0;
+    }
+                     completion:^(BOOL finished) {
+        [clearView stopActivityIndicator];
+        [clearView removeFromSuperview];
+        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+        [userDefaults removeObjectForKey:@"clearcache_preference"];
+    }];
 }
 
 @end

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -14,6 +14,11 @@
 
 @implementation BaseMasterViewController
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self addClearCacheMessage];
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -29,6 +29,11 @@
                                              selector:@selector(handleTcpJSONRPCChangeServerStatus:)
                                                  name:@"TcpJSONRPCChangeServerStatus"
                                                object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleXBMCServerHasChanged:)
+                                                 name:@"XBMCServerHasChanged"
+                                               object:nil];
 }
 
 - (void)handleDidEnterBackground:(NSNotification*)sender {
@@ -71,6 +76,10 @@
         // Send trigger to start the default controller
         [[NSNotificationCenter defaultCenter] postNotificationName:@"KodiStartDefaultController" object:nil userInfo:params];
     }
+}
+
+- (void)handleXBMCServerHasChanged:(NSNotification*)sender {
+    [self changeServerStatus:NO infoText:LOCALIZED_STR(@"No connection") icon:@"connection_off"];
 }
 
 @end

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -34,6 +34,26 @@
                                              selector:@selector(handleXBMCServerHasChanged:)
                                                  name:@"XBMCServerHasChanged"
                                                object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleLibraryNotification:)
+                                                 name:@"AudioLibrary.OnScanFinished"
+                                               object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleLibraryNotification:)
+                                                 name:@"AudioLibrary.OnCleanFinished"
+                                               object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleLibraryNotification:)
+                                                 name:@"VideoLibrary.OnScanFinished"
+                                               object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleLibraryNotification:)
+                                                 name:@"VideoLibrary.OnCleanFinished"
+                                               object:nil];
 }
 
 - (void)handleDidEnterBackground:(NSNotification*)sender {
@@ -80,6 +100,10 @@
 
 - (void)handleXBMCServerHasChanged:(NSNotification*)sender {
     [self changeServerStatus:NO infoText:LOCALIZED_STR(@"No connection") icon:@"connection_off"];
+}
+
+- (void)handleLibraryNotification:(NSNotification*)note {
+    [Utilities showMessage:note.name color:SUCCESS_MESSAGE_COLOR];
 }
 
 @end

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -1,0 +1,13 @@
+//
+//  BaseMasterViewController.m
+//  Kodi Remote
+//
+//  Created by Buschmann on 04.06.25.
+//  Copyright © 2025 Team Kodi. All rights reserved.
+//
+
+#import "BaseMasterViewController.h"
+
+@implementation BaseMasterViewController
+
+@end

--- a/XBMC Remote/MasterViewController.h
+++ b/XBMC Remote/MasterViewController.h
@@ -7,12 +7,13 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "BaseMasterViewController.h"
 #import "DSJSONRPC.h"
 #import "tcpJSONRPC.h"
 #import "CustomNavigationController.h"
 #import "MessagesView.h"
 
-@interface MasterViewController : UIViewController <UITableViewDataSource, UITableViewDelegate> {
+@interface MasterViewController : BaseMasterViewController <UITableViewDataSource, UITableViewDelegate> {
     IBOutlet UITableView *menuList;
     BOOL itemIsActive;
     UIImageView *globalConnectionStatus;

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -262,8 +262,6 @@
     [self addMessagesToRootView];
     
     [self addConnectionStatusToRootView];
-    
-    [self addClearCacheMessage];
 }
 
 - (void)viewDidLoad {

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -22,8 +22,6 @@
 #import "XBMCVirtualKeyboard.h"
 #import "Utilities.h"
 
-#define SERVER_TIMEOUT 2.0
-#define CONNECTION_ICON_SIZE 18
 #define MENU_ICON_SIZE 30
 #define ICON_MARGIN 10
 #define CONNECTION_STATUS_PADDING 4

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -20,7 +20,6 @@
 #import "AppInfoViewController.h"
 #import "tcpJSONRPC.h"
 #import "XBMCVirtualKeyboard.h"
-#import "ClearCacheView.h"
 #import "Utilities.h"
 
 #define SERVER_TIMEOUT 2.0
@@ -263,6 +262,8 @@
     [self addMessagesToRootView];
     
     [self addConnectionStatusToRootView];
+    
+    [self addClearCacheMessage];
 }
 
 - (void)viewDidLoad {
@@ -276,14 +277,7 @@
     menuList.frame = frame;
     
     menuList.separatorInset = UIEdgeInsetsMake(0, 0, 0, 0);
-    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    BOOL clearCache = [userDefaults boolForKey:@"clearcache_preference"];
-    if (clearCache) {
-        ClearCacheView *clearView = [[ClearCacheView alloc] initWithFrame:self.view.frame border:40];
-        [clearView startActivityIndicator];
-        [self.view addSubview:clearView];
-        [NSThread detachNewThreadSelector:@selector(startClearAppDiskCache:) toTarget:self withObject:clearView];
-    }
+    
     XBMCVirtualKeyboard *virtualKeyboard = [[XBMCVirtualKeyboard alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
     [self.view addSubview:virtualKeyboard];
     AppDelegate.instance.obj = [GlobalData getInstance];

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -342,35 +342,11 @@
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleLibraryNotification:)
-                                                 name:@"AudioLibrary.OnScanFinished"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleLibraryNotification:)
-                                                 name:@"AudioLibrary.OnCleanFinished"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleLibraryNotification:)
-                                                 name:@"VideoLibrary.OnScanFinished"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleLibraryNotification:)
-                                                 name:@"VideoLibrary.OnCleanFinished"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(showNotificationMessage:)
                                                  name:@"UIShowMessage"
                                                object:nil];
     
     [menuList selectRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] animated:YES scrollPosition:UITableViewScrollPositionNone];
-}
-
-- (void)handleLibraryNotification:(NSNotification*)note {
-    [Utilities showMessage:note.name color:SUCCESS_MESSAGE_COLOR];
 }
 
 - (void)showNotificationMessage:(NSNotification*)note {

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -24,7 +24,6 @@
 #import "Utilities.h"
 
 #define SERVER_TIMEOUT 2.0
-#define CLEARCACHE_TIMEOUT 2.0
 #define CONNECTION_ICON_SIZE 18
 #define MENU_ICON_SIZE 30
 #define ICON_MARGIN 10
@@ -244,29 +243,6 @@
                                   (height - arrowRight.frame.size.height) / 2,
                                   arrowRight.frame.size.width,
                                   arrowRight.frame.size.height);
-}
-
-#pragma mark - App clear disk cache methods
-
-- (void)startClearAppDiskCache:(ClearCacheView*)clearView {
-    [AppDelegate.instance clearAppDiskCache];
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, CLEARCACHE_TIMEOUT * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-        [self clearAppDiskCacheFinished:clearView];
-    });
-}
-
-- (void)clearAppDiskCacheFinished:(ClearCacheView*)clearView {
-    [UIView animateWithDuration:0.3
-                     animations:^{
-                         [clearView stopActivityIndicator];
-                         clearView.alpha = 0;
-                     }
-                     completion:^(BOOL finished) {
-                         [clearView stopActivityIndicator];
-                         [clearView removeFromSuperview];
-                         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-                         [userDefaults removeObjectForKey:@"clearcache_preference"];
-                     }];
 }
 
 #pragma mark - LifeCycle

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -343,11 +343,6 @@
     messagesView = [[MessagesView alloc] initWithFrame:CGRectZero deltaY:0 deltaX:0];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleDidEnterBackground:)
-                                                 name:UIApplicationDidEnterBackgroundNotification
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleEnterForeground:)
                                                  name:UIApplicationWillEnterForegroundNotification
                                                object:nil];
@@ -446,10 +441,6 @@
 
 - (void)handleLocalNetworkAccessError:(NSNotification*)sender {
     [Utilities showLocalNetworkAccessError:self];
-}
-
-- (void)handleDidEnterBackground:(NSNotification*)sender {
-    [self.tcpJSONRPCconnection stopNetworkCommunication];
 }
 
 - (void)handleEnterForeground:(NSNotification*)sender {

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -51,30 +51,9 @@
 }
 	
 - (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName {
-    NSMutableDictionary *params = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                   infoText, @"message",
-                                   iconName, @"icon_connection",
-                                   nil];
-    AppDelegate.instance.serverOnLine = status;
-    AppDelegate.instance.serverName = infoText;
-    NSString *notificationName;
-    if (status) {
-        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
-        notificationName = @"XBMCServerConnectionSuccess";
-        NSString *message = [NSString stringWithFormat:LOCALIZED_STR(@"Connected to %@"), AppDelegate.instance.obj.serverDescription];
-        [Utilities showMessage:message color:SUCCESS_MESSAGE_COLOR];
-    }
-    else {
-        [self.tcpJSONRPCconnection stopNetworkCommunication];
-        notificationName = @"XBMCServerConnectionFailed";
-    }
-    [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:nil userInfo:params];
+    [super changeServerStatus:status infoText:infoText icon:iconName];
     itemIsActive = NO;
     [Utilities setStyleOfMenuItems:menuList active:status];
-    if (status) {
-        // Send trigger to start the default controller
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"KodiStartDefaultController" object:nil userInfo:params];
-    }
 }
 
 #pragma mark - Table view methods & data source
@@ -348,11 +327,6 @@
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleTcpJSONRPCChangeServerStatus:)
-                                                 name:@"TcpJSONRPCChangeServerStatus"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(connectionStatus:)
                                                  name:@"XBMCServerConnectionSuccess"
                                                object:nil];
@@ -425,13 +399,6 @@
     
     // We are connected to server, we now need to share credentials with SDWebImageManager
     [Utilities setWebImageAuthorizationOnSuccessNotification:note];
-}
-
-- (void)handleTcpJSONRPCChangeServerStatus:(NSNotification*)sender {
-    BOOL statusValue = [[sender.userInfo objectForKey:@"status"] boolValue];
-    NSString *message = [sender.userInfo objectForKey:@"message"];
-    NSString *icon_connection = [sender.userInfo objectForKey:@"icon_connection"];
-    [self changeServerStatus:statusValue infoText:message icon:icon_connection];
 }
 
 - (void)handleLocalNetworkAccessError:(NSNotification*)sender {

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -343,11 +343,6 @@
     messagesView = [[MessagesView alloc] initWithFrame:CGRectZero deltaY:0 deltaX:0];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleEnterForeground:)
-                                                 name:UIApplicationWillEnterForegroundNotification
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleXBMCServerHasChanged:)
                                                  name:@"XBMCServerHasChanged"
                                                object:nil];
@@ -441,12 +436,6 @@
 
 - (void)handleLocalNetworkAccessError:(NSNotification*)sender {
     [Utilities showLocalNetworkAccessError:self];
-}
-
-- (void)handleEnterForeground:(NSNotification*)sender {
-    if (AppDelegate.instance.serverOnLine) {
-        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
-    }
 }
 
 - (void)handleXBMCServerHasChanged:(NSNotification*)sender {

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -322,11 +322,6 @@
     messagesView = [[MessagesView alloc] initWithFrame:CGRectZero deltaY:0 deltaX:0];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleXBMCServerHasChanged:)
-                                                 name:@"XBMCServerHasChanged"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(connectionStatus:)
                                                  name:@"XBMCServerConnectionSuccess"
                                                object:nil];
@@ -403,10 +398,6 @@
 
 - (void)handleLocalNetworkAccessError:(NSNotification*)sender {
     [Utilities showLocalNetworkAccessError:self];
-}
-
-- (void)handleXBMCServerHasChanged:(NSNotification*)sender {
-    [self changeServerStatus:NO infoText:LOCALIZED_STR(@"No connection") icon:@"connection_off"];
 }
 
 - (void)handleEnablingDefaultController {

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -290,16 +290,6 @@
     messagesView = [[MessagesView alloc] initWithFrame:CGRectZero deltaY:0 deltaX:0];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(connectionStatus:)
-                                                 name:@"XBMCServerConnectionSuccess"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(connectionStatus:)
-                                                 name:@"XBMCServerConnectionFailed"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleEnablingDefaultController)
                                                  name:@"KodiStartDefaultController"
                                                object:nil];
@@ -323,6 +313,7 @@
 }
 
 - (void)connectionStatus:(NSNotification*)note {
+    [super connectionStatus:note];
     NSDictionary *theData = note.userInfo;
     NSString *infoText = theData[@"message"];
     UITableViewCell *cell = [menuList cellForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
@@ -330,9 +321,6 @@
     [self setConnectionIcon:icon];
     UILabel *title = (UILabel*)[cell viewWithTag:XIB_MAIN_MENU_CELL_TITLE];
     title.text = infoText;
-    
-    // We are connected to server, we now need to share credentials with SDWebImageManager
-    [Utilities setWebImageAuthorizationOnSuccessNotification:note];
 }
 
 - (void)handleEnablingDefaultController {

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -332,11 +332,6 @@
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleLocalNetworkAccessError:)
-                                                 name:@"LocalNetworkAccessError"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleEnablingDefaultController)
                                                  name:@"KodiStartDefaultController"
                                                object:nil];
@@ -370,10 +365,6 @@
     
     // We are connected to server, we now need to share credentials with SDWebImageManager
     [Utilities setWebImageAuthorizationOnSuccessNotification:note];
-}
-
-- (void)handleLocalNetworkAccessError:(NSNotification*)sender {
-    [Utilities showLocalNetworkAccessError:self];
 }
 
 - (void)handleEnablingDefaultController {

--- a/XBMC Remote/ViewControllerIPad.h
+++ b/XBMC Remote/ViewControllerIPad.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "BaseMasterViewController.h"
 #import "DSJSONRPC.h"
 #import "tcpJSONRPC.h"
 #import "MessagesView.h"
@@ -19,7 +20,7 @@
 @class HostManagementViewController;
 @class AppInfoViewController;
 
-@interface ViewControllerIPad : UIViewController {
+@interface ViewControllerIPad : BaseMasterViewController {
     UIViewExt *rootView;
     UIView *leftMenuView;
     UIView *rightSlideView;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -549,11 +549,6 @@
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleDidEnterBackground:)
-                                                 name:UIApplicationDidEnterBackgroundNotification
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleEnterForeground:)
                                                  name:UIApplicationWillEnterForegroundNotification
                                                object:nil];
@@ -734,10 +729,6 @@
     }
     [self changeServerStatus:NO infoText:LOCALIZED_STR(@"No connection") icon:@"connection_off"];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCPlaylistHasChanged" object:nil];
-}
-
-- (void)handleDidEnterBackground:(NSNotification*)sender {
-    [self.tcpJSONRPCconnection stopNetworkCommunication];
 }
 
 - (void)handleEnterForeground:(NSNotification*)sender {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -549,11 +549,6 @@
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleEnterForeground:)
-                                                 name:UIApplicationWillEnterForegroundNotification
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleTcpJSONRPCShowSetup:)
                                                  name:@"TcpJSONRPCShowSetup"
                                                object:nil];
@@ -729,12 +724,6 @@
     }
     [self changeServerStatus:NO infoText:LOCALIZED_STR(@"No connection") icon:@"connection_off"];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCPlaylistHasChanged" object:nil];
-}
-
-- (void)handleEnterForeground:(NSNotification*)sender {
-    if (AppDelegate.instance.serverOnLine) {
-        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
-    }
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -659,11 +659,6 @@
                                       fullscreen:isFullscreen];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-    [self addClearCacheMessage];
-}
-
 - (BOOL)shouldAutorotate {
     return YES;
 }

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -16,7 +16,6 @@
 #import "HostManagementViewController.h"
 #import "AppInfoViewController.h"
 #import "XBMCVirtualKeyboard.h"
-#import "ClearCacheView.h"
 #import "CustomNavigationController.h"
 #import "Utilities.h"
 
@@ -457,18 +456,8 @@
     [self.view insertSubview:self.nowPlayingController.songDetailsView aboveSubview:rootView];
     [self.view insertSubview:self.nowPlayingController.BottomView aboveSubview:self.nowPlayingController.songDetailsView];
     [self.view insertSubview:self.nowPlayingController.playlistToolbarView belowSubview:self.nowPlayingController.BottomView];
-    
-    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    BOOL clearCache = [userDefaults boolForKey:@"clearcache_preference"];
-    if (clearCache) {
-        ClearCacheView *clearView = [[ClearCacheView alloc] initWithFrame:self.view.frame];
-        [clearView startActivityIndicator];
-        [self.view addSubview:clearView];
-        [NSThread detachNewThreadSelector:@selector(startClearAppDiskCache:) toTarget:self withObject:clearView];
-    }
 
     int bottomPadding = [Utilities getBottomPadding];
-    
     if (bottomPadding > 0) {
         CGRect frame = volumeSliderView.frame;
         frame.origin.y -= bottomPadding;
@@ -668,6 +657,11 @@
     [self.nowPlayingController setNowPlayingSize:UIScreen.mainScreen.bounds.size
                                             YPOS:-YPOS
                                       fullscreen:isFullscreen];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self addClearCacheMessage];
 }
 
 - (BOOL)shouldAutorotate {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -100,34 +100,17 @@
 }
 
 - (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName {
-    NSMutableDictionary *params = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                   infoText, @"message",
-                                   iconName, @"icon_connection",
-                                   nil];
-    AppDelegate.instance.serverOnLine = status;
-    AppDelegate.instance.serverName = infoText;
-    NSString *notificationName;
+    [super changeServerStatus:status infoText:infoText icon:iconName];
     if (status) {
-        [self.tcpJSONRPCconnection startNetworkCommunicationWithServer:AppDelegate.instance.obj.serverRawIP serverPort:AppDelegate.instance.obj.tcpPort];
-        notificationName = @"XBMCServerConnectionSuccess";
-        NSString *message = [NSString stringWithFormat:LOCALIZED_STR(@"Connected to %@"), AppDelegate.instance.obj.serverDescription];
-        [Utilities showMessage:message color:SUCCESS_MESSAGE_COLOR];
         [volumeSliderView startTimer];
     }
     else {
-        [self.tcpJSONRPCconnection stopNetworkCommunication];
-        notificationName = @"XBMCServerConnectionFailed";
         if (!extraTimer.valid) {
             extraTimer = [NSTimer scheduledTimerWithTimeInterval:CONNECTION_TIMEOUT target:self selector:@selector(offStackView) userInfo:nil repeats:NO];
         }
     }
-    [[NSNotificationCenter defaultCenter] postNotificationName:notificationName object:nil userInfo:params];
     [xbmcInfo setTitle:infoText forState:UIControlStateNormal];
     [Utilities setStyleOfMenuItems:menuViewController.tableView active:status];
-    if (status) {
-        // Send trigger to start the default controller
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"KodiStartDefaultController" object:nil userInfo:params];
-    }
 }
 
 - (void)offStackView {
@@ -554,11 +537,6 @@
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleTcpJSONRPCChangeServerStatus:)
-                                                 name:@"TcpJSONRPCChangeServerStatus"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(connectionStatus:)
                                                  name:@"XBMCServerConnectionSuccess"
                                                object:nil];
@@ -686,13 +664,6 @@
 - (void)handleTcpJSONRPCShowSetup:(NSNotification*)sender {
     BOOL showValue = [[sender.userInfo objectForKey:@"showSetup"] boolValue];
     [self showSetup:showValue];
-}
-
-- (void)handleTcpJSONRPCChangeServerStatus:(NSNotification*)sender {
-    BOOL statusValue = [[sender.userInfo objectForKey:@"status"] boolValue];
-    NSString *message = [sender.userInfo objectForKey:@"message"];
-    NSString *icon_connection = [sender.userInfo objectForKey:@"icon_connection"];
-    [self changeServerStatus:statusValue infoText:message icon:icon_connection];
 }
 
 - (void)handleLocalNetworkAccessError:(NSNotification*)sender {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -515,11 +515,6 @@
     messagesView = [[MessagesView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, DEFAULT_MSG_HEIGHT) deltaY:0 deltaX:0];
     messagesView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     [self.view addSubview:messagesView];
-
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleXBMCServerHasChanged:)
-                                                 name:@"XBMCServerHasChanged"
-                                               object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleStackScrollOnScreen:)
@@ -687,13 +682,13 @@
 }
 
 - (void)handleXBMCServerHasChanged:(NSNotification*)sender {
+    [super handleXBMCServerHasChanged:sender];
     [AppDelegate.instance.windowController.stackScrollViewController offView];
     NSIndexPath *selection = [menuViewController.tableView indexPathForSelectedRow];
     if (selection) {
         [menuViewController.tableView deselectRowAtIndexPath:selection animated:YES];
         [menuViewController setLastSelected:-1];
     }
-    [self changeServerStatus:NO infoText:LOCALIZED_STR(@"No connection") icon:@"connection_off"];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCPlaylistHasChanged" object:nil];
 }
 

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -21,8 +21,6 @@
 #import "Utilities.h"
 
 #define CONNECTION_TIMEOUT 240.0
-#define SERVER_TIMEOUT 2.0
-#define CLEARCACHE_TIMEOUT 2.0
 #define VIEW_PADDING 10 /* separation between toolbar views */
 #define TOOLBAR_HEIGHT 44
 #define XBMCLOGO_WIDTH 30
@@ -241,29 +239,6 @@
         [self saveLeftMenuSplit:maxMenuItems];
         didTouchLeftMenu = NO;
     }
-}
-
-#pragma mark - App clear disk cache methods
-
-- (void)startClearAppDiskCache:(ClearCacheView*)clearView {
-    [AppDelegate.instance clearAppDiskCache];
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, CLEARCACHE_TIMEOUT * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-        [self clearAppDiskCacheFinished:clearView];
-    });
-}
-
-- (void)clearAppDiskCacheFinished:(ClearCacheView*)clearView {
-    [UIView animateWithDuration:0.3
-                     animations:^{
-                         [clearView stopActivityIndicator];
-                         clearView.alpha = 0;
-                     }
-                     completion:^(BOOL finished) {
-                         [clearView stopActivityIndicator];
-                         [clearView removeFromSuperview];
-                         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-                         [userDefaults removeObjectForKey:@"clearcache_preference"];
-                     }];
 }
 
 #pragma mark - Persistence

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -542,11 +542,6 @@
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleLocalNetworkAccessError:)
-                                                 name:@"LocalNetworkAccessError"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleChangeBackgroundImage:)
                                                  name:@"IpadChangeBackgroundImage"
                                                object:nil];
@@ -635,10 +630,6 @@
 - (void)handleTcpJSONRPCShowSetup:(NSNotification*)sender {
     BOOL showValue = [[sender.userInfo objectForKey:@"showSetup"] boolValue];
     [self showSetup:showValue];
-}
-
-- (void)handleLocalNetworkAccessError:(NSNotification*)sender {
-    [Utilities showLocalNetworkAccessError:self];
 }
 
 - (void)hideSongInfoView {

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -88,12 +88,10 @@
 #pragma mark - ServerManagement
 
 - (void)connectionStatus:(NSNotification*)note {
+    [super connectionStatus:note];
     NSDictionary *theData = note.userInfo;
     NSString *icon_connection = theData[@"icon_connection"];
     connectionStatus.image = [UIImage imageNamed:icon_connection];
-    
-    // We are connected to server, we now need to share credentials with SDWebImageManager
-    [Utilities setWebImageAuthorizationOnSuccessNotification:note];
 }
 
 - (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName {
@@ -493,16 +491,6 @@
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleTcpJSONRPCShowSetup:)
                                                  name:@"TcpJSONRPCShowSetup"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(connectionStatus:)
-                                                 name:@"XBMCServerConnectionSuccess"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(connectionStatus:)
-                                                 name:@"XBMCServerConnectionFailed"
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -562,26 +562,6 @@
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleLibraryNotification:)
-                                                 name:@"AudioLibrary.OnScanFinished"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleLibraryNotification:)
-                                                 name:@"AudioLibrary.OnCleanFinished"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleLibraryNotification:)
-                                                 name:@"VideoLibrary.OnScanFinished"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleLibraryNotification:)
-                                                 name:@"VideoLibrary.OnCleanFinished"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(showNotificationMessage:)
                                                  name:@"UIShowMessage"
                                                object:nil];
@@ -591,10 +571,6 @@
     [super viewDidAppear:animated];
     BOOL showSetup = AppDelegate.instance.obj.serverIP.length == 0;
     [self showSetup:showSetup];
-}
-
-- (void)handleLibraryNotification:(NSNotification*)note {
-    [Utilities showMessage:note.name color:SUCCESS_MESSAGE_COLOR];
 }
 
 - (void)showNotificationMessage:(NSNotification*)note {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1124.

This PR introduces the base class `BaseMasterViewController` to hold common code which is shared between both iPad's main controller `ViewControllerIPad` and iPhone's `MasterViewController`. This reduces code duplication by moving the following methods and related notification registrations to the new base class:
- `handleDidEnterBackground`
- `handleEnterForeground`
- `handleTcpJSONRPCChangeServerStatus` with its helper `changeServerStatus`
- `handleXBMCServerHasChanged`
- `handleLibraryNotification`
- `handleLocalNetworkAccessError`
- `startClearAppDiskCache` and `clearAppDiskCacheFinished`
- `connectionStatus`

Also moves calling `addClearCacheMessage` into `viewWillAppear`, which fixes a layout issue on iPhone where the message was not drawn over the full screen as desired.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Introduce a base class for the iPhone and iPad main controllers
Bugfix: "Clearing app disk cache" with full width on iPhone