### PR TITLE
Bugfixes to main menu configuration

### DIFF
--- a/XBMC Remote/mainMenu.m
+++ b/XBMC Remote/mainMenu.m
@@ -6172,6 +6172,54 @@
     menu_Addons.subItem.rowHeight = SETTINGS_ROW_HEIGHT;
     menu_Addons.subItem.thumbWidth = SETTINGS_THUMB_WIDTH;
     
+    menu_Addons.subItem.subItem = [mainMenu new];
+    menu_Addons.subItem.subItem.mainMethod = [@[
+        @{},
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+        @{
+            @"method": @"Files.GetDirectory",
+        },
+    ] mutableCopy];
+    
+    menu_Addons.subItem.subItem.mainParameters = [@[
+        @{},
+        @{
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
+        @{
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
+        @{
+            @"rowHeight": @FILEMODE_ROW_HEIGHT,
+            @"thumbWidth": @FILEMODE_THUMB_WIDTH,
+        },
+    ] mutableCopy];
+    
+    menu_Addons.subItem.subItem.mainFields = @[
+        @{},
+        @{},
+        @{},
+        @{},
+    ];
+    
+    menu_Addons.subItem.subItem.enableSection = NO;
+    menu_Addons.subItem.subItem.rowHeight = SETTINGS_ROW_HEIGHT;
+    menu_Addons.subItem.subItem.thumbWidth = SETTINGS_ROW_HEIGHT;
+    menu_Addons.subItem.subItem.defaultThumb = @"nocover_filemode";
+    menu_Addons.subItem.subItem.sheetActions = @[
+        @[],
+        @[],
+        @[],
+        @[],
+    ];
+    
 #pragma mark - Kodi Settings
     __auto_type menu_Settings = [mainMenu new];
     menu_Settings.mainLabel = LOCALIZED_STR(@"XBMC Settings");


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
When browsing the tree structure of add-ons via the "Add-ons" main menu, the deepest level was not listing results, but playing the first item, e.g. Add-ons > Video Add-ons > Youtube > History.  To fix this, the next level `mainMethod` must be defined. Also fix the label for Pictures Add-ons.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix browsing "Add-ons" tree structure (e.g. Video Add-ons > Youtube > History)
Bugfix: Fix label for "Pictures Add-ons"