### PR TITLE
Improvement: Directly use noFoundLabel instead of a view

### DIFF
--- a/XBMC Remote/DetailViewController.h
+++ b/XBMC Remote/DetailViewController.h
@@ -44,7 +44,7 @@
     NSString *defaultThumb;
     int cellHeight;
     int thumbWidth;
-    IBOutlet UIView *noFoundView;
+    IBOutlet UILabel *noFoundLabel;
     int viewWidth;
     IBOutlet UIView *maskView;
     MoreItemsViewController *moreItemsViewController;
@@ -96,7 +96,6 @@
     NSDateFormatter *xbmcDateFormatter;
     NSDateFormatter *localHourMinuteFormatter;
     NSIndexPath *autoScrollTable;
-    __weak IBOutlet UILabel *noItemsLabel;
     BOOL stackscrollFullscreen;
     BOOL forceCollection;
     NSMutableDictionary *storeSections;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1027,7 +1027,7 @@
     self.indexView.hidden = YES;
     button6.hidden = YES;
     button7.hidden = YES;
-    [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
+    [Utilities alphaView:noFoundLabel AnimDuration:0.2 Alpha:0.0];
     [activityIndicatorView startAnimating];
     NSArray *buttonsIB = @[button1, button2, button3, button4, button5];
     if (chosenTab < buttonsIB.count) {
@@ -4738,7 +4738,7 @@
         return;
     }
     
-    [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
+    [Utilities alphaView:noFoundLabel AnimDuration:0.2 Alpha:0.0];
     elapsedTime = 0;
     startTime = [NSDate timeIntervalSinceReferenceDate];
     countExecutionTime = [NSTimer scheduledTimerWithTimeInterval:WARNING_TIMEOUT target:self selector:@selector(checkExecutionTime) userInfo:nil repeats:YES];
@@ -4962,7 +4962,7 @@
 }
 
 - (void)animateNoResultsFound {
-    [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
+    [Utilities alphaView:noFoundLabel AnimDuration:0.2 Alpha:1.0];
     [activityIndicatorView stopAnimating];
     [activeLayoutView.pullToRefreshView stopAnimating];
     [self setGridListButtonImage:enableCollectionView];
@@ -5298,10 +5298,10 @@
     [self setFilternameLabel:labelText];
     
     if (!self.richResults.count) {
-        [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
+        [Utilities alphaView:noFoundLabel AnimDuration:0.2 Alpha:1.0];
     }
     else {
-        [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
+        [Utilities alphaView:noFoundLabel AnimDuration:0.2 Alpha:0.0];
     }
     NSDictionary *itemSizes = parameters[@"itemSizes"];
     if (IS_IPHONE) {
@@ -5794,7 +5794,10 @@
     epgCachePath = AppDelegate.instance.epgCachePath;
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     hiddenLabel = [userDefaults boolForKey:@"hidden_label_preference"];
-    noItemsLabel.text = LOCALIZED_STR(@"No items found.");
+    noFoundLabel.text = LOCALIZED_STR(@"No items found.");
+    noFoundLabel.adjustsFontSizeToFitWidth = YES;
+    noFoundLabel.minimumScaleFactor = FONT_SCALING_MIN;
+    noFoundLabel.alpha = 0.0;
     loadAndPresentDataOnViewDidAppear = YES;
     sectionHeight = LIST_SECTION_HEADER_HEIGHT;
     epglockqueue = dispatch_queue_create("com.epg.arrayupdate", DISPATCH_QUEUE_SERIAL);

--- a/XBMC Remote/DetailViewController.xib
+++ b/XBMC Remote/DetailViewController.xib
@@ -22,8 +22,7 @@
                 <outlet property="buttonsViewEffect" destination="nls-7E-rmj" id="bzY-fZ-idY"/>
                 <outlet property="dataList" destination="37" id="93"/>
                 <outlet property="maskView" destination="siR-Fa-xLM" id="cez-Ud-wvD"/>
-                <outlet property="noFoundView" destination="135" id="140"/>
-                <outlet property="noItemsLabel" destination="136" id="4WA-ed-7Pa"/>
+                <outlet property="noFoundLabel" destination="136" id="d2d-uY-3DK"/>
                 <outlet property="view" destination="156" id="157"/>
             </connections>
         </placeholder>
@@ -40,20 +39,13 @@
                             <rect key="frame" x="0.0" y="0.0" width="320" height="416"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         </imageView>
-                        <view alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="135" userLabel="NoFound View">
-                            <rect key="frame" x="35" y="105" width="250" height="42"/>
+                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="No items found." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="136">
+                            <rect key="frame" x="85" y="106" width="150" height="42"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                            <subviews>
-                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="No items found." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="136">
-                                    <rect key="frame" x="50" y="1" width="150" height="40"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <color key="textColor" red="0.84919595718383789" green="0.84919595718383789" blue="0.84919595718383789" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                            </subviews>
-                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                        </view>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                         <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" indicatorStyle="black" style="plain" separatorStyle="default" rowHeight="76" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="37">
                             <rect key="frame" x="0.0" y="0.0" width="320" height="416"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -52,7 +52,7 @@
     IBOutlet UIButton *editTableButton;
     IBOutlet UIButton *PartyModeButton;
     IBOutlet UIImageView *backgroundImageView;
-    IBOutlet UIView *noFoundView;
+    IBOutlet UILabel *noFoundLabel;
     NSIndexPath *storeSelection;
     IBOutlet UIView *playlistToolbarView;
     IBOutlet UIView *playlistActionView;
@@ -79,7 +79,6 @@
     __weak IBOutlet UILabel *scrabbingRate;
     UIView *toolbarBackground;
     UISegmentedControl *playlistSegmentedControl;
-    __weak IBOutlet UILabel *noItemsLabel;
     NSString *storeLiveTVTitle;
     NSString *storeClearlogo;
     NSString *storeClearart;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1152,7 +1152,7 @@
         [Utilities AnimView:PartyModeButton AnimDuration:0.3 Alpha:0.0 XPos:-PartyModeButton.frame.size.width];
     }
     editTableButton.hidden = currentPlaylistID == PLAYERID_PICTURES;
-    [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
+    [Utilities alphaView:noFoundLabel AnimDuration:0.2 Alpha:0.0];
     [[Utilities getJsonRPC] callMethod:@"Playlist.GetItems"
                         withParameters:@{@"properties": @[@"thumbnail",
                                                           @"duration",
@@ -1176,12 +1176,12 @@
                    if ([methodResult isKindOfClass:[NSDictionary class]]) {
                        NSArray *playlistItems = methodResult[@"items"];
                        if (playlistItems.count == 0) {
-                           [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
+                           [Utilities alphaView:noFoundLabel AnimDuration:0.2 Alpha:1.0];
                            editTableButton.enabled = NO;
                            editTableButton.selected = NO;
                        }
                        else {
-                           [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:0.0];
+                           [Utilities alphaView:noFoundLabel AnimDuration:0.2 Alpha:0.0];
                            editTableButton.enabled = YES;
                        }
                        NSString *serverURL = [Utilities getImageServerURL];
@@ -1264,7 +1264,7 @@
 
 - (void)showPlaylistTableAnimated:(BOOL)animated {
     if (playlistData.count == 0) {
-        [Utilities alphaView:noFoundView AnimDuration:0.2 Alpha:1.0];
+        [Utilities alphaView:noFoundLabel AnimDuration:0.2 Alpha:1.0];
         [playlistTableView reloadData];
     }
     else {
@@ -2755,7 +2755,10 @@
     [editTableButton setTitle:LOCALIZED_STR(@"Done") forState:UIControlStateSelected];
     editTableButton.titleLabel.numberOfLines = 1;
     editTableButton.titleLabel.adjustsFontSizeToFitWidth = YES;
-    noItemsLabel.text = LOCALIZED_STR(@"No items found.");
+    noFoundLabel.text = LOCALIZED_STR(@"No items found.");
+    noFoundLabel.adjustsFontSizeToFitWidth = YES;
+    noFoundLabel.minimumScaleFactor = FONT_SCALING_MIN;
+    noFoundLabel.alpha = 0.0;
     [self addSegmentControl];
     bottomPadding = [Utilities getBottomPadding];
     [self setToolbar];

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -25,8 +25,7 @@
                 <outlet property="itemDescription" destination="HhJ-Ci-xP8" id="t3u-u4-cjL"/>
                 <outlet property="itemLogoImage" destination="gWQ-ZF-P81" id="JWW-p8-1uX"/>
                 <outlet property="jewelView" destination="4" id="57"/>
-                <outlet property="noFoundView" destination="132" id="135"/>
-                <outlet property="noItemsLabel" destination="134" id="POg-db-XEJ"/>
+                <outlet property="noFoundLabel" destination="134" id="cWH-OB-YZ6"/>
                 <outlet property="nowPlayingView" destination="92" id="95"/>
                 <outlet property="playlistActionView" destination="128" id="149"/>
                 <outlet property="playlistButton" destination="Z3l-yA-EDD" id="k08-dq-wTJ"/>
@@ -72,20 +71,13 @@
                             <rect key="frame" x="0.0" y="0.0" width="320" height="372"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <view alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="132" userLabel="NoFound View">
-                                    <rect key="frame" x="35" y="7" width="250" height="42"/>
+                                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="No items found." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="134">
+                                    <rect key="frame" x="85" y="8" width="150" height="42"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                    <subviews>
-                                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="No items found." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="134">
-                                            <rect key="frame" x="50" y="1" width="150" height="40"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <color key="textColor" red="0.84919595718383789" green="0.84919595718383789" blue="0.84919595718383789" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                </view>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
                                 <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="53" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="100">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="372"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Instead of placing the `UILabel` within a `UIView` and setting alpha for the view, we can directly use the `UILabel` for this.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Directly use noFoundLabel instead of a view