### PR TITLE
Maintenance: Change code to use nonatomic

### DIFF
--- a/XBMC Remote/BDKCollectionIndexView/BDKCollectionIndexView.h
+++ b/XBMC Remote/BDKCollectionIndexView/BDKCollectionIndexView.h
@@ -31,11 +31,11 @@ typedef NS_ENUM(NSInteger, BDKCollectionIndexViewDirection) {
 
 /** The direction in which the control is oriented; this is automatically set based on the frame given.
  */
-@property (readonly) BDKCollectionIndexViewDirection direction;
+@property (readonly, nonatomic) BDKCollectionIndexViewDirection direction;
 
 /** The index title at the index of `currentIndex`.
  */
-@property (readonly) NSString *currentIndexTitle;
+@property (readonly, nonatomic) NSString *currentIndexTitle;
 
 /** A class message to initialize and return an index view control, given a frame and a list of index titles.
  *  @param frame the frame to use when initializing the control.

--- a/XBMC Remote/BDKCollectionIndexView/BDKCollectionIndexView.m
+++ b/XBMC Remote/BDKCollectionIndexView/BDKCollectionIndexView.m
@@ -23,7 +23,7 @@
 
 /** A gesture recognizer that handles panning.
  */
-@property (readonly) CGFloat theDimension;
+@property (readonly, nonatomic) CGFloat theDimension;
 
 /** Handles events sent by the long press gesture recognizer.
  *  @param recognizer the sender of the event; usually a UILongPressGestureRecognizer.

--- a/XBMC Remote/GlobalData.h
+++ b/XBMC Remote/GlobalData.h
@@ -24,7 +24,7 @@
 @property (nonatomic, strong) NSString *serverPass;
 @property (nonatomic, strong) NSString *serverRawIP;
 @property (nonatomic, strong) NSString *serverIP;
-@property int tcpPort;
+@property (nonatomic) int tcpPort;
 @property (nonatomic, strong) NSString *serverPort;
 @property (nonatomic, strong) NSString *serverHWAddr;
 

--- a/XBMC Remote/KenBurns/JBKenBurnsView.h
+++ b/XBMC Remote/KenBurns/JBKenBurnsView.h
@@ -48,7 +48,7 @@
 @property (nonatomic, strong) NSMutableArray *imagesArray;
 @property (nonatomic) BOOL isLoop;
 @property (nonatomic) BOOL isLandscape;
-@property (weak) id<KenBurnsViewDelegate> delegate;
+@property (nonatomic, weak) id<KenBurnsViewDelegate> delegate;
 
 - (void)stopAnimation;
 - (void)animateWithImages:(NSArray*)images transitionDuration:(NSTimeInterval)time loop:(BOOL)isLoop isLandscape:(BOOL)isLandscape;

--- a/XBMC Remote/mainMenu.h
+++ b/XBMC Remote/mainMenu.h
@@ -51,9 +51,9 @@ typedef NS_ENUM(NSInteger, ViewModes) {
 @interface mainMenu : NSObject
 
 @property (nonatomic, copy) NSString *mainLabel;
-@property MenuItemFamily family;
-@property MenuItemType type;
-@property BOOL enableSection;
+@property (nonatomic) MenuItemFamily family;
+@property (nonatomic) MenuItemType type;
+@property (nonatomic) BOOL enableSection;
 @property (nonatomic, copy) NSString *icon;
 @property (nonatomic, copy) NSArray *mainMethod;
 @property (nonatomic, copy) NSString *defaultThumb;
@@ -62,15 +62,15 @@ typedef NS_ENUM(NSInteger, ViewModes) {
 @property (nonatomic, strong) NSMutableArray *mainParameters;
 @property (nonatomic, strong) mainMenu *subItem;
 @property (nonatomic, copy) NSArray *sheetActions;
-@property int rowHeight;
-@property int thumbWidth;
+@property (nonatomic) int rowHeight;
+@property (nonatomic) int thumbWidth;
 @property (nonatomic, copy) NSArray *showInfo;
-@property int maxXrightLabel;
-@property int widthLabel;
-@property int chooseTab;
-@property BOOL disableNavbarButtons;
+@property (nonatomic) int maxXrightLabel;
+@property (nonatomic) int widthLabel;
+@property (nonatomic) int chooseTab;
+@property (nonatomic) BOOL disableNavbarButtons;
 @property (nonatomic, copy) NSArray *showRuntime;
-@property BOOL noConvertTime;
+@property (nonatomic) BOOL noConvertTime;
 @property (nonatomic, copy) NSArray *filterModes;
 
 - (id)copyWithZone:(NSZone*)zone;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR was motivated by a discussion about use of `atomic` for properties. After review I found only a few properties which did not have atomic defined. Those do not seem to be used in multithreading context, so I made them `nonatomic`.

But while reviewing the code I found the method `loadDataFromDisk` was called `detachNewThreadSelector`. To my understanding this will decouple from main thread and therefore the properties used inside might be accessed (and changed) by different thread, e.g. `richResults`. To me it seems correct to use `performSelectorOnMainThread` in this case, or alternatively to make the related properties `atomic`. For now, I want for the first, but I am not sure, if the size of the serialized data can be big enough to better keep the loading running in background.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Change code to use nonatomic