### PR TITLE
Bugfix: Remove observers for AVCaptureDevice

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1107,6 +1107,12 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     [super viewWillDisappear:animated];
     [self resetRemote];
     self.slidingViewController.panGesture.delegate = nil;
+    [self.avCaptureDevice removeObserver:self
+                              forKeyPath:KEYPATH_TORCHACTIVE
+                                 context:TorchRemoteContext];
+    [self.avCaptureDevice removeObserver:self
+                              forKeyPath:KEYPATH_TORCHAVAILABLE
+                                 context:TorchRemoteContext];
 }
 
 - (void)toggleTorch {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Via ASC the following crash was reported.

```
Incident Identifier: B08874FB-159C-4D39-ACF0-81AF9E0E4FBA
Hardware Model:      iPhone10,4
Process:             Kodi Remote [72908]
Path:                /private/var/containers/Bundle/Application/7029D6FB-4616-4EF1-AC9E-C00E8609F11B/Kodi Remote.app/Kodi Remote
Identifier:          it.joethefox.XBMC-Remote
Version:             1.19 (5567)
AppStoreTools:       17C53
AppVariant:          1:iPhone10,4:16
Beta:                YES
Code Type:           ARM-64 (Native)
Role:                Non UI
Parent Process:      launchd [1]
Coalition:           it.joethefox.XBMC-Remote [1983]

Date/Time:           2025-12-28 04:04:03.5741 +0100
Launch Time:         2025-12-28 03:25:07.8525 +0100
OS Version:          iPhone OS 16.7.12 (20H364)
Release Type:        User
Baseband Version:    6.01.01
Report Version:      104

Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x000000000000001e
Exception Codes: 0x0000000000000001, 0x000000000000001e
VM Region Info: 0x1e is not in any region.  Bytes before following region: 68719476706
      REGION TYPE                 START - END      [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      UNUSED SPACE AT START
--->  
      commpage (reserved)     1000000000-7000000000 [384.0G] ---/--- SM=NUL  ...(unallocated)
Termination Reason: SIGNAL 11 Segmentation fault: 11
Terminating Process: exc handler [72908]

Triggered by Thread:  0


Thread 0 name:
Thread 0 Crashed:
0   libobjc.A.dylib               	0x00000001c4211220 object_isClass + 16 (objc-class.mm:217)
1   Foundation                    	0x00000001c52c9ff4 KVO_IS_RETAINING_ALL_OBSERVERS_OF_THIS_OBJECT_IF_IT_CRASHES_AN_OBSERVER_WAS_OVERRELEASED_OR_SMASHED + 72 (NSKeyValueObserving.m:1149)
2   Foundation                    	0x00000001c52fe8a8 NSKeyValueWillChangeWithPerThreadPendingNotifications + 292 (NSKeyValueObserving.m:1195)
3   AVFCapture                    	0x00000001e31f35bc -[AVCaptureFigVideoDevice _handleNotification:payload:] + 7132 (AVCaptureFigVideoDevice.m:7889)
4   CoreFoundation                	0x00000001caf73f78 __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 20 (CFRunLoop.c:1805)
5   CoreFoundation                	0x00000001cafd6034 __CFRunLoopDoBlocks + 360 (CFRunLoop.c:1847)
6   CoreFoundation                	0x00000001cafa9804 __CFRunLoopRun + 2524 (CFRunLoop.c:3201)
7   CoreFoundation                	0x00000001cafadd20 CFRunLoopRunSpecific + 584 (CFRunLoop.c:3418)
8   GraphicsServices              	0x000000020307d998 GSEventRunModal + 160 (GSEvent.c:2196)
9   UIKitCore                     	0x00000001cd24034c -[UIApplication _run] + 868 (UIApplication.m:3782)
10  UIKitCore                     	0x00000001cd23ffc4 UIApplicationMain + 312 (UIApplication.m:5372)
11  Kodi Remote                   	0x0000000102b9cc2c main + 80 (main.m:15)
12  dyld                          	0x00000001e876c344 start + 1860 (dyldMain.cpp:1165)
```

Posts in stackoverflow point to missing `removeObserver`, which this PR does now add. The removal is placed in `viewWillDisappear`, symmetrical to `viewWillAppear` which calls KVO's `addObserver`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Remove observers for AVCaptureDevice