### PR TITLE
Bugfix: Correct vertical position of custom button icon

### DIFF
--- a/XBMC Remote/CustomButtonCell.m
+++ b/XBMC Remote/CustomButtonCell.m
@@ -42,7 +42,7 @@
         CGFloat iconSize = CGRectGetHeight(self.onoffSwitch.frame);
         UIImageView *icon = [UIImageView new];
         icon.frame = CGRectMake(CGRectGetWidth(self.contentView.frame) - (CGRectGetWidth(self.onoffSwitch.frame) + iconSize) / 2 - CUSTOM_BUTTON_ITEM_SPACING,
-                                (CGRectGetHeight(self.contentView.frame) - iconSize) / 2,
+                                (CUSTOM_BUTTON_ITEM_HEIGHT - iconSize) / 2,
                                 iconSize,
                                 iconSize);
         icon.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The custom button icon is placed too high within the cell. This is fixed by simply using the cell's correct height `CUSTOM_BUTTON_ITEM_HEIGHT`.

Screenshot:
<img width="612" height="183" alt="Bildschirmfoto 2025-11-03 um 08 03 32" src="https://github.com/user-attachments/assets/5f79166b-ce7c-48b0-b15a-153125a848e7" />
_left = before, right = after_

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct vertical position of custom button icon