### PR TITLE
Maintenance: Cleanup obsolete framework methods

### DIFF
--- a/XBMC Remote/ActorCell.m
+++ b/XBMC Remote/ActorCell.m
@@ -74,8 +74,4 @@ int offsetY = 5;
     return self;
 }
 
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
-    [super setSelected:selected animated:animated];
-}
-
 @end

--- a/XBMC Remote/AppInfoViewController.m
+++ b/XBMC Remote/AppInfoViewController.m
@@ -52,10 +52,6 @@
     appDescription.font = [UIFont systemFontOfSize:floor(14 * scale)];
 }
 
-- (void)viewDidDisappear:(BOOL)animated {
-    [super viewDidDisappear:animated];
-}
-
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.edgesForExtendedLayout = 0;

--- a/XBMC Remote/CustomNavigationController.m
+++ b/XBMC Remote/CustomNavigationController.m
@@ -42,14 +42,6 @@
     navBarHairlineImageView.hidden = hideBottomLine;
 }
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
-}
-
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
 - (BOOL)shouldAutorotate {
     return NO;
 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5471,10 +5471,6 @@
     [self setButtonViewContent:chosenTab];
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
 - (void)revealMenu:(id)sender {
     [self.slidingViewController anchorTopViewTo:ECRight];
 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3174,14 +3174,6 @@
     return 0;
 }
 
-- (UIView*)tableView:(UITableView*)tableView viewForFooterInSection:(NSInteger)section {
-    return nil;
-}
-
-- (CGFloat)tableView:(UITableView*)tableView heightForFooterInSection:(NSInteger)section {
-    return 0;
-}
-
 #pragma mark - Content Filtering
 
 - (UIImageView*)findHairlineImageViewUnder:(UIView*)view {

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -258,22 +258,6 @@
 	}
 }
 
-- (UIView*)tableView:(UITableView*)tableView viewForHeaderInSection:(NSInteger)section {
-    return nil;
-}
-
-- (CGFloat)tableView:(UITableView*)tableView heightForHeaderInSection:(NSInteger)section {
-    return 0;
-}
-
-- (UIView*)tableView:(UITableView*)tableView viewForFooterInSection:(NSInteger)section {
-    return nil;
-}
-
-- (CGFloat)tableView:(UITableView*)tableView heightForFooterInSection:(NSInteger)section {
-    return 0;
-}
-
 - (void)tableView:(UITableView*)tableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath*)indexPath {
     [self modifyHost:indexPath];
 }

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -69,10 +69,6 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:@"RevealMenu" object:nil];
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
 - (BOOL)shouldAutorotate {
     return YES;
 }

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -308,10 +308,6 @@
     [self addMessagesToRootView];
 }
 
-- (void)viewWillDisappear:(BOOL)animated {
-    [super viewWillDisappear:animated];
-}
-
 - (void)viewDidLoad {
     [super viewDidLoad];
     

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -219,14 +219,11 @@
 }
 
 - (UIView*)tableView:(UITableView*)tableView viewForFooterInSection:(NSInteger)section {
-    UIImage *myImage = [UIImage imageNamed:@"blank"];
-	UIImageView *imageView = [[UIImageView alloc] initWithImage:myImage];
-	imageView.frame = CGRectMake(0, 0, 320, 8);
-	return imageView;
+	return nil;
 }
 
 - (CGFloat)tableView:(UITableView*)tableView heightForFooterInSection:(NSInteger)section {
-	return 1;
+	return 0;
 }
 
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -214,18 +214,6 @@
     return NO;
 }
 
-- (CGFloat)tableView:(UITableView*)tableView heightForHeaderInSection:(NSInteger)section {
-    return 0;
-}
-
-- (UIView*)tableView:(UITableView*)tableView viewForFooterInSection:(NSInteger)section {
-	return nil;
-}
-
-- (CGFloat)tableView:(UITableView*)tableView heightForFooterInSection:(NSInteger)section {
-	return 0;
-}
-
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
     if (indexPath.row == 0) {
         return PHONE_MENU_INFO_HEIGHT;

--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -94,10 +94,6 @@
 
 #pragma mark - LifeCycle
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
-}
-
 - (BOOL)shouldAutorotate {
     return YES;
 }

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -690,8 +690,4 @@
     }
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
 @end

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -742,14 +742,6 @@
     }
 }
 
-- (UIView*)tableView:(UITableView*)tableView viewForHeaderInSection:(NSInteger)section {
-    return nil;
-}
-
-- (CGFloat)tableView:(UITableView*)tableView heightForHeaderInSection:(NSInteger)section {
-    return 0;
-}
-
 - (UIView*)tableView:(UITableView*)tableView viewForFooterInSection:(NSInteger)section {
     UIView *helpView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, footerHeight)];
     if (xbmcSetting == SettingTypeUnsupported) {

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -871,8 +871,4 @@
     [self.view addGestureRecognizer:tap];
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
 @end

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1917,10 +1917,6 @@
                                                object:nil];
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-}
-
 - (BOOL)shouldAutorotate {
     return YES;
 }

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -115,14 +115,6 @@
     [Utilities enableDefaultController:self tableView:_tableView menuItems:mainMenuItems];
 }
 
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-}
-
-- (void)viewDidAppear:(BOOL)animated {
-    [super viewDidAppear:animated];
-}
-
 #pragma mark - Table view data source
 
 - (CGFloat)tableView:(UITableView*)tableView heightForRowAtIndexPath:(NSIndexPath*)indexPath {
@@ -221,12 +213,6 @@
 
 - (void)setLastSelected:(int)selection {
     lastSelected = selection;
-}
-
-#pragma mark - Memory management
-
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
 }
 
 @end

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -466,10 +466,6 @@
     [view.layer addAnimation:bounceAnimation forKey:@"bounceAnimation"];
 }
 
-- (void)loadView {
-    [super loadView];
-}
-
 // Implement viewDidLoad to do additional setup after loading the view, typically from a nib.
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -481,10 +477,6 @@
 
 - (void)handleAutoPan {
     [self moveStack];
-}
-
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
 }
 
 - (void)addViewInSlider:(UIViewController*)controller invokeByController:(UIViewController*)invokeByController isStackStartView:(BOOL)isStackStartView {
@@ -635,10 +627,6 @@
             }
         }
     }
-}
-
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
 }
 
 #pragma mark - Rotation support

--- a/XBMC Remote/jsonDataCell.m
+++ b/XBMC Remote/jsonDataCell.m
@@ -14,10 +14,4 @@
     return self;
 }
 
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
-    [super setSelected:selected animated:animated];
-
-    // Configure the view for the selected state
-}
-
 @end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Initially I only wanted to remove the anyway invisible footer on iPhone's main menu. In addition, this PR now removes the implementation of several framework methods which only return the default (`...HeaderInSection`, `...FooterInSection`) or where only `[super method]` is called.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Cleanup obsolete framework methods