### PR TITLE
Improvement: Support movable server list items

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -471,6 +471,11 @@
     [serverListTableView reloadData];
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    self.slidingViewController.panGesture.delegate = nil;
+}
+
 - (void)revealMenu:(NSNotification*)note {
     [self.slidingViewController anchorTopViewTo:ECRight];
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1413.

This PR implements support to move server list items. This improves the newly introduced support for starting the app via long pressing the icon and selecting a server, which is limited to top 4 servers in the server list.

Important catch: `panGesture` of `ECSlidingViewController`, which is used on iPhone, conflicts with moving list item. Therefor `panGesture` must be temporarily removed, when in editing mode., see https://stackoverflow.com/questions/9251735/cant-drag-uitableviewcell-from-its-current-position-when-reorder.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Support movable server list items