### PR TITLE
Bugfix: Missing volume update after coming back to foreground

### DIFF
--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -183,6 +183,7 @@
 }
 
 - (void)handleEnterForeground:(NSNotification*)sender {
+    [self readServerVolume];
     [self startTimer];
     [self setVolumeButtonMode];
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1381.

Read server volume on `WillEnterForeground` notification. Fixes an issue where the app was not updating the volume after coming back to foreground. This happened when changing Kodi volume while the app was in the background, and if the app uses TCP connection to receive `OnChange` notifications.

Background: The app only reads the volume from Kodi via a polling timer, if it is not connected via TCP to receive `OnChange` notifications. When coming back to foreground this timer is started again, but if a TCP connection is up, the volume is not read. So, _without_ TCP all would be fine, but _with_ TCP connection the app needs to read the volume at least once after coming back to foreground. This is what this fix does.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Missing volume update after coming back to foreground