### PR TITLE
Rework GlobalSearch

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -100,7 +100,7 @@
 @property (nonatomic, strong) mainMenu *playlistMusicVideos;
 @property (nonatomic, strong) mainMenu *playlistTvShows;
 @property (nonatomic, strong) mainMenu *playlistPVR;
-@property (nonatomic, strong) NSArray *globalSearchMenuLookup;
+@property (nonatomic, strong) MainMenuGlobalSearchLookup *globalSearchLookup;
 @property (nonatomic, assign) BOOL serverOnLine;
 @property (nonatomic, assign) BOOL serverTCPConnectionOpen;
 @property (nonatomic, assign) int serverVersion;

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -37,7 +37,7 @@
 @synthesize playlistMusicVideos;
 @synthesize playlistTvShows;
 @synthesize playlistPVR;
-@synthesize globalSearchMenuLookup;
+@synthesize globalSearchLookup;
 @synthesize serverName;
 
 + (AppDelegate*)instance {

--- a/XBMC Remote/mainMenu.h
+++ b/XBMC Remote/mainMenu.h
@@ -78,3 +78,32 @@ typedef NS_ENUM(NSInteger, ViewModes) {
 + (NSArray*)action_album;
 
 @end
+
+@interface LookupItem : NSObject
+
+- (instancetype)initWithPath:(mainMenu*)path label:(NSString*)label icon:(NSString*)icon itemId:(NSString*)itemId;
+
+@property (nonatomic, copy) mainMenu *menuPath;
+@property (nonatomic, assign) NSInteger menuTab;
+@property (nonatomic, copy) NSString *menuLabel;
+@property (nonatomic, copy) NSString *menuIcon;
+@property (nonatomic, copy) NSString *itemId;
+
+@end
+
+
+@interface MainMenuGlobalSearchLookup : NSObject {
+    NSArray *lookupTable;
+}
+
+- (instancetype)initWithConfiguration:(NSArray*)configTable;
+- (NSUInteger)getLookupIndexForItemId:(NSString*)itemid;
+- (NSString*)getThumbForItem:(NSDictionary*)item;
+- (LookupItem*)getLookupForItem:(id)item;
+- (mainMenu*)getMenuForItem:(id)item;
+- (NSInteger)getTabForItem:(id)item;
+- (mainMenu*)getMenuForIndex:(int)index;
+- (NSInteger)getTabForIndex:(int)index;
+- (NSString*)getLongNameForIndex:(int)index;
+
+@end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Implements a feature request brought up in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3244608#pid3244608).

Adds episodes to Global Search. 

While doing this, it became clear that adding / changing the Global Search items is hard to maintain as there are several lookups happening and the order of items in `globalSearchMenuLookup` must be taken into account when updating the macros which are used to access the lookup table. Therefore, the whole lookup is reworked and does programmatically build the required tables which then will be searched via `indexOfObjectPassingTest` to gather the desired index for further processing. From now on, any change in the Global Search configuration is just a 1-liner in the `mainMenu` class.

Screenshots:
<img width="464" height="504" alt="Bildschirmfoto 2025-10-31 um 20 50 46" src="https://github.com/user-attachments/assets/44ac2b97-de04-4ffa-accc-35ecbb056741" />


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Feature: Add episodes to Global Search
Mainteance: Rework GlobalSearch lookup for robustness and easier maintenance