### PR TITLE
Rework server list

### DIFF
--- a/Kodi Remote.xcodeproj/project.pbxproj
+++ b/Kodi Remote.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		C79B0EA52DF0CF6900046334 /* BaseMasterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C79B0EA42DF0CF6900046334 /* BaseMasterViewController.m */; };
 		C7B7D02A2F71B37F00689B5A /* UIViewController+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C7B7D0292F71B37F00689B5A /* UIViewController+Extensions.m */; };
 		C7B7D02D2F732AED00689B5A /* UIBarButtonItem+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C7B7D0262F71B18300689B5A /* UIBarButtonItem+Extensions.m */; };
+		C7B7D03A2F76D36E00689B5A /* UILabel+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = C7B7D0392F76D36E00689B5A /* UILabel+Extensions.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -349,6 +350,8 @@
 		C7B7D0282F71B1C100689B5A /* UIBarButtonItem+Extensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIBarButtonItem+Extensions.h"; sourceTree = "<group>"; };
 		C7B7D0292F71B37F00689B5A /* UIViewController+Extensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Extensions.m"; sourceTree = "<group>"; };
 		C7B7D02B2F71B39D00689B5A /* UIViewController+Extensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Extensions.h"; sourceTree = "<group>"; };
+		C7B7D0392F76D36E00689B5A /* UILabel+Extensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UILabel+Extensions.m"; sourceTree = "<group>"; };
+		C7B7D03D2F76D38A00689B5A /* UILabel+Extensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UILabel+Extensions.h"; sourceTree = "<group>"; };
 		C7D95E212DC0963100153267 /* id-ID */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "id-ID"; path = "id-ID.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C7D95E222DC0963100153267 /* id-ID */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "id-ID"; path = "id-ID.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C7F28D4826961FE50004B112 /* ConvenienceMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConvenienceMacros.h; sourceTree = "<group>"; };
@@ -763,6 +766,8 @@
 				C7B7D0262F71B18300689B5A /* UIBarButtonItem+Extensions.m */,
 				C7B7D02B2F71B39D00689B5A /* UIViewController+Extensions.h */,
 				C7B7D0292F71B37F00689B5A /* UIViewController+Extensions.m */,
+				C7B7D03D2F76D38A00689B5A /* UILabel+Extensions.h */,
+				C7B7D0392F76D36E00689B5A /* UILabel+Extensions.m */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -928,6 +933,7 @@
 				0F4156451646D810009E6DD4 /* JBKenBurnsView.m in Sources */,
 				C76451CF29C51221000AE949 /* UIImage+WebP.m in Sources */,
 				0F7F3DA5164A6D730080A14A /* ECSlidingViewController.m in Sources */,
+				C7B7D03A2F76D36E00689B5A /* UILabel+Extensions.m in Sources */,
 				C79B0EA52DF0CF6900046334 /* BaseMasterViewController.m in Sources */,
 				0F7F3DA6164A6D730080A14A /* UIImage+ImageWithUIView.m in Sources */,
 				0F7F3DAB164AAD0F0080A14A /* InitialSlidingViewController.m in Sources */,

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -31,6 +31,7 @@
 #import "RemoteController.h"
 #import "UIBarButtonItem+Extensions.h"
 #import "UIViewController+Extensions.h"
+#import "UILabel+Extensions.h"
 
 #import "GeneratedAssetSymbols.h"
 
@@ -5809,9 +5810,7 @@
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     hiddenLabel = [userDefaults boolForKey:@"hidden_label_preference"];
     noFoundLabel.text = LOCALIZED_STR(@"No items found.");
-    noFoundLabel.adjustsFontSizeToFitWidth = YES;
-    noFoundLabel.minimumScaleFactor = FONT_SCALING_MIN;
-    noFoundLabel.alpha = 0.0;
+    [noFoundLabel setNoFoundStyle];
     loadAndPresentDataOnViewDidAppear = YES;
     sectionHeight = LIST_SECTION_HEADER_HEIGHT;
     epglockqueue = dispatch_queue_create("com.epg.arrayupdate", DISPATCH_QUEUE_SERIAL);

--- a/XBMC Remote/Extensions/UILabel+Extensions.h
+++ b/XBMC Remote/Extensions/UILabel+Extensions.h
@@ -1,0 +1,13 @@
+//
+//  UILabel+Extensions.h
+//  Kodi Remote
+//
+//  Created by Buschmann on 27.03.26.
+//  Copyright © 2026 Team Kodi. All rights reserved.
+//
+
+@interface UILabel (Extensions)
+
+- (void)setNoFoundStyle;
+
+@end

--- a/XBMC Remote/Extensions/UILabel+Extensions.m
+++ b/XBMC Remote/Extensions/UILabel+Extensions.m
@@ -1,0 +1,26 @@
+//
+//  UILabel+Extensions.m
+//  Kodi Remote
+//
+//  Created by Buschmann on 27.03.26.
+//  Copyright © 2026 Team Kodi. All rights reserved.
+//
+
+#import "UILabel+Extensions.h"
+
+@import Foundation;
+
+@implementation UILabel (Extensions)
+
+- (void)setNoFoundStyle {
+    self.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    self.textColor = UIColor.lightGrayColor;
+    self.font = [UIFont systemFontOfSize:17];
+    self.textAlignment = NSTextAlignmentCenter;
+    self.adjustsFontSizeToFitWidth = YES;
+    self.minimumScaleFactor = FONT_SCALING_MIN;
+    self.numberOfLines = 2;
+    self.alpha = 0.0;
+}
+
+@end

--- a/XBMC Remote/HostManagementViewController.h
+++ b/XBMC Remote/HostManagementViewController.h
@@ -22,6 +22,7 @@
     NSIndexPath *storeServerSelection;
     __weak IBOutlet UIActivityIndicatorView *connectingActivityIndicator;
     AppInfoViewController *appInfoView;
+    UILabel *noFoundLabel;
     __weak IBOutlet UIButton *addHostButton;
     __weak IBOutlet UIView *supportedVersionView;
     __weak IBOutlet UILabel *supportedVersionLabel;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -244,8 +244,10 @@
 
 - (void)tableView:(UITableView*)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath*)indexPath {
 	if (editingStyle == UITableViewCellEditingStyleDelete) {
-        [AppDelegate.instance.arrayServerList removeObjectAtIndex:indexPath.row];
-        [AppDelegate.instance saveServerList];
+        if (indexPath.row < AppDelegate.instance.arrayServerList.count) {
+            [AppDelegate.instance.arrayServerList removeObjectAtIndex:indexPath.row];
+            [AppDelegate.instance saveServerList];
+        }
         if (indexPath.row < [tableView numberOfRowsInSection:indexPath.section]) {
             [tableView performBatchUpdates:^{
                 [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationRight];

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -239,7 +239,6 @@
     }
 }
 
-
 - (UITableViewCellEditingStyle)tableView:(UITableView*)aTableView editingStyleForRowAtIndexPath:(NSIndexPath*)indexPath {
     return UITableViewCellEditingStyleDelete;
 }
@@ -277,7 +276,7 @@
         }
         // Are there still editable entries?
         editTableButton.selected = editTableButton.enabled = AppDelegate.instance.arrayServerList.count > 0;
-	}
+    }
 }
 
 - (void)tableView:(UITableView*)tableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath*)indexPath {

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -64,12 +64,28 @@
         [Utilities resetKodiServerParameters];
         [Utilities saveLastServerIndex:nil];
         [connectingActivityIndicator stopAnimating];
-        [serverListTableView reloadData];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerHasChanged" object:nil];
     }
     HostViewController *hostController = [[HostViewController alloc] initWithNibName:@"HostViewController" bundle:nil];
     hostController.detailItem = item;
     [self.navigationController pushViewController:hostController animated:YES];
+}
+
+#pragma mark - Helper
+
+- (void)updateServerCellStatus {
+    for (NSIndexPath *indexPath in serverListTableView.indexPathsForVisibleRows) {
+        UITableViewCell *cell = [serverListTableView cellForRowAtIndexPath:indexPath];
+        UIImageView *iconView = (UIImageView*)[cell viewWithTag:XIB_HOST_MGMT_CELL_ICON];
+        NSIndexPath *selectedPath = storeServerSelection;
+        if (selectedPath && indexPath.row == selectedPath.row) {
+            NSString *iconName = [Utilities getConnectionStatusIconName];
+            iconView.image = [UIImage imageNamed:iconName];
+        }
+        else {
+            iconView.image = [UIImage imageNamed:@"connection_off"];
+        }
+    }
 }
 
 #pragma mark - Table view methods & data source
@@ -170,7 +186,6 @@
     [Utilities resetKodiServerParameters];
     AppDelegate.instance.serverOnLine = NO;
     [Utilities saveLastServerIndex:nil];
-    [serverListTableView reloadData];
 }
 
 - (void)selectServer:(NSNotification*)notification  {
@@ -295,7 +310,6 @@
     if (serverListTableView.editing || forceClose) {
         [serverListTableView setEditing:NO animated:YES];
         editTableButton.selected = NO;
-        [serverListTableView reloadData];
     }
     else {
         [serverListTableView setEditing:YES animated:YES];
@@ -754,7 +768,7 @@
 }
 
 - (void)connectionSuccess:(NSNotification*)note {
-    [serverListTableView reloadData];
+    [self updateServerCellStatus];
     
     // Gather active server
     storeServerSelection = [Utilities readLastServerIndex];
@@ -766,7 +780,7 @@
 }
 
 - (void)connectionFailed:(NSNotification*)note {
-    [serverListTableView reloadData];
+    [self updateServerCellStatus];
 }
 
 - (BOOL)shouldAutorotate {

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -249,9 +249,7 @@
             [AppDelegate.instance saveServerList];
         }
         if (indexPath.row < [tableView numberOfRowsInSection:indexPath.section]) {
-            [tableView performBatchUpdates:^{
-                [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationRight];
-            } completion:nil];
+            [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationRight];
         }
         
         // Be aware! Sending "XBMCServerHasChanged" results in calling reloadData. Therefore ensure this is not called

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -19,13 +19,14 @@
 // + 2 to cover two single-line separators
 #define HOSTMANAGERVC_MSG_HEIGHT (supportedVersionView.frame.size.height + 2)
 #define MARGIN 5
+#define LABEL_SPACING 8
+#define LABEL_HEIGHT 42
 #define IPAD_POPOVER_WIDTH 400
 #define IPAD_POPOVER_HEIGHT 500
 
 #define XIB_HOST_MGMT_CELL_ICON 1
 #define XIB_HOST_MGMT_CELL_LABEL 2
 #define XIB_HOST_MGMT_CELL_IP 3
-#define XIB_HOST_MGMT_CELL_NO_SERVER_FOUND 4
 
 @interface HostManagementViewController ()
 
@@ -95,9 +96,6 @@
 }
 
 - (NSInteger)tableView:(UITableView*)tableView numberOfRowsInSection:(NSInteger)section {
-    if (AppDelegate.instance.arrayServerList.count == 0 && !tableView.editing) {
-        return 1;
-    }
     return AppDelegate.instance.arrayServerList.count;
 }
 
@@ -110,15 +108,12 @@
     if (cell == nil) {
         NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"serverListCellView" owner:self options:nil];
         cell = nib[0];
-        UILabel *cellNoServerFound = (UILabel*)[cell viewWithTag:XIB_HOST_MGMT_CELL_NO_SERVER_FOUND];
         UILabel *cellLabel = (UILabel*)[cell viewWithTag:XIB_HOST_MGMT_CELL_LABEL];
         UILabel *cellIP = (UILabel*)[cell viewWithTag:XIB_HOST_MGMT_CELL_IP];
         
-        cellNoServerFound.highlightedTextColor = [Utilities get1stLabelColor];
         cellLabel.highlightedTextColor = [Utilities get1stLabelColor];
         cellIP.highlightedTextColor = [Utilities get2ndLabelColor];
         
-        cellNoServerFound.textColor = [Utilities getSystemGray1];
         cellLabel.textColor = [Utilities getSystemGray1];
         cellIP.textColor = [Utilities getSystemGray2];
         
@@ -129,40 +124,25 @@
         }
     }
     UIImageView *iconView = (UIImageView*)[cell viewWithTag:XIB_HOST_MGMT_CELL_ICON];
-    UILabel *cellNoServerFound = (UILabel*)[cell viewWithTag:XIB_HOST_MGMT_CELL_NO_SERVER_FOUND];
     UILabel *cellLabel = (UILabel*)[cell viewWithTag:XIB_HOST_MGMT_CELL_LABEL];
     UILabel *cellIP = (UILabel*)[cell viewWithTag:XIB_HOST_MGMT_CELL_IP];
-    if (AppDelegate.instance.arrayServerList.count == 0) {
-        iconView.hidden = YES;
-        cellNoServerFound.hidden = NO;
-        cellNoServerFound.text = LOCALIZED_STR(@"No saved hosts found");
-        cellLabel.text = @"";
-        cellIP.text = @"";
-        cell.accessoryType = UITableViewCellAccessoryNone;
-        editTableButton.enabled = NO;
-        return cell;
+    cellLabel.textAlignment = NSTextAlignmentLeft;
+    NSDictionary *item = AppDelegate.instance.arrayServerList[indexPath.row];
+    cellLabel.text = item[@"serverDescription"];
+    cellIP.text = item[@"serverIP"];
+    NSIndexPath *selectedPath = storeServerSelection;
+    if (selectedPath && indexPath.row == selectedPath.row) {
+        cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        NSString *iconName = [Utilities getConnectionStatusIconName];
+        iconView.image = [UIImage imageNamed:iconName];
+        [serverListTableView selectRowAtIndexPath:indexPath animated:YES scrollPosition:UITableViewScrollPositionMiddle];
     }
     else {
-        iconView.hidden = NO;
-        cellNoServerFound.hidden = YES;
-        cellLabel.textAlignment = NSTextAlignmentLeft;
-        NSDictionary *item = AppDelegate.instance.arrayServerList[indexPath.row];
-        cellLabel.text = item[@"serverDescription"];
-        cellIP.text = item[@"serverIP"];
-        NSIndexPath *selectedPath = storeServerSelection;
-        if (selectedPath && indexPath.row == selectedPath.row) {
-            cell.accessoryType = UITableViewCellAccessoryCheckmark;
-            NSString *iconName = [Utilities getConnectionStatusIconName];
-            iconView.image = [UIImage imageNamed:iconName];
-            [serverListTableView selectRowAtIndexPath:indexPath animated:YES scrollPosition:UITableViewScrollPositionMiddle];
-        }
-        else {
-            cell.accessoryType = UITableViewCellAccessoryNone;
-            iconView.image = [UIImage imageNamed:@"connection_off"];
-            [serverListTableView deselectRowAtIndexPath:indexPath animated:YES];
-        }
-        editTableButton.enabled = YES;
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        iconView.image = [UIImage imageNamed:@"connection_off"];
+        [serverListTableView deselectRowAtIndexPath:indexPath animated:YES];
     }
+    editTableButton.enabled = YES;
     return cell;
 }
 
@@ -290,7 +270,10 @@
             }
         }
         // Are there still editable entries?
-        editTableButton.selected = editTableButton.enabled = AppDelegate.instance.arrayServerList.count > 0;
+        if (AppDelegate.instance.arrayServerList.count == 0) {
+            editTableButton.selected = editTableButton.enabled = NO;
+            [Utilities alphaView:noFoundLabel AnimDuration:0.2 Alpha:1.0];
+        }
     }
 }
 
@@ -478,6 +461,13 @@
         UIImageView *xbmcLogoView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"kodi_logo_wide"]];
         self.navigationItem.titleView = xbmcLogoView;
     }
+    if (AppDelegate.instance.arrayServerList.count == 0) {
+        editTableButton.selected = editTableButton.enabled = NO;
+        noFoundLabel.alpha = 1.0;
+    }
+    else {
+        noFoundLabel.alpha = 0.0;
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -621,6 +611,21 @@
     longPressGesture.delegate = self;
     [longPressGesture addTarget:self action:@selector(handleLongPress)];
     [self.view addGestureRecognizer:longPressGesture];
+    
+    noFoundLabel = [[UILabel alloc] initWithFrame:CGRectMake(CGRectGetMinX(serverListTableView.frame) + LABEL_SPACING,
+                                                             CGRectGetMinY(serverListTableView.frame),
+                                                             CGRectGetWidth(serverListTableView.frame) - 2 * LABEL_SPACING,
+                                                             LABEL_HEIGHT)];
+    noFoundLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    noFoundLabel.text = LOCALIZED_STR(@"No saved hosts found");
+    noFoundLabel.textColor = UIColor.lightGrayColor;
+    noFoundLabel.font = [UIFont systemFontOfSize:17];
+    noFoundLabel.textAlignment = NSTextAlignmentCenter;
+    noFoundLabel.adjustsFontSizeToFitWidth = YES;
+    noFoundLabel.minimumScaleFactor = FONT_SCALING_MIN;
+    noFoundLabel.numberOfLines = 2;
+    noFoundLabel.alpha = 0.0;
+    [self.view addSubview:noFoundLabel];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(revealMenu:)

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -15,6 +15,7 @@
 #import "InitialSlidingViewController.h"
 #import "UIImageView+WebCache.h"
 #import "UIBarButtonItem+Extensions.h"
+#import "UILabel+Extensions.h"
 
 // + 2 to cover two single-line separators
 #define HOSTMANAGERVC_MSG_HEIGHT (supportedVersionView.frame.size.height + 2)
@@ -616,15 +617,8 @@
                                                              CGRectGetMinY(serverListTableView.frame),
                                                              CGRectGetWidth(serverListTableView.frame) - 2 * LABEL_SPACING,
                                                              LABEL_HEIGHT)];
-    noFoundLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     noFoundLabel.text = LOCALIZED_STR(@"No saved hosts found");
-    noFoundLabel.textColor = UIColor.lightGrayColor;
-    noFoundLabel.font = [UIFont systemFontOfSize:17];
-    noFoundLabel.textAlignment = NSTextAlignmentCenter;
-    noFoundLabel.adjustsFontSizeToFitWidth = YES;
-    noFoundLabel.minimumScaleFactor = FONT_SCALING_MIN;
-    noFoundLabel.numberOfLines = 2;
-    noFoundLabel.alpha = 0.0;
+    [noFoundLabel setNoFoundStyle];
     [self.view addSubview:noFoundLabel];
 
     [[NSNotificationCenter defaultCenter] addObserver:self

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2292,8 +2292,7 @@
     [[Utilities getJsonRPC] callMethod:actionRemove withParameters:paramsRemove onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (error == nil && methodError == nil) {
             [[Utilities getJsonRPC] callMethod:actionInsert withParameters:paramsInsert];
-            NSInteger numObj = playlistData.count;
-            if (sourceIndexPath.row < numObj) {
+            if (sourceIndexPath.row < playlistData.count) {
                 [playlistData removeObjectAtIndex:sourceIndexPath.row];
             }
             if (destinationIndexPath.row <= playlistData.count) {
@@ -2324,8 +2323,7 @@
         };
         [[Utilities getJsonRPC] callMethod:actionRemove withParameters:paramsRemove onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
             if (error == nil && methodError == nil) {
-                NSInteger numObj = playlistData.count;
-                if (indexPath.row < numObj) {
+                if (indexPath.row < playlistData.count) {
                     [playlistData removeObjectAtIndex:indexPath.row];
                 }
                 if (indexPath.row < [playlistTableView numberOfRowsInSection:indexPath.section]) {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -22,6 +22,7 @@
 #import "Utilities.h"
 #import "PlaylistProgressView.h"
 #import "UIBarButtonItem+Extensions.h"
+#import "UILabel+Extensions.h"
 
 @import QuartzCore;
 
@@ -2854,9 +2855,7 @@
     editTableButton.titleLabel.numberOfLines = 1;
     editTableButton.titleLabel.adjustsFontSizeToFitWidth = YES;
     noFoundLabel.text = LOCALIZED_STR(@"No items found.");
-    noFoundLabel.adjustsFontSizeToFitWidth = YES;
-    noFoundLabel.minimumScaleFactor = FONT_SCALING_MIN;
-    noFoundLabel.alpha = 0.0;
+    [noFoundLabel setNoFoundStyle];
     [self addSegmentControl];
     bottomPadding = [Utilities getBottomPadding];
     [self setToolbar];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2327,9 +2327,7 @@
                     [playlistData removeObjectAtIndex:indexPath.row];
                 }
                 if (indexPath.row < [playlistTableView numberOfRowsInSection:indexPath.section]) {
-                    [playlistTableView performBatchUpdates:^{
-                        [playlistTableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationRight];
-                    } completion:nil];
+                    [playlistTableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationRight];
                 }
                 if (storeSelection && indexPath.row < storeSelection.row) {
                     storeSelection = [NSIndexPath indexPathForRow:storeSelection.row - 1 inSection:storeSelection.section];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -14,6 +14,7 @@
 #import "StackScrollViewController.h"
 #import "Utilities.h"
 #import "CustomButtonCell.h"
+#import "UILabel+Extensions.h"
 
 #define TOOLBAR_HEIGHT 44.0
 #define BUTTON_SPACING 8.0
@@ -426,14 +427,8 @@
                                                              CGRectGetMinY(menuTableView.frame),
                                                              CGRectGetWidth(menuTableView.frame) - 2 * LABEL_SPACING,
                                                              LABEL_HEIGHT)];
-    noFoundLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     noFoundLabel.text = LOCALIZED_STR(@"No custom button defined.");
-    noFoundLabel.textColor = UIColor.lightGrayColor;
-    noFoundLabel.font = [UIFont systemFontOfSize:17];
-    noFoundLabel.textAlignment = NSTextAlignmentCenter;
-    noFoundLabel.adjustsFontSizeToFitWidth = YES;
-    noFoundLabel.minimumScaleFactor = FONT_SCALING_MIN;
-    noFoundLabel.numberOfLines = 2;
+    [noFoundLabel setNoFoundStyle];
     [self.view addSubview:noFoundLabel];
 
     [self loadCustomButtons];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -296,9 +296,7 @@
             [tableData removeObjectAtIndex:indexPath.row];
         }
         if (indexPath.row < [tableView numberOfRowsInSection:indexPath.section]) {
-            [tableView performBatchUpdates:^{
-                [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationRight];
-            } completion:nil];
+            [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationRight];
         }
         [self deleteCustomButton:indexPath.row];
 	}

--- a/XBMC Remote/serverListCellView.xib
+++ b/XBMC Remote/serverListCellView.xib
@@ -16,13 +16,6 @@
                 <rect key="frame" x="0.0" y="0.0" width="280" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label hidden="YES" opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="4" contentMode="left" fixedFrame="YES" text="No server found" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" translatesAutoresizingMaskIntoConstraints="NO" id="6">
-                        <rect key="frame" x="0.0" y="0.0" width="280" height="44"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                        <color key="textColor" red="0.66666668653488159" green="0.66666668653488159" blue="0.66666668653488159" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    </label>
                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="2" contentMode="left" fixedFrame="YES" text="My XBMC" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.90000000000000002" translatesAutoresizingMaskIntoConstraints="NO" id="4ry-PI-TW9">
                         <rect key="frame" x="35" y="2" width="245" height="20"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR applies two main changes:

#### Introduce `updateServerCellStatus`

The new method `updateServerCellStatus` updates the server list cell's connection status icon only. This allows to reduce the amount of `releadData` calls, which was before used to do this.

#### Introduce `noFoundLabel`

The UILabel `noFoundLabel` is used to signal an empty server list. It is faded in/out depending on the state of the list. This allows to remove the former solution which based on a dummy cell.

Other smaller changer were related to coding styles and minor refactoring.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Using UILabel to signal "No saved hosts found" instead of creating a dummy cell
Improvement: Avoid calling reloadData by only updating connection status icon when needed
Maintenance: Coding styles and minor refactoring