### PR TITLE
Improvement: Use frosted glass effect for Navigationbar and Toolbar

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -110,12 +110,14 @@
 }
 
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-    // iOS 13 and later use appearance for the navigationbar, from iOS 15 this is required as it else defaults to unwanted transparency
+    // Make navigation bar transparent
     if (@available(iOS 13, *)) {
         UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
         [appearance configureWithOpaqueBackground];
+        [appearance configureWithTransparentBackground];
+        appearance.backgroundEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
         appearance.titleTextAttributes = @{NSForegroundColorAttributeName : UIColor.whiteColor};
-        appearance.backgroundColor = NAVBAR_TINT_COLOR;
+        appearance.backgroundColor = UIColor.clearColor;
         [UINavigationBar appearance].standardAppearance = appearance;
         [UINavigationBar appearance].scrollEdgeAppearance = appearance;
     }

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -109,12 +109,14 @@
 }
 
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-    // iOS 13 and later use appearance for the navigationbar, from iOS 15 this is required as it else defaults to unwanted transparency
+    // Make navigation bar transparent
     if (@available(iOS 13, *)) {
         UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
         [appearance configureWithOpaqueBackground];
+        [appearance configureWithTransparentBackground];
+        appearance.backgroundEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
         appearance.titleTextAttributes = @{NSForegroundColorAttributeName : UIColor.whiteColor};
-        appearance.backgroundColor = NAVBAR_TINT_COLOR;
+        appearance.backgroundColor = UIColor.clearColor;
         [UINavigationBar appearance].standardAppearance = appearance;
         [UINavigationBar appearance].scrollEdgeAppearance = appearance;
     }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1058,11 +1058,9 @@
     if (moreItemsViewController == nil) {
         moreItemsViewController = [[MoreItemsViewController alloc] initWithFrame:CGRectMake(dataList.bounds.size.width, 0, dataList.bounds.size.width, dataList.bounds.size.height) mainMenu:moreMenu];
         moreItemsViewController.view.backgroundColor = UIColor.clearColor;
-        UIEdgeInsets tableViewInsets = UIEdgeInsetsZero;
-        tableViewInsets.bottom = buttonsViewBgToolbar.frame.size.height;
-        moreItemsViewController.tableView.contentInset = tableViewInsets;
-        moreItemsViewController.tableView.scrollIndicatorInsets = tableViewInsets;
-        [moreItemsViewController.tableView setContentOffset:CGPointMake(0, - tableViewInsets.top) animated:NO];
+        moreItemsViewController.tableView.contentInset = activeLayoutView.contentInset;
+        [self setViewInset:moreItemsViewController.tableView bottom:buttonsViewBgToolbar.frame.size.height];
+        [moreItemsViewController.tableView setContentOffset:CGPointMake(0, -moreItemsViewController.tableView.contentInset.top) animated:NO];
         [maskView insertSubview:moreItemsViewController.view aboveSubview:dataList];
     }
 
@@ -1910,13 +1908,13 @@
     }
     else if (sender.currentIndex == 0) {
         if (enableCollectionView) {
-            [collectionView setContentOffset:CGPointZero animated:NO];
+            [collectionView setContentOffset:CGPointMake(0, -collectionView.contentInset.top) animated:NO];
             if (sectionNameOverlayView == nil && stackscrollFullscreen) {
                 [self initSectionNameOverlayView];
             }
         }
         else {
-            [dataList setContentOffset:CGPointZero animated:NO];
+            [dataList setContentOffset:CGPointMake(0, -dataList.contentInset.top) animated:NO];
         }
         sectionNameLabel.text = @"🔍";
         return;
@@ -1957,7 +1955,7 @@
         if (index != NSNotFound) {
             NSIndexPath *path = [NSIndexPath indexPathForItem:index inSection:0];
             [collectionView scrollToItemAtIndexPath:path atScrollPosition:UICollectionViewScrollPositionTop animated:NO];
-            collectionView.contentOffset = CGPointMake(collectionView.contentOffset.x, collectionView.contentOffset.y - GRID_SECTION_HEADER_HEIGHT);
+            collectionView.contentOffset = CGPointMake(collectionView.contentOffset.x, collectionView.contentOffset.y - GRID_SECTION_HEADER_HEIGHT + [Utilities getTopPadding]);
         }
         return;
     }
@@ -2119,6 +2117,10 @@
 }
 
 #pragma mark - Table Management
+
+- (CGFloat)getTableInsetTop {
+    return IS_IPHONE ? [Utilities getTopPaddingWithNavBar:self.navigationController] : 0;
+}
 
 - (void)setSearchBar:(UISearchBar*)searchBar toDark:(BOOL)isDark {
     if (isDark) {
@@ -5478,7 +5480,7 @@
             // no button, no toolbar
             button1.hidden = button2.hidden = button3.hidden = button4.hidden = button5.hidden = YES;
             frame = dataList.frame;
-            frame.size.height = self.view.bounds.size.height;
+            frame.size.height = maskView.bounds.size.height;
             dataList.frame = frame;
             break;
         case 1:
@@ -5828,7 +5830,7 @@
     [self initSearchController];
     self.navigationController.view.backgroundColor = UIColor.blackColor;
     self.definesPresentationContext = NO;
-    iOSYDelta = self.searchController.searchBar.frame.size.height;
+    iOSYDelta = self.searchController.searchBar.frame.size.height - [self getTableInsetTop];
     dataList.tableHeaderView = [self createFakeSearchbarInDark:NO];
 
     if (@available(iOS 15.0, *)) {
@@ -5839,11 +5841,16 @@
 
     [button7 addTarget:self action:@selector(handleChangeSortLibrary) forControlEvents:UIControlEventTouchUpInside];
     self.edgesForExtendedLayout = UIRectEdgeNone;
+    UIEdgeInsets viewInsets = dataList.contentInset;
+    viewInsets.top = [self getTableInsetTop];
+    dataList.contentInset = viewInsets;
     dataList.indicatorStyle = UIScrollViewIndicatorStyleDefault;
     
-    CGRect frame = dataList.frame;
-    frame.size.height = self.view.bounds.size.height;
-    dataList.frame = frame;
+    CGRect frame = maskView.frame;
+    frame.origin.y -= [self getTableInsetTop];
+    frame.size.height += [self getTableInsetTop];
+    maskView.frame = frame;
+    
     buttonsViewBgToolbar.hidden = NO;
     
     __weak DetailViewController *weakSelf = self;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1059,11 +1059,9 @@
     if (moreItemsViewController == nil) {
         moreItemsViewController = [[MoreItemsViewController alloc] initWithFrame:CGRectMake(dataList.bounds.size.width, 0, dataList.bounds.size.width, dataList.bounds.size.height) mainMenu:moreMenu];
         moreItemsViewController.view.backgroundColor = UIColor.clearColor;
-        UIEdgeInsets tableViewInsets = UIEdgeInsetsZero;
-        tableViewInsets.bottom = buttonsViewBgToolbar.frame.size.height;
-        moreItemsViewController.tableView.contentInset = tableViewInsets;
-        moreItemsViewController.tableView.scrollIndicatorInsets = tableViewInsets;
-        [moreItemsViewController.tableView setContentOffset:CGPointMake(0, - tableViewInsets.top) animated:NO];
+        moreItemsViewController.tableView.contentInset = activeLayoutView.contentInset;
+        [self setViewInset:moreItemsViewController.tableView bottom:buttonsViewBgToolbar.frame.size.height];
+        [moreItemsViewController.tableView setContentOffset:CGPointMake(0, -moreItemsViewController.tableView.contentInset.top) animated:NO];
         [maskView insertSubview:moreItemsViewController.view aboveSubview:dataList];
     }
 
@@ -1907,13 +1905,13 @@
     }
     else if (sender.currentIndex == 0) {
         if (enableCollectionView) {
-            [collectionView setContentOffset:CGPointZero animated:NO];
+            [collectionView setContentOffset:CGPointMake(0, -collectionView.contentInset.top) animated:NO];
             if (sectionNameOverlayView == nil && stackscrollFullscreen) {
                 [self initSectionNameOverlayView];
             }
         }
         else {
-            [dataList setContentOffset:CGPointZero animated:NO];
+            [dataList setContentOffset:CGPointMake(0, -dataList.contentInset.top) animated:NO];
         }
         sectionNameLabel.text = @"🔍";
         return;
@@ -1954,7 +1952,7 @@
         if (index != NSNotFound) {
             NSIndexPath *path = [NSIndexPath indexPathForItem:index inSection:0];
             [collectionView scrollToItemAtIndexPath:path atScrollPosition:UICollectionViewScrollPositionTop animated:NO];
-            collectionView.contentOffset = CGPointMake(collectionView.contentOffset.x, collectionView.contentOffset.y - GRID_SECTION_HEADER_HEIGHT);
+            collectionView.contentOffset = CGPointMake(collectionView.contentOffset.x, collectionView.contentOffset.y - GRID_SECTION_HEADER_HEIGHT + [Utilities getTopPadding]);
         }
         return;
     }
@@ -2116,6 +2114,10 @@
 }
 
 #pragma mark - Table Management
+
+- (CGFloat)getTableInsetTop {
+    return IS_IPHONE ? [Utilities getTopPaddingWithNavBar:self.navigationController] : 0;
+}
 
 - (void)setSearchBar:(UISearchBar*)searchBar toDark:(BOOL)isDark {
     if (isDark) {
@@ -5464,7 +5466,7 @@
         case 0:
             // no button, no toolbar
             button1.hidden = button2.hidden = button3.hidden = button4.hidden = button5.hidden = YES;
-            [dataList setHeight:self.view.bounds.size.height];
+            [dataList setHeight:maskView.bounds.size.height];
             break;
         case 1:
             button2.hidden = button3.hidden = button4.hidden = button5.hidden = YES;
@@ -5813,7 +5815,7 @@
     [self initSearchController];
     self.navigationController.view.backgroundColor = UIColor.blackColor;
     self.definesPresentationContext = NO;
-    iOSYDelta = self.searchController.searchBar.frame.size.height;
+    iOSYDelta = self.searchController.searchBar.frame.size.height - [self getTableInsetTop];
     dataList.tableHeaderView = [self createFakeSearchbarInDark:NO];
 
     if (@available(iOS 15.0, *)) {
@@ -5824,9 +5826,16 @@
 
     [button7 addTarget:self action:@selector(handleChangeSortLibrary) forControlEvents:UIControlEventTouchUpInside];
     self.edgesForExtendedLayout = UIRectEdgeNone;
+    UIEdgeInsets viewInsets = dataList.contentInset;
+    viewInsets.top = [self getTableInsetTop];
+    dataList.contentInset = viewInsets;
     dataList.indicatorStyle = UIScrollViewIndicatorStyleDefault;
     
-    [dataList setHeight:self.view.bounds.size.height];
+    CGRect frame = maskView.frame;
+    frame.origin.y -= [self getTableInsetTop];
+    frame.size.height += [self getTableInsetTop];
+    maskView.frame = frame;
+    
     buttonsViewBgToolbar.hidden = NO;
     
     __weak DetailViewController *weakSelf = self;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -965,7 +965,14 @@
 }
 
 + (CGFloat)getTopPaddingWithNavBar:(UINavigationController*)navCtrl {
-    CGFloat topPadding = UIApplication.sharedApplication.statusBarFrame.size.height + navCtrl.navigationBar.frame.size.height;
+    // Workaround: Using CGRectGetMaxY resolves a layout issue where otherwise the inset ends below the navbar (e.g.
+    // iPhone 14 Pro iOS18), but at the same time it causes an issue with the inset not taking into account the status
+    // bar (e.g. iPod Touch iOS15.5). This seems to be caused by calling this method from viewDidLoad instead
+    // of willLayoutSubviews. This workaround avoids rework of DetailVC's delicate layout.
+    CGFloat topPadding = CGRectGetMaxY(navCtrl.navigationBar.frame);
+    if (topPadding <= navCtrl.navigationBar.frame.size.height) {
+        topPadding = UIApplication.sharedApplication.statusBarFrame.size.height + navCtrl.navigationBar.frame.size.height;
+    }
     return topPadding;
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
### Frosted Glass Effect
Use frosted glass effect (`[UIBlurEffect effectWithStyle:UIBlurEffectStyleDark]`) for navbar and toolbar. Let the table views extend underneath the frosted glass and adapt `contentInset` accordingly. 

Special care is needed for the following areas:
- To have `SVPullToRefresh` working as expected it is important to explicitly set `contentInset` instead of automatic adjustment.
- For iPad it is important to hide the toolbar's effect view `buttonsViewEffect` while being in fullscreen library view.


### Glitch with Sticky Headers for collection view
When changing the layout for the table and collection view to extend underneath the navbar, an issue became visible on some devices (in my case the glitch shows on iPhone 14 Pro iOS 18.5 sim, but not on iPod Touch 7G iOS 15.5 sim). The issue is caused by how the app retrieves `contentInset.top`, it follows the approach

`UIApplication.sharedApplication.statusBarFrame.size.height + navCtrl.navigationBar.frame.size.height`

But in fact, the navigation bar ends 1/3 px above, as it is also reported when using 

`CGRectGetMaxY(navCtrl.navigationBar.frame`

Issue (see small visible area between section header and navbar):
<a href="https://ibb.co/nsSpD9bk"><img src="https://i.ibb.co/XZTHz1bJ/Bildschirmfoto-2025-06-22-um-10-32-52.png" alt="Bildschirmfoto-2025-06-22-um-10-32-52" border="0"></a>

Solutions are either to use the `CGRectGetMaxY` equation, or to increase `contentInset.top ` to slightly overlap with the navigation bar.


### Other
In addition, some smaller refactoring, more comments and coding style changes were added.


### Screenshots
Screenshots (left = current, right = dark blur): https://ibb.co/zW9r4NRv
Video: [link to video](https://www.dropbox.com/scl/fi/yv2ma9anvczqejw5pa6ka/frosted_glass_scrolling.mov?rlkey=skzfynudzmx3rr4rf9undo55k&e=1&st=ww0lfs3k&dl=0)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Use frosted glass effect for Navigationbar and Toolbar