### PR TITLE
Bugfix: Fix crash when closing remote's QuickHelpScreen

### DIFF
--- a/XBMC Remote/RemoteController.xib
+++ b/XBMC Remote/RemoteController.xib
@@ -455,7 +455,7 @@
                                         <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </state>
                                     <connections>
-                                        <action selector="toggleQuickHelp:" destination="-1" eventType="touchUpInside" id="170"/>
+                                        <action selector="toggleQuickHelp" destination="-1" eventType="touchUpInside" id="8cs-rD-SxV"/>
                                     </connections>
                                 </button>
                             </subviews>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issues reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3246217#pid3246217).

Call correct method `toggleQuickHelp` (instead of `toggleQuickHelp:`) when closing remote's `quickHelpView`. This was a regression caused by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1351, which removed the parameter from `toggleQuickHelp:` but missed to update the xib.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix crash when closing remote's QuickHelpScreen