### PR TITLE
Improvement: NowPlaying overlay shows codec when Kodi is minimized to tray

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -926,9 +926,9 @@
     BOOL exceedsCompactDiscRate = [bps integerValue] >= 16 && [kHz integerValue] >= 88;
     hiresImage.hidden = !(isLossless && (exceedsCompactDiscBits || exceedsCompactDiscRate));
     
-    bps = bps.length ? [NSString stringWithFormat:@"%@ Bit", bps] : @"";
+    bps = bps.length ? [NSString stringWithFormat:@"%@ %@", bps, LOCALIZED_STR(@"bit")] : @"";
     
-    kHz = kHz.length ? [NSString stringWithFormat:@"%@ kHz", kHz] : @"";
+    kHz = kHz.length ? [NSString stringWithFormat:@"%@ %@", kHz, LOCALIZED_STR(@"kHz")] : @"";
     
     NSString *newLine = bps.length && kHz.length ? @"\n" : @"";
     NSString *samplerate = [NSString stringWithFormat:@"%@%@%@", bps, newLine, kHz];
@@ -936,7 +936,7 @@
     songNumChannels.hidden = NO;
     songNumChanImage.image = nil;
     
-    bitrate = bitrate.length ? [NSString stringWithFormat:@"%@\nkbit/s", bitrate] : @"";
+    bitrate = bitrate.length ? [NSString stringWithFormat:@"%@\n%@", bitrate, LOCALIZED_STR(@"kbit/s")] : @"";
     songSampleRate.text = bitrate;
     songSampleRate.hidden = NO;
     songSampleRateImage.image = nil;

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -337,6 +337,10 @@
 "Focal length" = "Focal length";
 "Camera model" = "Camera model";
 
+"bit" = "bit";
+"kHz" = "kHz";
+"kbit/s" = "kbit/s";
+
 "Received unexpected JSON object." = "Received unexpected JSON object.";
 
 "QUICK HELP" = "QUICK HELP";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR is related to https://github.com/xbmc/xbmc/issues/19344 which was raised and discussed long ago with Kodi developers. 

### Background
The app uses `XBMC.GetInfoLabels` to read information on audio/video codecs of the current playing item and image/exif data when showing images. This information is displayed in the NowPlaying overlay. I personally have a use case (and maybe others as well), where Kodi is running on a headless system for music playback and is minimized to tray. When minimizing Kodi the info labels just not updated anymore and keep the data from the last time they were updated in non-minimized mode. The right solution is to use `Player.GetProperties` which is always up-to-date.
Problem with `Player.GetProperties` is that this give an empty response for audiostrreams on Kodi versions < 19, and that `Player.GetProperties` does not provide audiostream's bits-per-sample and video stream's aspect ratio and resolution.

### Approach
The approach taken is to let the app prefer data from `Player.GetProperties` by reading this first, and only fill empty fields with information coming from 'XBMC.GetInfoLabels'. This keeps supporting Kodi < 19, and improves the user experience for headless systems (as mine 😊).
Best would be to also see bits-per-sample, aspect ratio and resolution directly shared via `Player.GetProperties`, I might raise a feature request to Kodi. 

As a side note: _resolution_ can be derived from video's _height_ by mimicking Kodi's logic to derive the resolution. For _aspect ratio_ this does not work as expected, I saw differences for videos with dimensions of 352x288.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: NowPlaying overlay shows codec when Kodi is minimized to tray