### PR TITLE
Improvement: iPad custom buttons view with same size as remote itself

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1259,7 +1259,7 @@
 
 - (void)enterCustomButtonsIPad {
     RightMenuViewController *rightMenuViewController = [[RightMenuViewController alloc] initWithNibName:@"RightMenuViewController" bundle:nil];
-    rightMenuViewController.modalPresentationStyle = UIModalPresentationFormSheet;
+    rightMenuViewController.modalPresentationStyle = UIModalPresentationCurrentContext;
     rightMenuViewController.view.frame = self.view.frame;
     [self presentViewController:rightMenuViewController animated:YES completion:nil];
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Use `UIModalPresentationCurrentContext` for custom button view on iPad. This makes the view use the same dimensions as the parent remote view.

Screenshots (left = before, right = after):
<img width="841" height="399" alt="Bildschirmfoto 2025-11-08 um 15 12 04" src="https://github.com/user-attachments/assets/05a61fcb-d7cf-4805-bf98-bfe6f074b521" />

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: iPad custom buttons view with same size as remote itself