### PR TITLE
Improvement: iOS style haptic feedback via UIImpactFeedbackGenerator

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -586,13 +586,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
                                                        selector:@selector(longpressKey:)
                                                        userInfo:params
                                                         repeats:NO];
-    
-    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    BOOL startVibrate = [userDefaults boolForKey:@"vibrate_preference"];
-    if (startVibrate) {
-        [[UIDevice currentDevice] playInputClick];
-        AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
-    }
+    [Utilities giveHapticFeedback];
 }
 
 - (IBAction)stopHoldKey:(id)sender {
@@ -839,13 +833,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
 
 - (IBAction)startVibrate:(id)sender {
     [self processButtonPress:[sender tag]];
-    
-    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    BOOL startVibrate = [userDefaults boolForKey:@"vibrate_preference"];
-    if (startVibrate) {
-        [[UIDevice currentDevice] playInputClick];
-        AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
-    }
+    [Utilities giveHapticFeedback];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputFinished" object:nil userInfo:nil];
 }
 
@@ -937,6 +925,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
 - (IBAction)handleButtonLongPress:(UILongPressGestureRecognizer*)gestureRecognizer {
     if (gestureRecognizer.state == UIGestureRecognizerStateBegan) {
         [self processButtonLongPress:gestureRecognizer.view.tag];
+        [Utilities giveHapticFeedback];
     }
 }
 

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -91,6 +91,7 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (CGFloat)getTopPadding;
 + (CGFloat)getTopPaddingWithNavBar:(UINavigationController*)navCtrl;
 + (void)sendXbmcHttp:(NSString*)command;
++ (void)giveHapticFeedback;
 + (NSString*)getAppVersionString;
 + (void)checkForReviewRequest;
 + (void)checkLocalNetworkAccess;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -975,6 +975,19 @@
     [[NSURLSession.sharedSession dataTaskWithURL:[NSURL URLWithString:serverHTTP]] resume];
 }
 
++ (void)giveHapticFeedback {
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    BOOL feedbackEnabled = [userDefaults boolForKey:@"vibrate_preference"];
+    if (feedbackEnabled) {
+        static UIImpactFeedbackGenerator *generator;
+        static dispatch_once_t once;
+        dispatch_once(&once, ^{
+            generator = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleMedium];
+        });
+        [generator impactOccurred];
+    }
+}
+
 + (NSString*)getAppVersionString {
     NSDictionary *infoDict = NSBundle.mainBundle.infoDictionary;
     NSString *appVersion = [NSString stringWithFormat:@"v%@ (%@)", infoDict[@"CFBundleShortVersionString"], infoDict[(NSString*)kCFBundleVersionKey]];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Avoids code duplication by introducing a helper method `giveHapticFeedback`, which is placed in `Utilities` for future purpose (providing haptic feedback from other controllers as well). The instance of `UIImpactFeedbackGenerator` is made static and only created once to avoid feedback delays. The feedback is now a medium haptic one-time impact (`UIImpactFeedbackStyleMedium`) which comes right with touching the remote buttons. This is more in line with how other iOS functions give haptic feedback.

Important: This requires to have system level haptic feedback enabled in the setting of your iOS device.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: iOS style haptic feedback via UIImpactFeedbackGenerator