### PR TITLE
Bugfix: Fix gesture remote control after entering NowPlaying

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -986,6 +986,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     if (IS_IPHONE && !isEmbeddedMode) {
         // Allow panning gesture for full view (but gestureRecognizer will skip if GestureZone is touched)
         [self.navigationController.view addGestureRecognizer:self.slidingViewController.panGesture];
+        self.slidingViewController.underRightViewController = nil;
         self.slidingViewController.anchorLeftPeekAmount   = 0;
         self.slidingViewController.anchorLeftRevealAmount = 0;
         self.slidingViewController.panGesture.delegate = self;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression of #1342 which was reported via TestFlight for build 1.19 (5567).

Reset `ECSlidingVC`s internal `underRightViewController` when initializing the remote. This fixes gesture remote control after entering NowPlaying screen.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix gesture remote control after entering NowPlaying