### PR TITLE
Bugfix: Remove NowPlaying background in case no artwork was found

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -526,9 +526,9 @@
                                     completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *url) {
                  if (error == nil) {
                      [weakSelf processLoadedThumbImage:weakSelf thumb:thumb image:image enableJewel:enableJewel];
-                     [weakSelf updateBlurredCoverBackground:image];
-                     [weakSelf notifyChangeForBackgroundImage:fanart coverImage:image];
                  }
+                 [weakSelf updateBlurredCoverBackground:image];
+                 [weakSelf notifyChangeForBackgroundImage:fanart coverImage:image];
              }];
         }
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Update covers also in case of image loading error. This lets the blurred background image vanish, if there is no fanart or cover art found.

Screenshots:
<img width="753" height="605" alt="Bildschirmfoto 2025-11-17 um 13 00 45" src="https://github.com/user-attachments/assets/b95b13aa-939b-44c3-bcc5-a62ef3ea18ef" />

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Remove NowPlaying background in case no artwork was found