### PR TITLE
Bugfix: Avoid volume "0" after waking up app

### DIFF
--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -242,7 +242,7 @@
 }
 
 - (void)showServerVolume {
-    if (AppDelegate.instance.serverOnLine && serverVolume > -1) {
+    if (serverVolume > -1) {
         volumeLabel.text = [NSString stringWithFormat:@"%d", serverVolume];
         volumeSlider.value = serverVolume;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported and discussed in the support forum.

After app wakeup on iOS devices (not happening on simulator) often volume "0" was shown. This happens when either no server is connected, or reading the server volume via JSON API returned an error. This was caused by #1382 which introduced reading the volume from server on `WillEnterForeground`. This is too early to guarantee the network is available (similar problems were seen when reducing the time to reconnect the app after wakeup), this requires `DidBecomeActive`. Moving this read access to `DidBecomeActive` lets the app properly read volume from a running server. 

Even with this change another race condition could theoretically happen, where `AppDelegate.instance.serverOnLine == NO` even though the server volume could be read successfully. After reviewing the logic, the check for `serverOnLine` is not required, only checking `serverVolume` is sufficient.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid volume "0" after waking up app