### PR TITLE
Maintenance: Ensure custom button array holds mutable items

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -324,10 +324,8 @@
         title.text = alertCtrl.textFields[0].text;
         
         customButton *arrayButtons = [customButton new];
-        if ([arrayButtons.buttons[indexPath.row] respondsToSelector:@selector(setObject:forKey:)]) {
-            arrayButtons.buttons[indexPath.row][@"label"] = alertCtrl.textFields[0].text;
-            [arrayButtons saveData];
-        }
+        arrayButtons.buttons[indexPath.row][@"label"] = alertCtrl.textFields[0].text;
+        [arrayButtons saveData];
     }];
     UIAlertAction *cancelButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:nil];
     [alertCtrl addAction:updateButton];

--- a/XBMC Remote/customButton.h
+++ b/XBMC Remote/customButton.h
@@ -12,7 +12,6 @@
 
 @property (nonatomic, strong) NSMutableArray *buttons;
 
-- (void)loadData;
 - (void)saveData;
 
 @end

--- a/XBMC Remote/customButton.m
+++ b/XBMC Remote/customButton.m
@@ -32,12 +32,14 @@
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *filename = [NSString stringWithFormat:@"customButtons_%@.dat", [self getServerKey]];
     NSMutableArray *tempArray = [Utilities unarchivePath:paths[0] file:filename];
-    if (tempArray) {
-        [self setButtons:tempArray];
+    
+    // Make sure the objects in the button array are mutable. The user might edit them.
+    NSMutableArray *buttonArray = [[NSMutableArray alloc] initWithCapacity:tempArray.count];
+    for (id object in tempArray) {
+        id mutableObject = [object mutableCopy];
+        [buttonArray addObject:mutableObject];
     }
-    else {
-        buttons = [NSMutableArray new];
-    }
+    buttons = buttonArray;
 }
 
 - (void)saveData {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR ensures the custom button array `buttons`  in `customButton` holds mutable items. This allows to remove a `respondsToSelector` check.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Ensure custom button array holds mutable items