### PR TITLE
Improvement: Do not continue re-connect after quit/shutdown/hibernate/suspend

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -57,14 +57,7 @@
         [serverListTableView deselectRowAtIndexPath:item animated:YES];
         cell.accessoryType = UITableViewCellAccessoryNone;
         storeServerSelection = nil;
-        AppDelegate.instance.obj.serverDescription = @"";
-        AppDelegate.instance.obj.serverUser = @"";
-        AppDelegate.instance.obj.serverPass = @"";
-        AppDelegate.instance.obj.serverRawIP = @"";
-        AppDelegate.instance.obj.serverIP = @"";
-        AppDelegate.instance.obj.serverPort = @"";
-        AppDelegate.instance.obj.serverHWAddr = @"";
-        AppDelegate.instance.obj.tcpPort = 0;
+        [Utilities resetKodiServerParameters];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerHasChanged" object:nil];
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
         [userDefaults setObject:@(-1) forKey:@"lastServer"];
@@ -169,15 +162,8 @@
     [serverListTableView deselectRowAtIndexPath:indexPath animated:YES];
     cell.accessoryType = UITableViewCellAccessoryNone;
     storeServerSelection = nil;
-    AppDelegate.instance.obj.serverDescription = @"";
-    AppDelegate.instance.obj.serverUser = @"";
-    AppDelegate.instance.obj.serverPass = @"";
-    AppDelegate.instance.obj.serverRawIP = @"";
-    AppDelegate.instance.obj.serverIP = @"";
-    AppDelegate.instance.obj.serverPort = @"";
-    AppDelegate.instance.obj.serverHWAddr = @"";
+    [Utilities resetKodiServerParameters];
     AppDelegate.instance.serverOnLine = NO;
-    AppDelegate.instance.obj.tcpPort = 0;
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [userDefaults setObject:@(-1) forKey:@"lastServer"];
     ((UIImageView*)[cell viewWithTag:XIB_HOST_MGMT_CELL_ICON]).image = [UIImage imageNamed:@"connection_off"];
@@ -235,14 +221,7 @@
             }
             else if (storeServerSelection.row == indexPath.row) {
                 storeServerSelection = nil;
-                AppDelegate.instance.obj.serverDescription = @"";
-                AppDelegate.instance.obj.serverUser = @"";
-                AppDelegate.instance.obj.serverPass = @"";
-                AppDelegate.instance.obj.serverRawIP = @"";
-                AppDelegate.instance.obj.serverIP = @"";
-                AppDelegate.instance.obj.serverPort = @"";
-                AppDelegate.instance.obj.serverHWAddr = @"";
-                AppDelegate.instance.obj.tcpPort = 0;
+                [Utilities resetKodiServerParameters];
                 [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerHasChanged" object:nil];
                 [userDefaults setObject:@(-1) forKey:@"lastServer"];
             }

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -267,6 +267,14 @@
     }
 }
 
+#pragma mark - Helper
+
+- (void)handleDisconnectActiveServer {
+    // Deselect any current active server
+    NSIndexPath *selection = [serverListTableView indexPathForSelectedRow];
+    [self deselectServerAtIndexPath:selection];
+}
+
 #pragma mark - Long Press & Action sheet
 
 - (void)handleLongPress {
@@ -635,6 +643,11 @@
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(enablePopGestureRecognizer:)
                                                  name:@"ECSlidingViewTopDidReset"
+                                               object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleDisconnectActiveServer)
+                                                 name:@"DisconnectActiveServer"
                                                object:nil];
 }
 

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -129,5 +129,6 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (UIViewController*)topMostController;
 + (UIViewController*)topMostControllerIgnoringClass:(Class)ignoredClass;
 + (uint64_t)memoryFootprint;
++ (void)resetKodiServerParameters;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1417,4 +1417,15 @@
     return vmInfo.phys_footprint;
 }
 
++ (void)resetKodiServerParameters {
+    AppDelegate.instance.obj.serverDescription = @"";
+    AppDelegate.instance.obj.serverUser = @"";
+    AppDelegate.instance.obj.serverPass = @"";
+    AppDelegate.instance.obj.serverRawIP = @"";
+    AppDelegate.instance.obj.serverIP = @"";
+    AppDelegate.instance.obj.serverPort = @"";
+    AppDelegate.instance.obj.serverHWAddr = @"";
+    AppDelegate.instance.obj.tcpPort = 0;
+}
+
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -507,11 +507,14 @@
     return alertCtrl;
 }
 
-+ (void)powerAction:(NSString*)command {
++ (void)powerAction:(NSString*)command onSuccess:(void (^)(void))onSuccess {
     [[Utilities getJsonRPC] callMethod:command withParameters:@{} onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         // User already confirmed, so we only show a short-lived message.
         if (methodError == nil && error == nil) {
             [Utilities showMessage:LOCALIZED_STR(@"Command executed") color:SUCCESS_MESSAGE_COLOR];
+            if (onSuccess) {
+                onSuccess();
+            }
         }
         else {
             [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
@@ -538,51 +541,55 @@
     }
     else {
         UIAlertAction *action_pwr_off_system = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Power off System") style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
-            [self powerAction:@"System.Shutdown"];
-            [Utilities disconnectFromActiveServer];
+            [self powerAction:@"System.Shutdown" onSuccess:^{
+                [Utilities disconnectFromActiveServer];
+            }];
         }];
         [alertCtrl addAction:action_pwr_off_system];
         
         UIAlertAction *action_quit_kodi = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Quit XBMC application") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"Application.Quit"];
-            [Utilities disconnectFromActiveServer];
+            [self powerAction:@"Application.Quit" onSuccess:^{
+                [Utilities disconnectFromActiveServer];
+            }];
         }];
         [alertCtrl addAction:action_quit_kodi];
         
         UIAlertAction *action_hibernate = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Hibernate") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"System.Hibernate"];
-            [Utilities disconnectFromActiveServer];
+            [self powerAction:@"System.Hibernate" onSuccess:^{
+                [Utilities disconnectFromActiveServer];
+            }];
         }];
         [alertCtrl addAction:action_hibernate];
         
         UIAlertAction *action_suspend = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Suspend") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"System.Suspend"];
-            [Utilities disconnectFromActiveServer];
+            [self powerAction:@"System.Suspend" onSuccess:^{
+                [Utilities disconnectFromActiveServer];
+            }];
         }];
         [alertCtrl addAction:action_suspend];
         
         UIAlertAction *action_reboot = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Reboot") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"System.Reboot"];
+            [self powerAction:@"System.Reboot" onSuccess:nil];
         }];
         [alertCtrl addAction:action_reboot];
         
         UIAlertAction *action_scan_audio_lib = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Update Audio Library") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"AudioLibrary.Scan"];
+            [self powerAction:@"AudioLibrary.Scan" onSuccess:nil];
         }];
         [alertCtrl addAction:action_scan_audio_lib];
         
         UIAlertAction *action_clean_audio_lib = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Clean Audio Library") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"AudioLibrary.Clean"];
+            [self powerAction:@"AudioLibrary.Clean" onSuccess:nil];
         }];
         [alertCtrl addAction:action_clean_audio_lib];
         
         UIAlertAction *action_scan_video_lib = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Update Video Library") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"VideoLibrary.Scan"];
+            [self powerAction:@"VideoLibrary.Scan" onSuccess:nil];
         }];
         [alertCtrl addAction:action_scan_video_lib];
         
         UIAlertAction *action_clean_video_lib = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Clean Video Library") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [self powerAction:@"VideoLibrary.Clean"];
+            [self powerAction:@"VideoLibrary.Clean" onSuccess:nil];
         }];
         [alertCtrl addAction:action_clean_video_lib];
     }

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -539,21 +539,25 @@
     else {
         UIAlertAction *action_pwr_off_system = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Power off System") style:UIAlertActionStyleDestructive handler:^(UIAlertAction *action) {
             [self powerAction:@"System.Shutdown"];
+            [Utilities disconnectFromActiveServer];
         }];
         [alertCtrl addAction:action_pwr_off_system];
         
         UIAlertAction *action_quit_kodi = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Quit XBMC application") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
             [self powerAction:@"Application.Quit"];
+            [Utilities disconnectFromActiveServer];
         }];
         [alertCtrl addAction:action_quit_kodi];
         
         UIAlertAction *action_hibernate = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Hibernate") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
             [self powerAction:@"System.Hibernate"];
+            [Utilities disconnectFromActiveServer];
         }];
         [alertCtrl addAction:action_hibernate];
         
         UIAlertAction *action_suspend = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Suspend") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
             [self powerAction:@"System.Suspend"];
+            [Utilities disconnectFromActiveServer];
         }];
         [alertCtrl addAction:action_suspend];
         
@@ -1426,6 +1430,13 @@
     AppDelegate.instance.obj.serverPort = @"";
     AppDelegate.instance.obj.serverHWAddr = @"";
     AppDelegate.instance.obj.tcpPort = 0;
+}
+
++ (void)disconnectFromActiveServer {
+    [Utilities resetKodiServerParameters];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    [userDefaults setObject:@(-1) forKey:@"lastServer"];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"DisconnectActiveServer" object:nil];
 }
 
 @end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes #633.

Stop re-connection attempts after user selected Quit Application, Shutdown System, Hibernate System or Suspend System from the power menu and Kodi reported success. To stay consistent with the status reflected in the UI, the current selected server is unselected. After Remote App relaunch there is no server connection attempted to be connected again. The user needs to select the desired server again.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Do not continue re-connect after quit/shutdown/hibernate/suspend