### PR TITLE
Bugfix: Fix server list / search views for iPhones with wide screen

### DIFF
--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -78,6 +78,10 @@
         }
         tcpPortUI.text = item[@"tcpPort"];
     }
+    // Move view right out of self.view
+    CGRect frame = discoveredInstancesView.frame;
+    frame.origin.x = self.view.frame.size.width;
+    discoveredInstancesView.frame = frame;
 }
 
 - (IBAction)dismissView:(id)sender {

--- a/XBMC Remote/HostViewController.xib
+++ b/XBMC Remote/HostViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -453,7 +453,7 @@ TCP port</string>
                             <color key="backgroundColor" red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="0.94999999999999996" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="47">
-                            <rect key="frame" x="414" y="202" width="320" height="213"/>
+                            <rect key="frame" x="320" y="202" width="320" height="213"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="46">

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -35,7 +35,7 @@
     CustomNavigationController *navController = [[CustomNavigationController alloc] initWithRootViewController:hostManagementViewController];
     navController.navigationBar.barStyle = UIBarStyleBlack;
     navController.navigationBar.tintColor = ICON_TINT_COLOR;
-    [Utilities addShadowsToView:navController.view viewFrame:self.view.frame];
+    [Utilities addShadowsToView:navController.view viewFrame:navController.view.frame];
     
     self.view.tintColor = APP_TINT_COLOR;
     [navController hideNavBarBottomLine:YES];

--- a/XBMC Remote/InitialSlidingViewController.xib
+++ b/XBMC Remote/InitialSlidingViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,9 +14,10 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="1">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="416"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <color key="backgroundColor" red="0.14117647059999999" green="0.14117647059999999" blue="0.14117647059999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="92" y="18"/>
         </view>
     </objects>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
On iPhone with wide screen, e.g. iPhone 16 Pro Max, both the server list view (`HostManagementVC`) and the server search view (`HostVC`) have an incorrect layout. In the server list the `InitialSldingVC`'s must be auto-scaling and the vertical shadow must be applied with `navController's` frame dimensions. In the server search view `discoveredInstancesView` must be kept right outside the visible area until results are shown. This needs the view to be programmatically placed there, instead of just hardcoding a position in the xib which worked for most display widths until now.

Screenshot from iPhone 16 Pro Max: https://postimg.cc/yWVRZ0YL (each pair shows left = before, right = after)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix server list / search views for iPhones with wide screen