### PR TITLE
Do not call setNeedsLayout in DetailVC's configureView

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3839,7 +3839,6 @@
         else {
             self.navigationItem.rightBarButtonItems = @[remoteButton];
         }
-        [self.view setNeedsLayout];
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This partially rolls back #1294, which fixed an issue regarding wrong layout of NowPlaying when entered via DetailVC.
But `setNeedsLayout` is only needed in NowPlaying and not in DetailVC. In DetailVC this even has an unwanted side effect (`self.navigationController` is `nil` in `viewDidLoad`). Hence we remove this call again.

FInally, I guess most of such issues are caused by doing too much layout work in `viewDidLoad` instead of `layoutSubviews`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: setNeedsLayout not required in DetailVC's configureView