### PR TITLE
Bugfix: Update torch on DidBecomeActive instead WillEnterForeground

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1043,12 +1043,12 @@
                                                object:nil];
     
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleEnterForeground)
-                                                 name:UIApplicationWillEnterForegroundNotification
+                                             selector:@selector(handleDidBecomeActive)
+                                                 name:UIApplicationDidBecomeActiveNotification
                                                object:nil];
 }
 
-- (void)handleEnterForeground {
+- (void)handleDidBecomeActive {
     // Update torch mode
     torchIsOn = [Utilities isTorchOn];
     [Utilities turnTorchOn:torchButton on:torchIsOn];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3246217#pid3246217).

With https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1354 the torch status is updated on receiving the `WillEnterForeground` notification. While this worked during testing the PR on an iPhone, this solution seems to be unreliable. I could reproduce the reported issue this as well, but not always. I suspect that, similar to reconnection attempts using network, the torch state should only be read after `DidBecomeActive` was reached.

The app reads the torch state by
```
AVCaptureDevice *device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
if (device.hasTorch && device.hasFlash) {
    torchIsOn = device.torchActive;
}
```

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Update torch on DidBecomeActive instead WillEnterForeground