### PR TITLE
Rework color averaging and related image methods

### DIFF
--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -42,6 +42,7 @@
 #define FONT_SHADOW_STRONG [Utilities getGrayColor:0 alpha:0.8]
 #define ERROR_MESSAGE_COLOR [Utilities getSystemRed:0.95]
 #define SUCCESS_MESSAGE_COLOR [Utilities getSystemGreen:0.95]
+#define UI_AVERAGE_DEFAULT_COLOR [Utilities getSystemGray2]
 
 /*
  * Dimension and layout macros

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -152,10 +152,11 @@
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     BOOL autocolor_preference = [userDefaults boolForKey:@"autocolor_ui_preference"];
     if (!autocolor_preference) {
-        return [Utilities getSystemGray2];
+        return UI_AVERAGE_DEFAULT_COLOR;
     }
     
-    return [Utilities averageColor:image];
+    UIColor *uiColor = [Utilities averageColor:image];
+    return uiColor ?: UI_AVERAGE_DEFAULT_COLOR;
 }
 
 + (UIColor*)tailorColor:(UIColor*)color satscale:(CGFloat)satscale brightscale:(CGFloat)brightscale brightmin:(CGFloat)brightmin brightmax:(CGFloat)brightmax {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR applies two changes. 

First, it refactors the whole process into two main blocks: the image creation in `createLinearSRGBFromImage` and the color averaging itself in `averageColorForImageRef`. The reworked methods do a better job checking for errors and unexpected formats, and will result in `nil` in such case. The math to calculate the average color itself stays unchanged.

Second, it introduces the default color `UI_AVERAGE_DEFAULT_COLOR` to which the UI colorization falls back in case the image color averaging returns with an error (e.g. unsupported format). This fallback color is the same as if UI colorization is switched off in the app settings. 

Screenshots:
<img width="721" height="373" alt="Bildschirmfoto 2025-11-25 um 22 03 08" src="https://github.com/user-attachments/assets/e8e69099-5c3b-4dad-9b30-27c558af1bef"/>
_UI colors on color averaging error (left = before PR, right = with PR)_

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Refactor image creation and calculation around average UI color
Improvement: Fall back to default color if color averaging faces an error