### PR TITLE
Bugfix: Disable underRightVC for server list view

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -445,6 +445,9 @@
     self.preferredContentSize = size;
     [super viewWillAppear:animated];
     if (IS_IPHONE) {
+        self.slidingViewController.underRightViewController = nil;
+        self.slidingViewController.anchorLeftPeekAmount   = 0;
+        self.slidingViewController.anchorLeftRevealAmount = 0;
         self.slidingViewController.panGesture.delegate = self;
         [self.navigationController.view addGestureRecognizer:self.slidingViewController.panGesture];
     }

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -42,10 +42,6 @@
     hostManagementViewController.mainMenu = self.mainMenu;
     self.topViewController = navController;
     
-    self.slidingViewController.underRightViewController = nil;
-    self.slidingViewController.anchorLeftPeekAmount   = 0;
-    self.slidingViewController.anchorLeftRevealAmount = 0;
-    
     // Hide the inital HostManagementVC in case the "start view" is not main menu to avoid disturbing
     // sliding out (this view) and in (the targeted view).
     self.topViewController.view.hidden = [Utilities getIndexPathForDefaultController:self.mainMenu] != nil;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression caused by reworking iPhone main controller initialization (0adb368b). The issue fixed is that `underRightVC` became visible for the `HostManagmentVC` (server list view) once the NowPlaying screen was entered before.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Disable underRightVC for server list view