### PR TITLE
Improvement: Use common selection color also for main menu

### DIFF
--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -32,8 +32,7 @@
 #define GRIDVIEW_SECTION_COLOR [Utilities getGrayColor:44 alpha:1.0]
 #define SYSTEMGRAY6_DARKMODE [Utilities getGrayColor:28 alpha:1] // Gray:28 is similar to systemGray6 in Dark Mode
 #define SYSTEMGRAY6_LIGHTMODE [Utilities getGrayColor:242 alpha:1] // Gray:242 is similar to systemGray6 in Light Mode
-#define MAINMENU_SELECTED_COLOR [Utilities getGrayColor:8 alpha:1]
-#define MAINMENU_SERVER_COLOR [Utilities getGrayColor:53 alpha:1]
+#define MAINMENU_SELECTED_COLOR [Utilities getGrayColor:58 alpha:1] // Gray:58 is similar to systemGray4 in Dark Mode
 #define ACTOR_SELECTED_COLOR [Utilities getGrayColor:128 alpha:0.5]
 #define INFO_POPOVER_COLOR [Utilities getGrayColor:0 alpha:0.8]
 #define IPAD_MENU_SEPARATOR [Utilities getGrayColor:77 alpha:0.6]

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -90,7 +90,7 @@
         title.numberOfLines = 2;
         title.text = [Utilities getConnectionStatusServerName];
         [self setConnectionIcon:icon];
-        cell.backgroundColor = MAINMENU_SERVER_COLOR;
+        cell.backgroundColor = UIColor.clearColor;
     }
     else {
         // Adapt layout for main menu cells


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Use same color for selected main menu cell as for selected cells in dark mode. Use clear background for the server cell on iPhone.

Screenshots: https://ibb.co/qFrG5GGg

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Use common selection color also for main menu