### PR TITLE
Bugfix: Make custom buttons work for multi-select and editable settings

### DIFF
--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -270,6 +270,7 @@
             break;
             
         case SettingTypeMultiselect:
+        case SettingTypeInput:
             value = self.detailItem[@"value"] ?: @"";
             break;
             

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -269,6 +269,10 @@
             value = @(storeSliderValue);
             break;
             
+        case SettingTypeMultiselect:
+            value = self.detailItem[@"value"] ?: @"";
+            break;
+            
         default:
             value = @"";
             break;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Custom buttons for multi-select settings (e.g. "Skip steps") were always sending a malformatted command, not sending the array of values, but an empty string. Custom buttons for editable settings (e.g. "Track naming template") were always sending an empty string instead of the desired value.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Make custom buttons work for multi-select and editable settings