### PR TITLE
Streamline colors and button style / behaviour

### DIFF
--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		C7B7D02A2F71B37F00689B5A /* UIViewController+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C7B7D0292F71B37F00689B5A /* UIViewController+Extensions.m */; };
 		C7B7D02D2F732AED00689B5A /* UIBarButtonItem+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C7B7D0262F71B18300689B5A /* UIBarButtonItem+Extensions.m */; };
 		C7B7D03A2F76D36E00689B5A /* UILabel+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C7B7D0392F76D36E00689B5A /* UILabel+Extensions.m */; };
+		C7BBD0AD2FAA680500133407 /* UIButton+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C7BBD0AC2FAA680500133407 /* UIButton+Extensions.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -360,6 +361,8 @@
 		C7B7D02B2F71B39D00689B5A /* UIViewController+Extensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Extensions.h"; sourceTree = "<group>"; };
 		C7B7D0392F76D36E00689B5A /* UILabel+Extensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UILabel+Extensions.m"; sourceTree = "<group>"; };
 		C7B7D03D2F76D38A00689B5A /* UILabel+Extensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UILabel+Extensions.h"; sourceTree = "<group>"; };
+		C7BBD0AC2FAA680500133407 /* UIButton+Extensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIButton+Extensions.m"; sourceTree = "<group>"; };
+		C7BBD0AE2FAA682800133407 /* UIButton+Extensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIButton+Extensions.h"; sourceTree = "<group>"; };
 		C7D95E212DC0963100153267 /* id-ID */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "id-ID"; path = "id-ID.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C7D95E222DC0963100153267 /* id-ID */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "id-ID"; path = "id-ID.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C7F28D4826961FE50004B112 /* ConvenienceMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConvenienceMacros.h; sourceTree = "<group>"; };
@@ -760,6 +763,8 @@
 				C752A3BE2F827E23008154C8 /* NSString+Extensions.m */,
 				C7B7D0282F71B1C100689B5A /* UIBarButtonItem+Extensions.h */,
 				C7B7D0262F71B18300689B5A /* UIBarButtonItem+Extensions.m */,
+				C7BBD0AE2FAA682800133407 /* UIButton+Extensions.h */,
+				C7BBD0AC2FAA680500133407 /* UIButton+Extensions.m */,
 				C7B7D02B2F71B39D00689B5A /* UIViewController+Extensions.h */,
 				C7B7D0292F71B37F00689B5A /* UIViewController+Extensions.m */,
 				C7B7D03D2F76D38A00689B5A /* UILabel+Extensions.h */,
@@ -948,6 +953,7 @@
 				0F00207816EE247A003822B5 /* OBSlider.m in Sources */,
 				0F284A5216F63C9A00AFC1EF /* PosterLabel.m in Sources */,
 				0F284A5516F6419700AFC1EF /* PosterCell.m in Sources */,
+				C7BBD0AD2FAA680500133407 /* UIButton+Extensions.m in Sources */,
 				0F8E308816FA536C009DEE72 /* PosterHeaderView.m in Sources */,
 				C78C30F528F877870055CD95 /* VersionCheck.m in Sources */,
 				C76451D629C51221000AE949 /* UIView+WebCacheOperation.m in Sources */,

--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -22,6 +22,7 @@
  */
 #define APP_TINT_COLOR [Utilities getGrayColor:0 alpha:0.3]
 #define ICON_TINT_COLOR UIColor.lightGrayColor
+#define ICON_TINT_COLOR_DARK UIColor.darkGrayColor
 #define ICON_TINT_COLOR_ACTIVE UIColor.systemBlueColor
 #define REMOTE_CONTROL_BAR_TINT_COLOR [Utilities getGrayColor:12 alpha:1]
 #define SLIDER_DEFAULT_COLOR UIColor.lightGrayColor

--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -22,6 +22,7 @@
  */
 #define APP_TINT_COLOR [UIColor getGrayColor:0 alpha:0.3]
 #define ICON_TINT_COLOR UIColor.lightGrayColor
+#define ICON_TINT_COLOR_DARK UIColor.darkGrayColor
 #define ICON_TINT_COLOR_ACTIVE UIColor.systemBlueColor
 #define REMOTE_CONTROL_BAR_TINT_COLOR [UIColor getGrayColor:12 alpha:1]
 #define SLIDER_DEFAULT_COLOR UIColor.lightGrayColor

--- a/XBMC Remote/CustomButtonCell.m
+++ b/XBMC Remote/CustomButtonCell.m
@@ -12,6 +12,8 @@
 #define CUSTOM_BUTTON_ITEM_SPACING 4.0
 #define CUSTOM_BUTTON_LABEL_PADDING 4.0
 #define CUSTOM_BUTTON_BACKGROUND_INSET 2.0
+#define ICON_ALPHA 0.8 // Reduce alpha to soften appearance next to button name
+#define ICON_ALPHA_DISABLED 0.5 // Align with alpha of disabled UISwitch
 
 @implementation CustomButtonCell
 
@@ -34,7 +36,7 @@
         onoff.frame = frame;
         onoff.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin;
         onoff.hidden = YES;
-        onoff.alpha = 0.9;
+        onoff.alpha = ICON_ALPHA;
         [self.contentView addSubview:onoff];
         self.onoffSwitch = onoff;
         
@@ -46,7 +48,7 @@
                                 iconSize,
                                 iconSize);
         icon.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin;
-        icon.alpha = 0.8;
+        icon.alpha = ICON_ALPHA;
         [self.contentView addSubview:icon];
         self.buttonIcon = icon;
         
@@ -82,11 +84,11 @@
     [super setEditing:editing animated:animated];
     if (editing) {
         self.onoffSwitch.enabled = NO;
-        self.buttonIcon.alpha = 0.5;
+        self.buttonIcon.alpha = ICON_ALPHA_DISABLED;
     }
     else {
         self.onoffSwitch.enabled = YES;
-        self.buttonIcon.alpha = 0.8;
+        self.buttonIcon.alpha = ICON_ALPHA;
     }
 }
 

--- a/XBMC Remote/CustomButtonCell.m
+++ b/XBMC Remote/CustomButtonCell.m
@@ -65,7 +65,6 @@
         title.adjustsFontSizeToFitWidth = YES;
         title.minimumScaleFactor = FONT_SCALING_MIN;
         title.textColor = UIColor.lightGrayColor;
-        title.highlightedTextColor = UIColor.grayColor;
         [self.contentView addSubview:title];
         self.buttonLabel = title;
         

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3800,7 +3800,9 @@
                              animations:^{
                 collectionView.alpha = 1;
                 dataList.alpha = 1;
-                [fullscreenButton setImage:[UIImage imageNamed:@"button_fullscreen"] forState:UIControlStateNormal];
+                UIImage *buttonImage = [UIImage imageNamed:@"button_fullscreen"];
+                buttonImage = [buttonImage colorizeWithColor:ICON_TINT_COLOR];
+                [fullscreenButton setImage:buttonImage forState:UIControlStateNormal];
                 fullscreenButton.backgroundColor = UIColor.clearColor;
             }
                              completion:^(BOOL finished) {
@@ -3864,8 +3866,10 @@
                                 options:UIViewAnimationOptionCurveEaseInOut
                              animations:^{
                 collectionView.alpha = 1;
-                [fullscreenButton setImage:[UIImage imageNamed:@"button_exit_fullscreen"] forState:UIControlStateNormal];
-                fullscreenButton.backgroundColor = [UIColor getGrayColor:0 alpha:0.5];
+                UIImage *buttonImage = [UIImage imageNamed:@"button_exit_fullscreen"];
+                buttonImage = [buttonImage colorizeWithColor:ICON_TINT_COLOR];
+                [fullscreenButton setImage:buttonImage forState:UIControlStateNormal];
+                fullscreenButton.backgroundColor = INFO_POPOVER_COLOR;
             }
                              completion:^(BOOL finished) {
                 [activityIndicatorView stopAnimating];
@@ -6075,10 +6079,10 @@
                 fullscreenButton.showsTouchWhenHighlighted = YES;
                 fullscreenButton.frame = CGRectMake(0, 0, FULLSCREEN_BUTTON_SIZE, FULLSCREEN_BUTTON_SIZE);
                 fullscreenButton.contentMode = UIViewContentModeCenter;
-                [fullscreenButton setImage:[UIImage imageNamed:@"button_fullscreen"] forState:UIControlStateNormal];
+                UIImage *buttonImage = [UIImage imageNamed:@"button_fullscreen"];
+                buttonImage = [buttonImage colorizeWithColor:ICON_TINT_COLOR];
+                [fullscreenButton setImage:buttonImage forState:UIControlStateNormal];
                 fullscreenButton.layer.cornerRadius = 2;
-                fullscreenButton.tintColor = UIColor.whiteColor;
-                fullscreenButton.alpha = 0.9;
                 [fullscreenButton addTarget:self action:@selector(toggleFullscreen) forControlEvents:UIControlEventTouchUpInside];
                 fullscreenButton.frame = CGRectMake(titleView.frame.size.width - fullscreenButton.frame.size.width, titleView.frame.size.height / 2 - fullscreenButton.frame.size.height / 2, fullscreenButton.frame.size.width, fullscreenButton.frame.size.height);
                 [titleView addSubview:fullscreenButton];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -6126,6 +6126,7 @@
         NSString *viewKey = [NSString stringWithFormat:@"%@_grid_preference", [self getCacheKey:methods[@"method"] parameters:tempDict]];
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
         [userDefaults setBool:![userDefaults boolForKey:viewKey] forKey:viewKey];
+        [self setGridListButtonImage:!enableCollectionView];
         [UIView animateWithDuration:0.2
                               delay:0.0
                             options:UIViewAnimationOptionCurveEaseIn

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -823,14 +823,12 @@
 
 - (void)setGridListButtonImage:(BOOL)isGridView {
     NSString *imgName = isGridView ? @"st_view_grid" : @"st_view_list";
-    UIImage *image = [Utilities colorizeImage:[UIImage imageNamed:imgName] withColor:ICON_TINT_COLOR];
-    [button6 setBackgroundImage:image forState:UIControlStateNormal];
+    [button6 setDatabaseToolbarStyle:[UIImage imageNamed:imgName]];
 }
 
 - (void)setSortButtonImage:(NSString*)sortOrder {
     NSString *imgName = [sortOrder isEqualToString:@"descending"] ? @"st_sort_desc" : @"st_sort_asc";
-    UIImage *image = [Utilities colorizeImage:[UIImage imageNamed:imgName] withColor:ICON_TINT_COLOR];
-    [button7 setBackgroundImage:image forState:UIControlStateNormal];
+    [button7 setDatabaseToolbarStyle:[UIImage imageNamed:imgName]];
 }
 
 - (void)setButtonViewContent:(int)activeTab {
@@ -3018,7 +3016,6 @@
     
     // Add Info button to bottom-right corner
     albumInfoButton.alpha = 0.8;
-    albumInfoButton.showsTouchWhenHighlighted = YES;
     albumInfoButton.frame = CGRectMake(albumDetailView.bounds.size.width - INFO_BUTTON_SIZE,
                                        albumDetailView.bounds.size.height - INFO_BUTTON_SIZE - TINY_PADDING,
                                        INFO_BUTTON_SIZE,
@@ -3830,9 +3827,7 @@
                              animations:^{
                 collectionView.alpha = 1;
                 dataList.alpha = 1;
-                UIImage *buttonImage = [UIImage imageNamed:@"button_fullscreen"];
-                buttonImage = [Utilities colorizeImage:buttonImage withColor:ICON_TINT_COLOR];
-                [fullscreenButton setImage:buttonImage forState:UIControlStateNormal];
+                [fullscreenButton setIconStyle:[UIImage imageNamed:@"button_fullscreen"]];
                 fullscreenButton.backgroundColor = UIColor.clearColor;
             }
                              completion:^(BOOL finished) {
@@ -3896,9 +3891,7 @@
                                 options:UIViewAnimationOptionCurveEaseInOut
                              animations:^{
                 collectionView.alpha = 1;
-                UIImage *buttonImage = [UIImage imageNamed:@"button_exit_fullscreen"];
-                buttonImage = [Utilities colorizeImage:buttonImage withColor:ICON_TINT_COLOR];
-                [fullscreenButton setImage:buttonImage forState:UIControlStateNormal];
+                [fullscreenButton setIconStyle:[UIImage imageNamed:@"button_exit_fullscreen"]];
                 fullscreenButton.backgroundColor = INFO_POPOVER_COLOR;
             }
                              completion:^(BOOL finished) {
@@ -5446,9 +5439,6 @@
     mainMenu *menuItem = self.detailItem;
     NSArray *buttons = menuItem.mainButtons;
     NSArray *buttonsIB = @[button1, button2, button3, button4, button5];
-    UIImage *imageOff = nil;
-    UIImage *imageOn = nil;
-    UIImage *img = nil;
     CGRect frame;
     NSInteger count = buttons.count;
     // If >6 buttons are required, only use 4 normal buttons and keep 5th for "more items"
@@ -5456,12 +5446,7 @@
         count = MAX_NORMAL_BUTTONS;
     }
     for (int i = 0; i < count; i++) {
-        img = [UIImage imageNamed:buttons[i]];
-        imageOff = [Utilities colorizeImage:img withColor:ICON_TINT_COLOR];
-        imageOn = [Utilities colorizeImage:img withColor:ICON_TINT_COLOR_ACTIVE];
-        [buttonsIB[i] setBackgroundImage:imageOff forState:UIControlStateNormal];
-        [buttonsIB[i] setBackgroundImage:imageOn forState:UIControlStateSelected];
-        [buttonsIB[i] setBackgroundImage:imageOn forState:UIControlStateHighlighted];
+        [buttonsIB[i] setDatabaseToolbarStyle:[UIImage imageNamed:buttons[i]]];
         [buttonsIB[i] setEnabled:YES];
     }
     activeTab = MIN(activeTab, MAX_NORMAL_BUTTONS);
@@ -5501,12 +5486,7 @@
             break;
         default:
             // 6 or more buttons/actions require a "more" button
-            img = [UIImage imageNamed:@"st_more"];
-            imageOff = [Utilities colorizeImage:img withColor:ICON_TINT_COLOR];
-            imageOn = [Utilities colorizeImage:img withColor:ICON_TINT_COLOR_ACTIVE];
-            [buttonsIB.lastObject setBackgroundImage:imageOff forState:UIControlStateNormal];
-            [buttonsIB.lastObject setBackgroundImage:imageOn forState:UIControlStateSelected];
-            [buttonsIB.lastObject setBackgroundImage:imageOn forState:UIControlStateHighlighted];
+            [buttonsIB.lastObject setDatabaseToolbarStyle:[UIImage imageNamed:@"st_more"]];
             [buttonsIB.lastObject setEnabled:YES];
             break;
     }
@@ -6098,12 +6078,9 @@
             if (fullscreenButton == nil) {
                 fullscreenButton = [UIButton buttonWithType:UIButtonTypeCustom];
                 fullscreenButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin;
-                fullscreenButton.showsTouchWhenHighlighted = YES;
                 fullscreenButton.frame = CGRectMake(0, 0, FULLSCREEN_BUTTON_SIZE, FULLSCREEN_BUTTON_SIZE);
                 fullscreenButton.contentMode = UIViewContentModeCenter;
-                UIImage *buttonImage = [UIImage imageNamed:@"button_fullscreen"];
-                buttonImage = [Utilities colorizeImage:buttonImage withColor:ICON_TINT_COLOR];
-                [fullscreenButton setImage:buttonImage forState:UIControlStateNormal];
+                [fullscreenButton setIconStyle:[UIImage imageNamed:@"button_fullscreen"]];
                 fullscreenButton.layer.cornerRadius = 2;
                 [fullscreenButton addTarget:self action:@selector(toggleFullscreen) forControlEvents:UIControlEventTouchUpInside];
                 fullscreenButton.frame = CGRectMake(titleView.frame.size.width - fullscreenButton.frame.size.width, titleView.frame.size.height / 2 - fullscreenButton.frame.size.height / 2, fullscreenButton.frame.size.width, fullscreenButton.frame.size.height);

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3830,7 +3830,9 @@
                              animations:^{
                 collectionView.alpha = 1;
                 dataList.alpha = 1;
-                [fullscreenButton setImage:[UIImage imageNamed:@"button_fullscreen"] forState:UIControlStateNormal];
+                UIImage *buttonImage = [UIImage imageNamed:@"button_fullscreen"];
+                buttonImage = [Utilities colorizeImage:buttonImage withColor:ICON_TINT_COLOR];
+                [fullscreenButton setImage:buttonImage forState:UIControlStateNormal];
                 fullscreenButton.backgroundColor = UIColor.clearColor;
             }
                              completion:^(BOOL finished) {
@@ -3894,8 +3896,10 @@
                                 options:UIViewAnimationOptionCurveEaseInOut
                              animations:^{
                 collectionView.alpha = 1;
-                [fullscreenButton setImage:[UIImage imageNamed:@"button_exit_fullscreen"] forState:UIControlStateNormal];
-                fullscreenButton.backgroundColor = [Utilities getGrayColor:0 alpha:0.5];
+                UIImage *buttonImage = [UIImage imageNamed:@"button_exit_fullscreen"];
+                buttonImage = [Utilities colorizeImage:buttonImage withColor:ICON_TINT_COLOR];
+                [fullscreenButton setImage:buttonImage forState:UIControlStateNormal];
+                fullscreenButton.backgroundColor = INFO_POPOVER_COLOR;
             }
                              completion:^(BOOL finished) {
                 [activityIndicatorView stopAnimating];
@@ -6097,10 +6101,10 @@
                 fullscreenButton.showsTouchWhenHighlighted = YES;
                 fullscreenButton.frame = CGRectMake(0, 0, FULLSCREEN_BUTTON_SIZE, FULLSCREEN_BUTTON_SIZE);
                 fullscreenButton.contentMode = UIViewContentModeCenter;
-                [fullscreenButton setImage:[UIImage imageNamed:@"button_fullscreen"] forState:UIControlStateNormal];
+                UIImage *buttonImage = [UIImage imageNamed:@"button_fullscreen"];
+                buttonImage = [Utilities colorizeImage:buttonImage withColor:ICON_TINT_COLOR];
+                [fullscreenButton setImage:buttonImage forState:UIControlStateNormal];
                 fullscreenButton.layer.cornerRadius = 2;
-                fullscreenButton.tintColor = UIColor.whiteColor;
-                fullscreenButton.alpha = 0.9;
                 [fullscreenButton addTarget:self action:@selector(toggleFullscreen) forControlEvents:UIControlEventTouchUpInside];
                 fullscreenButton.frame = CGRectMake(titleView.frame.size.width - fullscreenButton.frame.size.width, titleView.frame.size.height / 2 - fullscreenButton.frame.size.height / 2, fullscreenButton.frame.size.width, fullscreenButton.frame.size.height);
                 [titleView addSubview:fullscreenButton];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -824,14 +824,12 @@
 
 - (void)setGridListButtonImage:(BOOL)isGridView {
     NSString *imgName = isGridView ? @"st_view_grid" : @"st_view_list";
-    UIImage *image = [[UIImage imageNamed:imgName] colorizeWithColor:ICON_TINT_COLOR];
-    [button6 setBackgroundImage:image forState:UIControlStateNormal];
+    [button6 setDatabaseToolbarStyle:[UIImage imageNamed:imgName]];
 }
 
 - (void)setSortButtonImage:(NSString*)sortOrder {
     NSString *imgName = [sortOrder isEqualToString:@"descending"] ? @"st_sort_desc" : @"st_sort_asc";
-    UIImage *image = [[UIImage imageNamed:imgName] colorizeWithColor:ICON_TINT_COLOR];
-    [button7 setBackgroundImage:image forState:UIControlStateNormal];
+    [button7 setDatabaseToolbarStyle:[UIImage imageNamed:imgName]];
 }
 
 - (void)setButtonViewContent:(int)activeTab {
@@ -2994,7 +2992,6 @@
     
     // Add Info button to bottom-right corner
     albumInfoButton.alpha = 0.8;
-    albumInfoButton.showsTouchWhenHighlighted = YES;
     albumInfoButton.frame = CGRectMake(albumDetailView.bounds.size.width - INFO_BUTTON_SIZE,
                                        albumDetailView.bounds.size.height - INFO_BUTTON_SIZE - TINY_PADDING,
                                        INFO_BUTTON_SIZE,
@@ -3800,9 +3797,7 @@
                              animations:^{
                 collectionView.alpha = 1;
                 dataList.alpha = 1;
-                UIImage *buttonImage = [UIImage imageNamed:@"button_fullscreen"];
-                buttonImage = [buttonImage colorizeWithColor:ICON_TINT_COLOR];
-                [fullscreenButton setImage:buttonImage forState:UIControlStateNormal];
+                [fullscreenButton setIconStyle:[UIImage imageNamed:@"button_fullscreen"]];
                 fullscreenButton.backgroundColor = UIColor.clearColor;
             }
                              completion:^(BOOL finished) {
@@ -3866,9 +3861,7 @@
                                 options:UIViewAnimationOptionCurveEaseInOut
                              animations:^{
                 collectionView.alpha = 1;
-                UIImage *buttonImage = [UIImage imageNamed:@"button_exit_fullscreen"];
-                buttonImage = [buttonImage colorizeWithColor:ICON_TINT_COLOR];
-                [fullscreenButton setImage:buttonImage forState:UIControlStateNormal];
+                [fullscreenButton setIconStyle:[UIImage imageNamed:@"button_exit_fullscreen"]];
                 fullscreenButton.backgroundColor = INFO_POPOVER_COLOR;
             }
                              completion:^(BOOL finished) {
@@ -5434,21 +5427,13 @@
     MainMenu *menuItem = self.detailItem;
     NSArray *buttons = menuItem.mainButtons;
     NSArray *buttonsIB = @[button1, button2, button3, button4, button5];
-    UIImage *imageOff = nil;
-    UIImage *imageOn = nil;
-    UIImage *img = nil;
     NSInteger count = buttons.count;
     // If >6 buttons are required, only use 4 normal buttons and keep 5th for "more items"
     if (count > MAX_NORMAL_BUTTONS + 1) {
         count = MAX_NORMAL_BUTTONS;
     }
     for (int i = 0; i < count; i++) {
-        img = [UIImage imageNamed:buttons[i]];
-        imageOff = [img colorizeWithColor:ICON_TINT_COLOR];
-        imageOn = [img colorizeWithColor:ICON_TINT_COLOR_ACTIVE];
-        [buttonsIB[i] setBackgroundImage:imageOff forState:UIControlStateNormal];
-        [buttonsIB[i] setBackgroundImage:imageOn forState:UIControlStateSelected];
-        [buttonsIB[i] setBackgroundImage:imageOn forState:UIControlStateHighlighted];
+        [buttonsIB[i] setDatabaseToolbarStyle:[UIImage imageNamed:buttons[i]]];
         [buttonsIB[i] setEnabled:YES];
     }
     activeTab = MIN(activeTab, MAX_NORMAL_BUTTONS);
@@ -5486,12 +5471,7 @@
             break;
         default:
             // 6 or more buttons/actions require a "more" button
-            img = [UIImage imageNamed:@"st_more"];
-            imageOff = [img colorizeWithColor:ICON_TINT_COLOR];
-            imageOn = [img colorizeWithColor:ICON_TINT_COLOR_ACTIVE];
-            [buttonsIB.lastObject setBackgroundImage:imageOff forState:UIControlStateNormal];
-            [buttonsIB.lastObject setBackgroundImage:imageOn forState:UIControlStateSelected];
-            [buttonsIB.lastObject setBackgroundImage:imageOn forState:UIControlStateHighlighted];
+            [buttonsIB.lastObject setDatabaseToolbarStyle:[UIImage imageNamed:@"st_more"]];
             [buttonsIB.lastObject setEnabled:YES];
             break;
     }
@@ -6076,12 +6056,9 @@
             if (fullscreenButton == nil) {
                 fullscreenButton = [UIButton buttonWithType:UIButtonTypeCustom];
                 fullscreenButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin;
-                fullscreenButton.showsTouchWhenHighlighted = YES;
                 fullscreenButton.frame = CGRectMake(0, 0, FULLSCREEN_BUTTON_SIZE, FULLSCREEN_BUTTON_SIZE);
                 fullscreenButton.contentMode = UIViewContentModeCenter;
-                UIImage *buttonImage = [UIImage imageNamed:@"button_fullscreen"];
-                buttonImage = [buttonImage colorizeWithColor:ICON_TINT_COLOR];
-                [fullscreenButton setImage:buttonImage forState:UIControlStateNormal];
+                [fullscreenButton setIconStyle:[UIImage imageNamed:@"button_fullscreen"]];
                 fullscreenButton.layer.cornerRadius = 2;
                 [fullscreenButton addTarget:self action:@selector(toggleFullscreen) forControlEvents:UIControlEventTouchUpInside];
                 fullscreenButton.frame = CGRectMake(titleView.frame.size.width - fullscreenButton.frame.size.width, titleView.frame.size.height / 2 - fullscreenButton.frame.size.height / 2, fullscreenButton.frame.size.width, fullscreenButton.frame.size.height);

--- a/XBMC Remote/DetailViewController.xib
+++ b/XBMC Remote/DetailViewController.xib
@@ -76,7 +76,7 @@
                                     <items>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="OQd-aJ-obl"/>
                                         <barButtonItem style="plain" id="yuj-lW-yot">
-                                            <button key="customView" hidden="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="117" userLabel="Button1">
+                                            <button key="customView" hidden="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="117" userLabel="Button1">
                                                 <rect key="frame" x="10.5" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -94,7 +94,7 @@
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="IVe-28-sl6"/>
                                         <barButtonItem style="plain" id="cRW-wf-x2D">
-                                            <button key="customView" hidden="YES" tag="1" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="119" userLabel="Button2">
+                                            <button key="customView" hidden="YES" tag="1" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="119" userLabel="Button2">
                                                 <rect key="frame" x="54.5" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -112,7 +112,7 @@
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="dSm-ED-j5s"/>
                                         <barButtonItem style="plain" id="4He-Lr-2WZ">
-                                            <button key="customView" hidden="YES" tag="2" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="121" userLabel="Button3">
+                                            <button key="customView" hidden="YES" tag="2" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="121" userLabel="Button3">
                                                 <rect key="frame" x="99" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -130,7 +130,7 @@
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="Gi1-6Y-y4k"/>
                                         <barButtonItem style="plain" id="TE7-pJ-4WE">
-                                            <button key="customView" hidden="YES" tag="3" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="122" userLabel="Button4">
+                                            <button key="customView" hidden="YES" tag="3" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="122" userLabel="Button4">
                                                 <rect key="frame" x="143" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -148,7 +148,7 @@
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="ZdQ-hl-bWG"/>
                                         <barButtonItem style="plain" id="d4P-SH-Im4">
-                                            <button key="customView" hidden="YES" tag="4" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="123" userLabel="Button5">
+                                            <button key="customView" hidden="YES" tag="4" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="123" userLabel="Button5">
                                                 <rect key="frame" x="187.5" y="7" width="34" height="30"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -166,7 +166,7 @@
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="C79-Cc-JFa"/>
                                         <barButtonItem style="plain" id="rHQ-LZ-GMb">
-                                            <button key="customView" hidden="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="kky-5P-ej6" userLabel="Button6">
+                                            <button key="customView" hidden="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="kky-5P-ej6" userLabel="Button6">
                                                 <rect key="frame" x="231.5" y="5" width="34" height="34"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" backgroundImage="st_view_list"/>
@@ -174,7 +174,7 @@
                                         </barButtonItem>
                                         <barButtonItem style="plain" systemItem="flexibleSpace" id="bQB-y4-wNs"/>
                                         <barButtonItem style="plain" id="WWo-3h-QTx">
-                                            <button key="customView" hidden="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="17m-9l-ySa" userLabel="Button7">
+                                            <button key="customView" hidden="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="17m-9l-ySa" userLabel="Button7">
                                                 <rect key="frame" x="276" y="5" width="34" height="34"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <state key="normal" backgroundImage="st_sort_asc"/>

--- a/XBMC Remote/Extensions/UIButton+Extensions.h
+++ b/XBMC Remote/Extensions/UIButton+Extensions.h
@@ -1,0 +1,18 @@
+//
+//  UIButton+Extensions.h
+//  Kodi Remote
+//
+//  Created by Buschmann on 05.05.26.
+//  Copyright © 2026 Team Kodi. All rights reserved.
+//
+
+@import UIKit;
+
+@interface UIButton (Extensions)
+
+- (void)setTextStyle;
+- (void)setIconStyle:(UIImage*)image;
+- (void)setIconStyle:(UIImage*)image withColor:(UIColor*)color;
+- (void)setDatabaseToolbarStyle:(UIImage*)image;
+
+@end

--- a/XBMC Remote/Extensions/UIButton+Extensions.m
+++ b/XBMC Remote/Extensions/UIButton+Extensions.m
@@ -1,0 +1,50 @@
+//
+//  UIButton+Extensions.m
+//  Kodi Remote
+//
+//  Created by Buschmann on 05.05.26.
+//  Copyright © 2026 Team Kodi. All rights reserved.
+//
+
+#import "UIButton+Extensions.h"
+
+@implementation UIButton (Extensions)
+
+- (void)setTextStyle {
+    [self setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
+    [self setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
+    [self setTitleColor:UIColor.grayColor forState:UIControlStateDisabled];
+}
+
+- (void)setIconStyle:(UIImage*)image {
+    [self setIconStyle:image withColor:ICON_TINT_COLOR];
+}
+
+- (void)setIconStyle:(UIImage*)image withColor:(UIColor*)color {
+    if (!image) {
+        return;
+    }
+    
+    // Set icon colors
+    UIImage *imageNormal = color ? [image colorizeWithColor:color] : image;
+    [self setImage:imageNormal forState:UIControlStateNormal];
+    [self setImage:nil forState:UIControlStateSelected];
+    [self setImage:nil forState:UIControlStateHighlighted];
+    self.showsTouchWhenHighlighted = NO;
+}
+
+- (void)setDatabaseToolbarStyle:(UIImage*)image {
+    if (!image) {
+        return;
+    }
+    
+    // Set icon colors
+    UIImage *imageNormal = [image colorizeWithColor:ICON_TINT_COLOR];
+    UIImage *imageActive = [image colorizeWithColor:ICON_TINT_COLOR_ACTIVE];
+    [self setBackgroundImage:imageNormal forState:UIControlStateNormal];
+    [self setBackgroundImage:imageActive forState:UIControlStateSelected];
+    [self setBackgroundImage:nil forState:UIControlStateHighlighted];
+    self.showsTouchWhenHighlighted = NO;
+}
+
+@end

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -549,19 +549,15 @@
     supportedVersionLabel.text = LOCALIZED_STR(@"Supported XBMC version is Eden (11) or higher");
     
     editTableButton.titleLabel.font = [UIFont systemFontOfSize:15];
-    [editTableButton setTitleColor:UIColor.grayColor forState:UIControlStateDisabled];
-    [editTableButton setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];
-    [editTableButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
+    [editTableButton setTextStyle];
     editTableButton.titleLabel.shadowOffset = CGSizeZero;
     
     addHostButton.titleLabel.font = [UIFont systemFontOfSize:15];
-    [addHostButton setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];
-    [addHostButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
+    [addHostButton setTextStyle];
     addHostButton.titleLabel.shadowOffset = CGSizeZero;
     
     serverInfoButton.titleLabel.font = [UIFont systemFontOfSize:15];
-    [serverInfoButton setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];
-    [serverInfoButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
+    [serverInfoButton setTextStyle];
     serverInfoButton.titleLabel.shadowOffset = CGSizeZero;
     
     serverListTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
@@ -584,8 +580,6 @@
         UIImage *image = [UIImage imageNamed:@"kodi_logo_wide"];
         UIButton *xbmcLogo = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, image.size.width, image.size.height)];
         [xbmcLogo setImage:image forState:UIControlStateNormal];
-        [xbmcLogo setImage:image forState:UIControlStateHighlighted];
-        xbmcLogo.showsTouchWhenHighlighted = NO;
         [xbmcLogo addTarget:self action:@selector(infoView) forControlEvents:UIControlEventTouchUpInside];
         self.navigationItem.titleView = xbmcLogo;
         UIImage *menuImg = [UIImage imageNamed:@"button_menu"];

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -549,19 +549,15 @@
     supportedVersionLabel.text = LOCALIZED_STR(@"Supported XBMC version is Eden (11) or higher");
     
     editTableButton.titleLabel.font = [UIFont systemFontOfSize:15];
-    [editTableButton setTitleColor:UIColor.grayColor forState:UIControlStateDisabled];
-    [editTableButton setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];
-    [editTableButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
+    [editTableButton setTextStyle];
     editTableButton.titleLabel.shadowOffset = CGSizeZero;
     
     addHostButton.titleLabel.font = [UIFont systemFontOfSize:15];
-    [addHostButton setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];
-    [addHostButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
+    [addHostButton setTextStyle];
     addHostButton.titleLabel.shadowOffset = CGSizeZero;
     
     serverInfoButton.titleLabel.font = [UIFont systemFontOfSize:15];
-    [serverInfoButton setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];
-    [serverInfoButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
+    [serverInfoButton setTextStyle];
     serverInfoButton.titleLabel.shadowOffset = CGSizeZero;
     
     serverListTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
@@ -579,8 +575,6 @@
         UIImage *image = [UIImage imageNamed:@"kodi_logo_wide"];
         UIButton *xbmcLogo = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, image.size.width, image.size.height)];
         [xbmcLogo setImage:image forState:UIControlStateNormal];
-        [xbmcLogo setImage:image forState:UIControlStateHighlighted];
-        xbmcLogo.showsTouchWhenHighlighted = NO;
         [xbmcLogo addTarget:self action:@selector(infoView) forControlEvents:UIControlEventTouchUpInside];
         self.navigationItem.titleView = xbmcLogo;
         UIImage *menuImg = [UIImage imageNamed:@"button_menu"];

--- a/XBMC Remote/Kodi Remote-Prefix.pch
+++ b/XBMC Remote/Kodi Remote-Prefix.pch
@@ -5,6 +5,7 @@
 #import "UIImage+Extensions.h"
 #import "NSString+Extensions.h"
 #import "UIBarButtonItem+Extensions.h"
+#import "UIButton+Extensions.h"
 #import "UILabel+Extensions.h"
 #import "UIViewController+Extensions.h"
 #import "UIImageView+WebCache.h"

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -89,7 +89,7 @@
         title.numberOfLines = 1;
         title.text = item.mainLabel;
         icon.highlightedImage = [UIImage imageNamed:iconName];
-        icon.image = [icon.highlightedImage colorizeWithColor:UIColor.grayColor];
+        icon.image = [icon.highlightedImage colorizeWithColor:ICON_TINT_COLOR];
         cell.backgroundColor = UIColor.clearColor;
     }
     return cell;

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -90,7 +90,7 @@
         title.numberOfLines = 1;
         title.text = item.mainLabel;
         icon.highlightedImage = [UIImage imageNamed:iconName];
-        icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:UIColor.grayColor];
+        icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:ICON_TINT_COLOR];
         cell.backgroundColor = UIColor.clearColor;
     }
     return cell;

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -208,7 +208,7 @@
 
 - (void)setConnectionIcon:(UIImageView*)icon {
     // Load icon for top row in main menu
-    UIColor *iconColor = AppDelegate.instance.serverOnLine ? KODI_BLUE_COLOR : UIColor.grayColor;
+    UIColor *iconColor = AppDelegate.instance.serverOnLine ? KODI_BLUE_COLOR : ICON_TINT_COLOR;
     UIImage *image = [[UIImage imageNamed:@"st_kodi_action"] colorizeWithColor:iconColor];
     icon.highlightedImage = image;
     icon.image = image;

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -209,7 +209,7 @@
 
 - (void)setConnectionIcon:(UIImageView*)icon {
     // Load icon for top row in main menu
-    UIColor *iconColor = AppDelegate.instance.serverOnLine ? KODI_BLUE_COLOR : UIColor.grayColor;
+    UIColor *iconColor = AppDelegate.instance.serverOnLine ? KODI_BLUE_COLOR : ICON_TINT_COLOR;
     UIImage *image = [Utilities colorizeImage:[UIImage imageNamed:@"st_kodi_action"] withColor:iconColor];
     icon.highlightedImage = image;
     icon.image = image;

--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -77,7 +77,7 @@
                                               ICON_HEIGHT);
         UIImageView *iconImage = [[UIImageView alloc] initWithFrame:iconImageViewRect];
         UIImage *image = [Utilities setLightDarkModeImageAsset:[UIImage imageNamed:item[@"icon"]]
-                                                    lightColor:UIColor.darkGrayColor
+                                                    lightColor:ICON_TINT_COLOR_DARK
                                                      darkColor:ICON_TINT_COLOR];
         iconImage.image = image;
         [cell.contentView addSubview:iconImage];

--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -78,7 +78,7 @@
         UIImageView *iconImage = [[UIImageView alloc] initWithFrame:iconImageViewRect];
         UIImage *image = [Utilities setLightDarkModeImageAsset:[UIImage imageNamed:item[@"icon"]]
                                                     lightColor:UIColor.darkGrayColor
-                                                     darkColor:UIColor.lightGrayColor];
+                                                     darkColor:ICON_TINT_COLOR];
         iconImage.image = image;
         [cell.contentView addSubview:iconImage];
     }

--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -78,7 +78,7 @@
         UIImageView *iconImage = [[UIImageView alloc] initWithFrame:iconImageViewRect];
         UIImage *image = [Utilities setLightDarkModeImageAsset:[UIImage imageNamed:item[@"icon"]]
                                                 lightModeColor:UIColor.darkGrayColor
-                                                 darkModeColor:UIColor.lightGrayColor];
+                                                 darkModeColor:ICON_TINT_COLOR];
         iconImage.image = image;
         [cell.contentView addSubview:iconImage];
     }

--- a/XBMC Remote/MoreItemsViewController.m
+++ b/XBMC Remote/MoreItemsViewController.m
@@ -77,7 +77,7 @@
                                               ICON_HEIGHT);
         UIImageView *iconImage = [[UIImageView alloc] initWithFrame:iconImageViewRect];
         UIImage *image = [Utilities setLightDarkModeImageAsset:[UIImage imageNamed:item[@"icon"]]
-                                                lightModeColor:UIColor.darkGrayColor
+                                                lightModeColor:ICON_TINT_COLOR_DARK
                                                  darkModeColor:ICON_TINT_COLOR];
         iconImage.image = image;
         [cell.contentView addSubview:iconImage];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -283,31 +283,26 @@
 - (void)updateRepeatButton:(NSString*)mode {
     if ([mode isEqualToString:@"all"]) {
         UIImage *image = [UIImage imageNamed:@"button_repeat_all"];
-        image = [image colorizeWithColor:KODI_BLUE_COLOR];
-        [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
+        [repeatButton setIconStyle:image withColor:KODI_BLUE_COLOR];
     }
     else if ([mode isEqualToString:@"one"]) {
         UIImage *image = [UIImage imageNamed:@"button_repeat_one"];
-        image = [image colorizeWithColor:KODI_BLUE_COLOR];
-        [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
+        [repeatButton setIconStyle:image withColor:KODI_BLUE_COLOR];
     }
     else {
         UIImage *image = [UIImage imageNamed:@"button_repeat"];
-        image = [image colorizeWithColor:IS_IPAD ? UIColor.whiteColor : ICON_TINT_COLOR];
-        [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
+        [repeatButton setIconStyle:image withColor:nil];
     }
 }
 
 - (void)updateShuffleButton:(BOOL)shuffle {
     if (shuffle) {
         UIImage *image = [UIImage imageNamed:@"button_shuffle_on"];
-        image = [image colorizeWithColor:KODI_BLUE_COLOR];
-        [shuffleButton setBackgroundImage:image forState:UIControlStateNormal];
+        [shuffleButton setIconStyle:image withColor:KODI_BLUE_COLOR];
     }
     else {
         UIImage *image = [UIImage imageNamed:@"button_shuffle"];
-        image = [image colorizeWithColor:IS_IPAD ? UIColor.whiteColor : ICON_TINT_COLOR];
-        [shuffleButton setBackgroundImage:image forState:UIControlStateNormal];
+        [shuffleButton setIconStyle:image withColor:nil];
     }
 }
 
@@ -430,8 +425,6 @@
 - (void)setButtonImageAndStartDemo:(UIImage*)buttonImage {
     if (nowPlayingView.hidden || startFlipDemo) {
         [playlistButton setImage:buttonImage forState:UIControlStateNormal];
-        [playlistButton setImage:buttonImage forState:UIControlStateHighlighted];
-        [playlistButton setImage:buttonImage forState:UIControlStateSelected];
         if (startFlipDemo) {
             [NSTimer scheduledTimerWithTimeInterval:FLIP_DEMO_DELAY target:self selector:@selector(startFlipDemo) userInfo:nil repeats:NO];
             startFlipDemo = NO;
@@ -1588,8 +1581,6 @@
                     animations:^{
         // Animate transition to new button image
         [button setImage:buttonImage forState:UIControlStateNormal];
-        [button setImage:buttonImage forState:UIControlStateHighlighted];
-        [button setImage:buttonImage forState:UIControlStateSelected];
                      }
                      completion:nil
     ];
@@ -2484,7 +2475,6 @@
     NSString *imageName = isFullscreen ? @"button_exit_fullscreen" : @"button_fullscreen";
     UIImage *image = [UIImage imageNamed:imageName];
     [fullscreenToggleButton setImage:image forState:UIControlStateNormal];
-    [fullscreenToggleButton setImage:image forState:UIControlStateHighlighted];
     
     [self setCoverSize:currentType];
 }
@@ -2560,7 +2550,6 @@
     
     // Prepare iPad fullscreen toggle button
     fullscreenToggleButton = [self.view viewWithTag:TAG_ID_TOGGLE];
-    fullscreenToggleButton.showsTouchWhenHighlighted = YES;
 }
 
 - (BOOL)enableJewelCases {
@@ -2817,15 +2806,11 @@
     [editTableButton setBackgroundImage:[UIImage new] forState:UIControlStateHighlighted];
     [editTableButton setBackgroundImage:[UIImage new] forState:UIControlStateSelected];
     editTableButton.titleLabel.font = [UIFont systemFontOfSize:15];
-    [editTableButton setTitleColor:UIColor.grayColor forState:UIControlStateDisabled];
-    [editTableButton setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];
-    [editTableButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
+    [editTableButton setTextStyle];
     editTableButton.titleLabel.shadowOffset = CGSizeZero;
     
     PartyModeButton.titleLabel.font = [UIFont systemFontOfSize:15];
-    [PartyModeButton setTitleColor:UIColor.grayColor forState:UIControlStateNormal];
-    [PartyModeButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
-    [PartyModeButton setTitleColor:UIColor.whiteColor forState:UIControlStateHighlighted];
+    [PartyModeButton setTextStyle];
     PartyModeButton.titleLabel.shadowOffset = CGSizeZero;
 }
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2495,10 +2495,8 @@
     // Adapt fullscreen toggle button icon to current screen mode
     NSString *imageName = isFullscreen ? @"button_exit_fullscreen" : @"button_fullscreen";
     UIImage *image = [UIImage imageNamed:imageName];
-    image = [Utilities colorizeImage:image withColor:UIColor.whiteColor];
     [fullscreenToggleButton setImage:image forState:UIControlStateNormal];
     [fullscreenToggleButton setImage:image forState:UIControlStateHighlighted];
-    fullscreenToggleButton.alpha = 0.9;
     
     [self setCoverSize:currentType];
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -287,31 +287,26 @@
 - (void)updateRepeatButton:(NSString*)mode {
     if ([mode isEqualToString:@"all"]) {
         UIImage *image = [UIImage imageNamed:@"button_repeat_all"];
-        image = [Utilities colorizeImage:image withColor:KODI_BLUE_COLOR];
-        [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
+        [repeatButton setIconStyle:image withColor:KODI_BLUE_COLOR];
     }
     else if ([mode isEqualToString:@"one"]) {
         UIImage *image = [UIImage imageNamed:@"button_repeat_one"];
-        image = [Utilities colorizeImage:image withColor:KODI_BLUE_COLOR];
-        [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
+        [repeatButton setIconStyle:image withColor:KODI_BLUE_COLOR];
     }
     else {
         UIImage *image = [UIImage imageNamed:@"button_repeat"];
-        image = [Utilities colorizeImage:image withColor:IS_IPAD ? UIColor.whiteColor : ICON_TINT_COLOR];
-        [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
+        [repeatButton setIconStyle:image withColor:nil];
     }
 }
 
 - (void)updateShuffleButton:(BOOL)shuffle {
     if (shuffle) {
         UIImage *image = [UIImage imageNamed:@"button_shuffle_on"];
-        image = [Utilities colorizeImage:image withColor:KODI_BLUE_COLOR];
-        [shuffleButton setBackgroundImage:image forState:UIControlStateNormal];
+        [shuffleButton setIconStyle:image withColor:KODI_BLUE_COLOR];
     }
     else {
         UIImage *image = [UIImage imageNamed:@"button_shuffle"];
-        image = [Utilities colorizeImage:image withColor:IS_IPAD ? UIColor.whiteColor : ICON_TINT_COLOR];
-        [shuffleButton setBackgroundImage:image forState:UIControlStateNormal];
+        [shuffleButton setIconStyle:image withColor:nil];
     }
 }
 
@@ -434,8 +429,6 @@
 - (void)setButtonImageAndStartDemo:(UIImage*)buttonImage {
     if (nowPlayingView.hidden || startFlipDemo) {
         [playlistButton setImage:buttonImage forState:UIControlStateNormal];
-        [playlistButton setImage:buttonImage forState:UIControlStateHighlighted];
-        [playlistButton setImage:buttonImage forState:UIControlStateSelected];
         if (startFlipDemo) {
             [NSTimer scheduledTimerWithTimeInterval:FLIP_DEMO_DELAY target:self selector:@selector(startFlipDemo) userInfo:nil repeats:NO];
             startFlipDemo = NO;
@@ -1592,9 +1585,7 @@
                     animations:^{
         // Animate transition to new button image
         [button setImage:buttonImage forState:UIControlStateNormal];
-        [button setImage:buttonImage forState:UIControlStateHighlighted];
-        [button setImage:buttonImage forState:UIControlStateSelected];
-                     } 
+                     }
                      completion:nil
     ];
 }
@@ -2496,7 +2487,6 @@
     NSString *imageName = isFullscreen ? @"button_exit_fullscreen" : @"button_fullscreen";
     UIImage *image = [UIImage imageNamed:imageName];
     [fullscreenToggleButton setImage:image forState:UIControlStateNormal];
-    [fullscreenToggleButton setImage:image forState:UIControlStateHighlighted];
     
     [self setCoverSize:currentType];
 }
@@ -2576,7 +2566,6 @@
     
     // Prepare iPad fullscreen toggle button
     fullscreenToggleButton = [self.view viewWithTag:TAG_ID_TOGGLE];
-    fullscreenToggleButton.showsTouchWhenHighlighted = YES;
 }
 
 - (BOOL)enableJewelCases {
@@ -2822,15 +2811,11 @@
 
 - (void)setToolbar {
     editTableButton.titleLabel.font = [UIFont systemFontOfSize:15];
-    [editTableButton setTitleColor:UIColor.grayColor forState:UIControlStateDisabled];
-    [editTableButton setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];
-    [editTableButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
+    [editTableButton setTextStyle];
     editTableButton.titleLabel.shadowOffset = CGSizeZero;
     
     PartyModeButton.titleLabel.font = [UIFont systemFontOfSize:15];
-    [PartyModeButton setTitleColor:UIColor.grayColor forState:UIControlStateNormal];
-    [PartyModeButton setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
-    [PartyModeButton setTitleColor:UIColor.whiteColor forState:UIControlStateHighlighted];
+    [PartyModeButton setTextStyle];
     PartyModeButton.titleLabel.shadowOffset = CGSizeZero;
 }
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2823,16 +2823,6 @@
 }
 
 - (void)setToolbar {
-    UIButton *buttonItem = nil;
-    for (int i = 1; i < 8; i++) {
-        buttonItem = (UIButton*)[self.view viewWithTag:i];
-        [buttonItem setBackgroundImage:[UIImage new] forState:UIControlStateNormal];
-        [buttonItem setBackgroundImage:[UIImage new] forState:UIControlStateHighlighted];
-    }
-    
-    [editTableButton setBackgroundImage:[UIImage new] forState:UIControlStateNormal];
-    [editTableButton setBackgroundImage:[UIImage new] forState:UIControlStateHighlighted];
-    [editTableButton setBackgroundImage:[UIImage new] forState:UIControlStateSelected];
     editTableButton.titleLabel.font = [UIFont systemFontOfSize:15];
     [editTableButton setTitleColor:UIColor.grayColor forState:UIControlStateDisabled];
     [editTableButton setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -297,7 +297,7 @@
     }
     else {
         UIImage *image = [UIImage imageNamed:@"button_repeat"];
-        image = [Utilities colorizeImage:image withColor:IS_IPAD ? UIColor.whiteColor : UIColor.lightGrayColor];
+        image = [Utilities colorizeImage:image withColor:IS_IPAD ? UIColor.whiteColor : ICON_TINT_COLOR];
         [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
     }
 }
@@ -310,7 +310,7 @@
     }
     else {
         UIImage *image = [UIImage imageNamed:@"button_shuffle"];
-        image = [Utilities colorizeImage:image withColor:IS_IPAD ? UIColor.whiteColor : UIColor.lightGrayColor];
+        image = [Utilities colorizeImage:image withColor:IS_IPAD ? UIColor.whiteColor : ICON_TINT_COLOR];
         [shuffleButton setBackgroundImage:image forState:UIControlStateNormal];
     }
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2795,16 +2795,6 @@
 }
 
 - (void)setToolbar {
-    UIButton *buttonItem = nil;
-    for (int i = 1; i < 8; i++) {
-        buttonItem = (UIButton*)[self.view viewWithTag:i];
-        [buttonItem setBackgroundImage:[UIImage new] forState:UIControlStateNormal];
-        [buttonItem setBackgroundImage:[UIImage new] forState:UIControlStateHighlighted];
-    }
-    
-    [editTableButton setBackgroundImage:[UIImage new] forState:UIControlStateNormal];
-    [editTableButton setBackgroundImage:[UIImage new] forState:UIControlStateHighlighted];
-    [editTableButton setBackgroundImage:[UIImage new] forState:UIControlStateSelected];
     editTableButton.titleLabel.font = [UIFont systemFontOfSize:15];
     [editTableButton setTextStyle];
     editTableButton.titleLabel.shadowOffset = CGSizeZero;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -293,7 +293,7 @@
     }
     else {
         UIImage *image = [UIImage imageNamed:@"button_repeat"];
-        image = [image colorizeWithColor:IS_IPAD ? UIColor.whiteColor : UIColor.lightGrayColor];
+        image = [image colorizeWithColor:IS_IPAD ? UIColor.whiteColor : ICON_TINT_COLOR];
         [repeatButton setBackgroundImage:image forState:UIControlStateNormal];
     }
 }
@@ -306,7 +306,7 @@
     }
     else {
         UIImage *image = [UIImage imageNamed:@"button_shuffle"];
-        image = [image colorizeWithColor:IS_IPAD ? UIColor.whiteColor : UIColor.lightGrayColor];
+        image = [image colorizeWithColor:IS_IPAD ? UIColor.whiteColor : ICON_TINT_COLOR];
         [shuffleButton setBackgroundImage:image forState:UIControlStateNormal];
     }
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2483,10 +2483,8 @@
     // Adapt fullscreen toggle button icon to current screen mode
     NSString *imageName = isFullscreen ? @"button_exit_fullscreen" : @"button_fullscreen";
     UIImage *image = [UIImage imageNamed:imageName];
-    image = [image colorizeWithColor:UIColor.whiteColor];
     [fullscreenToggleButton setImage:image forState:UIControlStateNormal];
     [fullscreenToggleButton setImage:image forState:UIControlStateHighlighted];
-    fullscreenToggleButton.alpha = 0.9;
     
     [self setCoverSize:currentType];
 }

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -135,7 +135,7 @@
                                             <rect key="frame" x="30" y="4" width="180" height="22"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                         </imageView>
-                                        <button opaque="NO" alpha="0.80000000000000004" contentMode="scaleAspectFit" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lna-Os-O4e" userLabel="Button Close">
+                                        <button opaque="NO" alpha="0.80000000000000004" contentMode="scaleAspectFit" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lna-Os-O4e" userLabel="Button Close">
                                             <rect key="frame" x="210" y="0.0" width="30" height="22"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                                             <state key="normal" image="button_close"/>
@@ -315,7 +315,7 @@
                                             <color key="shadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <size key="shadowOffset" width="1" height="1"/>
                                         </label>
-                                        <button hidden="YES" opaque="NO" tag="8" contentMode="center" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="176" userLabel="Button Shuffle">
+                                        <button hidden="YES" opaque="NO" tag="8" contentMode="center" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="176" userLabel="Button Shuffle">
                                             <rect key="frame" x="16" y="128" width="28" height="30"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -330,7 +330,7 @@
                                                 <action selector="changeShuffle:" destination="-1" eventType="touchUpInside" id="178"/>
                                             </connections>
                                         </button>
-                                        <button hidden="YES" opaque="NO" tag="9" contentMode="center" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="179" userLabel="Button Repeat">
+                                        <button hidden="YES" opaque="NO" tag="9" contentMode="center" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="179" userLabel="Button Repeat">
                                             <rect key="frame" x="276" y="128" width="28" height="30"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -415,7 +415,7 @@
                     <rect key="frame" x="0.0" y="372" width="320" height="44"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                     <subviews>
-                        <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="2Vm-UV-m1b" userLabel="Button Stop">
+                        <button opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="2Vm-UV-m1b" userLabel="Button Stop">
                             <rect key="frame" x="11" y="5" width="38" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -423,14 +423,14 @@
                                 <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
-                            <state key="highlighted" image="now_playing_stop">
+                            <state key="highlighted">
                                 <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <connections>
                                 <action selector="startVibrate:" destination="-1" eventType="touchUpInside" id="0gg-od-R4W"/>
                             </connections>
                         </button>
-                        <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="9JE-J0-LsM" userLabel="Button Back">
+                        <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="9JE-J0-LsM" userLabel="Button Back">
                             <rect key="frame" x="50" y="5" width="38" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -438,7 +438,7 @@
                                 <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
-                            <state key="highlighted" image="now_playing_previous">
+                            <state key="highlighted">
                                 <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <connections>
@@ -446,7 +446,7 @@
                                 <outletCollection property="gestureRecognizers" destination="SPf-AK-dc6" appends="YES" id="p93-Mw-B5b"/>
                             </connections>
                         </button>
-                        <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="dUQ-7x-bHs" userLabel="Button Rewind">
+                        <button opaque="NO" tag="6" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="dUQ-7x-bHs" userLabel="Button Rewind">
                             <rect key="frame" x="92" y="5" width="38" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <gestureRecognizers/>
@@ -455,7 +455,7 @@
                                 <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
-                            <state key="highlighted" image="now_playing_seek_backward">
+                            <state key="highlighted">
                                 <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <connections>
@@ -463,7 +463,7 @@
                                 <outletCollection property="gestureRecognizers" destination="162" appends="YES" id="AxH-Sx-ZVi"/>
                             </connections>
                         </button>
-                        <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="4Kp-hV-AcM" userLabel="Button Playpause">
+                        <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="4Kp-hV-AcM" userLabel="Button Playpause">
                             <rect key="frame" x="139" y="1" width="42" height="42"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -471,14 +471,14 @@
                                 <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
-                            <state key="highlighted" image="now_playing_pause">
+                            <state key="highlighted">
                                 <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <connections>
                                 <action selector="startVibrate:" destination="-1" eventType="touchUpInside" id="yL2-H1-Eba"/>
                             </connections>
                         </button>
-                        <button opaque="NO" tag="7" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="e2z-dH-Njp" userLabel="Button Forward">
+                        <button opaque="NO" tag="7" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="e2z-dH-Njp" userLabel="Button Forward">
                             <rect key="frame" x="187" y="5" width="38" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <gestureRecognizers/>
@@ -487,7 +487,7 @@
                                 <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
-                            <state key="highlighted" image="now_playing_seek_forward">
+                            <state key="highlighted">
                                 <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <connections>
@@ -495,7 +495,7 @@
                                 <outletCollection property="gestureRecognizers" destination="164" appends="YES" id="RsE-qQ-xwL"/>
                             </connections>
                         </button>
-                        <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" id="cnS-6H-tni" userLabel="Button Next">
+                        <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="cnS-6H-tni" userLabel="Button Next">
                             <rect key="frame" x="228" y="5" width="38" height="34"/>
                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
@@ -503,7 +503,7 @@
                                 <color key="titleColor" red="0.19607843459999999" green="0.30980393290000002" blue="0.52156865600000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
-                            <state key="highlighted" image="now_playing_next">
+                            <state key="highlighted">
                                 <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <connections>
@@ -519,7 +519,7 @@
                                 <color key="titleColor" red="0.1960784314" green="0.30980392159999998" blue="0.52156862749999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
-                            <state key="highlighted" image="now_playing_playlist">
+                            <state key="highlighted">
                                 <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <connections>

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -304,14 +304,13 @@ static void *TorchRemoteContext = &TorchRemoteContext;
                          completion:nil];
     }
     if ([sender isKindOfClass:[UIButton class]]) {
-        [sender setImage:[self getImageForRemoteMode] forState:UIControlStateNormal];
+        [sender setIconStyle:[self getImageForRemoteMode]];
     }
     [self saveRemoteMode];
 }
 
 - (UIImage*)getImageForRemoteMode {
-    UIImage *gestureImage = [UIImage imageNamed:isGestureViewActive ? @"icon_remote" : @"icon_finger"];
-    return [Utilities colorizeImage:gestureImage withColor:ICON_TINT_COLOR];
+    return [UIImage imageNamed:isGestureViewActive ? @"icon_remote" : @"icon_finger"];
 }
 
 - (void)setLayoutForGestureMode {
@@ -1139,8 +1138,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
 
 - (void)setTorchIcon:(BOOL)torchActive {
     UIImage *buttonImage = [UIImage imageNamed:torchActive ? @"torch_on" : @"torch"];
-    buttonImage = [Utilities colorizeImage:buttonImage withColor:ICON_TINT_COLOR];
-    [torchButton setImage:buttonImage forState:UIControlStateNormal];
+    [torchButton setIconStyle:buttonImage];
 }
 
 - (void)dismissModal {
@@ -1189,15 +1187,11 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     
     // Add buttons to toolbar
     frame.origin.x -= ToolbarPadding;
-    UIImage *buttonImage;
     if (IS_IPAD) {
         UIButton *customButton = [UIButton buttonWithType:UIButtonTypeCustom];
         frame.origin.x += ToolbarPadding;
         customButton.frame = frame;
-        customButton.showsTouchWhenHighlighted = YES;
-        buttonImage = [UIImage imageNamed:@"icon_custom_buttons"];
-        buttonImage = [Utilities colorizeImage:buttonImage withColor:ICON_TINT_COLOR];
-        [customButton setImage:buttonImage forState:UIControlStateNormal];
+        [customButton setIconStyle:[UIImage imageNamed:@"icon_custom_buttons"]];
         [customButton addTarget:self action:@selector(enterCustomButtons) forControlEvents:UIControlEventTouchUpInside];
         [remoteToolbar addSubview:customButton];
     }
@@ -1205,35 +1199,27 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     UIButton *gestureButton = [UIButton buttonWithType:UIButtonTypeCustom];
     frame.origin.x += ToolbarPadding;
     gestureButton.frame = frame;
-    gestureButton.showsTouchWhenHighlighted = YES;
-    [gestureButton setImage:[self getImageForRemoteMode] forState:UIControlStateNormal];
+    [gestureButton setIconStyle:[self getImageForRemoteMode]];
     [gestureButton addTarget:self action:@selector(toggleGestureZone:) forControlEvents:UIControlEventTouchUpInside];
     [remoteToolbar addSubview:gestureButton];
     
     UIButton *keyboardButton = [UIButton buttonWithType:UIButtonTypeCustom];
     frame.origin.x += ToolbarPadding;
     keyboardButton.frame = frame;
-    keyboardButton.showsTouchWhenHighlighted = YES;
-    buttonImage = [UIImage imageNamed:@"icon_keyboard"];
-    buttonImage = [Utilities colorizeImage:buttonImage withColor:ICON_TINT_COLOR];
-    [keyboardButton setImage:buttonImage forState:UIControlStateNormal];
+    [keyboardButton setIconStyle:[UIImage imageNamed:@"icon_keyboard"]];
     [keyboardButton addTarget:self action:@selector(toggleVirtualKeyboard) forControlEvents:UIControlEventTouchUpInside];
     [remoteToolbar addSubview:keyboardButton];
 
     UIButton *helpButton = [UIButton buttonWithType:UIButtonTypeCustom];
     frame.origin.x += ToolbarPadding;
     helpButton.frame = frame;
-    helpButton.showsTouchWhenHighlighted = YES;
-    buttonImage = [UIImage imageNamed:@"button_info"];
-    buttonImage = [Utilities colorizeImage:buttonImage withColor:ICON_TINT_COLOR];
-    [helpButton setImage:buttonImage forState:UIControlStateNormal];
+    [helpButton setIconStyle:[UIImage imageNamed:@"button_info"]];
     [helpButton addTarget:self action:@selector(toggleQuickHelp) forControlEvents:UIControlEventTouchUpInside];
     [remoteToolbar addSubview:helpButton];
     
     torchButton = [UIButton buttonWithType:UIButtonTypeCustom];
     frame.origin.x += ToolbarPadding;
     torchButton.frame = frame;
-    torchButton.showsTouchWhenHighlighted = YES;
     torchButton.enabled = self.avCaptureDevice.torchAvailable;
     [self setTorchIcon:torchIsOn];
     [torchButton addTarget:self action:@selector(toggleTorch) forControlEvents:UIControlEventTouchUpInside];
@@ -1243,10 +1229,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
         positionButton = [UIButton buttonWithType:UIButtonTypeCustom];
         frame.origin.x += ToolbarPadding;
         positionButton.frame = frame;
-        positionButton.showsTouchWhenHighlighted = YES;
-        buttonImage = [UIImage imageNamed:@"icon_up_down"];
-        buttonImage = [Utilities colorizeImage:buttonImage withColor:ICON_TINT_COLOR];
-        [positionButton setImage:buttonImage forState:UIControlStateNormal];
+        [positionButton setIconStyle:[UIImage imageNamed:@"icon_up_down"]];
         [positionButton addTarget:self action:@selector(toggleRemotePosition) forControlEvents:UIControlEventTouchUpInside];
         [remoteToolbar addSubview:positionButton];
     }
@@ -1254,10 +1237,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
         UIButton *closeButton = [UIButton buttonWithType:UIButtonTypeCustom];
         frame.origin.x += ToolbarPadding;
         closeButton.frame = frame;
-        closeButton.showsTouchWhenHighlighted = YES;
-        buttonImage = [UIImage imageNamed:@"button_close"];
-        buttonImage = [Utilities colorizeImage:buttonImage withColor:ICON_TINT_COLOR];
-        [closeButton setImage:buttonImage forState:UIControlStateNormal];
+        [closeButton setIconStyle:[UIImage imageNamed:@"button_close"]];
         [closeButton addTarget:self action:@selector(dismissModal) forControlEvents:UIControlEventTouchUpInside];
         [remoteToolbar addSubview:closeButton];
     }

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -300,14 +300,13 @@ static void *TorchRemoteContext = &TorchRemoteContext;
                          completion:nil];
     }
     if ([sender isKindOfClass:[UIButton class]]) {
-        [sender setImage:[self getImageForRemoteMode] forState:UIControlStateNormal];
+        [sender setIconStyle:[self getImageForRemoteMode]];
     }
     [self saveRemoteMode];
 }
 
 - (UIImage*)getImageForRemoteMode {
-    UIImage *gestureImage = [UIImage imageNamed:isGestureViewActive ? @"icon_remote" : @"icon_finger"];
-    return [gestureImage colorizeWithColor:ICON_TINT_COLOR];
+    return [UIImage imageNamed:isGestureViewActive ? @"icon_remote" : @"icon_finger"];
 }
 
 - (void)setLayoutForGestureMode {
@@ -1119,8 +1118,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
 
 - (void)setTorchIcon:(BOOL)torchActive {
     UIImage *buttonImage = [UIImage imageNamed:torchActive ? @"torch_on" : @"torch"];
-    buttonImage = [buttonImage colorizeWithColor:ICON_TINT_COLOR];
-    [torchButton setImage:buttonImage forState:UIControlStateNormal];
+    [torchButton setIconStyle:buttonImage];
 }
 
 - (void)dismissModal {
@@ -1167,15 +1165,11 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     
     // Add buttons to toolbar
     frame.origin.x -= ToolbarPadding;
-    UIImage *buttonImage;
     if (IS_IPAD) {
         UIButton *customButton = [UIButton buttonWithType:UIButtonTypeCustom];
         frame.origin.x += ToolbarPadding;
         customButton.frame = frame;
-        customButton.showsTouchWhenHighlighted = YES;
-        buttonImage = [UIImage imageNamed:@"icon_custom_buttons"];
-        buttonImage = [buttonImage colorizeWithColor:ICON_TINT_COLOR];
-        [customButton setImage:buttonImage forState:UIControlStateNormal];
+        [customButton setIconStyle:[UIImage imageNamed:@"icon_custom_buttons"]];
         [customButton addTarget:self action:@selector(enterCustomButtons) forControlEvents:UIControlEventTouchUpInside];
         [remoteToolbar addSubview:customButton];
     }
@@ -1183,35 +1177,27 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     UIButton *gestureButton = [UIButton buttonWithType:UIButtonTypeCustom];
     frame.origin.x += ToolbarPadding;
     gestureButton.frame = frame;
-    gestureButton.showsTouchWhenHighlighted = YES;
-    [gestureButton setImage:[self getImageForRemoteMode] forState:UIControlStateNormal];
+    [gestureButton setIconStyle:[self getImageForRemoteMode]];
     [gestureButton addTarget:self action:@selector(toggleGestureZone:) forControlEvents:UIControlEventTouchUpInside];
     [remoteToolbar addSubview:gestureButton];
     
     UIButton *keyboardButton = [UIButton buttonWithType:UIButtonTypeCustom];
     frame.origin.x += ToolbarPadding;
     keyboardButton.frame = frame;
-    keyboardButton.showsTouchWhenHighlighted = YES;
-    buttonImage = [UIImage imageNamed:@"icon_keyboard"];
-    buttonImage = [buttonImage colorizeWithColor:ICON_TINT_COLOR];
-    [keyboardButton setImage:buttonImage forState:UIControlStateNormal];
+    [keyboardButton setIconStyle:[UIImage imageNamed:@"icon_keyboard"]];
     [keyboardButton addTarget:self action:@selector(toggleVirtualKeyboard) forControlEvents:UIControlEventTouchUpInside];
     [remoteToolbar addSubview:keyboardButton];
 
     UIButton *helpButton = [UIButton buttonWithType:UIButtonTypeCustom];
     frame.origin.x += ToolbarPadding;
     helpButton.frame = frame;
-    helpButton.showsTouchWhenHighlighted = YES;
-    buttonImage = [UIImage imageNamed:@"button_info"];
-    buttonImage = [buttonImage colorizeWithColor:ICON_TINT_COLOR];
-    [helpButton setImage:buttonImage forState:UIControlStateNormal];
+    [helpButton setIconStyle:[UIImage imageNamed:@"button_info"]];
     [helpButton addTarget:self action:@selector(toggleQuickHelp) forControlEvents:UIControlEventTouchUpInside];
     [remoteToolbar addSubview:helpButton];
     
     torchButton = [UIButton buttonWithType:UIButtonTypeCustom];
     frame.origin.x += ToolbarPadding;
     torchButton.frame = frame;
-    torchButton.showsTouchWhenHighlighted = YES;
     torchButton.enabled = self.avCaptureDevice.torchAvailable;
     [self setTorchIcon:torchIsOn];
     [torchButton addTarget:self action:@selector(toggleTorch) forControlEvents:UIControlEventTouchUpInside];
@@ -1221,10 +1207,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
         positionButton = [UIButton buttonWithType:UIButtonTypeCustom];
         frame.origin.x += ToolbarPadding;
         positionButton.frame = frame;
-        positionButton.showsTouchWhenHighlighted = YES;
-        buttonImage = [UIImage imageNamed:@"icon_up_down"];
-        buttonImage = [buttonImage colorizeWithColor:ICON_TINT_COLOR];
-        [positionButton setImage:buttonImage forState:UIControlStateNormal];
+        [positionButton setIconStyle:[UIImage imageNamed:@"icon_up_down"]];
         [positionButton addTarget:self action:@selector(toggleRemotePosition) forControlEvents:UIControlEventTouchUpInside];
         [remoteToolbar addSubview:positionButton];
     }
@@ -1232,10 +1215,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
         UIButton *closeButton = [UIButton buttonWithType:UIButtonTypeCustom];
         frame.origin.x += ToolbarPadding;
         closeButton.frame = frame;
-        closeButton.showsTouchWhenHighlighted = YES;
-        buttonImage = [UIImage imageNamed:@"button_close"];
-        buttonImage = [buttonImage colorizeWithColor:ICON_TINT_COLOR];
-        [closeButton setImage:buttonImage forState:UIControlStateNormal];
+        [closeButton setIconStyle:[UIImage imageNamed:@"button_close"]];
         [closeButton addTarget:self action:@selector(dismissModal) forControlEvents:UIControlEventTouchUpInside];
         [remoteToolbar addSubview:closeButton];
     }

--- a/XBMC Remote/RemoteController.xib
+++ b/XBMC Remote/RemoteController.xib
@@ -480,7 +480,7 @@
                                         <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </state>
-                                    <state key="highlighted" image="button_close">
+                                    <state key="highlighted">
                                         <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </state>
                                     <connections>

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -232,6 +232,20 @@
     }
 }
 
+- (void)highlightCustomButton:(NSIndexPath*)indexPath {
+    // Short animation to highlight the button selection
+    CustomButtonCell *cell = [menuTableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:indexPath.row inSection:0]];
+    [UIView animateWithDuration:0.1
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        cell.alpha = 0.1;
+    }
+                     completion:^(BOOL finished) {
+        cell.alpha = 1.0;
+    }];
+}
+
 #pragma mark - UISwitch
 
 - (void)toggleSwitch:(UISwitch*)onoff {
@@ -347,6 +361,7 @@
             NSDictionary *parameters = tableData[indexPath.row][@"action"][@"params"] ?: @{};
             [self xbmcAction:command params:parameters uiControl:nil];
         }
+        [self highlightCustomButton:indexPath];
     }
 }
 

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -132,7 +132,7 @@
     
     // plus button
     UIImage *image = [UIImage imageNamed:@"icon_plus"];
-    image = [Utilities colorizeImage:image withColor:UIColor.lightGrayColor];
+    image = [Utilities colorizeImage:image withColor:ICON_TINT_COLOR];
     CGFloat originX = IS_IPHONE ? (ANCHOR_RIGHT_PEEK + PANEL_SHADOW_SIZE) : 0 + BUTTON_SPACING;
     moreButton = [[UIButton alloc] initWithFrame:CGRectMake(originX, 0, TOOLBAR_HEIGHT, TOOLBAR_HEIGHT)];
     moreButton.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -130,15 +130,12 @@
     [newView addSubview:effectView];
     
     // plus button
-    UIImage *image = [UIImage imageNamed:@"icon_plus"];
-    image = [image colorizeWithColor:ICON_TINT_COLOR];
     CGFloat originX = IS_IPHONE ? (ANCHOR_RIGHT_PEEK + PANEL_SHADOW_SIZE) : 0 + BUTTON_SPACING;
     moreButton = [[UIButton alloc] initWithFrame:CGRectMake(originX, 0, TOOLBAR_HEIGHT, TOOLBAR_HEIGHT)];
     moreButton.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
     moreButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
     moreButton.enabled = AppDelegate.instance.serverOnLine;
-    [moreButton setImage:image forState:UIControlStateNormal];
-    [moreButton setImage:image forState:UIControlStateHighlighted];
+    [moreButton setIconStyle:[UIImage imageNamed:@"icon_plus"]];
     [moreButton addTarget:self action:@selector(addButtonToList:) forControlEvents:UIControlEventTouchUpInside];
     [newView addSubview:moreButton];
     
@@ -147,9 +144,7 @@
     editTableButton = [[UIButton alloc] initWithFrame:CGRectMake(originX, 0, BUTTON_WIDTH, TOOLBAR_HEIGHT)];
     editTableButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
     editTableButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
-    [editTableButton setTitleColor:UIColor.darkGrayColor forState:UIControlStateDisabled];
-    [editTableButton setTitleColor:UIColor.lightGrayColor forState:UIControlStateNormal];
-    [editTableButton setTitleColor:UIColor.lightGrayColor forState:UIControlStateSelected];
+    [editTableButton setTextStyle];
     [editTableButton setTitle:LOCALIZED_STR(@"Edit") forState:UIControlStateNormal];
     [editTableButton setTitle:LOCALIZED_STR(@"Done") forState:UIControlStateSelected];
     [editTableButton addTarget:self action:@selector(editTable:) forControlEvents:UIControlEventTouchUpInside];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -131,15 +131,12 @@
     [newView addSubview:effectView];
     
     // plus button
-    UIImage *image = [UIImage imageNamed:@"icon_plus"];
-    image = [Utilities colorizeImage:image withColor:ICON_TINT_COLOR];
     CGFloat originX = IS_IPHONE ? (ANCHOR_RIGHT_PEEK + PANEL_SHADOW_SIZE) : 0 + BUTTON_SPACING;
     moreButton = [[UIButton alloc] initWithFrame:CGRectMake(originX, 0, TOOLBAR_HEIGHT, TOOLBAR_HEIGHT)];
     moreButton.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
     moreButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
     moreButton.enabled = AppDelegate.instance.serverOnLine;
-    [moreButton setImage:image forState:UIControlStateNormal];
-    [moreButton setImage:image forState:UIControlStateHighlighted];
+    [moreButton setIconStyle:[UIImage imageNamed:@"icon_plus"]];
     [moreButton addTarget:self action:@selector(addButtonToList:) forControlEvents:UIControlEventTouchUpInside];
     [newView addSubview:moreButton];
     
@@ -148,9 +145,7 @@
     editTableButton = [[UIButton alloc] initWithFrame:CGRectMake(originX, 0, BUTTON_WIDTH, TOOLBAR_HEIGHT)];
     editTableButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
     editTableButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentRight;
-    [editTableButton setTitleColor:UIColor.darkGrayColor forState:UIControlStateDisabled];
-    [editTableButton setTitleColor:UIColor.lightGrayColor forState:UIControlStateNormal];
-    [editTableButton setTitleColor:UIColor.lightGrayColor forState:UIControlStateSelected];
+    [editTableButton setTextStyle];
     [editTableButton setTitle:LOCALIZED_STR(@"Edit") forState:UIControlStateNormal];
     [editTableButton setTitle:LOCALIZED_STR(@"Done") forState:UIControlStateSelected];
     [editTableButton addTarget:self action:@selector(editTable:) forControlEvents:UIControlEventTouchUpInside];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -231,6 +231,20 @@
     }
 }
 
+- (void)highlightCustomButton:(NSIndexPath*)indexPath {
+    // Short animation to highlight the button selection
+    CustomButtonCell *cell = [menuTableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:indexPath.row inSection:0]];
+    [UIView animateWithDuration:0.1
+                          delay:0.0
+                        options:UIViewAnimationOptionCurveEaseInOut
+                     animations:^{
+        cell.alpha = 0.1;
+    }
+                     completion:^(BOOL finished) {
+        cell.alpha = 1.0;
+    }];
+}
+
 #pragma mark - UISwitch
 
 - (void)toggleSwitch:(UISwitch*)onoff {
@@ -346,6 +360,7 @@
             NSDictionary *parameters = tableData[indexPath.row][@"action"][@"params"] ?: @{};
             [self xbmcAction:command params:parameters uiControl:nil];
         }
+        [self highlightCustomButton:indexPath];
     }
 }
 

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -131,7 +131,7 @@
     
     // plus button
     UIImage *image = [UIImage imageNamed:@"icon_plus"];
-    image = [image colorizeWithColor:UIColor.lightGrayColor];
+    image = [image colorizeWithColor:ICON_TINT_COLOR];
     CGFloat originX = IS_IPHONE ? (ANCHOR_RIGHT_PEEK + PANEL_SHADOW_SIZE) : 0 + BUTTON_SPACING;
     moreButton = [[UIButton alloc] initWithFrame:CGRectMake(originX, 0, TOOLBAR_HEIGHT, TOOLBAR_HEIGHT)];
     moreButton.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -63,7 +63,6 @@
         [self.view addSubview:imageBackground];
         
         activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
-        activityIndicator.color = UIColor.grayColor;
         activityIndicator.center = CGPointMake(frame.size.width / 2, frame.size.height / 2);
         activityIndicator.hidesWhenStopped = YES;
         [self.view addSubview:activityIndicator];

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -64,7 +64,6 @@
         [self.view addSubview:imageBackground];
         
         activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
-        activityIndicator.color = UIColor.grayColor;
         activityIndicator.center = CGPointMake(frame.size.width / 2, frame.size.height / 2);
         activityIndicator.hidesWhenStopped = YES;
         [self.view addSubview:activityIndicator];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -555,7 +555,7 @@
     [coverView animateAlpha:1.0 duration:0.1];
 }
 
-- (void)setIOS7barTintColor:(UIColor*)tintColor {
+- (void)setTopBarTintColor:(UIColor*)tintColor {
     toolbar.tintColor = tintColor;
     [self setNavigationBarTint:tintColor];
 }
@@ -1347,7 +1347,7 @@
                         }
                         if (image != nil) {
                             UIColor *newColor = [Utilities textTintColor:[Utilities getUIColorFromImage:image]];
-                            [strongSelf setIOS7barTintColor:newColor];
+                            [strongSelf setTopBarTintColor:newColor];
                             foundTintColor = newColor;
                         }
                         [strongSelf elaborateImage:image fallbackImage:[UIImage imageNamed:placeHolderImage]];
@@ -1797,7 +1797,7 @@
             }
         }
         
-        [self setIOS7barTintColor:ICON_TINT_COLOR];
+        [self setTopBarTintColor:ICON_TINT_COLOR];
         viewTitle.textAlignment = NSTextAlignmentCenter;
         bottomShadow.hidden = YES;
     }
@@ -1806,12 +1806,7 @@
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    if (foundTintColor != nil) {
-        [self setIOS7barTintColor:foundTintColor];
-    }
-    else {
-        [self setIOS7barTintColor:ICON_TINT_COLOR];
-    }
+    [self setTopBarTintColor:foundTintColor ?: ICON_TINT_COLOR];
     CGFloat alphaValue = 0.2;
     if (closeButton.alpha == 1) {
         alphaValue = 1;
@@ -1843,7 +1838,7 @@
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [self setIOS7barTintColor:ICON_TINT_COLOR];
+    [self setTopBarTintColor:ICON_TINT_COLOR];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -562,7 +562,7 @@
     [Utilities alphaView:coverView AnimDuration:0.1 Alpha:1.0];
 }
 
-- (void)setIOS7barTintColor:(UIColor*)tintColor {
+- (void)setTopBarTintColor:(UIColor*)tintColor {
     toolbar.tintColor = tintColor;
     [self setNavigationBarTint:tintColor];
 }
@@ -1388,7 +1388,7 @@
                         }
                         if (image != nil) {
                             UIColor *newColor = [Utilities textTintColor:[Utilities getUIColorFromImage:image]];
-                            [strongSelf setIOS7barTintColor:newColor];
+                            [strongSelf setTopBarTintColor:newColor];
                             foundTintColor = newColor;
                         }
                         [strongSelf elaborateImage:image fallbackImage:[UIImage imageNamed:placeHolderImage]];
@@ -1838,7 +1838,7 @@
             }
         }
         
-        [self setIOS7barTintColor:ICON_TINT_COLOR];
+        [self setTopBarTintColor:ICON_TINT_COLOR];
         viewTitle.textAlignment = NSTextAlignmentCenter;
         bottomShadow.hidden = YES;
     }
@@ -1847,12 +1847,7 @@
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    if (foundTintColor != nil) {
-        [self setIOS7barTintColor:foundTintColor];
-    }
-    else {
-        [self setIOS7barTintColor:ICON_TINT_COLOR];
-    }
+    [self setTopBarTintColor:foundTintColor ?: ICON_TINT_COLOR];
     CGFloat alphaValue = 0.2;
     if (closeButton.alpha == 1) {
         alphaValue = 1;
@@ -1883,7 +1878,7 @@
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [self setIOS7barTintColor:ICON_TINT_COLOR];
+    [self setTopBarTintColor:ICON_TINT_COLOR];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1604,7 +1604,7 @@
 
 - (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
     if (AppDelegate.instance.serverVersion > 11 && ![self isModal]) {
-        UIImage *image = [Utilities colorizeImage:[UIImage imageNamed:@"table_arrow_right"] withColor:UIColor.grayColor];
+        UIImage *image = [Utilities colorizeImage:[UIImage imageNamed:@"table_arrow_right"] withColor:ICON_TINT_COLOR];
         cell.accessoryView = [[UIImageView alloc] initWithImage:image];
         cell.accessoryView.alpha = ARROW_ALPHA;
     }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1563,7 +1563,7 @@
 
 - (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
     if (AppDelegate.instance.serverVersion > 11 && ![self isModal]) {
-        UIImage *image = [[UIImage imageNamed:@"table_arrow_right"] colorizeWithColor:UIColor.grayColor];
+        UIImage *image = [[UIImage imageNamed:@"table_arrow_right"] colorizeWithColor:ICON_TINT_COLOR];
         cell.accessoryView = [[UIImageView alloc] initWithImage:image];
         cell.accessoryView.alpha = ARROW_ALPHA;
     }

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -131,3 +131,12 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (void)resetKodiServerParameters;
 
 @end
+
+@interface UIButton (Extensions)
+
+- (void)setTextStyle;
+- (void)setIconStyle:(UIImage*)image;
+- (void)setIconStyle:(UIImage*)image withColor:(UIColor*)color;
+- (void)setDatabaseToolbarStyle:(UIImage*)image;
+
+@end

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1456,3 +1456,46 @@
 }
 
 @end
+
+#pragma mark - UIButton extensions
+
+@implementation UIButton (Extensions)
+
+- (void)setTextStyle {
+    [self setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
+    [self setTitleColor:UIColor.whiteColor forState:UIControlStateSelected];
+    [self setTitleColor:UIColor.grayColor forState:UIControlStateDisabled];
+}
+
+- (void)setIconStyle:(UIImage*)image {
+    [self setIconStyle:image withColor:ICON_TINT_COLOR];
+}
+
+- (void)setIconStyle:(UIImage*)image withColor:(UIColor*)color {
+    if (!image) {
+        return;
+    }
+    
+    // Set icon colors
+    UIImage *imageNormal = color ? [Utilities colorizeImage:image withColor:color] : image;
+    [self setImage:imageNormal forState:UIControlStateNormal];
+    [self setImage:nil forState:UIControlStateSelected];
+    [self setImage:nil forState:UIControlStateHighlighted];
+    self.showsTouchWhenHighlighted = NO;
+}
+
+- (void)setDatabaseToolbarStyle:(UIImage*)image {
+    if (!image) {
+        return;
+    }
+    
+    // Set icon colors
+    UIImage *imageNormal = [Utilities colorizeImage:image withColor:ICON_TINT_COLOR];
+    UIImage *imageActive = [Utilities colorizeImage:image withColor:ICON_TINT_COLOR_ACTIVE];
+    [self setBackgroundImage:imageNormal forState:UIControlStateNormal];
+    [self setBackgroundImage:imageActive forState:UIControlStateSelected];
+    [self setBackgroundImage:nil forState:UIControlStateHighlighted];
+    self.showsTouchWhenHighlighted = NO;
+}
+
+@end

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -378,7 +378,7 @@
     
     // remote button next to volume control buttons
     UIImage *image = [UIImage imageNamed:@"icon_menu_remote"];
-    image = [image colorizeWithColor:UIColor.lightGrayColor];
+    image = [image colorizeWithColor:ICON_TINT_COLOR];
     UIButton *remoteButton = [[UIButton alloc] initWithFrame:CGRectMake(leftMenuView.frame.size.width - REMOTE_PADDING - REMOTE_ICON_SIZE, self.view.frame.size.height - (TOOLBAR_HEIGHT + REMOTE_ICON_SIZE) / 2 - [Utilities getBottomPadding], REMOTE_ICON_SIZE, REMOTE_ICON_SIZE)];
     [remoteButton setImage:image forState:UIControlStateNormal];
     [remoteButton setImage:image forState:UIControlStateHighlighted];
@@ -388,7 +388,7 @@
     
     // "show desktop" button next to remote button
     image = [UIImage imageNamed:@"icon_menu_playing"];
-    image = [image colorizeWithColor:UIColor.lightGrayColor];
+    image = [image colorizeWithColor:ICON_TINT_COLOR];
     UIButton *showDesktopButton = [[UIButton alloc] initWithFrame:CGRectMake(leftMenuView.frame.size.width + DESKTOP_PADDING, self.view.frame.size.height - (TOOLBAR_HEIGHT + REMOTE_ICON_SIZE) / 2 - [Utilities getBottomPadding], REMOTE_ICON_SIZE, REMOTE_ICON_SIZE)];
     [showDesktopButton setImage:image forState:UIControlStateNormal];
     [showDesktopButton setImage:image forState:UIControlStateHighlighted];
@@ -414,7 +414,7 @@
     
     // 3rd right most element
     image = [UIImage imageNamed:@"icon_menu_settings"];
-    image = [image colorizeWithColor:UIColor.lightGrayColor];
+    image = [image colorizeWithColor:ICON_TINT_COLOR];
     settingsButton = [[UIButton alloc] initWithFrame:CGRectMake(xbmcLogo.frame.origin.x - SETTINGSBUTTON_WIDTH - BUTTON_PADDING, self.view.frame.size.height - TOOLBAR_HEIGHT, SETTINGSBUTTON_WIDTH, TOOLBAR_HEIGHT)];
     [settingsButton setImage:image forState:UIControlStateNormal];
     [settingsButton setImage:image forState:UIControlStateHighlighted];
@@ -424,7 +424,7 @@
     
     // 4th right most element
     image = [UIImage imageNamed:@"icon_power"];
-    image = [image colorizeWithColor:UIColor.lightGrayColor];
+    image = [image colorizeWithColor:ICON_TINT_COLOR];
     powerButton = [[UIButton alloc] initWithFrame:CGRectMake(settingsButton.frame.origin.x - POWERBUTTON_WIDTH - BUTTON_PADDING, self.view.frame.size.height - TOOLBAR_HEIGHT, POWERBUTTON_WIDTH, TOOLBAR_HEIGHT)];
     [powerButton setImage:image forState:UIControlStateNormal];
     [powerButton setImage:image forState:UIControlStateHighlighted];

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -379,21 +379,15 @@
     [self.view addSubview:volumeSliderView];
     
     // remote button next to volume control buttons
-    UIImage *image = [UIImage imageNamed:@"icon_menu_remote"];
-    image = [Utilities colorizeImage:image withColor:ICON_TINT_COLOR];
     UIButton *remoteButton = [[UIButton alloc] initWithFrame:CGRectMake(leftMenuView.frame.size.width - REMOTE_PADDING - REMOTE_ICON_SIZE, self.view.frame.size.height - (TOOLBAR_HEIGHT + REMOTE_ICON_SIZE) / 2 - [Utilities getBottomPadding], REMOTE_ICON_SIZE, REMOTE_ICON_SIZE)];
-    [remoteButton setImage:image forState:UIControlStateNormal];
-    [remoteButton setImage:image forState:UIControlStateHighlighted];
+    [remoteButton setIconStyle:[UIImage imageNamed:@"icon_menu_remote"]];
     remoteButton.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
     [remoteButton addTarget:self action:@selector(showRemote) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:remoteButton];
     
     // "show desktop" button next to remote button
-    image = [UIImage imageNamed:@"icon_menu_playing"];
-    image = [Utilities colorizeImage:image withColor:ICON_TINT_COLOR];
     UIButton *showDesktopButton = [[UIButton alloc] initWithFrame:CGRectMake(leftMenuView.frame.size.width + DESKTOP_PADDING, self.view.frame.size.height - (TOOLBAR_HEIGHT + REMOTE_ICON_SIZE) / 2 - [Utilities getBottomPadding], REMOTE_ICON_SIZE, REMOTE_ICON_SIZE)];
-    [showDesktopButton setImage:image forState:UIControlStateNormal];
-    [showDesktopButton setImage:image forState:UIControlStateHighlighted];
+    [showDesktopButton setIconStyle:[UIImage imageNamed:@"icon_menu_playing"]];
     showDesktopButton.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
     [showDesktopButton addTarget:self action:@selector(showDesktop) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:showDesktopButton];
@@ -404,32 +398,22 @@
     [self.view addSubview:connectionStatus];
     
     // 2nd right most element
-    image = [UIImage imageNamed:@"app_logo_small"];
     xbmcLogo = [[UIButton alloc] initWithFrame:CGRectMake(CGRectGetMinX(connectionStatus.frame) - XBMCLOGO_WIDTH - CONNECTION_PADDING, self.view.frame.size.height - TOOLBAR_HEIGHT, XBMCLOGO_WIDTH, TOOLBAR_HEIGHT)];
-    [xbmcLogo setImage:image forState:UIControlStateNormal];
-    [xbmcLogo setImage:image forState:UIControlStateHighlighted];
-    xbmcLogo.showsTouchWhenHighlighted = NO;
+    [xbmcLogo setIconStyle:[UIImage imageNamed:@"app_logo_small"] withColor:KODI_BLUE_COLOR];
     [xbmcLogo addTarget:self action:@selector(toggleInfoView) forControlEvents:UIControlEventTouchUpInside];
     xbmcLogo.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin;
-    xbmcLogo.alpha = 0.9;
     [self.view addSubview:xbmcLogo];
     
     // 3rd right most element
-    image = [UIImage imageNamed:@"icon_menu_settings"];
-    image = [Utilities colorizeImage:image withColor:ICON_TINT_COLOR];
     settingsButton = [[UIButton alloc] initWithFrame:CGRectMake(xbmcLogo.frame.origin.x - SETTINGSBUTTON_WIDTH - BUTTON_PADDING, self.view.frame.size.height - TOOLBAR_HEIGHT, SETTINGSBUTTON_WIDTH, TOOLBAR_HEIGHT)];
-    [settingsButton setImage:image forState:UIControlStateNormal];
-    [settingsButton setImage:image forState:UIControlStateHighlighted];
+    [settingsButton setIconStyle:[UIImage imageNamed:@"icon_menu_settings"]];
     settingsButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin;
     [settingsButton addTarget:self action:@selector(enterAppSettings) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:settingsButton];
     
     // 4th right most element
-    image = [UIImage imageNamed:@"icon_power"];
-    image = [Utilities colorizeImage:image withColor:ICON_TINT_COLOR];
     powerButton = [[UIButton alloc] initWithFrame:CGRectMake(settingsButton.frame.origin.x - POWERBUTTON_WIDTH - BUTTON_PADDING, self.view.frame.size.height - TOOLBAR_HEIGHT, POWERBUTTON_WIDTH, TOOLBAR_HEIGHT)];
-    [powerButton setImage:image forState:UIControlStateNormal];
-    [powerButton setImage:image forState:UIControlStateHighlighted];
+    [powerButton setIconStyle:[UIImage imageNamed:@"icon_power"]];
     powerButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin;
     [powerButton addTarget:self action:@selector(powerControl) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:powerButton];
@@ -449,8 +433,7 @@
     xbmcInfo.titleLabel.shadowOffset = CGSizeZero;
     xbmcInfo.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
     [xbmcInfo addTarget:self action:@selector(toggleSetup) forControlEvents:UIControlEventTouchUpInside];
-    [xbmcInfo setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];
-    [xbmcInfo setTitleColor:UIColor.grayColor forState:UIControlStateSelected];
+    [xbmcInfo setTextStyle];
     [self.view addSubview:xbmcInfo];
     
     menuViewController.tableView.separatorInset = UIEdgeInsetsZero;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -377,21 +377,15 @@
     [self.view addSubview:volumeSliderView];
     
     // remote button next to volume control buttons
-    UIImage *image = [UIImage imageNamed:@"icon_menu_remote"];
-    image = [image colorizeWithColor:ICON_TINT_COLOR];
     UIButton *remoteButton = [[UIButton alloc] initWithFrame:CGRectMake(leftMenuView.frame.size.width - REMOTE_PADDING - REMOTE_ICON_SIZE, self.view.frame.size.height - (TOOLBAR_HEIGHT + REMOTE_ICON_SIZE) / 2 - [Utilities getBottomPadding], REMOTE_ICON_SIZE, REMOTE_ICON_SIZE)];
-    [remoteButton setImage:image forState:UIControlStateNormal];
-    [remoteButton setImage:image forState:UIControlStateHighlighted];
+    [remoteButton setIconStyle:[UIImage imageNamed:@"icon_menu_remote"]];
     remoteButton.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
     [remoteButton addTarget:self action:@selector(showRemote) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:remoteButton];
     
     // "show desktop" button next to remote button
-    image = [UIImage imageNamed:@"icon_menu_playing"];
-    image = [image colorizeWithColor:ICON_TINT_COLOR];
     UIButton *showDesktopButton = [[UIButton alloc] initWithFrame:CGRectMake(leftMenuView.frame.size.width + DESKTOP_PADDING, self.view.frame.size.height - (TOOLBAR_HEIGHT + REMOTE_ICON_SIZE) / 2 - [Utilities getBottomPadding], REMOTE_ICON_SIZE, REMOTE_ICON_SIZE)];
-    [showDesktopButton setImage:image forState:UIControlStateNormal];
-    [showDesktopButton setImage:image forState:UIControlStateHighlighted];
+    [showDesktopButton setIconStyle:[UIImage imageNamed:@"icon_menu_playing"]];
     showDesktopButton.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
     [showDesktopButton addTarget:self action:@selector(showDesktop) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:showDesktopButton];
@@ -402,32 +396,22 @@
     [self.view addSubview:connectionStatus];
     
     // 2nd right most element
-    image = [UIImage imageNamed:@"app_logo_small"];
     xbmcLogo = [[UIButton alloc] initWithFrame:CGRectMake(CGRectGetMinX(connectionStatus.frame) - XBMCLOGO_WIDTH - CONNECTION_PADDING, self.view.frame.size.height - TOOLBAR_HEIGHT, XBMCLOGO_WIDTH, TOOLBAR_HEIGHT)];
-    [xbmcLogo setImage:image forState:UIControlStateNormal];
-    [xbmcLogo setImage:image forState:UIControlStateHighlighted];
-    xbmcLogo.showsTouchWhenHighlighted = NO;
+    [xbmcLogo setIconStyle:[UIImage imageNamed:@"app_logo_small"] withColor:KODI_BLUE_COLOR];
     [xbmcLogo addTarget:self action:@selector(toggleInfoView) forControlEvents:UIControlEventTouchUpInside];
     xbmcLogo.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin;
-    xbmcLogo.alpha = 0.9;
     [self.view addSubview:xbmcLogo];
     
     // 3rd right most element
-    image = [UIImage imageNamed:@"icon_menu_settings"];
-    image = [image colorizeWithColor:ICON_TINT_COLOR];
     settingsButton = [[UIButton alloc] initWithFrame:CGRectMake(xbmcLogo.frame.origin.x - SETTINGSBUTTON_WIDTH - BUTTON_PADDING, self.view.frame.size.height - TOOLBAR_HEIGHT, SETTINGSBUTTON_WIDTH, TOOLBAR_HEIGHT)];
-    [settingsButton setImage:image forState:UIControlStateNormal];
-    [settingsButton setImage:image forState:UIControlStateHighlighted];
+    [settingsButton setIconStyle:[UIImage imageNamed:@"icon_menu_settings"]];
     settingsButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin;
     [settingsButton addTarget:self action:@selector(enterAppSettings) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:settingsButton];
     
     // 4th right most element
-    image = [UIImage imageNamed:@"icon_power"];
-    image = [image colorizeWithColor:ICON_TINT_COLOR];
     powerButton = [[UIButton alloc] initWithFrame:CGRectMake(settingsButton.frame.origin.x - POWERBUTTON_WIDTH - BUTTON_PADDING, self.view.frame.size.height - TOOLBAR_HEIGHT, POWERBUTTON_WIDTH, TOOLBAR_HEIGHT)];
-    [powerButton setImage:image forState:UIControlStateNormal];
-    [powerButton setImage:image forState:UIControlStateHighlighted];
+    [powerButton setIconStyle:[UIImage imageNamed:@"icon_power"]];
     powerButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin;
     [powerButton addTarget:self action:@selector(powerControl) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:powerButton];
@@ -447,8 +431,7 @@
     xbmcInfo.titleLabel.shadowOffset = CGSizeZero;
     xbmcInfo.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin;
     [xbmcInfo addTarget:self action:@selector(toggleSetup) forControlEvents:UIControlEventTouchUpInside];
-    [xbmcInfo setTitleColor:UIColor.grayColor forState:UIControlStateHighlighted];
-    [xbmcInfo setTitleColor:UIColor.grayColor forState:UIControlStateSelected];
+    [xbmcInfo setTextStyle];
     [self.view addSubview:xbmcInfo];
     
     menuViewController.tableView.separatorInset = UIEdgeInsetsZero;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -380,7 +380,7 @@
     
     // remote button next to volume control buttons
     UIImage *image = [UIImage imageNamed:@"icon_menu_remote"];
-    image = [Utilities colorizeImage:image withColor:UIColor.lightGrayColor];
+    image = [Utilities colorizeImage:image withColor:ICON_TINT_COLOR];
     UIButton *remoteButton = [[UIButton alloc] initWithFrame:CGRectMake(leftMenuView.frame.size.width - REMOTE_PADDING - REMOTE_ICON_SIZE, self.view.frame.size.height - (TOOLBAR_HEIGHT + REMOTE_ICON_SIZE) / 2 - [Utilities getBottomPadding], REMOTE_ICON_SIZE, REMOTE_ICON_SIZE)];
     [remoteButton setImage:image forState:UIControlStateNormal];
     [remoteButton setImage:image forState:UIControlStateHighlighted];
@@ -390,7 +390,7 @@
     
     // "show desktop" button next to remote button
     image = [UIImage imageNamed:@"icon_menu_playing"];
-    image = [Utilities colorizeImage:image withColor:UIColor.lightGrayColor];
+    image = [Utilities colorizeImage:image withColor:ICON_TINT_COLOR];
     UIButton *showDesktopButton = [[UIButton alloc] initWithFrame:CGRectMake(leftMenuView.frame.size.width + DESKTOP_PADDING, self.view.frame.size.height - (TOOLBAR_HEIGHT + REMOTE_ICON_SIZE) / 2 - [Utilities getBottomPadding], REMOTE_ICON_SIZE, REMOTE_ICON_SIZE)];
     [showDesktopButton setImage:image forState:UIControlStateNormal];
     [showDesktopButton setImage:image forState:UIControlStateHighlighted];
@@ -416,7 +416,7 @@
     
     // 3rd right most element
     image = [UIImage imageNamed:@"icon_menu_settings"];
-    image = [Utilities colorizeImage:image withColor:UIColor.lightGrayColor];
+    image = [Utilities colorizeImage:image withColor:ICON_TINT_COLOR];
     settingsButton = [[UIButton alloc] initWithFrame:CGRectMake(xbmcLogo.frame.origin.x - SETTINGSBUTTON_WIDTH - BUTTON_PADDING, self.view.frame.size.height - TOOLBAR_HEIGHT, SETTINGSBUTTON_WIDTH, TOOLBAR_HEIGHT)];
     [settingsButton setImage:image forState:UIControlStateNormal];
     [settingsButton setImage:image forState:UIControlStateHighlighted];
@@ -426,7 +426,7 @@
     
     // 4th right most element
     image = [UIImage imageNamed:@"icon_power"];
-    image = [Utilities colorizeImage:image withColor:UIColor.lightGrayColor];
+    image = [Utilities colorizeImage:image withColor:ICON_TINT_COLOR];
     powerButton = [[UIButton alloc] initWithFrame:CGRectMake(settingsButton.frame.origin.x - POWERBUTTON_WIDTH - BUTTON_PADDING, self.view.frame.size.height - TOOLBAR_HEIGHT, POWERBUTTON_WIDTH, TOOLBAR_HEIGHT)];
     [powerButton setImage:image forState:UIControlStateNormal];
     [powerButton setImage:image forState:UIControlStateHighlighted];

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -112,15 +112,9 @@
         img = [Utilities colorizeImage:img withColor:UIColor.grayColor];
         [muteButton setImage:img forState:UIControlStateNormal];
         
-        img = [UIImage imageNamed:@"volume_1"];
-        img = [Utilities colorizeImage:img withColor:ICON_TINT_COLOR];
-        [minusButton setImage:img forState:UIControlStateNormal];
-        [minusButton setImage:img forState:UIControlStateHighlighted];
+        [minusButton setIconStyle:[UIImage imageNamed:@"volume_1"]];
         
-        img = [UIImage imageNamed:@"volume_3"];
-        img = [Utilities colorizeImage:img withColor:ICON_TINT_COLOR];
-        [plusButton setImage:img forState:UIControlStateNormal];
-        [plusButton setImage:img forState:UIControlStateHighlighted];
+        [plusButton setIconStyle:[UIImage imageNamed:@"volume_3"]];
         
         [self readServerVolume];
         

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -95,15 +95,9 @@
         img = [img colorizeWithColor:UIColor.grayColor];
         [muteButton setImage:img forState:UIControlStateNormal];
         
-        img = [UIImage imageNamed:@"volume_1"];
-        img = [img colorizeWithColor:ICON_TINT_COLOR];
-        [minusButton setImage:img forState:UIControlStateNormal];
-        [minusButton setImage:img forState:UIControlStateHighlighted];
+        [minusButton setIconStyle:[UIImage imageNamed:@"volume_1"]];
         
-        img = [UIImage imageNamed:@"volume_3"];
-        img = [img colorizeWithColor:ICON_TINT_COLOR];
-        [plusButton setImage:img forState:UIControlStateNormal];
-        [plusButton setImage:img forState:UIControlStateHighlighted];
+        [plusButton setIconStyle:[UIImage imageNamed:@"volume_3"]];
         
         [self readServerVolume];
         

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -156,7 +156,7 @@
     title.font = [UIFont fontWithName:@"Roboto-Regular" size:20];
     title.text = item.mainLabel;
     icon.highlightedImage = [UIImage imageNamed:iconName];
-    icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:UIColor.grayColor];
+    icon.image = [Utilities colorizeImage:icon.highlightedImage withColor:ICON_TINT_COLOR];
     return cell;
 }
 

--- a/XBMC Remote/iPad/MenuViewController.m
+++ b/XBMC Remote/iPad/MenuViewController.m
@@ -154,7 +154,7 @@
     title.font = [UIFont fontWithName:@"Roboto-Regular" size:20];
     title.text = item.mainLabel;
     icon.highlightedImage = [UIImage imageNamed:iconName];
-    icon.image = [icon.highlightedImage colorizeWithColor:UIColor.grayColor];
+    icon.image = [icon.highlightedImage colorizeWithColor:ICON_TINT_COLOR];
     return cell;
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
As discussed in reviews of previous PRs it is desired to further streamline the colors, button styles and button behaviour. The main change in this PR is to define common button styles which can be set via `UIButton extensions` which are added to `Utilities`. 

There are three main styles defined:
1. Text style buttons (like "Edit")
2. Icon style buttons using `setImage` (that's the majority of buttons)
3. Icon style buttons using `setBackgroundImage` and overlays  (only used for toolbar in database browser)

All icon buttons use a common style which highlights the button by the default way of darkening the icon, not using `showsTouchWhenHighlighted` anymore. Selected database browser icons use a blue tint for selected state. Only few exceptions are kept for colored icons like the Kodi icon and the white NowPlaying controls (incl. shuffle/repeat/fullscreen).

To align custom buttons to the highlight-by-fade theme an alpha animation is implemented for custom button selection.

For this change I am sure we will need to test before mainlining. The changes are quite visible when e.g. using playback controls, remote toolbar buttons or when changing volume. Some of the buttons before this change were not highlighting selection at all. Generally, I think the highlighting by darkening the icon is a very elegant way to give user feedback.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Common button style / behaviour
Improvement: Buttons highlighted on selection