### PR TITLE
Bugfix: Fixes around iPad fullscreen fanart

### DIFF
--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -55,6 +55,7 @@
     NSDateFormatter *localEndDateFormatter;
     BOOL isPvrDetail;
     UIToolbar *toolbar;
+    UIVisualEffectView *effectView;
     NSMutableArray *sheetActions;
     UIBarButtonItem *actionSheetButtonItem;
     UIBarButtonItem *extraButton;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -181,7 +181,7 @@
             [Utilities createTransparentToolbar:toolbar];
             [self.view addSubview:toolbar];
             
-            UIVisualEffectView *effectView = [[UIVisualEffectView alloc] initWithFrame:toolbar.frame];
+            effectView = [[UIVisualEffectView alloc] initWithFrame:toolbar.frame];
             effectView.autoresizingMask = toolbar.autoresizingMask;
             effectView.effect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
             [self.view insertSubview:effectView belowSubview:toolbar];
@@ -1431,6 +1431,7 @@
                                                 options:UIViewAnimationOptionCurveEaseInOut
                                              animations:^{
                                                 scrollView.alpha = 1.0;
+                                                effectView.alpha = 1.0;
                                                 toolbar.alpha = 1.0;
                                                 arrow_back_up.alpha = ARROW_ALPHA;
                                              }
@@ -1449,6 +1450,7 @@
                             options:UIViewAnimationOptionCurveEaseInOut
                          animations:^{
                             scrollView.alpha = 0.0;
+                            effectView.alpha = 0.0;
                             toolbar.alpha = 0.0;
                             arrow_back_up.alpha = 0.0;
                             arrow_continue_down.alpha = 0.0;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes issues reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3247139#pid3247139).

Two independent fixes are required:
1. When entering fullscreen artwork on iPad `effectView` must be faded out (as `toolbar` and `scrollView` itself). When leaving fullscreen artwork, `effectView` must be faded in again. 
2. Set the correct inset after coming back from fullscreen fanart. The inset was not correctly to set to a minimum of `-scrollView.contentInset.top` in case of less content on the detail view. In such case "scrolled down" and "scrolled up" is same and the same inset must be used.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fixes around iPad fullscreen fanart