### PR TITLE
Bugfix: Fix showing amount of results in different languages

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -785,7 +785,8 @@
     NSUInteger numResult = self.filteredListContent.count;
     if (numResult > 0) {
         if (numResult > 1) {
-            results = LOCALIZED_STR_ARGS(@"%lu results", numResult);
+            // Keep cast to (int) as "%d" is used for many translated languages
+            results = LOCALIZED_STR_ARGS(@"%d results", (int)numResult);
         }
         else {
             results = LOCALIZED_STR(@"1 result");


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/commit/7d9936f7923c818528f8dd74ccd76a86958b6df5 and reported in https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1328. The regression caused showing multiple results without translations: "x results" was shown (x > 1).

Keep cast to `(int)` to avoid warning when using the `"%d"` argument. The `"%d"` argument is part of already translated strings for many languages and shall be kept.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix showing amount of results in different languages