### PR TITLE
Improvement: Avoid double settings button on iPhone remote screen

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -193,7 +193,7 @@
     
     [self setupGestureView];
     if ([Utilities hasRemoteToolBar]) {
-        [self createRemoteToolbar:gestureImage width:newWidth xMin:ANCHOR_RIGHT_PEEK yMax:TOOLBAR_PARENT_HEIGHT isEmbedded:YES];
+        [self createRemoteToolbar:gestureImage width:newWidth xMin:ANCHOR_RIGHT_PEEK yMax:TOOLBAR_PARENT_HEIGHT];
     }
     else {
         // Overload "stop" button with gesture icon in case the toolbar cannot be displayed (e.g. iPhone 4S)
@@ -270,7 +270,7 @@
     }
     [self setupGestureView];
     if ([Utilities hasRemoteToolBar]) {
-        [self createRemoteToolbar:gestureImage width:remoteControlView.frame.size.width xMin:0 yMax:self.view.bounds.size.height isEmbedded:NO];
+        [self createRemoteToolbar:gestureImage width:remoteControlView.frame.size.width xMin:0 yMax:self.view.bounds.size.height];
     }
 }
 
@@ -1240,13 +1240,12 @@
     [self saveRemoteMode];
 }
 
-- (void)createRemoteToolbar:(UIImage*)gestureButtonImg width:(CGFloat)width xMin:(CGFloat)xMin yMax:(CGFloat)yMax isEmbedded:(BOOL)isEmbedded {
+- (void)createRemoteToolbar:(UIImage*)gestureButtonImg width:(CGFloat)width xMin:(CGFloat)xMin yMax:(CGFloat)yMax {
     torchIsOn = [Utilities isTorchOn];
-    // Non-embedded layout has 5 buttons (Settings > Gesture > Keyboard > Info > Torch with Flex around the buttons)
-    // Embedded layout has 4 buttons (Gesture > Keyboard > Info > Torch with Flex around the buttons)
-    // iPhone has an addtional button to toggle the remote's position is available
+    // Button layout has 4 buttons (Gesture > Keyboard > Info > Torch > Additional with Flex around the buttons)
+    // iPhone has an addtional button to toggle the remote's vertical position
     // iPad has an additional button to close the modal view
-    int numButtons = isEmbedded ? 5 : 6;
+    int numButtons = 5;
     CGFloat ToolbarFlexSpace = ((width - numButtons * TOOLBAR_ICON_SIZE) / (numButtons + 1));
     CGFloat ToolbarPadding = (TOOLBAR_ICON_SIZE + ToolbarFlexSpace);
     
@@ -1264,16 +1263,6 @@
     
     // Add buttons to toolbar
     frame.origin.x -= ToolbarPadding;
-    if (!isEmbedded) {
-        UIButton *settingButton = [UIButton buttonWithType:UIButtonTypeCustom];
-        frame.origin.x += ToolbarPadding;
-        settingButton.frame = frame;
-        settingButton.showsTouchWhenHighlighted = YES;
-        [settingButton setImage:[UIImage imageNamed:@"default-right-menu-icon"] forState:UIControlStateNormal];
-        [settingButton addTarget:self action:@selector(handleSettingsButton:) forControlEvents:UIControlEventTouchUpInside];
-        settingButton.alpha = 0.8;
-        [remoteToolbar addSubview:settingButton];
-    }
     
     UIButton *gestureButton = [UIButton buttonWithType:UIButtonTypeCustom];
     frame.origin.x += ToolbarPadding;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Remove settings button from iPhone's remote toolbar. This is already placed in the navigation bar.

Screenshots (left = before, right = after): https://ibb.co/KzsRc3yd

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Avoid double settings button on iPhone remote screen