### PR TITLE
Maintenance: Introduce non-localized IDs for "Start in view"

### DIFF
--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -301,21 +301,21 @@
 			</array>
 			<key>Values</key>
 			<array>
-				<string>Main Menu</string>
-				<string>Music</string>
-				<string>Movies</string>
-				<string>Videos</string>
-				<string>TV Shows</string>
-				<string>Pictures</string>
-				<string>Live TV</string>
-				<string>Radio</string>
-				<string>Favourites</string>
-				<string>Now Playing</string>
-				<string>Remote Control</string>
-				<string>Global Search</string>
-				<string>Files</string>
-				<string>Add-ons</string>
-				<string>Kodi Settings</string>
+				<string>start_menu_main</string>
+				<string>start_menu_music</string>
+				<string>start_menu_movies</string>
+				<string>start_menu_videos</string>
+				<string>start_menu_tvshows</string>
+				<string>start_menu_pictures</string>
+				<string>start_menu_livetv</string>
+				<string>start_menu_radio</string>
+				<string>start_menu_favourites</string>
+				<string>start_menu_nowplaying</string>
+				<string>start_menu_remote</string>
+				<string>start_menu_search</string>
+				<string>start_menu_files</string>
+				<string>start_menu_addons</string>
+				<string>start_menu_settings</string>
 			</array>
 		</dict>
 		<dict>

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1141,16 +1141,33 @@
 + (NSIndexPath*)getIndexPathForDefaultController:(NSArray*)menuItems {
     // Read the default controller from the app settings
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    NSString *label = [userDefaults stringForKey:@"start_menu"];
+    NSString *startId = [userDefaults stringForKey:@"start_menu"];
+    
+    // Map startId to MenuItemType (default = TypeNone = 0)
+    NSDictionary *defaultMenus = @{
+        @"start_menu_main": @(TypeNone),
+        @"start_menu_music": @(TypeMusic),
+        @"start_menu_movies": @(TypeMovies),
+        @"start_menu_videos": @(TypeVideos),
+        @"start_menu_tvshows": @(TypeTvShows),
+        @"start_menu_pictures": @(TypePictures),
+        @"start_menu_livetv": @(TypeLiveTv),
+        @"start_menu_radio": @(TypeRadio),
+        @"start_menu_favourites": @(TypeFavourites),
+        @"start_menu_nowplaying": @(TypeNowPlaying),
+        @"start_menu_remote": @(TypeRemote),
+        @"start_menu_search": @(TypeGlobalSearch),
+        @"start_menu_files": @(TypeFiles),
+        @"start_menu_addons": @(TypeAddons),
+        @"start_menu_settings": @(TypeSettings),
+    };
+    MenuItemType startMenuType = [defaultMenus[startId] intValue];
     
     // Search for the index path of the desired controller
-    for (int row = 0; row < menuItems.count; ++row) {
-        mainMenu *item = menuItems[row];
-        if ([item.mainLabel isEqualToString:LOCALIZED_STR(label)]) {
-            return [NSIndexPath indexPathForRow:row inSection:0];
-        }
-    }
-    return nil;
+    NSUInteger index = [menuItems indexOfObjectPassingTest:^BOOL(mainMenu *item, NSUInteger idx, BOOL *stop) {
+      return item.type == startMenuType;
+    }];
+    return index != NSNotFound ? [NSIndexPath indexPathForRow:index inSection:0] : nil;
 }
 
 + (void)enableDefaultController:(id<UITableViewDelegate>)viewController tableView:(UITableView*)tableView menuItems:(NSArray*)menuItems {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Allows to remove comparison of localized strings to find the start menu. Needs mapping of non-localized ID to enum, followed by searching menu with desired type. This makes the implementation independent of translation differences which can happen between `Root` and `Localizable.strings`. 

Requires users to again set "Start in view" in app settings. If new app version is installed on top of old app settings, the app will start with main menu (default).

Needs to have both #1343 and #1344 merged and then rebased.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Introduce non-localized IDs for "Start in view"