### PR TITLE
Improve: Resize HostVCs tip view

### DIFF
--- a/XBMC Remote/HostViewController.xib
+++ b/XBMC Remote/HostViewController.xib
@@ -369,18 +369,18 @@ TCP port</string>
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="z1M-ev-5kX" userLabel="View - tip">
-                            <rect key="frame" x="0.0" y="260" width="320" height="155"/>
+                            <rect key="frame" x="0.0" y="245" width="320" height="160"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                             <subviews>
                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" fixedFrame="YES" image="button_info" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                                     <rect key="frame" x="2" y="6" width="20" height="20"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <color key="tintColor" systemColor="linkColor"/>
                                 </imageView>
                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="How-to activate the remote app in Kodi" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="92">
                                     <rect key="frame" x="25" y="5" width="285" height="20"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="0.65000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                     <color key="shadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
@@ -388,7 +388,7 @@ TCP port</string>
                                 </label>
                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="11" translatesAutoresizingMaskIntoConstraints="NO" id="100">
                                     <rect key="frame" x="25" y="27" width="285" height="105"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                     <string key="text">Settings &gt; Services &gt; Control:
 1. Web Server &gt; Allow remote control via HTTP
 2. Application Control &gt; Allow remote control from applications on other systems</string>
@@ -399,12 +399,12 @@ TCP port</string>
                                     <size key="shadowOffset" width="0.0" height="1"/>
                                 </label>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" alpha="0.80000000000000004" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="st_kodi_action" id="dVE-tO-jAs">
-                                    <rect key="frame" x="150" y="134" width="20" height="20"/>
+                                    <rect key="frame" x="150" y="139" width="20" height="20"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                     <color key="tintColor" systemColor="linkColor"/>
                                 </imageView>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="qfc-bq-JEV" userLabel="Help Wiki">
-                                    <rect key="frame" x="5" y="134" width="145" height="20"/>
+                                    <rect key="frame" x="5" y="139" width="145" height="20"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -416,7 +416,7 @@ TCP port</string>
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="WjS-8Z-d9q" userLabel="Help Forum">
-                                    <rect key="frame" x="169" y="134" width="146" height="20"/>
+                                    <rect key="frame" x="168" y="139" width="147" height="20"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMinY="YES"/>
                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Implements a suggestion from the support forum.

Add more padding between toolbar items down to bottom (needed for popover on iPad) and up to detail text (needed to keep visual appealing look on small devices like iPod Touch).

Screenshots:
<img width="851" height="225" alt="Bildschirmfoto 2025-12-10 um 07 14 06" src="https://github.com/user-attachments/assets/420fab62-b675-4ec0-ad3c-51fbe92e4fc8"/>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improve: Resize HostVCs tip view