### PR TITLE
Bugfix: Save correct active server index

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -259,7 +259,7 @@
             if (indexPath.row < selectedPath.row) {
                 // When removing a server above the active one, the index for the active server reduces by 1.
                 storeServerSelection = [NSIndexPath indexPathForRow:selectedPath.row - 1 inSection:selectedPath.section];
-                [Utilities saveLastServerIndex:selectedPath];
+                [Utilities saveLastServerIndex:storeServerSelection];
             }
             else if (selectedPath.row == indexPath.row) {
                 // When removing the active server, invalidate the server parameters, which will stop the connection.


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Not sure why I missed this initially. When removing a server above the active server, of course the new (reduced by 1) index must be saved.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Save correct active server index