### PR TITLE
Bugfix: Avoid animation glitch for iPhone's playlist toggle button

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1488,7 +1488,7 @@
             buttonImage = [self resizeToolbarThumb:image];
         }
         if (!buttonImage.size.width) {
-            buttonImage = [self resizeToolbarThumb:[UIImage imageNamed:@"st_nowplaying_small"]];
+            buttonImage = [UIImage imageNamed:@"st_nowplaying_small"];
         }
     }
     else {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
The button `playlistButton`which is used to toggle between playlist and NowPlaying screen on iPhone uses "st_nowplaying_small" as icon. To avoid showing it in different sizes _during_ and _after_ the animation following a button press, we keep this unscaled (as the other icon "now_playing_playlist" as well).

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid animation glitch for iPhone's playlist toggle button
