### PR TITLE
Bugfix: NowPlaying dimensions potentially wrong after entering from library view

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3847,14 +3847,14 @@
         UIBarButtonItem *remoteButton = [[UIBarButtonItem alloc] initWithImage:remoteButtonImage style:UIBarButtonItemStylePlain target:self action:@selector(showRemote)];
         UIImage *nowPlayingButtonImage = [UIImage imageNamed:@"icon_menu_playing"];
         UIBarButtonItem *nowPlayingButton = [[UIBarButtonItem alloc] initWithImage:nowPlayingButtonImage style:UIBarButtonItemStylePlain target:self action:@selector(showNowPlaying)];
-         if (!menuItem.disableNowPlaying) {
-             self.navigationItem.rightBarButtonItems = @[remoteButton,
-                                                         nowPlayingButton];
-         }
-         else {
-             self.navigationItem.rightBarButtonItems = @[remoteButton];
-         }
-   }
+        if (!menuItem.disableNowPlaying) {
+            self.navigationItem.rightBarButtonItems = @[remoteButton,
+                                                        nowPlayingButton];
+        }
+        else {
+            self.navigationItem.rightBarButtonItems = @[remoteButton];
+        }
+    }
 }
 
 - (void)leaveFullscreen {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3854,6 +3854,7 @@
         else {
             self.navigationItem.rightBarButtonItems = @[remoteButton];
         }
+        [self.view setNeedsLayout];
     }
 }
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -92,6 +92,7 @@
     // Update the user interface for the detail item.
     if (self.detailItem) {
         self.navigationItem.title = LOCALIZED_STR(@"Now Playing");
+        [self.view setNeedsLayout];
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue where the NowPlaying screen was not having correct dimensions when entering it from library view.

Screenshots (simulator iPod Touch 7G, iOS 15.5):
<a href="https://ibb.co/BmMcvLG"><img src="https://i.ibb.co/kpC5zKJ/Bildschirmfoto-2025-06-24-um-09-34-15.png" alt="Bildschirmfoto-2025-06-24-um-09-34-15" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: NowPlaying dimensions potentially wrong after entering from library view