### PR TITLE
Bugfix: Use single lined cell layout for movie tags

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2570,6 +2570,7 @@
             [item[@"family"] isEqualToString:@"type"] ||
             [item[@"family"] isEqualToString:@"genreid"] ||
             [item[@"family"] isEqualToString:@"channelgroupid"] ||
+            [item[@"family"] isEqualToString:@"tagid"] ||
             [item[@"family"] isEqualToString:@"roleid"]) {
             genre.hidden = YES;
             runtimeyear.hidden = YES;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3246543#pid3246543).

Not sure why I had overseen this from the very first time this feature was released. Movie tags should be shown as single lined item.

Screenshots:
<img width="545" height="592" alt="Bildschirmfoto 2025-11-28 um 22 53 47" src="https://github.com/user-attachments/assets/85c6241b-7fb3-4599-a0ec-b9a36ff9249f"/>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use single lined cell layout for movie tags