### PR TITLE
Rework settings layout for iPad and some iOS versions

### DIFF
--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -390,6 +390,7 @@
 
 - (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
 	cell.backgroundColor = [Utilities getSystemGray6];
+    cell.tintColor = [Utilities getSystemBlue];
     cell.accessoryType = UITableViewCellAccessoryNone;
 
     UILabel *cellLabel = (UILabel*)[cell viewWithTag:SETTINGS_CELL_LABEL];

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -388,7 +388,7 @@
     return numRows;
 }
 
-- (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
+- (void)layoutCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
 	cell.backgroundColor = [Utilities getSystemGray6];
     cell.tintColor = [Utilities getSystemBlue];
     cell.accessoryType = UITableViewCellAccessoryNone;
@@ -685,6 +685,7 @@
         textInputField.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
         [cell.contentView addSubview:textInputField];
 	}
+    [self layoutCell:cell forRowAtIndexPath:indexPath];
     return cell;
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The settings cell tint should use `systemBlue` for better readability of accessory check marks. This is well recognizable from the screenshots in dark and light mode.

For iOS 17.2 (and others?) `heightForRowAtIndexPath` is called before `willDisplayCell`, which results in wrong cell sizes. This is avoided when finishing the cell layout in `cellForRowAtIndexPath`.

Screenshots (top = new, bottom = before): https://ibb.co/BVh7bj9t

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Better readability of accessory check marks for settings on iPad
Bugfix: Fix layout for settings cells for some iOS versions
