### PR TITLE
Add localization for new "Volume control" setting

### DIFF
--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -47,3 +47,6 @@
 "Kodi Settings" = "Kodi Settings";
 "Main Menu changes needs app restart" = "Main Menu changes needs app restart";
 "Episode identifier" = "Episode identifier";
+"Volume control" = "Volume control";
+"CEC support via volume buttons" = "CEC support via volume buttons";
+"The app controls volume via buttons and a slider. The slider will always change the Kodi internal volume level. The buttons allow to control AV equipment's volume level via CEC, if this mode is enabled and Kodi identified a compatible device. The CEC functionality is embedded within Kodi itself." = "The app controls volume via buttons and a slider. The slider will always change the Kodi internal volume level. The buttons allow to control AV equipment's volume level via CEC, if this mode is enabled and Kodi identified a compatible device. The CEC functionality is embedded within Kodi itself.";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Adds the localization for the new "Volume control" setting group.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Add localization for new "Volume control" setting