### PR TITLE
Maintenance: Initialize VirtualKeyboard in base class controller

### DIFF
--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "BaseMasterViewController.h"
+#import "XBMCVirtualKeyboard.h"
 #import "AppDelegate.h"
 #import "Utilities.h"
 
@@ -29,6 +30,9 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    XBMCVirtualKeyboard *virtualKeyboard = [XBMCVirtualKeyboard new];
+    [self.view addSubview:virtualKeyboard];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleDidEnterBackground:)

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -19,7 +19,6 @@
 #import "InitialSlidingViewController.h"
 #import "AppInfoViewController.h"
 #import "tcpJSONRPC.h"
-#import "XBMCVirtualKeyboard.h"
 #import "Utilities.h"
 
 #define MENU_ICON_SIZE 30
@@ -273,8 +272,6 @@
     
     menuList.separatorInset = UIEdgeInsetsMake(0, 0, 0, 0);
     
-    XBMCVirtualKeyboard *virtualKeyboard = [[XBMCVirtualKeyboard alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
-    [self.view addSubview:virtualKeyboard];
     AppDelegate.instance.obj = [GlobalData getInstance];
     menuList.scrollsToTop = NO;
     

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -15,7 +15,6 @@
 #import "AppDelegate.h"
 #import "HostManagementViewController.h"
 #import "AppInfoViewController.h"
-#import "XBMCVirtualKeyboard.h"
 #import "CustomNavigationController.h"
 #import "Utilities.h"
 #import "RemoteController.h"
@@ -320,8 +319,6 @@
     int deltaY = [Utilities getTopPadding];
     [self setNeedsStatusBarAppearanceUpdate];
     self.view.tintColor = APP_TINT_COLOR;
-    XBMCVirtualKeyboard *virtualKeyboard = [[XBMCVirtualKeyboard alloc] initWithFrame:CGRectMake(0, 0, 1, 1)];
-    [self.view addSubview:virtualKeyboard];
     AppDelegate.instance.obj = [GlobalData getInstance];
     
     // Create the left menu


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Adding `XBMCVirtualKeyboard` subview can be moved to `BaseMasterVC`'s `viewDidLoad`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Initialize VirtualKeyboard in base class controller