### PR TITLE
Bugfix: Fix potential crash when deleting active server from list

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -251,6 +251,14 @@
 	if (editingStyle == UITableViewCellEditingStyleDelete) {
         [AppDelegate.instance.arrayServerList removeObjectAtIndex:indexPath.row];
         [AppDelegate.instance saveServerList];
+        if (indexPath.row < [tableView numberOfRowsInSection:indexPath.section]) {
+            [tableView performBatchUpdates:^{
+                [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationRight];
+            } completion:nil];
+        }
+        
+        // Be aware! Sending "XBMCServerHasChanged" results in calling reloadData. Therefore ensure this is not called
+        // between updating arrayServerList and changing tableView to avoid a crash due to inconsistent amount of rows.
         NSIndexPath *selectedPath = storeServerSelection;
         if (selectedPath) {
             if (indexPath.row < selectedPath.row) {
@@ -265,11 +273,6 @@
                 [Utilities saveLastServerIndex:nil];
                 [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerHasChanged" object:nil];
             }
-        }
-        if (indexPath.row < [tableView numberOfRowsInSection:indexPath.section]) {
-            [tableView performBatchUpdates:^{
-                [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationRight];
-            } completion:nil];
         }
         // Are there still editable entries?
         editTableButton.selected = editTableButton.enabled = AppDelegate.instance.arrayServerList.count > 0;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Reported for v1.19 via AppStore.

Sending "XBMCServerHasChanged" results in calling `reloadData`. Therefore ensure this is not called between updating `arrayServerList` and changing `tableView` to avoid a crash due to inconsistent amount of rows. This fixes a crash when deleting the active server after moving it upwards in the server list.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix potential crash when deleting active server from list