### PR TITLE
Small changes to custom button view (RightMenuVC)

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -347,10 +347,7 @@
     }
     if ([tableData[indexPath.row][@"action"] count]) {
         NSString *command = tableData[indexPath.row][@"action"][@"command"];
-        if ([command isEqualToString:@"AddButton"]) {
-            [self addButtonToList:nil];
-        }
-        else if (command != nil) {
+        if (command != nil) {
             NSDictionary *parameters = tableData[indexPath.row][@"action"][@"params"] ?: @{};
             [self xbmcAction:command params:parameters uiControl:nil];
         }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes an issue reported in [this from post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3246625#pid3246625).

The custom button view's "plus" button is disabled on receiving `"XBMCServerConnectionFailed"` (and enabled on `"XBMCServerConnectionSuccess"`. This works well for iPhone where the `RightMenuVC` is already active, but hidden behind the `RemoteController`'s view. On iPad the custom button view is loaded when pressing the custom button icon. Therefore it is required to check for server connection state when creating the "plus"  button. This covers an iPad corner case where the remote view is shown, then the server is disconnected, followed by user entering the custom button view.

This PR also removes some unused code in `didSelectRowAtIndexPath`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Disable "plus" button on iPad when not connected to server
Maintenance: Remove custom button code not being used anymore