### PR TITLE
Minor rework in StackViewController

### DIFF
--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -626,10 +626,6 @@
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     BOOL isViewOutOfScreen = NO;
-    CGFloat posX = SLIDE_VIEWS_START_X_POS;
-    if (viewControllersStack.count == 1) {
-        posX = slideViews.subviews[0].frame.origin.x;
-    }
     for (UIViewController *subController in viewControllersStack) {
         // If we have a view in fullscreen, keep it fullscreen
         if (fullscreenView != nil && [fullscreenView isEqual:subController.view]) {
@@ -661,7 +657,7 @@
             if (viewAtLeft2 == nil) {
                 if (viewAtRight == nil) {
                     [self changeFrame:subController.view
-                              originX:posX
+                              originX:SLIDE_VIEWS_START_X_POS
                                height:self.view.frame.size.height - bottomPadding];
                 }
                 else {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This change just does some minor refactoring to iPad's `StackViewController` which was triggered by working on introduction of frame helper extensions for `UIView`.

1. There is no need to deal with `viewAtRight` in `viewWillTransitionToSize` as anyway all views will be processed when looping through `viewControllersStack`.
2. `isViewOutOfScreen == YES` is the rare case. So, check for this in an `else if` condition and handle the common case in the `else` condition.
3. Use `CGRectGetMaxX`
4. In case only single view is rotated, the origin will always be placed at `posX = SLIDE_VIEWS_START_X_POS`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Minor rework in StackViewController