### PR TITLE
Improved NowPlaying and playlist details for streams

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -141,6 +141,27 @@
     return headerLabel;
 }
 
+- (NSString*)getHostForStreamItem:(id)item {
+    NSString *file = [Utilities getStringFromItem:item[@"file"]];
+    NSURL *url = [NSURL URLWithString:file];
+    if (url) {
+        NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:YES];
+        if (urlComponents) {
+            NSString *host = urlComponents.host;
+            if (host.length) {
+                return host;
+            }
+        }
+    }
+    return nil;
+}
+
+- (NSString*)getTitleFromQueryFormat:(NSString*)title {
+    title = [title stringByRemovingPercentEncoding];
+    title = [title stringByReplacingOccurrencesOfString:@"+" withString:@" "];
+    return title;
+}
+
 - (void)updateBlurredCoverBackground:(UIImage*)image {
     // Show blurred cover background (iPhone only, as iPad uses other layout)
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
@@ -495,6 +516,13 @@
     // Keep year always visible at the tail
     artistName.lineBreakMode = year.length ? NSLineBreakByTruncatingMiddle : NSLineBreakByTruncatingTail;
     
+    // For streams
+    NSString *host = [self getHostForStreamItem:item];
+    if (host) {
+        title = [self getTitleFromQueryFormat:title];
+        artist = host;
+    }
+    
     // top to bottom: songName, artistName, albumName
     songName.text = title;
     artistName.text = artist;
@@ -719,6 +747,7 @@
                                     @"description",
                                     @"year",
                                     @"director",
+                                    @"file",
                                     @"plot"] mutableCopy];
     if (AppDelegate.instance.serverVersion > 11) {
         [properties addObject:@"art"];
@@ -1207,6 +1236,13 @@
                            NSString *thumbnailPath = [self getNowPlayingThumbnailPath:item];
                            NSString *stringURL = [Utilities formatStringURL:thumbnailPath serverURL:serverURL];
                            NSString *file = [Utilities getStringFromItem:item[@"file"]];
+                           // For streams
+                           NSString *host = [self getHostForStreamItem:item];
+                           if (host) {
+                               label = [self getTitleFromQueryFormat:label];
+                               artist = host;
+                               type = @"stream";
+                           }
                            [playlistData addObject:[NSMutableDictionary dictionaryWithObjectsAndKeys:
                                                     idItem, @"idItem",
                                                     file, @"file",
@@ -2085,7 +2121,8 @@
         subLabel.text = [Utilities formatTVShowStringForSeasonTrailing:item[@"season"] episode:item[@"episode"] title:item[@"showtitle"]];
     }
     else if ([item[@"type"] isEqualToString:@"song"] ||
-             [item[@"type"] isEqualToString:@"musicvideo"]) {
+             [item[@"type"] isEqualToString:@"musicvideo"] ||
+             [item[@"type"] isEqualToString:@"stream"]) {
         subLabel.text = item[@"artist"];
     }
     else if ([item[@"type"] isEqualToString:@"movie"]) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR adds special processing for streams. Assumption is that a stream will have a valid `host` in `NSURLComponents`. In this case percent encoding is removed and `"+"` is replaced by `" "` to take into account that some plugins, like "ORF Radiothek", share query-like labels via the API (see the screenshots). The host name is shown as detailing text for both playlist and NowPlaying screen.

Screenshots (top = NowPlaying, bottom = Playlist, left = before, left = after)
<img width="993" height="638" alt="Bildschirmfoto 2025-11-23 um 16 33 07" src="https://github.com/user-attachments/assets/0432c89d-2aef-4936-8b5b-683140f71f8f"/>
_Playing a stream via "ORF Radiothek" Addon and "Play Trailer" for a move from the dababase_

<img width="992" height="633" alt="Bildschirmfoto 2025-11-23 um 16 33 24" src="https://github.com/user-attachments/assets/dade7edf-002e-4cec-b933-0e8247ea6207"/>

_Playing a youtube video and playing the live stream from "Red Bull TV" Addon_

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improved NowPlaying and playlist details for streams