### PR TITLE
Improvement: Use rounded rect border for server detail text fields

### DIFF
--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -605,6 +605,7 @@
     for (UITextField *textfield in [self getAllEntryMaskLabels]) {
         textfield.layer.borderColor = UIColor.lightGrayColor.CGColor;
         textfield.layer.borderWidth = 1.0 / UIScreen.mainScreen.scale;
+        textfield.borderStyle = UITextBorderStyleRoundedRect;
         textfield.backgroundColor = [Utilities getSystemGray6];
         textfield.tintColor = [Utilities get1stLabelColor];
     }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Suggested via TestFlight.

This PR lets all server detail text fields use `UITextBorderStyleRoundedRect` border style, which aligns with all other text fields in the app.

Screenshots:
<img width="746" height="234" alt="Bildschirmfoto 2025-12-29 um 09 40 44" src="https://github.com/user-attachments/assets/e5e19de5-a5c5-4a4f-9ade-d69099d192bb"/>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Use rounded rect border for server detail text fields