### PR TITLE
Improvement: Add runtime to detail view of episodes and  music videos

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -651,16 +651,18 @@
     else if ([item[@"family"] isEqualToString:@"episodeid"]) {
         placeHolderImage = @"nocover_tvshows_episode_wall";
         
-        mainLabel1.text = LOCALIZED_STR(@"TV SHOW");
-        mainLabel2.text = LOCALIZED_STR(@"FIRST AIRED");
-        mainLabel3.text = LOCALIZED_STR(@"DIRECTOR");
+        mainLabel0.text = LOCALIZED_STR(@"TV SHOW");
+        mainLabel1.text = LOCALIZED_STR(@"FIRST AIRED");
+        mainLabel2.text = LOCALIZED_STR(@"DIRECTOR");
+        mainLabel3.text = LOCALIZED_STR(@"RUNTIME");
         mainLabel4.text = LOCALIZED_STR(@"WRITER");
         mainLabel5.text = LOCALIZED_STR(@"SUMMARY");
         castMainLabel.text = LOCALIZED_STR(@"CAST");
         parentalRatingMainLabel.text = LOCALIZED_STR(@"PARENTAL RATING");
-        subLabel1.text = [Utilities formatTVShowStringForSeasonTrailing:item[@"season"] episode:item[@"episode"] title:item[@"showtitle"]];
-        subLabel2.text = [Utilities getDateFromItem:item[@"firstaired"] dateStyle:NSDateFormatterLongStyle];
-        subLabel3.text = [Utilities getStringFromItem:item[@"director"]];
+        subLabel0.text = [Utilities formatTVShowStringForSeasonTrailing:item[@"season"] episode:item[@"episode"] title:item[@"showtitle"]];
+        subLabel1.text = [Utilities getDateFromItem:item[@"firstaired"] dateStyle:NSDateFormatterLongStyle];
+        subLabel2.text = [Utilities getStringFromItem:item[@"director"]];
+        subLabel3.text = [Utilities getStringFromItem:item[@"runtime"]];
         subLabel4.text = [Utilities getStringFromItem:item[@"writer"]];
         subLabel5.text = [Utilities getStringFromItem:item[@"plot"]];
         
@@ -714,16 +716,18 @@
         NSString *director = [Utilities getStringFromItem:item[@"director"]];
         NSString *year = [Utilities getYearFromItem:item[@"year"]];
         
-        mainLabel1.text = LOCALIZED_STR(@"ARTIST");
-        mainLabel2.text = LOCALIZED_STR(@"GENRE");
-        mainLabel3.text = [self formatDirectorYearHeading:director year:year];
+        mainLabel0.text = LOCALIZED_STR(@"ARTIST");
+        mainLabel1.text = LOCALIZED_STR(@"GENRE");
+        mainLabel2.text = [self formatDirectorYearHeading:director year:year];
+        mainLabel3.text = LOCALIZED_STR(@"RUNTIME");
         mainLabel4.text = LOCALIZED_STR(@"STUDIO");
         mainLabel5.text = LOCALIZED_STR(@"SUMMARY");
         castMainLabel.text = @"";
         parentalRatingMainLabel.text = LOCALIZED_STR(@"PARENTAL RATING");
-        subLabel1.text = [Utilities getStringFromItem:item[@"artist"]];
-        subLabel2.text = [Utilities getStringFromItem:item[@"genre"]];
-        subLabel3.text = [self formatDirectorYear:director year:year];
+        subLabel0.text = [Utilities getStringFromItem:item[@"artist"]];
+        subLabel1.text = [Utilities getStringFromItem:item[@"genre"]];
+        subLabel2.text = [self formatDirectorYear:director year:year];
+        subLabel3.text = [Utilities getStringFromItem:item[@"runtime"]];
         subLabel4.text = [Utilities getStringFromItem:item[@"studio"]];
         subLabel5.text = [Utilities getStringFromItem:item[@"plot"]];
         


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR implements a feature suggestion by a user. It adds runtime to the details view for episodes and music videos. Due to lack of a database providing runtime values for episodes and music vides, this needs testing.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Add runtime to detail view of music videos and episodes