### PR TITLE
Maintenance: Migrate to UIScene

### DIFF
--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		0FEA79FC165FBBED00BB281F /* XBMCVirtualKeyboard.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA79FB165FBBEC00BB281F /* XBMCVirtualKeyboard.m */; };
 		0FEAE76816EA632800387DED /* ActorCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FEAE76716EA632800387DED /* ActorCell.m */; };
 		0FEE08161704819A00EC9BC7 /* FloatingHeaderFlowLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FEE08151704819A00EC9BC7 /* FloatingHeaderFlowLayout.m */; };
+		C70B9C7C2DE1CB6900F14093 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C70B9C7B2DE1CB6900F14093 /* SceneDelegate.m */; };
 		C7106D792D33C25400A96C93 /* BroadcastProgressView.m in Sources */ = {isa = PBXBuildFile; fileRef = C7106D782D33C25400A96C93 /* BroadcastProgressView.m */; };
 		C7106D7B2D33EEE000A96C93 /* ProgressBarView.m in Sources */ = {isa = PBXBuildFile; fileRef = C7106D7A2D33EEE000A96C93 /* ProgressBarView.m */; };
 		C7106D842D33FBCE00A96C93 /* PlaylistProgressView.m in Sources */ = {isa = PBXBuildFile; fileRef = C7106D832D33FBCE00A96C93 /* PlaylistProgressView.m */; };
@@ -266,6 +267,8 @@
 		B1FF37DE1709D1EB005473FF /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		B1FF37DF1709D1ED005473FF /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C703692827148CEF0049F9BF /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
+		C70B9C7B2DE1CB6900F14093 /* SceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
+		C70B9C7D2DE1CBA300F14093 /* SceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
 		C70F41D02BA4D98E00847C75 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		C7106D752D2FC9BC00A96C93 /* af-ZA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "af-ZA"; path = "af-ZA.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C7106D762D2FC9BC00A96C93 /* af-ZA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "af-ZA"; path = "af-ZA.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -566,6 +569,8 @@
 				0FDFC67C15377CE9000BE837 /* Settings.bundle */,
 				0F554909151D1187007E633F /* AppDelegate.h */,
 				0F55490A151D1187007E633F /* AppDelegate.m */,
+				C70B9C7D2DE1CBA300F14093 /* SceneDelegate.h */,
+				C70B9C7B2DE1CB6900F14093 /* SceneDelegate.m */,
 				C79B0EA62DF0CF8C00046334 /* BaseMasterViewController.h */,
 				C79B0EA42DF0CF6900046334 /* BaseMasterViewController.m */,
 				0F554C1E151D14DA007E633F /* mainMenu.h */,
@@ -926,6 +931,7 @@
 				0F5A504C155FA8640062FD6E /* HostManagementViewController.m in Sources */,
 				0F545D0B1575563100B6320D /* OBShapedButton.m in Sources */,
 				0F545D0C1575563100B6320D /* UIImage+ColorAtPixel.m in Sources */,
+				C70B9C7C2DE1CB6900F14093 /* SceneDelegate.m in Sources */,
 				0F4063351578C6CD00596B61 /* MoreItemsViewController.m in Sources */,
 				0F540662160C82E900853B02 /* CustomNavigationController.m in Sources */,
 				C72CDAF22DD27AB800AFB2FA /* LocalNetworkAlert.swift in Sources */,

--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -1174,6 +1174,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XBMC Remote/Kodi Remote-Prefix.pch";
 				INFOPLIST_FILE = "XBMC Remote/Kodi Remote-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-w",
@@ -1192,6 +1193,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XBMC Remote/Kodi Remote-Prefix.pch";
 				INFOPLIST_FILE = "XBMC Remote/Kodi Remote-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "it.joethefox.XBMC-Remote";
 				PRODUCT_NAME = "Kodi Remote";

--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		0FEA79FC165FBBED00BB281F /* XBMCVirtualKeyboard.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA79FB165FBBEC00BB281F /* XBMCVirtualKeyboard.m */; };
 		0FEAE76816EA632800387DED /* ActorCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FEAE76716EA632800387DED /* ActorCell.m */; };
 		0FEE08161704819A00EC9BC7 /* FloatingHeaderFlowLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FEE08151704819A00EC9BC7 /* FloatingHeaderFlowLayout.m */; };
+		C70B9C7C2DE1CB6900F14093 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C70B9C7B2DE1CB6900F14093 /* SceneDelegate.m */; };
 		C7106D792D33C25400A96C93 /* BroadcastProgressView.m in Sources */ = {isa = PBXBuildFile; fileRef = C7106D782D33C25400A96C93 /* BroadcastProgressView.m */; };
 		C7106D7B2D33EEE000A96C93 /* ProgressBarView.m in Sources */ = {isa = PBXBuildFile; fileRef = C7106D7A2D33EEE000A96C93 /* ProgressBarView.m */; };
 		C7106D842D33FBCE00A96C93 /* PlaylistProgressView.m in Sources */ = {isa = PBXBuildFile; fileRef = C7106D832D33FBCE00A96C93 /* PlaylistProgressView.m */; };
@@ -264,6 +265,8 @@
 		B1FF37DE1709D1EB005473FF /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		B1FF37DF1709D1ED005473FF /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C703692827148CEF0049F9BF /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
+		C70B9C7B2DE1CB6900F14093 /* SceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
+		C70B9C7D2DE1CBA300F14093 /* SceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
 		C70F41D02BA4D98E00847C75 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		C7106D752D2FC9BC00A96C93 /* af-ZA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "af-ZA"; path = "af-za.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C7106D762D2FC9BC00A96C93 /* af-ZA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "af-ZA"; path = "af-za.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -571,6 +574,8 @@
 				0FDFC67C15377CE9000BE837 /* Settings.bundle */,
 				0F554909151D1187007E633F /* AppDelegate.h */,
 				0F55490A151D1187007E633F /* AppDelegate.m */,
+				C70B9C7D2DE1CBA300F14093 /* SceneDelegate.h */,
+				C70B9C7B2DE1CB6900F14093 /* SceneDelegate.m */,
 				C79B0EA62DF0CF8C00046334 /* BaseMasterViewController.h */,
 				C79B0EA42DF0CF6900046334 /* BaseMasterViewController.m */,
 				C77FB74E2D1C702700EB698F /* BaseActionViewController.h */,
@@ -937,6 +942,7 @@
 				0F545D0B1575563100B6320D /* OBShapedButton.m in Sources */,
 				0F545D0C1575563100B6320D /* UIImage+ColorAtPixel.m in Sources */,
 				C752A3BF2F827E23008154C8 /* NSString+Extensions.m in Sources */,
+				C70B9C7C2DE1CB6900F14093 /* SceneDelegate.m in Sources */,
 				0F4063351578C6CD00596B61 /* MoreItemsViewController.m in Sources */,
 				C77FB74D2D1C6FFC00EB698F /* BaseActionViewController.m in Sources */,
 				0F540662160C82E900853B02 /* CustomNavigationController.m in Sources */,

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -81,6 +81,10 @@
 #define WOL_PORT 9
 
 + (AppDelegate*)instance;
++ (UIWindowScene*)scene;
++ (UIWindow*)keyWindow;
++ (UIStatusBarManager*)statusBarManager;
++ (UIInterfaceOrientation)interfaceOrientation;
 
 - (void)saveServerList;
 - (void)clearAppDiskCache;

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -88,9 +88,9 @@
 - (NSURL*)getServerJSONEndPoint;
 - (NSDictionary*)getServerHTTPHeaders;
 
-@property (strong, nonatomic) UIWindow *window;
 @property (strong, nonatomic) CustomNavigationController *navigationController;
 @property (nonatomic, strong) ViewControllerIPad *windowController;
+@property (nonatomic, strong) UIViewController *appRootController;
 @property (strong, nonatomic) NSString *dataFilePath;
 @property (strong, nonatomic) NSString *libraryCachePath;
 @property (strong, nonatomic) NSString *epgCachePath;

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -80,6 +80,10 @@
 #define WOL_PORT 9
 
 + (AppDelegate*)instance;
++ (UIWindowScene*)scene;
++ (UIWindow*)keyWindow;
++ (UIStatusBarManager*)statusBarManager;
++ (UIInterfaceOrientation)interfaceOrientation;
 
 - (void)saveServerList;
 - (void)clearAppDiskCache;

--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -87,9 +87,9 @@
 - (NSURL*)getServerJSONEndPoint;
 - (NSDictionary*)getServerHTTPHeaders;
 
-@property (strong, nonatomic) UIWindow *window;
 @property (strong, nonatomic) CustomNavigationController *navigationController;
 @property (nonatomic, strong) ViewControllerIPad *windowController;
+@property (nonatomic, strong) UIViewController *appRootController;
 @property (strong, nonatomic) NSString *dataFilePath;
 @property (strong, nonatomic) NSString *libraryCachePath;
 @property (strong, nonatomic) NSString *epgCachePath;

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -14,7 +14,6 @@
 #import "InitialSlidingViewController.h"
 #import "UIImageView+WebCache.h"
 #import "Utilities.h"
-#import "Kodi_Remote-Swift.h"
 
 #include <arpa/inet.h>
 #include <net/if.h>
@@ -123,7 +122,7 @@
     // Load user defaults, if not yet set. Avoids need to check for nil.
     [self registerDefaultsFromSettingsBundle];
     
-    [self setIdleTimerFromUserDefaults];
+    [Utilities setIdleTimerFromUserDefaults];
     
     // Create GlobalDate which holds the Kodi server parameters
     obj = [GlobalData getInstance];
@@ -196,10 +195,6 @@
     [NSNotificationCenter.defaultCenter postNotificationName:@"SelectKodiServer" object:nil userInfo:params];
     
     return result;
-}
-
-- (void)setIdleTimerFromUserDefaults {
-    UIApplication.sharedApplication.idleTimerDisabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"lockscreen_preference"];
 }
 
 - (void)sendWOL:(NSString*)MAC withPort:(NSInteger)WOLport {
@@ -285,34 +280,6 @@
 - (void)application:(UIApplication*)application performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem completionHandler:(void(^)(BOOL))completionHandler {
     // Use shortcut title (= server description) to map to server list and connect the server.
     [self connectToServerFromList:shortcutItem.localizedTitle];
-}
-
-- (void)applicationDidEnterBackground:(UIApplication*)application {
-    // Add the server description and address to shortcutItems, which is shown when longpressing the app icon.
-    NSMutableArray *items = [[NSMutableArray alloc] initWithCapacity:self.arrayServerList.count];
-    for (NSDictionary *server in self.arrayServerList) {
-        UIApplicationShortcutIcon *icon = [UIApplicationShortcutIcon iconWithType:UIApplicationShortcutIconTypeFavorite];
-        UIApplicationShortcutItem *shortcut = [[UIApplicationShortcutItem alloc] initWithType:@"ConnectServer"
-                                                                               localizedTitle:server[@"serverDescription"]
-                                                                            localizedSubtitle:server[@"serverIP"]
-                                                                                         icon:icon
-                                                                                     userInfo:nil];
-        [items addObject:shortcut];
-    }
-    application.shortcutItems = items;
-}
-
-- (void)applicationWillEnterForeground:(UIApplication*)application {
-    [self setIdleTimerFromUserDefaults];
-}
-
-- (void)applicationDidBecomeActive:(UIApplication*)application {
-    // Trigger Local Network Privacy Alert once after app launch
-    static dispatch_once_t once;
-    dispatch_once(&once, ^{
-        LocalNetworkAlertClass *localNetworkAlert = [LocalNetworkAlertClass new];
-        [localNetworkAlert triggerLocalNetworkPrivacyAlert];
-    });
 }
 
 - (void)applicationDidReceiveMemoryWarning:(UIApplication*)application {

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -345,4 +345,27 @@
     [[NSURLCache sharedURLCache] removeAllCachedResponses];
 }
 
++ (UIWindowScene*)scene {
+    NSArray *scenes= UIApplication.sharedApplication.connectedScenes.allObjects;
+    UIWindowScene *scene = scenes[0];
+    return scene;
+}
+
++ (UIWindow*)keyWindow {
+    /* WORKAROUND: Instead of keyWindow we return the first window. As this app only supports
+     * a single window, this works and avoids a problem caused by the implementation of most app's
+     * UIViewControllers which use keyWindow.safeAreaInset in viewDidLoad instead of willLayoutSubView.
+    return AppDelegate.scene.keyWindow;
+     */
+    return AppDelegate.scene.windows.firstObject;
+}
+
++ (UIStatusBarManager*)statusBarManager {
+    return AppDelegate.scene.statusBarManager;
+}
+
++ (UIInterfaceOrientation)interfaceOrientation {
+    return AppDelegate.scene.interfaceOrientation;
+}
+
 @end

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -163,40 +163,6 @@
 
 #pragma mark - Helper
 
-- (BOOL)connectToServerFromList:(NSString*)host {
-    if (!host.length) {
-        return NO;
-    }
-    
-    // Host name needs ".local." at the end
-    if ([host hasSuffix:@".local"]) {
-        host = [host stringByAppendingString:@"."];
-    }
-    
-    // Try to map server name or IP address to the list of Kodi servers
-    NSInteger index = [self.arrayServerList indexOfObjectPassingTest:^BOOL(NSDictionary *obj, NSUInteger idx, BOOL *stop) {
-        return [host isEqualToString:obj[@"serverDescription"]] || [host isEqualToString:obj[@"serverIP"]];
-    }];
-    
-    // We want to connect to the desired server only. If this is not present, disconnect from any active server.
-    BOOL result = NO;
-    NSIndexPath *serverIndexPath;
-    NSDictionary *params;
-    if (index != NSNotFound) {
-        serverIndexPath = [NSIndexPath indexPathForRow:index inSection:0];
-        params = @{@"index": @(index)};
-        result = YES;
-    }
-    
-    // Case 1: App just starts. Set the last active server before readKodiServerParameters is called
-    [Utilities saveLastServerIndex:serverIndexPath];
-    
-    // Case 2: App already runs. Send a notification to select the server via its index.
-    [NSNotificationCenter.defaultCenter postNotificationName:@"SelectKodiServer" object:nil userInfo:params];
-    
-    return result;
-}
-
 - (void)sendWOL:(NSString*)MAC withPort:(NSInteger)WOLport {
     CFSocketRef     WOLsocket;
     WOLsocket = CFSocketCreate(kCFAllocatorDefault, PF_INET, SOCK_DGRAM, IPPROTO_UDP, 0, NULL, NULL);
@@ -270,16 +236,6 @@
             NSLog(@"CFSocketSendData error: %li", CFSocketSendData_error);
         }
     }
-}
-
-- (BOOL)application:(UIApplication*)app openURL:(NSURL*)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id>*)options {
-    // Use URL host to map to server list and connect the server.
-    return [self connectToServerFromList:url.host.stringByRemovingPercentEncoding];
-}
-
-- (void)application:(UIApplication*)application performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem completionHandler:(void(^)(BOOL))completionHandler {
-    // Use shortcut title (= server description) to map to server list and connect the server.
-    [self connectToServerFromList:shortcutItem.localizedTitle];
 }
 
 - (void)applicationDidReceiveMemoryWarning:(UIApplication*)application {

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -22,9 +22,9 @@
 
 @implementation AppDelegate
 
-@synthesize window = _window;
 @synthesize navigationController = _navigationController;
 @synthesize windowController = _windowController;
+@synthesize appRootController;
 @synthesize dataFilePath;
 @synthesize arrayServerList;
 @synthesize serverOnLine;
@@ -125,11 +125,6 @@
     
     [self setIdleTimerFromUserDefaults];
     
-    // Create and set interface style for window
-    self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
-    [self setInterfaceStyleFromUserDefaults];
-    [self.window makeKeyAndVisible];
-    
     // Create GlobalDate which holds the Kodi server parameters
     obj = [GlobalData getInstance];
     
@@ -141,12 +136,12 @@
     if (IS_IPHONE) {
         InitialSlidingViewController *initialSlidingViewController = [[InitialSlidingViewController alloc] initWithNibName:@"InitialSlidingViewController" bundle:nil];
         initialSlidingViewController.mainMenuTable = mainMenuItems;
-        self.window.rootViewController = initialSlidingViewController;
+        appRootController = initialSlidingViewController;
     }
     else {
         self.windowController = [[ViewControllerIPad alloc] initWithNibName:@"ViewControllerIPad" bundle:nil];
         self.windowController.mainMenuTable = mainMenuItems;
-        self.window.rootViewController = self.windowController;
+        appRootController = self.windowController;
     }
     return YES;
 }
@@ -205,23 +200,6 @@
 
 - (void)setIdleTimerFromUserDefaults {
     UIApplication.sharedApplication.idleTimerDisabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"lockscreen_preference"];
-}
-
-- (void)setInterfaceStyleFromUserDefaults {
-    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    NSString *mode = [userDefaults stringForKey:@"theme_mode"];
-    if (@available(iOS 13.0, *)) {
-        UIUserInterfaceStyle style = UIUserInterfaceStyleUnspecified;
-        if (mode.length) {
-            if ([mode isEqualToString:@"dark_mode"]) {
-                style = UIUserInterfaceStyleDark;
-            }
-            else if ([mode isEqualToString:@"light_mode"]) {
-                style = UIUserInterfaceStyleLight;
-            }
-        }
-        self.window.overrideUserInterfaceStyle = style;
-    }
 }
 
 - (void)sendWOL:(NSString*)MAC withPort:(NSInteger)WOLport {

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -267,6 +267,9 @@
 
 + (UIWindowScene*)scene {
     NSArray *scenes= UIApplication.sharedApplication.connectedScenes.allObjects;
+    if (scenes.count == 0) {
+        return nil;
+    }
     UIWindowScene *scene = scenes[0];
     return scene;
 }

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -342,4 +342,27 @@
     [[NSURLCache sharedURLCache] removeAllCachedResponses];
 }
 
++ (UIWindowScene*)scene {
+    NSArray *scenes= UIApplication.sharedApplication.connectedScenes.allObjects;
+    UIWindowScene *scene = scenes[0];
+    return scene;
+}
+
++ (UIWindow*)keyWindow {
+    /* WORKAROUND: Instead of keyWindow we return the first window. As this app only supports
+     * a single window, this works and avoids a problem caused by the implementation of most app's
+     * UIViewControllers which use keyWindow.safeAreaInset in viewDidLoad instead of willLayoutSubView.
+    return AppDelegate.scene.keyWindow;
+     */
+    return AppDelegate.scene.windows.firstObject;
+}
+
++ (UIStatusBarManager*)statusBarManager {
+    return AppDelegate.scene.statusBarManager;
+}
+
++ (UIInterfaceOrientation)interfaceOrientation {
+    return AppDelegate.scene.interfaceOrientation;
+}
+
 @end

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -21,9 +21,9 @@
 
 @implementation AppDelegate
 
-@synthesize window = _window;
 @synthesize navigationController = _navigationController;
 @synthesize windowController = _windowController;
+@synthesize appRootController;
 @synthesize dataFilePath;
 @synthesize arrayServerList;
 @synthesize serverOnLine;
@@ -124,11 +124,6 @@
     
     [self setIdleTimerFromUserDefaults];
     
-    // Create and set interface style for window
-    self.window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
-    [self setInterfaceStyleFromUserDefaults];
-    [self.window makeKeyAndVisible];
-    
     // Create GlobalDate which holds the Kodi server parameters
     obj = [GlobalData getInstance];
     
@@ -140,12 +135,12 @@
     if (IS_IPHONE) {
         InitialSlidingViewController *initialSlidingViewController = [[InitialSlidingViewController alloc] initWithNibName:@"InitialSlidingViewController" bundle:nil];
         initialSlidingViewController.mainMenuTable = mainMenuItems;
-        self.window.rootViewController = initialSlidingViewController;
+        appRootController = initialSlidingViewController;
     }
     else {
         self.windowController = [[ViewControllerIPad alloc] initWithNibName:@"ViewControllerIPad" bundle:nil];
         self.windowController.mainMenuTable = mainMenuItems;
-        self.window.rootViewController = self.windowController;
+        appRootController = self.windowController;
     }
     return YES;
 }
@@ -204,23 +199,6 @@
 
 - (void)setIdleTimerFromUserDefaults {
     UIApplication.sharedApplication.idleTimerDisabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"lockscreen_preference"];
-}
-
-- (void)setInterfaceStyleFromUserDefaults {
-    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    NSString *mode = [userDefaults stringForKey:@"theme_mode"];
-    if (@available(iOS 13.0, *)) {
-        UIUserInterfaceStyle style = UIUserInterfaceStyleUnspecified;
-        if (mode.length) {
-            if ([mode isEqualToString:@"dark_mode"]) {
-                style = UIUserInterfaceStyleDark;
-            }
-            else if ([mode isEqualToString:@"light_mode"]) {
-                style = UIUserInterfaceStyleLight;
-            }
-        }
-        self.window.overrideUserInterfaceStyle = style;
-    }
 }
 
 - (void)sendWOL:(NSString*)MAC withPort:(NSInteger)WOLport {

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -162,40 +162,6 @@
 
 #pragma mark - Helper
 
-- (BOOL)connectToServerFromList:(NSString*)host {
-    if (!host.length) {
-        return NO;
-    }
-    
-    // Host name needs ".local." at the end
-    if ([host hasSuffix:@".local"]) {
-        host = [host stringByAppendingString:@"."];
-    }
-    
-    // Try to map server name or IP address to the list of Kodi servers
-    NSInteger index = [self.arrayServerList indexOfObjectPassingTest:^BOOL(NSDictionary *obj, NSUInteger idx, BOOL *stop) {
-        return [host isEqualToString:obj[@"serverDescription"]] || [host isEqualToString:obj[@"serverIP"]];
-    }];
-    
-    // We want to connect to the desired server only. If this is not present, disconnect from any active server.
-    BOOL result = NO;
-    NSIndexPath *serverIndexPath;
-    NSDictionary *params;
-    if (index != NSNotFound) {
-        serverIndexPath = [NSIndexPath indexPathForRow:index inSection:0];
-        params = @{@"index": @(index)};
-        result = YES;
-    }
-    
-    // Case 1: App just starts. Set the last active server before readKodiServerParameters is called
-    [Utilities saveLastServerIndex:serverIndexPath];
-    
-    // Case 2: App already runs. Send a notification to select the server via its index.
-    [NSNotificationCenter.defaultCenter postNotificationName:@"SelectKodiServer" object:nil userInfo:params];
-    
-    return result;
-}
-
 - (void)sendWOL:(NSString*)MAC withPort:(NSInteger)WOLport {
     CFSocketRef WOLsocket;
     WOLsocket = CFSocketCreate(kCFAllocatorDefault, PF_INET, SOCK_DGRAM, IPPROTO_UDP, 0, NULL, NULL);
@@ -267,16 +233,6 @@
             NSLog(@"CFSocketSendData error: %li", CFSocketSendData_error);
         }
     }
-}
-
-- (BOOL)application:(UIApplication*)app openURL:(NSURL*)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id>*)options {
-    // Use URL host to map to server list and connect the server.
-    return [self connectToServerFromList:url.host.stringByRemovingPercentEncoding];
-}
-
-- (void)application:(UIApplication*)application performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem completionHandler:(void(^)(BOOL))completionHandler {
-    // Use shortcut title (= server description) to map to server list and connect the server.
-    completionHandler([self connectToServerFromList:shortcutItem.localizedTitle]);
 }
 
 - (void)applicationDidReceiveMemoryWarning:(UIApplication*)application {

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -13,7 +13,6 @@
 #import "GlobalData.h"
 #import "InitialSlidingViewController.h"
 #import "Utilities.h"
-#import "Kodi_Remote-Swift.h"
 
 #include <arpa/inet.h>
 #include <net/if.h>
@@ -122,7 +121,7 @@
     // Load user defaults, if not yet set. Avoids need to check for nil.
     [self registerDefaultsFromSettingsBundle];
     
-    [self setIdleTimerFromUserDefaults];
+    [Utilities setIdleTimerFromUserDefaults];
     
     // Create GlobalDate which holds the Kodi server parameters
     obj = [GlobalData getInstance];
@@ -195,10 +194,6 @@
     [NSNotificationCenter.defaultCenter postNotificationName:@"SelectKodiServer" object:nil userInfo:params];
     
     return result;
-}
-
-- (void)setIdleTimerFromUserDefaults {
-    UIApplication.sharedApplication.idleTimerDisabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"lockscreen_preference"];
 }
 
 - (void)sendWOL:(NSString*)MAC withPort:(NSInteger)WOLport {
@@ -282,34 +277,6 @@
 - (void)application:(UIApplication*)application performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem completionHandler:(void(^)(BOOL))completionHandler {
     // Use shortcut title (= server description) to map to server list and connect the server.
     completionHandler([self connectToServerFromList:shortcutItem.localizedTitle]);
-}
-
-- (void)applicationDidEnterBackground:(UIApplication*)application {
-    // Add the server description and address to shortcutItems, which is shown when longpressing the app icon.
-    NSMutableArray *items = [[NSMutableArray alloc] initWithCapacity:self.arrayServerList.count];
-    for (NSDictionary *server in self.arrayServerList) {
-        UIApplicationShortcutIcon *icon = [UIApplicationShortcutIcon iconWithType:UIApplicationShortcutIconTypeFavorite];
-        UIApplicationShortcutItem *shortcut = [[UIApplicationShortcutItem alloc] initWithType:@"ConnectServer"
-                                                                               localizedTitle:server[@"serverDescription"]
-                                                                            localizedSubtitle:server[@"serverIP"]
-                                                                                         icon:icon
-                                                                                     userInfo:nil];
-        [items addObject:shortcut];
-    }
-    application.shortcutItems = items;
-}
-
-- (void)applicationWillEnterForeground:(UIApplication*)application {
-    [self setIdleTimerFromUserDefaults];
-}
-
-- (void)applicationDidBecomeActive:(UIApplication*)application {
-    // Trigger Local Network Privacy Alert once after app launch
-    static dispatch_once_t once;
-    dispatch_once(&once, ^{
-        LocalNetworkAlertClass *localNetworkAlert = [LocalNetworkAlertClass new];
-        [localNetworkAlert triggerLocalNetworkPrivacyAlert];
-    });
 }
 
 - (void)applicationDidReceiveMemoryWarning:(UIApplication*)application {

--- a/XBMC Remote/BaseActionViewController.m
+++ b/XBMC Remote/BaseActionViewController.m
@@ -193,7 +193,7 @@
     svc.delegate = self;
     if (IS_IPAD) {
         // On iPad presenting from the active ViewController results in blank screen
-        ctrl = UIApplication.sharedApplication.keyWindow.rootViewController;
+        ctrl = AppDelegate.keyWindow.rootViewController;
     }
     if (![svc isBeingPresented]) {
         if (ctrl.presentedViewController) {

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -36,12 +36,12 @@
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleDidEnterBackground:)
-                                                 name:UIApplicationDidEnterBackgroundNotification
+                                                 name:UISceneDidEnterBackgroundNotification
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleEnterForeground:)
-                                                 name:UIApplicationWillEnterForegroundNotification
+                                                 name:UISceneWillEnterForegroundNotification
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self

--- a/XBMC Remote/ClearCacheView.m
+++ b/XBMC Remote/ClearCacheView.m
@@ -33,7 +33,7 @@
         label.font = [UIFont boldSystemFontOfSize:26];
         label.textColor = UIColor.whiteColor;
         label.backgroundColor = UIColor.clearColor;
-        busyView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
+        busyView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
         busyView.hidesWhenStopped = YES;
         busyView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
         busyView.frame = CGRectMake(self.frame.size.width / 2 - busyView.frame.size.width / 2 - borderWidth / 2, label.frame.size.height + label.frame.origin.y, busyView.frame.size.width, busyView.frame.size.height);

--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -14,8 +14,8 @@
  */
 #define IS_IPHONE (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone)
 #define IS_IPAD (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
-#define IS_PORTRAIT UIInterfaceOrientationIsPortrait(UIApplication.sharedApplication.statusBarOrientation)
-#define IS_LANDSCAPE UIInterfaceOrientationIsLandscape(UIApplication.sharedApplication.statusBarOrientation)
+#define IS_PORTRAIT UIInterfaceOrientationIsPortrait(AppDelegate.interfaceOrientation)
+#define IS_LANDSCAPE UIInterfaceOrientationIsLandscape(AppDelegate.interfaceOrientation)
  
 /*
  * Color defines

--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -20,8 +20,8 @@
  */
 #define IS_IPHONE (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone)
 #define IS_IPAD (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad)
-#define IS_PORTRAIT UIInterfaceOrientationIsPortrait(UIApplication.sharedApplication.statusBarOrientation)
-#define IS_LANDSCAPE UIInterfaceOrientationIsLandscape(UIApplication.sharedApplication.statusBarOrientation)
+#define IS_PORTRAIT UIInterfaceOrientationIsPortrait(AppDelegate.interfaceOrientation)
+#define IS_LANDSCAPE UIInterfaceOrientationIsLandscape(AppDelegate.interfaceOrientation)
  
 /*
  * Color defines

--- a/XBMC Remote/CustomButtonCell.m
+++ b/XBMC Remote/CustomButtonCell.m
@@ -69,7 +69,7 @@
         self.buttonLabel = title;
         
         // Activity indicator is placed on top of onoff switch
-        UIActivityIndicatorView *busyView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
+        UIActivityIndicatorView *busyView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
         busyView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin;
         busyView.hidesWhenStopped = YES;
         busyView.center = onoff.center;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -864,7 +864,7 @@
     UIEdgeInsets viewInsets = scrollView.contentInset;
     viewInsets.bottom = bottomInset;
     scrollView.contentInset = viewInsets;
-    scrollView.scrollIndicatorInsets = viewInsets;
+    scrollView.verticalScrollIndicatorInsets = viewInsets;
 }
 
 - (void)hideButtonList:(BOOL)hide {
@@ -1065,7 +1065,7 @@
         UIEdgeInsets tableViewInsets = UIEdgeInsetsZero;
         tableViewInsets.bottom = buttonsViewBgToolbar.frame.size.height;
         moreItemsViewController.tableView.contentInset = tableViewInsets;
-        moreItemsViewController.tableView.scrollIndicatorInsets = tableViewInsets;
+        moreItemsViewController.tableView.verticalScrollIndicatorInsets = tableViewInsets;
         [moreItemsViewController.tableView setContentOffset:CGPointMake(0, - tableViewInsets.top) animated:NO];
         [maskView insertSubview:moreItemsViewController.view aboveSubview:dataList];
     }
@@ -1622,7 +1622,7 @@
         flowLayout.scrollDirection = UICollectionViewScrollDirectionVertical;
         collectionView = [[UICollectionView alloc] initWithFrame:dataList.frame collectionViewLayout:flowLayout];
         collectionView.contentInset = dataList.contentInset;
-        collectionView.scrollIndicatorInsets = dataList.scrollIndicatorInsets;
+        collectionView.verticalScrollIndicatorInsets = dataList.verticalScrollIndicatorInsets;
         collectionView.backgroundColor = UIColor.clearColor;
         collectionView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
         collectionView.delegate = self;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -878,7 +878,7 @@
     UIEdgeInsets viewInsets = scrollView.contentInset;
     viewInsets.bottom = bottomInset;
     scrollView.contentInset = viewInsets;
-    scrollView.scrollIndicatorInsets = viewInsets;
+    scrollView.verticalScrollIndicatorInsets = viewInsets;
 }
 
 - (void)hideButtonList:(BOOL)hide {
@@ -1079,7 +1079,7 @@
         UIEdgeInsets tableViewInsets = UIEdgeInsetsZero;
         tableViewInsets.bottom = buttonsViewBgToolbar.frame.size.height;
         moreItemsViewController.tableView.contentInset = tableViewInsets;
-        moreItemsViewController.tableView.scrollIndicatorInsets = tableViewInsets;
+        moreItemsViewController.tableView.verticalScrollIndicatorInsets = tableViewInsets;
         [moreItemsViewController.tableView setContentOffset:CGPointMake(0, - tableViewInsets.top) animated:NO];
         [maskView insertSubview:moreItemsViewController.view aboveSubview:dataList];
     }
@@ -1636,7 +1636,7 @@
         flowLayout.scrollDirection = UICollectionViewScrollDirectionVertical;
         collectionView = [[UICollectionView alloc] initWithFrame:dataList.frame collectionViewLayout:flowLayout];
         collectionView.contentInset = dataList.contentInset;
-        collectionView.scrollIndicatorInsets = dataList.scrollIndicatorInsets;
+        collectionView.verticalScrollIndicatorInsets = dataList.verticalScrollIndicatorInsets;
         collectionView.backgroundColor = UIColor.clearColor;
         collectionView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
         collectionView.delegate = self;

--- a/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
+++ b/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
@@ -512,7 +512,7 @@ CGPoint center = self.topView.center;
 
 - (CGFloat)screenWidthForOrientation:(BOOL)isLandscape {
     CGSize size = UIScreen.mainScreen.bounds.size;
-    UIApplication *application = UIApplication.sharedApplication;
+    UIStatusBarManager *application = AppDelegate.statusBarManager;
     if (isLandscape) {
         size = CGSizeMake(size.height, size.width);
     }

--- a/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
+++ b/XBMC Remote/ECSlidingViewController/ECSlidingViewController.m
@@ -512,12 +512,12 @@ CGPoint center = self.topView.center;
 
 - (CGFloat)screenWidthForOrientation:(BOOL)isLandscape {
     CGSize size = UIScreen.mainScreen.bounds.size;
-    UIStatusBarManager *application = AppDelegate.statusBarManager;
+    UIStatusBarManager *statusBarManager = AppDelegate.statusBarManager;
     if (isLandscape) {
         size = CGSizeMake(size.height, size.width);
     }
-    if (!application.statusBarHidden) {
-        size.height -= MIN(application.statusBarFrame.size.width, application.statusBarFrame.size.height);
+    if (!statusBarManager.statusBarHidden) {
+        size.height -= MIN(statusBarManager.statusBarFrame.size.width, statusBarManager.statusBarFrame.size.height);
     }
     return size.width;
 }

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -725,7 +725,7 @@
          withParameters:parameters
            onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
                if (error == nil && methodError == nil) {
-                   [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil userInfo:nil];
+                   [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillEnterForegroundNotification object:nil userInfo:nil];
                }
                else {
                    UIAlertController *alertCtrl = [Utilities createAlertOK:LOCALIZED_STR(@"Cannot do that") message:nil];

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -740,7 +740,7 @@
          withParameters:parameters
            onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
                if (error == nil && methodError == nil) {
-                   [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil userInfo:nil];
+                   [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillEnterForegroundNotification object:nil userInfo:nil];
                }
                else {
                    UIAlertController *alertCtrl = [Utilities createAlertOK:LOCALIZED_STR(@"Cannot do that") message:nil];

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -731,7 +731,7 @@
          withParameters:parameters
            onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
                if (error == nil && methodError == nil) {
-                   [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification object:nil userInfo:nil];
+                   [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillEnterForegroundNotification object:nil userInfo:nil];
                }
                else {
                    UIAlertController *alertCtrl = [Utilities createAlertOK:LOCALIZED_STR(@"Cannot do that") message:nil];

--- a/XBMC Remote/Kodi Remote-Info.plist
+++ b/XBMC Remote/Kodi Remote-Info.plist
@@ -61,7 +61,17 @@
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<false/>
 		<key>UISceneConfigurations</key>
-		<dict/>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
 	</dict>
 	<key>UIDesignRequiresCompatibility</key>
 	<true/>

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -203,7 +203,7 @@
 
 - (void)addConnectionStatusToRootView {
     // Add connection status icon to root view of new controller
-    UIView *rootView = UIApplication.sharedApplication.keyWindow.rootViewController.view;
+    UIView *rootView = AppDelegate.keyWindow.rootViewController.view;
     [rootView addSubview:globalConnectionStatus];
 }
 

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -190,7 +190,7 @@
 
 - (void)addConnectionStatusToRootView {
     // Add connection status icon to root view of new controller
-    UIView *rootView = UIApplication.sharedApplication.keyWindow.rootViewController.view;
+    UIView *rootView = AppDelegate.keyWindow.rootViewController.view;
     [rootView addSubview:globalConnectionStatus];
 }
 

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -185,7 +185,7 @@
 
 - (void)addConnectionStatusToRootView {
     // Add connection status icon to root view of new controller
-    UIView *rootView = UIApplication.sharedApplication.keyWindow.rootViewController.view;
+    UIView *rootView = AppDelegate.keyWindow.rootViewController.view;
     [rootView addSubview:globalConnectionStatus];
 }
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2679,12 +2679,12 @@
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleEnterForeground:)
-                                                 name:UIApplicationWillEnterForegroundNotification
+                                                 name:UISceneWillEnterForegroundNotification
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleDidEnterBackground:)
-                                                 name:UIApplicationDidEnterBackgroundNotification
+                                                 name:UISceneDidEnterBackgroundNotification
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2539,12 +2539,12 @@
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleEnterForeground:)
-                                                 name:UIApplicationWillEnterForegroundNotification
+                                                 name:UISceneWillEnterForegroundNotification
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleDidEnterBackground:)
-                                                 name:UIApplicationDidEnterBackgroundNotification
+                                                 name:UISceneDidEnterBackgroundNotification
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2535,12 +2535,12 @@
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleEnterForeground:)
-                                                 name:UIApplicationWillEnterForegroundNotification
+                                                 name:UISceneWillEnterForegroundNotification
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleDidEnterBackground:)
-                                                 name:UIApplicationDidEnterBackgroundNotification
+                                                 name:UISceneDidEnterBackgroundNotification
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self

--- a/XBMC Remote/PosterCell.m
+++ b/XBMC Remote/PosterCell.m
@@ -70,7 +70,7 @@
         
         [self setPosterCellLayout:frame];
 
-        _busyView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
+        _busyView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
         _busyView.hidesWhenStopped = YES;
         _busyView.center = _posterThumbnail.center;
         _busyView.tag = POSTER_CELL_ACTIVTYINDICATOR;

--- a/XBMC Remote/RecentlyAddedCell.m
+++ b/XBMC Remote/RecentlyAddedCell.m
@@ -80,7 +80,7 @@
         
         [self setRecentlyAddedCellLayout:frame];
 
-        _busyView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
+        _busyView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
         _busyView.hidesWhenStopped = YES;
         _busyView.center = _posterThumbnail.center;
         _busyView.tag = RECENTLY_ADDED_CELL_ACTIVTYINDICATOR;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1051,7 +1051,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleDidBecomeActive)
-                                                 name:UIApplicationDidBecomeActiveNotification
+                                                 name:UISceneDidActivateNotification
                                                object:nil];
     
     [self.avCaptureDevice addObserver:self

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1001,7 +1001,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleDidBecomeActive)
-                                                 name:UIApplicationDidBecomeActiveNotification
+                                                 name:UISceneDidActivateNotification
                                                object:nil];
     
     [self.avCaptureDevice addObserver:self

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -998,7 +998,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleDidBecomeActive)
-                                                 name:UIApplicationDidBecomeActiveNotification
+                                                 name:UISceneDidActivateNotification
                                                object:nil];
     
     [self.avCaptureDevice addObserver:self

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -183,7 +183,7 @@
             [[NSNotificationCenter defaultCenter] postNotificationName:@"LeaveFullscreen" object:nil userInfo:nil];
             [[NSNotificationCenter defaultCenter] postNotificationName:@"StackScrollOnScreen" object:nil];
             [[NSNotificationCenter defaultCenter] postNotificationName:@"MainMenuDeselectSection" object:nil userInfo:nil];
-            [UIApplication.sharedApplication.keyWindow.rootViewController dismissViewControllerAnimated:YES completion:nil];
+            [AppDelegate.keyWindow.rootViewController dismissViewControllerAnimated:YES completion:nil];
             detailViewController.view.frame = CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height);
             [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:detailViewController invokeByController:self isStackStartView:YES];
         }

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -177,7 +177,7 @@
             [[NSNotificationCenter defaultCenter] postNotificationName:@"LeaveFullscreen" object:nil userInfo:nil];
             [[NSNotificationCenter defaultCenter] postNotificationName:@"StackScrollOnScreen" object:nil];
             [[NSNotificationCenter defaultCenter] postNotificationName:@"MainMenuDeselectSection" object:nil userInfo:nil];
-            [UIApplication.sharedApplication.keyWindow.rootViewController dismissViewControllerAnimated:YES completion:nil];
+            [AppDelegate.keyWindow.rootViewController dismissViewControllerAnimated:YES completion:nil];
             detailViewController.view.frame = CGRectMake(0, 0, STACKSCROLL_WIDTH, self.view.frame.size.height);
             [AppDelegate.instance.windowController.stackScrollViewController addViewInSlider:detailViewController invokeByController:self isStackStartView:YES];
         }

--- a/XBMC Remote/SDWebImage/SDImageCache.m
+++ b/XBMC Remote/SDWebImage/SDImageCache.m
@@ -141,7 +141,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(backgroundCleanDisk)
-                                                     name:UIApplicationDidEnterBackgroundNotification
+                                                     name:UISceneDidEnterBackgroundNotification
                                                    object:nil];
 #endif
     }

--- a/XBMC Remote/SDWebImage/SDImageCache.m
+++ b/XBMC Remote/SDWebImage/SDImageCache.m
@@ -140,7 +140,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(backgroundCleanDisk)
-                                                     name:UIApplicationDidEnterBackgroundNotification
+                                                     name:UISceneDidEnterBackgroundNotification
                                                    object:nil];
 #endif
     }

--- a/XBMC Remote/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
+++ b/XBMC Remote/SVPullToRefresh/UIScrollView+SVPullToRefresh.m
@@ -130,7 +130,7 @@ static char UIScrollViewPullToRefreshView;
     if (self = [super initWithFrame:frame]) {
         
         // default styling values
-        self.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhite;
+        self.activityIndicatorViewStyle = UIActivityIndicatorViewStyleMedium;
         self.textColor = UIColor.whiteColor;
         self.autoresizingMask = UIViewAutoresizingFlexibleWidth;
         self.state = SVPullToRefreshStateStopped;
@@ -312,7 +312,7 @@ static char UIScrollViewPullToRefreshView;
 
 - (UIActivityIndicatorView*)activityIndicatorView {
     if (!_activityIndicatorView) {
-        _activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
+        _activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
         _activityIndicatorView.hidesWhenStopped = YES;
         [self addSubview:_activityIndicatorView];
     }

--- a/XBMC Remote/SceneDelegate.h
+++ b/XBMC Remote/SceneDelegate.h
@@ -8,7 +8,10 @@
 
 @import UIKit;
 
-@interface SceneDelegate : UIResponder <UIWindowSceneDelegate> {}
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate> {
+    UIApplicationShortcutItem *launchShortcutItem;
+    id launchURLContexts;
+}
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/XBMC Remote/SceneDelegate.h
+++ b/XBMC Remote/SceneDelegate.h
@@ -1,0 +1,15 @@
+//
+//  SceneDelegate.h
+//  Kodi Remote
+//
+//  Created by Buschmann on 24.05.25.
+//  Copyright © 2025 Team Kodi. All rights reserved.
+//
+
+@import UIKit;
+
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate> {}
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/XBMC Remote/SceneDelegate.h
+++ b/XBMC Remote/SceneDelegate.h
@@ -10,7 +10,7 @@
 
 @interface SceneDelegate : UIResponder <UIWindowSceneDelegate> {
     UIApplicationShortcutItem *launchShortcutItem;
-    id launchURLContexts;
+    NSSet<UIOpenURLContext*>* launchURLContexts;
 }
 
 @property (strong, nonatomic) UIWindow *window;

--- a/XBMC Remote/SceneDelegate.m
+++ b/XBMC Remote/SceneDelegate.m
@@ -8,6 +8,8 @@
 
 #import "SceneDelegate.h"
 #import "AppDelegate.h"
+#import "Utilities.h"
+#import "Kodi_Remote-Swift.h"
 
 @implementation SceneDelegate
 
@@ -22,6 +24,34 @@
     
     // Set interface style for window
     [self setInterfaceStyleFromUserDefaults];
+}
+
+- (void)sceneWillEnterForeground:(UIScene*)scene {
+    [Utilities setIdleTimerFromUserDefaults];
+}
+
+- (void)sceneDidBecomeActive:(UIScene*)scene {
+    // Trigger Local Network Privacy Alert once after app launch
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        LocalNetworkAlertClass *localNetworkAlert = [LocalNetworkAlertClass new];
+        [localNetworkAlert triggerLocalNetworkPrivacyAlert];
+    });
+}
+
+- (void)sceneDidEnterBackground:(UIScene*)scene {
+    // Add the server description and address to shortcutItems, which is shown when longpressing the app icon.
+    NSMutableArray *items = [[NSMutableArray alloc] initWithCapacity:AppDelegate.instance.arrayServerList.count];
+    for (NSDictionary *server in AppDelegate.instance.arrayServerList) {
+        UIApplicationShortcutIcon *icon = [UIApplicationShortcutIcon iconWithType:UIApplicationShortcutIconTypeFavorite];
+        UIApplicationShortcutItem *shortcut = [[UIApplicationShortcutItem alloc] initWithType:@"ConnectServer"
+                                                                               localizedTitle:server[@"serverDescription"]
+                                                                            localizedSubtitle:server[@"serverIP"]
+                                                                                         icon:icon
+                                                                                     userInfo:nil];
+        [items addObject:shortcut];
+    }
+    UIApplication.sharedApplication.shortcutItems = items;
 }
 
 - (void)setInterfaceStyleFromUserDefaults {

--- a/XBMC Remote/SceneDelegate.m
+++ b/XBMC Remote/SceneDelegate.m
@@ -24,6 +24,10 @@
     
     // Set interface style for window
     [self setInterfaceStyleFromUserDefaults];
+    
+    // Store launch options
+    launchShortcutItem = connectionOptions.shortcutItem;
+    launchURLContexts = connectionOptions.URLContexts;
 }
 
 - (void)sceneWillEnterForeground:(UIScene*)scene {
@@ -37,6 +41,17 @@
         LocalNetworkAlertClass *localNetworkAlert = [LocalNetworkAlertClass new];
         [localNetworkAlert triggerLocalNetworkPrivacyAlert];
     });
+    
+    // As per Apple documentation
+    // https://developer.apple.com/documentation/uikit/menus_and_shortcuts/add_home_screen_quick_actions
+    if (launchShortcutItem) {
+        [self windowScene:(UIWindowScene*)scene performActionForShortcutItem:launchShortcutItem completionHandler:nil];
+        launchShortcutItem = nil;
+    }
+    if (launchURLContexts) {
+        [self scene:scene openURLContexts:launchURLContexts];
+        launchURLContexts = nil;
+    }
 }
 
 - (void)sceneDidEnterBackground:(UIScene*)scene {
@@ -52,6 +67,54 @@
         [items addObject:shortcut];
     }
     UIApplication.sharedApplication.shortcutItems = items;
+}
+
+- (void)windowScene:(UIWindowScene*)windowScene performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem completionHandler:(void(^)(BOOL))completionHandler {
+    // Use shortcut title (= server description) to map to server list and connect the server.
+    [self connectToServerFromList:shortcutItem.localizedTitle];
+}
+
+- (void)scene:(UIScene*)scene openURLContexts:(NSSet<UIOpenURLContext*>*)URLContexts {
+    // Use URL host to map to server list and connect the server.
+    UIOpenURLContext *urlContext = URLContexts.allObjects.firstObject;
+    NSURL *url = urlContext.URL;
+    [self connectToServerFromList:url.host.stringByRemovingPercentEncoding];
+}
+
+#pragma mark - Helper
+
+- (BOOL)connectToServerFromList:(NSString*)host {
+    if (!host.length) {
+        return NO;
+    }
+    
+    // Host name needs ".local." at the end
+    if ([host hasSuffix:@".local"]) {
+        host = [host stringByAppendingString:@"."];
+    }
+    
+    // Try to map server name or IP address to the list of Kodi servers
+    NSInteger index = [AppDelegate.instance.arrayServerList indexOfObjectPassingTest:^BOOL(NSDictionary *obj, NSUInteger idx, BOOL *stop) {
+        return [host isEqualToString:obj[@"serverDescription"]] || [host isEqualToString:obj[@"serverIP"]];
+    }];
+    
+    // We want to connect to the desired server only. If this is not present, disconnect from any active server.
+    BOOL result = NO;
+    NSIndexPath *serverIndexPath;
+    NSDictionary *params;
+    if (index != NSNotFound) {
+        serverIndexPath = [NSIndexPath indexPathForRow:index inSection:0];
+        params = @{@"index": @(index)};
+        result = YES;
+    }
+    
+    // Case 1: App just starts. Set the last active server before readKodiServerParameters is called
+    [Utilities saveLastServerIndex:serverIndexPath];
+    
+    // Case 2: App already runs. Send a notification to select the server via its index.
+    [NSNotificationCenter.defaultCenter postNotificationName:@"SelectKodiServer" object:nil userInfo:params];
+    
+    return result;
 }
 
 - (void)setInterfaceStyleFromUserDefaults {

--- a/XBMC Remote/SceneDelegate.m
+++ b/XBMC Remote/SceneDelegate.m
@@ -1,0 +1,44 @@
+//
+//  SceneDelegate.m
+//  Kodi Remote
+//
+//  Created by Buschmann on 24.05.25.
+//  Copyright © 2025 Team Kodi. All rights reserved.
+//
+
+#import "SceneDelegate.h"
+#import "AppDelegate.h"
+
+@implementation SceneDelegate
+
+@synthesize window;
+
+- (void)scene:(UIScene*)scene willConnectToSession:(UISceneSession*)session options:(UISceneConnectionOptions*)connectionOptions {
+    // Create window using AppDelegate's controllers
+    window = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+    window.windowScene = (UIWindowScene*)scene;
+    window.rootViewController = AppDelegate.instance.appRootController;
+    [window makeKeyAndVisible];
+    
+    // Set interface style for window
+    [self setInterfaceStyleFromUserDefaults];
+}
+
+- (void)setInterfaceStyleFromUserDefaults {
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    NSString *mode = [userDefaults stringForKey:@"theme_mode"];
+    if (@available(iOS 13.0, *)) {
+        UIUserInterfaceStyle style = UIUserInterfaceStyleUnspecified;
+        if (mode.length) {
+            if ([mode isEqualToString:@"dark_mode"]) {
+                style = UIUserInterfaceStyleDark;
+            }
+            else if ([mode isEqualToString:@"light_mode"]) {
+                style = UIUserInterfaceStyleLight;
+            }
+        }
+        window.overrideUserInterfaceStyle = style;
+    }
+}
+
+@end

--- a/XBMC Remote/SceneDelegate.m
+++ b/XBMC Remote/SceneDelegate.m
@@ -45,7 +45,7 @@
     // As per Apple documentation
     // https://developer.apple.com/documentation/uikit/menus_and_shortcuts/add_home_screen_quick_actions
     if (launchShortcutItem) {
-        [self windowScene:(UIWindowScene*)scene performActionForShortcutItem:launchShortcutItem completionHandler:nil];
+        [self windowScene:(UIWindowScene*)scene performActionForShortcutItem:launchShortcutItem completionHandler:^(BOOL finished) {}];
         launchShortcutItem = nil;
     }
     if (launchURLContexts) {

--- a/XBMC Remote/SceneDelegate.m
+++ b/XBMC Remote/SceneDelegate.m
@@ -31,6 +31,7 @@
 }
 
 - (void)sceneWillEnterForeground:(UIScene*)scene {
+    [self setInterfaceStyleFromUserDefaults];
     [Utilities setIdleTimerFromUserDefaults];
 }
 

--- a/XBMC Remote/SceneDelegate.m
+++ b/XBMC Remote/SceneDelegate.m
@@ -72,7 +72,7 @@
 
 - (void)windowScene:(UIWindowScene*)windowScene performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem completionHandler:(void(^)(BOOL))completionHandler {
     // Use shortcut title (= server description) to map to server list and connect the server.
-    [self connectToServerFromList:shortcutItem.localizedTitle];
+    completionHandler([self connectToServerFromList:shortcutItem.localizedTitle]);
 }
 
 - (void)scene:(UIScene*)scene openURLContexts:(NSSet<UIOpenURLContext*>*)URLContexts {

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -62,7 +62,7 @@
         imageBackground.frame = frame;
         [self.view addSubview:imageBackground];
         
-        activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
+        activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
         activityIndicator.center = CGPointMake(frame.size.width / 2, frame.size.height / 2);
         activityIndicator.hidesWhenStopped = YES;
         [self.view addSubview:activityIndicator];

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -58,7 +58,7 @@
         imageBackground.frame = frame;
         [self.view addSubview:imageBackground];
         
-        activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
+        activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
         activityIndicator.center = CGPointMake(frame.size.width / 2, frame.size.height / 2);
         activityIndicator.hidesWhenStopped = YES;
         [self.view addSubview:activityIndicator];

--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -29,12 +29,12 @@ NSInputStream *inStream;
         
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(handleDidBecomeActive:)
-                                                     name:UIApplicationDidBecomeActiveNotification
+                                                     name:UISceneDidActivateNotification
                                                    object:nil];
         
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(handleDidEnterBackground:)
-                                                     name:UIApplicationDidEnterBackgroundNotification
+                                                     name:UISceneDidEnterBackgroundNotification
                                                    object:nil];
         
         [[NSNotificationCenter defaultCenter] addObserver:self

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -129,5 +129,6 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (void)saveLastServerIndex:(NSIndexPath*)indexPath;
 + (void)readKodiServerParameters;
 + (void)resetKodiServerParameters;
++ (void)setIdleTimerFromUserDefaults;
 
 @end

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -104,5 +104,6 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (void)saveLastServerIndex:(NSIndexPath*)indexPath;
 + (void)readKodiServerParameters;
 + (void)resetKodiServerParameters;
++ (void)setIdleTimerFromUserDefaults;
 
 @end

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -103,5 +103,6 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (void)saveLastServerIndex:(NSIndexPath*)indexPath;
 + (void)readKodiServerParameters;
 + (void)resetKodiServerParameters;
++ (void)setIdleTimerFromUserDefaults;
 
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1455,4 +1455,8 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerHasChanged" object:nil];
 }
 
++ (void)setIdleTimerFromUserDefaults {
+    UIApplication.sharedApplication.idleTimerDisabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"lockscreen_preference"];
+}
+
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -634,7 +634,7 @@
     svc.delegate = fromctrl;
     if (IS_IPAD) {
         // On iPad presenting from the active ViewController results in blank screen
-        ctrl = UIApplication.sharedApplication.keyWindow.rootViewController;
+        ctrl = AppDelegate.keyWindow.rootViewController;
     }
     if (![svc isBeingPresented]) {
         if (ctrl.presentedViewController) {
@@ -955,17 +955,17 @@
 }
 
 + (CGFloat)getBottomPadding {
-    CGFloat bottomPadding = UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom;
+    CGFloat bottomPadding = AppDelegate.keyWindow.safeAreaInsets.bottom;
     return bottomPadding;
 }
 
 + (CGFloat)getTopPadding {
-    CGFloat topPadding = UIApplication.sharedApplication.keyWindow.safeAreaInsets.top;
+    CGFloat topPadding = AppDelegate.keyWindow.safeAreaInsets.top;
     return topPadding;
 }
 
 + (CGFloat)getTopPaddingWithNavBar:(UINavigationController*)navCtrl {
-    CGFloat topPadding = UIApplication.sharedApplication.statusBarFrame.size.height + navCtrl.navigationBar.frame.size.height;
+    CGFloat topPadding = AppDelegate.statusBarManager.statusBarFrame.size.height + navCtrl.navigationBar.frame.size.height;
     return topPadding;
 }
 
@@ -1378,7 +1378,7 @@
 }
 
 + (UIViewController*)topMostControllerIgnoringClass:(Class)ignoredClass {
-    UIViewController *topController = UIApplication.sharedApplication.keyWindow.rootViewController;
+    UIViewController *topController = AppDelegate.keyWindow.rootViewController;
     while (topController.presentedViewController) {
         if ([topController.presentedViewController isKindOfClass:ignoredClass]) {
             // We want to ignore any ignoredClass being the top most controller.

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -751,17 +751,17 @@
 }
 
 + (CGFloat)getBottomPadding {
-    CGFloat bottomPadding = UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom;
+    CGFloat bottomPadding = AppDelegate.keyWindow.safeAreaInsets.bottom;
     return bottomPadding;
 }
 
 + (CGFloat)getTopPadding {
-    CGFloat topPadding = UIApplication.sharedApplication.keyWindow.safeAreaInsets.top;
+    CGFloat topPadding = AppDelegate.keyWindow.safeAreaInsets.top;
     return topPadding;
 }
 
 + (CGFloat)getTopPaddingWithNavBar:(UINavigationController*)navCtrl {
-    CGFloat topPadding = UIApplication.sharedApplication.statusBarFrame.size.height + navCtrl.navigationBar.frame.size.height;
+    CGFloat topPadding = AppDelegate.statusBarManager.statusBarFrame.size.height + navCtrl.navigationBar.frame.size.height;
     return topPadding;
 }
 
@@ -1103,7 +1103,7 @@
 }
 
 + (UIViewController*)topMostControllerIgnoringClass:(Class)ignoredClass {
-    UIViewController *topController = UIApplication.sharedApplication.keyWindow.rootViewController;
+    UIViewController *topController = AppDelegate.keyWindow.rootViewController;
     while (topController.presentedViewController) {
         if ([topController.presentedViewController isKindOfClass:ignoredClass]) {
             // We want to ignore any ignoredClass being the top most controller.

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1180,4 +1180,8 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerHasChanged" object:nil];
 }
 
++ (void)setIdleTimerFromUserDefaults {
+    UIApplication.sharedApplication.idleTimerDisabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"lockscreen_preference"];
+}
+
 @end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -751,17 +751,17 @@
 }
 
 + (CGFloat)getBottomPadding {
-    CGFloat bottomPadding = UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom;
+    CGFloat bottomPadding = AppDelegate.keyWindow.safeAreaInsets.bottom;
     return bottomPadding;
 }
 
 + (CGFloat)getTopPadding {
-    CGFloat topPadding = UIApplication.sharedApplication.keyWindow.safeAreaInsets.top;
+    CGFloat topPadding = AppDelegate.keyWindow.safeAreaInsets.top;
     return topPadding;
 }
 
 + (CGFloat)getTopPaddingWithNavBar:(UINavigationController*)navCtrl {
-    CGFloat topPadding = UIApplication.sharedApplication.statusBarFrame.size.height + navCtrl.navigationBar.frame.size.height;
+    CGFloat topPadding = AppDelegate.statusBarManager.statusBarFrame.size.height + navCtrl.navigationBar.frame.size.height;
     return topPadding;
 }
 
@@ -1096,7 +1096,7 @@
 }
 
 + (UIViewController*)topMostControllerIgnoringClass:(Class)ignoredClass {
-    UIViewController *topController = UIApplication.sharedApplication.keyWindow.rootViewController;
+    UIViewController *topController = AppDelegate.keyWindow.rootViewController;
     while (topController.presentedViewController) {
         if ([topController.presentedViewController isKindOfClass:ignoredClass]) {
             // We want to ignore any ignoredClass being the top most controller.

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1173,4 +1173,8 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerHasChanged" object:nil];
 }
 
++ (void)setIdleTimerFromUserDefaults {
+    UIApplication.sharedApplication.idleTimerDisabled = [[NSUserDefaults standardUserDefaults] boolForKey:@"lockscreen_preference"];
+}
+
 @end

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -147,7 +147,7 @@
     RemoteController *remoteController = [[RemoteController alloc] initWithNibName:@"RemoteController" bundle:nil];
     remoteController.modalPresentationStyle = UIModalPresentationFormSheet;
     remoteController.preferredContentSize = remoteController.view.frame.size;
-    [UIApplication.sharedApplication.keyWindow.rootViewController presentViewController:remoteController animated:YES completion:nil];
+    [AppDelegate.keyWindow.rootViewController presentViewController:remoteController animated:YES completion:nil];
 }
 
 - (void)toggleInfoView {

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -138,12 +138,12 @@
         
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(handleDidBecomeActive:)
-                                                     name:UIApplicationDidBecomeActiveNotification
+                                                     name:UISceneDidActivateNotification
                                                    object:nil];
         
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(handleDidEnterBackground:)
-                                                     name:UIApplicationDidEnterBackgroundNotification
+                                                     name:UISceneDidEnterBackgroundNotification
                                                    object:nil];
     }
     return self;

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -115,12 +115,12 @@
         
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(handleDidBecomeActive:)
-                                                     name:UIApplicationDidBecomeActiveNotification
+                                                     name:UISceneDidActivateNotification
                                                    object:nil];
         
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(handleDidEnterBackground:)
-                                                     name:UIApplicationDidEnterBackgroundNotification
+                                                     name:UISceneDidEnterBackgroundNotification
                                                    object:nil];
     }
     return self;

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -114,12 +114,12 @@
         
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(handleDidBecomeActive:)
-                                                     name:UIApplicationDidBecomeActiveNotification
+                                                     name:UISceneDidActivateNotification
                                                    object:nil];
         
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(handleDidEnterBackground:)
-                                                     name:UIApplicationDidEnterBackgroundNotification
+                                                     name:UISceneDidEnterBackgroundNotification
                                                    object:nil];
     }
     return self;

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -191,7 +191,7 @@
             RemoteController *remoteController = [[RemoteController alloc] initWithNibName:@"RemoteController" bundle:nil];
             remoteController.modalPresentationStyle = UIModalPresentationFormSheet;
             remoteController.preferredContentSize = remoteController.view.frame.size;
-            [UIApplication.sharedApplication.keyWindow.rootViewController presentViewController:remoteController animated:YES completion:nil];
+            [AppDelegate.keyWindow.rootViewController presentViewController:remoteController animated:YES completion:nil];
             if (IS_IPAD) {
                 if (lastSelected != -1) {
                     // Restore the selected item and unselect remote again (remote is only a popover)

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -189,7 +189,7 @@
             RemoteController *remoteController = [[RemoteController alloc] initWithNibName:@"RemoteController" bundle:nil];
             remoteController.modalPresentationStyle = UIModalPresentationFormSheet;
             remoteController.preferredContentSize = remoteController.view.frame.size;
-            [UIApplication.sharedApplication.keyWindow.rootViewController presentViewController:remoteController animated:YES completion:nil];
+            [AppDelegate.keyWindow.rootViewController presentViewController:remoteController animated:YES completion:nil];
             if (IS_IPAD) {
                 if (lastSelected != -1) {
                     // Restore the selected item and unselect remote again (remote is only a popover)

--- a/XBMC Remote/tcpJSONRPC.m
+++ b/XBMC Remote/tcpJSONRPC.m
@@ -29,12 +29,12 @@ NSInputStream *inStream;
         
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(handleDidBecomeActive:)
-                                                     name:UIApplicationDidBecomeActiveNotification
+                                                     name:UISceneDidActivateNotification
                                                    object:nil];
         
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(handleDidEnterBackground:)
-                                                     name:UIApplicationDidEnterBackgroundNotification
+                                                     name:UISceneDidEnterBackgroundNotification
                                                    object:nil];
         
         [[NSNotificationCenter defaultCenter] addObserver:self


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1267.

This PR migrates the app to `UIScene` by introducing `SceneDelegate` and adapting to `UIScene` lifecycle. 

After having a deeper look into it, I feel it is too complicated to maintain both `UIWindow` and `UIScene` in parallel, so this can only be merged when the minimum supported iOS version is changed to 13.0 or higher.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Migrate to UIScene