### PR TITLE
Bugfix: "Error 153" for embedded youtube videos (trailers)

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1624,7 +1624,19 @@
 
 - (void)loadTrailerInWebKit:(id)sender {
     trailerPlayButton.hidden = YES;
-    NSURLRequest *urlrequest = [NSURLRequest requestWithURL:embedVideoURL];
+    NSMutableURLRequest *urlrequest = [NSMutableURLRequest requestWithURL:embedVideoURL];
+    
+    /*
+     Add Referer and origin to fix youtube "Error 153"
+     References:
+     https://developers.google.com/youtube/terms/required-minimum-functionality?hl=en#embedded-player-api-client-identity
+     https://stackoverflow.com/questions/79802987/youtube-error-153-video-player-configuration-error-when-embedding-youtube-video
+     */
+    NSString *bundleID = NSBundle.mainBundle.bundleIdentifier;
+    NSString *referrer = [NSString stringWithFormat:@"https://%@", bundleID.lowercaseString];
+    [urlrequest addValue:referrer forHTTPHeaderField:@"Referer"];
+    [urlrequest addValue:referrer forHTTPHeaderField:@"origin"];
+    
     [trailerWebView loadRequest:urlrequest];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported in the support forums. 

For embedded youtube videos, like used for movie trailers, there was "Error 153: Video player configuration error" shown.

Screenshots:
<img width="792" height="241" alt="Bildschirmfoto 2025-12-17 um 09 18 03" src="https://github.com/user-attachments/assets/b2ddcf78-7794-4548-8e6f-56d2a281bd1c"/>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: "Error 153" for embedded youtube videos (trailers)