### PR TITLE
Improvement: Use frosted glass effect for toolbars

### DIFF
--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -40,6 +40,7 @@
     IBOutlet UIButton *button6;
     IBOutlet UIButton *button7;
     IBOutlet UIView *buttonsView;
+    IBOutlet UIVisualEffectView *buttonsViewEffect;
     NSString *defaultThumb;
     int cellHeight;
     int thumbWidth;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3865,7 +3865,7 @@
         }
                          completion:^(BOOL finished) {
             viewWidth = STACKSCROLL_WIDTH;
-            button1.alpha = button2.alpha = button3.alpha = button4.alpha = button5.alpha = button6.alpha = button7.alpha = buttonsViewBgToolbar.alpha = topNavigationLabel.alpha = 1.0;
+            button1.alpha = button2.alpha = button3.alpha = button4.alpha = button5.alpha = button6.alpha = button7.alpha = buttonsViewBgToolbar.alpha = buttonsViewEffect.alpha = topNavigationLabel.alpha = 1.0;
             if ([self collectionViewCanBeEnabled]) {
                 button6.hidden = NO;
             }
@@ -3912,7 +3912,7 @@
                          animations:^{
             collectionView.alpha = 0;
             dataList.alpha = 0;
-            button1.alpha = button2.alpha = button3.alpha = button4.alpha = button5.alpha = button6.alpha = button7.alpha = buttonsViewBgToolbar.alpha = topNavigationLabel.alpha = 0.0;
+            button1.alpha = button2.alpha = button3.alpha = button4.alpha = button5.alpha = button6.alpha = button7.alpha = buttonsViewBgToolbar.alpha = buttonsViewEffect.alpha = topNavigationLabel.alpha = 0.0;
         }
                          completion:^(BOOL finished) {
             button6.hidden = YES;
@@ -5903,7 +5903,7 @@
     
     // Gray background for toolbar
     if (IS_IPHONE) {
-        buttonsView.backgroundColor = TOOLBAR_TINT_COLOR;
+        buttonsView.backgroundColor = UIColor.clearColor;
     }
     else {
         buttonsViewBgToolbar.backgroundColor = TOOLBAR_TINT_COLOR;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5906,7 +5906,7 @@
         buttonsView.backgroundColor = UIColor.clearColor;
     }
     else {
-        buttonsViewBgToolbar.backgroundColor = TOOLBAR_TINT_COLOR;
+        buttonsViewBgToolbar.backgroundColor = UIColor.clearColor;
     }
     
     if ([methods[@"albumView"] boolValue]) {

--- a/XBMC Remote/DetailViewController.xib
+++ b/XBMC Remote/DetailViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,6 +19,7 @@
                 <outlet property="button7" destination="17m-9l-ySa" id="S4d-wL-mvU"/>
                 <outlet property="buttonsView" destination="116" id="134"/>
                 <outlet property="buttonsViewBgToolbar" destination="sPd-OR-uGy" id="DhA-1U-cyk"/>
+                <outlet property="buttonsViewEffect" destination="nls-7E-rmj" id="bzY-fZ-idY"/>
                 <outlet property="dataList" destination="37" id="93"/>
                 <outlet property="maskView" destination="siR-Fa-xLM" id="cez-Ud-wvD"/>
                 <outlet property="noFoundView" destination="135" id="140"/>
@@ -68,6 +69,15 @@
                             <rect key="frame" x="0.0" y="372" width="320" height="44"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <subviews>
+                                <visualEffectView opaque="NO" contentMode="scaleToFill" id="nls-7E-rmj">
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Ong-jx-H4V">
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    </view>
+                                    <blurEffect style="dark"/>
+                                </visualEffectView>
                                 <toolbar hidden="YES" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" fixedFrame="YES" barStyle="black" translatesAutoresizingMaskIntoConstraints="NO" id="sPd-OR-uGy">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
@@ -182,7 +192,6 @@
                                     </items>
                                 </toolbar>
                             </subviews>
-                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <activityIndicatorView contentMode="scaleToFill" fixedFrame="YES" hidesWhenStopped="YES" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="95">
                             <rect key="frame" x="141" y="189" width="37" height="37"/>

--- a/XBMC Remote/HostManagementViewController.h
+++ b/XBMC Remote/HostManagementViewController.h
@@ -25,7 +25,6 @@
     __weak IBOutlet UIButton *addHostButton;
     __weak IBOutlet UIView *supportedVersionView;
     __weak IBOutlet UILabel *supportedVersionLabel;
-    __weak IBOutlet UIToolbar *bottomToolbar;
     __weak IBOutlet UIVisualEffectView *bottomToolbarEffect;
     UITextView *serverInfoView;
     __weak IBOutlet UIButton *serverInfoButton;

--- a/XBMC Remote/HostManagementViewController.h
+++ b/XBMC Remote/HostManagementViewController.h
@@ -27,6 +27,7 @@
     __weak IBOutlet UILabel *supportedVersionLabel;
     __weak IBOutlet UIToolbar *bottomToolbar;
     __weak IBOutlet UIImageView *bottomToolbarShadowImageView;
+    __weak IBOutlet UIVisualEffectView *bottomToolbarEffect;
     UITextView *serverInfoView;
     __weak IBOutlet UIButton *serverInfoButton;
     NSTimer *serverInfoTimer;

--- a/XBMC Remote/HostManagementViewController.h
+++ b/XBMC Remote/HostManagementViewController.h
@@ -26,7 +26,6 @@
     __weak IBOutlet UIView *supportedVersionView;
     __weak IBOutlet UILabel *supportedVersionLabel;
     __weak IBOutlet UIToolbar *bottomToolbar;
-    __weak IBOutlet UIImageView *bottomToolbarShadowImageView;
     __weak IBOutlet UIVisualEffectView *bottomToolbarEffect;
     UITextView *serverInfoView;
     __weak IBOutlet UIButton *serverInfoButton;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -487,13 +487,10 @@
         bottomPadding = SERVERPOPUP_BOTTOMPADDING;
     }
     
-    // Transparent toolbar
-    [Utilities createTransparentToolbar:bottomToolbar];
-    
-    CGRect frame = bottomToolbar.frame;
+    CGRect frame = bottomToolbarEffect.frame;
     frame.origin.y -= bottomPadding;
     frame.size.height += bottomPadding;
-    bottomToolbarEffect.frame = bottomToolbar.frame = frame;
+    bottomToolbarEffect.frame = frame;
     
     frame = addHostButton.frame;
     frame.origin.y -= bottomPadding;
@@ -509,14 +506,14 @@
     
     frame = serverListTableView.frame;
     frame.origin.y = frame.origin.y + deltaY;
-    frame.size.height = frame.size.height - deltaY + bottomToolbar.frame.size.height - bottomPadding;
+    frame.size.height = frame.size.height - deltaY + bottomToolbarEffect.frame.size.height - bottomPadding;
     serverListTableView.frame = frame;
     
     UIEdgeInsets viewInsets = serverListTableView.contentInset;
-    viewInsets.bottom = bottomToolbar.frame.size.height - bottomPadding;
+    viewInsets.bottom = bottomToolbarEffect.frame.size.height - bottomPadding;
     serverListTableView.contentInset = viewInsets;
     
-    CGFloat toolbarHeight = bottomToolbar.frame.size.height;
+    CGFloat toolbarHeight = bottomToolbarEffect.frame.size.height;
     serverInfoView = [[UITextView alloc] initWithFrame:CGRectMake(MARGIN, deltaY + MARGIN, self.view.frame.size.width - 2 * MARGIN, self.view.frame.size.height - deltaY - toolbarHeight - 2 * MARGIN)];
     serverInfoView.autoresizingMask = UIViewAutoresizingFlexibleWidth |
                                       UIViewAutoresizingFlexibleHeight |

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -486,10 +486,14 @@
     if (IS_IPAD) {
         bottomPadding = SERVERPOPUP_BOTTOMPADDING;
     }
+    
+    // Transparent toolbar
+    [Utilities createTransparentToolbar:bottomToolbar];
+    
     CGRect frame = bottomToolbar.frame;
     frame.origin.y -= bottomPadding;
     frame.size.height += bottomPadding;
-    bottomToolbar.frame = frame;
+    bottomToolbarEffect.frame = bottomToolbar.frame = frame;
     
     frame = bottomToolbarShadowImageView.frame;
     frame.origin.y -= bottomPadding;
@@ -506,6 +510,15 @@
     frame = serverInfoButton.frame;
     frame.origin.y -= bottomPadding;
     serverInfoButton.frame = frame;
+    
+    frame = serverListTableView.frame;
+    frame.origin.y = frame.origin.y + deltaY;
+    frame.size.height = frame.size.height - deltaY + bottomToolbar.frame.size.height - bottomPadding;
+    serverListTableView.frame = frame;
+    
+    UIEdgeInsets viewInsets = serverListTableView.contentInset;
+    viewInsets.bottom = bottomToolbar.frame.size.height - bottomPadding;
+    serverListTableView.contentInset = viewInsets;
     
     CGFloat toolbarHeight = bottomToolbar.frame.size.height;
     serverInfoView = [[UITextView alloc] initWithFrame:CGRectMake(MARGIN, deltaY + MARGIN, self.view.frame.size.width - 2 * MARGIN, self.view.frame.size.height - deltaY - toolbarHeight - 2 * MARGIN)];
@@ -555,9 +568,6 @@
     
     if (IS_IPAD) {
         self.edgesForExtendedLayout = UIRectEdgeNone;
-        CGRect frame = backgroundImageView.frame;
-        frame.size.height = frame.size.height + 8;
-        backgroundImageView.frame = frame;
         self.view.backgroundColor = UIColor.blackColor;
         self.navigationController.navigationBar.barStyle = UIBarStyleBlack;
         self.navigationController.navigationBar.tintColor = ICON_TINT_COLOR;
@@ -566,11 +576,6 @@
         CGRect frame = supportedVersionView.frame;
         frame.origin.y = frame.origin.y + deltaY;
         supportedVersionView.frame = frame;
-        
-        frame = serverListTableView.frame;
-        frame.origin.y = frame.origin.y + deltaY;
-        frame.size.height = frame.size.height - deltaY - bottomPadding;
-        serverListTableView.frame = frame;
         
         frame = connectingActivityIndicator.frame;
         frame.origin.y = frame.origin.y + deltaY;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -495,10 +495,6 @@
     frame.size.height += bottomPadding;
     bottomToolbarEffect.frame = bottomToolbar.frame = frame;
     
-    frame = bottomToolbarShadowImageView.frame;
-    frame.origin.y -= bottomPadding;
-    bottomToolbarShadowImageView.frame = frame;
-    
     frame = addHostButton.frame;
     frame.origin.y -= bottomPadding;
     addHostButton.frame = frame;

--- a/XBMC Remote/HostManagementViewController.xib
+++ b/XBMC Remote/HostManagementViewController.xib
@@ -11,7 +11,6 @@
             <connections>
                 <outlet property="addHostButton" destination="10" id="nxP-ze-Fwa"/>
                 <outlet property="backgroundImageView" destination="9" id="24"/>
-                <outlet property="bottomToolbar" destination="q9g-cA-CZS" id="9Kn-SK-f4i"/>
                 <outlet property="bottomToolbarEffect" destination="ciQ-0V-gEM" id="U1n-sc-qGY"/>
                 <outlet property="connectingActivityIndicator" destination="26" id="27"/>
                 <outlet property="editTableButton" destination="5" id="18"/>
@@ -50,11 +49,6 @@
                     </view>
                     <blurEffect style="dark"/>
                 </visualEffectView>
-                <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" fixedFrame="YES" barStyle="black" translatesAutoresizingMaskIntoConstraints="NO" id="q9g-cA-CZS">
-                    <rect key="frame" x="0.0" y="203" width="320" height="44"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                    <items/>
-                </toolbar>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="10">
                     <rect key="frame" x="10" y="211" width="125" height="28"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>

--- a/XBMC Remote/HostManagementViewController.xib
+++ b/XBMC Remote/HostManagementViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,6 +12,7 @@
                 <outlet property="addHostButton" destination="10" id="nxP-ze-Fwa"/>
                 <outlet property="backgroundImageView" destination="9" id="24"/>
                 <outlet property="bottomToolbar" destination="q9g-cA-CZS" id="9Kn-SK-f4i"/>
+                <outlet property="bottomToolbarEffect" destination="ciQ-0V-gEM" id="U1n-sc-qGY"/>
                 <outlet property="connectingActivityIndicator" destination="26" id="27"/>
                 <outlet property="editTableButton" destination="5" id="18"/>
                 <outlet property="serverInfoButton" destination="WtD-wt-do5" id="6jU-nT-b83"/>
@@ -30,11 +31,29 @@
                     <rect key="frame" x="0.0" y="0.0" width="320" height="248"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 </imageView>
+                <tableView clipsSubviews="YES" tag="1" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="1" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="8">
+                    <rect key="frame" x="0.0" y="34" width="320" height="169"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                    <gestureRecognizers/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="16"/>
+                        <outlet property="delegate" destination="-1" id="17"/>
+                    </connections>
+                </tableView>
+                <visualEffectView opaque="NO" contentMode="scaleToFill" id="ciQ-0V-gEM">
+                    <rect key="frame" x="0.0" y="203" width="320" height="44"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                    <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="q03-gX-23o">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    </view>
+                    <blurEffect style="dark"/>
+                </visualEffectView>
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" fixedFrame="YES" barStyle="black" translatesAutoresizingMaskIntoConstraints="NO" id="q9g-cA-CZS">
                     <rect key="frame" x="0.0" y="203" width="320" height="44"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <items/>
-                    <color key="barTintColor" red="0.098039215686274508" green="0.098039215686274508" blue="0.098039215686274508" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </toolbar>
                 <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="10">
                     <rect key="frame" x="10" y="211" width="125" height="28"/>
@@ -91,16 +110,6 @@
                         <action selector="editTable:forceClose:" destination="-1" eventType="touchUpInside" id="19"/>
                     </connections>
                 </button>
-                <tableView clipsSubviews="YES" tag="1" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="1" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="8">
-                    <rect key="frame" x="0.0" y="34" width="320" height="169"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                    <gestureRecognizers/>
-                    <connections>
-                        <outlet property="dataSource" destination="-1" id="16"/>
-                        <outlet property="delegate" destination="-1" id="17"/>
-                    </connections>
-                </tableView>
                 <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TtA-IV-ddn" userLabel="View - Supported Version">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="34"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -199,7 +199,13 @@
     CGRect frame = self.view.bounds;
     UIView *newView = [[UIView alloc] initWithFrame:CGRectMake(0, frame.size.height - footerHeight, frame.size.width, footerHeight)];
     newView.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleWidth;
-    newView.backgroundColor = TOOLBAR_TINT_COLOR;
+    newView.backgroundColor = UIColor.clearColor;
+    
+    // Add visual effect
+    UIVisualEffectView *effectView = [[UIVisualEffectView alloc] initWithFrame:newView.frame];
+    effectView.autoresizingMask = newView.autoresizingMask;
+    effectView.effect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
+    [newView addSubview:effectView];
     
     // ...more button
     CGFloat originX = self.peekLeftAmount + BUTTON_SPACING;
@@ -580,16 +586,9 @@
     
     mainMenu *menuItems = self.rightMenuItems[0];
     CGFloat bottomPadding = IS_IPAD ? 0 : [Utilities getBottomPadding];
-    CGFloat footerHeight = 0;
-    if (menuItems.family == FamilyRemote) {
-        footerHeight = TOOLBAR_HEIGHT + bottomPadding;
-        [self.view addSubview:[self createTableFooterView:footerHeight]];
-    }
-    if (menuItems.family == FamilyNowPlaying || menuItems.family == FamilyRemote) {
-        volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectZero leftAnchor:ANCHOR_RIGHT_PEEK isSliderType:YES];
-        [volumeSliderView startTimer];
-    }
-    menuTableView = [[UITableView alloc] initWithFrame:CGRectMake(self.peekLeftAmount, deltaY, frame.size.width - self.peekLeftAmount, self.view.frame.size.height - deltaY - footerHeight) style:UITableViewStylePlain];
+    CGFloat footerHeight = menuItems.family == FamilyRemote ? TOOLBAR_HEIGHT + bottomPadding : 0;
+    
+    menuTableView = [[UITableView alloc] initWithFrame:CGRectMake(self.peekLeftAmount, deltaY, frame.size.width - self.peekLeftAmount, self.view.frame.size.height - deltaY) style:UITableViewStylePlain];
     menuTableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     menuTableView.delegate = self;
     menuTableView.dataSource = self;
@@ -597,8 +596,17 @@
     menuTableView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
     [menuTableView setScrollEnabled:menuItems.enableSection];
     menuTableView.separatorInset = UIEdgeInsetsMake(0, 0, 0, 0);
+    menuTableView.contentInset = UIEdgeInsetsMake(0, 0, footerHeight, 0);
     menuTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
     [self.view addSubview:menuTableView];
+    
+    if (menuItems.family == FamilyRemote) {
+        [self.view addSubview:[self createTableFooterView:footerHeight]];
+    }
+    if (menuItems.family == FamilyNowPlaying || menuItems.family == FamilyRemote) {
+        volumeSliderView = [[VolumeSliderView alloc] initWithFrame:CGRectZero leftAnchor:ANCHOR_RIGHT_PEEK isSliderType:YES];
+        [volumeSliderView startTimer];
+    }
 
     if (AppDelegate.instance.obj.serverIP.length != 0) {
         if (!AppDelegate.instance.serverOnLine) {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -125,9 +125,6 @@
             }
         }
         if (IS_IPAD) {
-            toolbar = [UIToolbar new];
-            toolbar.barStyle = UIBarStyleBlack;
-            toolbar.translucent = YES;
             viewTitle = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, STACKSCROLL_WIDTH, TITLE_HEIGHT)];
             viewTitle.backgroundColor = UIColor.clearColor;
             viewTitle.textAlignment = NSTextAlignmentLeft;
@@ -169,6 +166,7 @@
             [items addObject:spaceFixedRight];
             [items addObject:spaceUndo];
             
+            toolbar = [UIToolbar new];
             toolbar.items = items;
             toolbar.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleWidth;
             toolbar.contentMode = UIViewContentModeScaleAspectFill;
@@ -179,7 +177,15 @@
                                        CGRectGetMinY(mainViewBounds),
                                        CGRectGetWidth(mainViewBounds),
                                        toolbarHeight);
+            // Transparent toolbar
+            [Utilities createTransparentToolbar:toolbar];
             [self.view addSubview:toolbar];
+            
+            UIVisualEffectView *effectView = [[UIVisualEffectView alloc] initWithFrame:toolbar.frame];
+            effectView.autoresizingMask = toolbar.autoresizingMask;
+            effectView.effect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
+            [self.view insertSubview:effectView belowSubview:toolbar];
+            
             scrollView.contentInset = UIEdgeInsetsMake(toolbarHeight, 0, 0, 0);
         }
         else {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Inspired by #1290 but avoiding the complications caused when also using frosted glass for the navigation bar. The implementation is done for the relevant toolbars DetailVC (library view), RightMenuVC (custom button view), HostManagementVC (server list view) and ShowInfoVC (item's detail view).

In future I might replace the remaining two instances of `UIToolbar` by views with buttons. This will avoid the -- for now undesired -- visual change when iOS26 introduces "liquid glass".

Screenshots of library view:
<a href="https://ibb.co/8nd649c8"><img src="https://i.ibb.co/JWy5FHQk/Bildschirmfoto-2025-07-26-um-17-23-45.png" alt="Bildschirmfoto-2025-07-26-um-17-23-45" border="0"></a>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Use frosted glass effect for toolbars