### PR TITLE
Improvement: Ensure that custom buttons show icons

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3629,7 +3629,7 @@
         NSDictionary *newButton = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                    item[@"label"], @"label",
                                    @"string", @"type",
-                                   item[@"thumbnail"], @"icon",
+                                   @"", @"icon",
                                    @(0), @"xbmcSetting",
                                    item[@"genre"], @"helpText",
                                    [NSDictionary dictionaryWithObjectsAndKeys:
@@ -3646,7 +3646,7 @@
         NSDictionary *newButton = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                    item[@"label"], @"label",
                                    @"string", @"type",
-                                   item[@"thumbnail"], @"icon",
+                                   @"", @"icon",
                                    @(0), @"xbmcSetting",
                                    item[@"genre"], @"helpText",
                                    [NSDictionary dictionaryWithObjectsAndKeys:

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -177,17 +177,27 @@
     title.textColor = fontColor;
     title.highlightedTextColor = fontColor;
     
+    NSString *command = tableData[indexPath.row][@"action"][@"command"];
     if ([tableData[indexPath.row][@"label"] isEqualToString:LOCALIZED_STR(@"LED Torch")]) {
         icon.alpha = 0.8;
         if (torchIsOn) {
             iconName = @"torch_on";
         }
     }
-    if ([tableData[indexPath.row][@"type"] isEqualToString:@"xbmc-exec-addon"]) {
+    if ([command isEqualToString:@"Addons.ExecuteAddon"]) {
         [icon sd_setImageWithURL:[NSURL URLWithString:tableData[indexPath.row][@"icon"]]
                 placeholderImage:[UIImage imageNamed:@"blank"]
                          options:SDWebImageScaleToNativeSize];
         icon.alpha = 1.0;
+    }
+    else if ([command isEqualToString:@"Input.ExecuteAction"]) {
+        icon.image = [UIImage imageNamed:@"default-right-action-icon"];
+    }
+    else if ([command isEqualToString:@"GUI.ActivateWindow"]) {
+        icon.image = [UIImage imageNamed:@"default-right-window-icon"];
+    }
+    else if ([command isEqualToString:@"Settings.SetSettingValue"]) {
+        icon.image = [UIImage imageNamed:@"default-right-menu-icon"];
     }
     else {
         icon.image = [UIImage imageNamed:iconName];

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -253,7 +253,6 @@
 }
 
 - (void)addActionButton:(UIAlertController*)alertCtrl {
-    NSString *command = @"Settings.SetSettingValue";
     id value = @"";
     NSString *type = self.detailItem[@"year"] ?: @"string";
     switch (xbmcSetting) {
@@ -278,11 +277,11 @@
     NSDictionary *newButton = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                alertCtrl.textFields[0].text, @"label",
                                type, @"type",
-                               @"default-right-menu-icon", @"icon",
+                               @"", @"icon",
                                @(xbmcSetting), @"xbmcSetting",
                                self.detailItem[@"genre"], @"helpText",
                                [NSDictionary dictionaryWithObjectsAndKeys:
-                                command, @"command",
+                                @"Settings.SetSettingValue", @"command",
                                 params, @"params",
                                 nil], @"action",
                                nil];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Do not save custom button's icon name, except for downloadable images (used only for add-ons). Instead, derive the custom button icon from the button's executed command. This avoids the remote app not being able to load icons from its image library in case of renaming. This also introduces custom button icons for actions and windows.

Screenshots: https://ibb.co/S7xS8p2B

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Ensure that custom buttons show icons