### PR TITLE
Improvement: Unselect App Settings immediately in iPhone main menu

### DIFF
--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -103,6 +103,9 @@
     mainMenu *item = self.mainMenu[indexPath.row];
     if (item.family == FamilyAppSettings) {
         [self enterAppSettings];
+        
+        // Unselect App Settings again immediately. We leave the app, there is no active submenu.
+        [tableView deselectRowAtIndexPath:indexPath animated:YES];
         return;
     }
     else if (!AppDelegate.instance.serverOnLine && item.family != FamilyServer) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Implements a suggestion from [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3246217#pid3246217).

Unselect App Settings immediately in iPhone main menu. We leave the app, there is no active submenu which needs highlighting.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Unselect App Settings immediately in iPhone main menu