### PR TITLE
Bugfix: Do not make iPad corner visible after pull-to-sync in fullscreen

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -502,7 +502,7 @@
 - (void)setFilternameLabel:(NSString*)labelText {
     labelText = [Utilities stripBBandHTML:labelText];
     self.navigationItem.title = labelText;
-    if (IS_IPHONE) {
+    if (IS_IPHONE || stackscrollFullscreen) {
         return;
     }
     [UIView animateWithDuration:0.1


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes a minor visual glitch reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3242227#pid3242227).

Do not update `topNavigationLabel` in iPad fullscreen mode. Avoids that `topNavigationLabel` becomes visible (alpha = 1) again in fullscreen after pull-to-sync.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not make iPad corner visible after pull-to-sync in fullscreen