### PR TITLE
Improve performance of color averaging for images

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -23,6 +23,7 @@
 #define XBMC_LOGO_PADDING 10
 #define PERSISTENCE_KEY_VERSION @"VersionUnderReview"
 #define PERSISTENCE_KEY_PLAYBACK_ATTEMPTS @"PlaybackAttempts"
+#define IMAGE_SIZE_COLOR_AVERAGING CGSizeMake(64, 64) // Scale (down) to this size before averaging an image color
 
 @implementation Utilities
 
@@ -137,7 +138,7 @@
 }
 
 + (UIColor*)averageColor:(UIImage*)image {
-    CGImageRef linearSrgbImageRef = [self createLinearSRGBFromImage:image size:CGSizeZero];
+    CGImageRef linearSrgbImageRef = [self createLinearSRGBFromImage:image size:IMAGE_SIZE_COLOR_AVERAGING];
     if (linearSrgbImageRef == NULL) {
         return nil;
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
### Background
The averaging of image colors, which is used to colorize UI elements, is currently quite computing intense as it applies the averaging to the whole image size. Even for images with relatively small resolution like 128x128 this results in >16k loops with read/add/store operations. In real use cases images might have resolutions beyond 1080p (@2 million loops). 

### Approach
This PR keeps the core of color averaging calculation unchanged, but scales the images to a fixed size of 64x64 pixels. This way the calculation loop takes a constant time for its 256 loops. The gain by doing lesser loops will be partially eaten up by the additional time the scaling takes. The overall gain increases with higher resolution, the break-even, I assume from the measurement, is around 128x128 pixel image size.

### Impact on timing
I measured the average time it takes for the whole color averaging (scaling + loops) on an iPhone 14 Pro, using real images.

Use case: old > new (relative change)
Scrolling 330 TV stations (grid): 5.0 ms > 4.3 ms (-16%)
Scrolling 330 TV station (list): 1.78 ms > 1.84 ms (+3%)
Loading 5 different album views: 16.9 ms > 11.0 ms (-35%)
Loading 9 different movie details: 6.1 ms > 2.1 ms (-65%)

When repeating the loading of a detail view the speed is up 16x higher, depending on the image resolution.
10x same movie details: 14.6 ms > 1.0 ms (-93%)
10x same album view: 7.0 ms > 6.1 ms (-13%)
5x same episode view: 7.7 ms > 4.0 ms (-48%)

### Impact on memory
Also the memory consumption is showing a small improvement.

Use case: old > new (relative change)
Scrolling TV stations (grid): 185.7 MB > 183.2 MB (-1.4%)
Scrolling TV station (list): 51.4 MB > 51.0 MB (-0.8%)
Loading 10 albums: 64.5 MB > 63.6 MB (-1.4%)
Loading 9 movies: 145.9 MB > 143.7 MB (-1.5%)

### Summary
Main benefit of this change is the processing time required for the averaging process, which now scaling more gracefully with higher resolution of processed images. The gain in memory is negligible .

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Better performance of color averaging for images