### PR TITLE
Maintenance: Remove unused UIImageView from rightCellView

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -28,7 +28,6 @@
 #define ONOFF_BUTTON_TAG_OFFSET 1000
 
 #define XIB_RIGHT_MENU_CELL_ICON 1
-#define XIB_RIGHT_MENU_CELL_STATUS 2
 #define XIB_RIGHT_MENU_CELL_TITLE 3
 
 @interface RightMenuViewController ()
@@ -93,10 +92,7 @@
     
     // Reset to default for each cell to allow dequeuing
     UIImageView *icon = (UIImageView*)[cell viewWithTag:XIB_RIGHT_MENU_CELL_ICON];
-    UIImageView *status = (UIImageView*)[cell viewWithTag:XIB_RIGHT_MENU_CELL_STATUS];
     UILabel *title = (UILabel*)[cell viewWithTag:XIB_RIGHT_MENU_CELL_TITLE];
-    status.hidden = YES;
-    status.image = nil;
     icon.hidden = NO;
     icon.image = nil;
     icon.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin;

--- a/XBMC Remote/rightCellView.xib
+++ b/XBMC Remote/rightCellView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,10 +19,6 @@
                     <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.60000002384185791" tag="1" contentMode="scaleAspectFit" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4">
                         <rect key="frame" x="240" y="12" width="25" height="25"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES"/>
-                    </imageView>
-                    <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.60000002384185791" tag="2" contentMode="scaleAspectFit" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kca-dF-2Rb">
-                        <rect key="frame" x="10" y="12" width="25" height="25"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES"/>
                     </imageView>
                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="3" contentMode="left" fixedFrame="YES" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="6">
                         <rect key="frame" x="24" y="0.0" width="202" height="50"/>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Minor cleanup: Remove unused `UIImageView` from `rightCellView`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Remove unused UIImageView from rightCellView