### PR TITLE
Rework playlist

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -359,6 +359,10 @@
 - (void)serverIsDisconnected {
     currentPlaylistID = PLAYERID_UNKNOWN;
     storedItemID = 0;
+    [self nothingIsPlaying];
+    if (playlistData.count == 0) {
+        return;
+    }
     [UIView animateWithDuration:0.1
                           delay:0.0
                         options:UIViewAnimationOptionCurveEaseInOut
@@ -371,7 +375,6 @@
         [playlistTableView reloadData];
         [self notifyChangeForPlaylistHeader];
     }];
-    [self nothingIsPlaying];
 }
 
 - (void)nothingIsPlaying {

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2334,6 +2334,11 @@
             else {
                 [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
             }
+            // Are there still editable entries?
+            if (playlistData.count == 0) {
+                editTableButton.selected = editTableButton.enabled = NO;
+                [Utilities alphaView:noFoundLabel AnimDuration:0.2 Alpha:1.0];
+            }
         }];
     }
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2305,10 +2305,8 @@
             else if (sourceIndexPath.row < storeSelection.row && destinationIndexPath.row >= storeSelection.row) {
                 storeSelection = [NSIndexPath indexPathForRow:storeSelection.row - 1 inSection:storeSelection.section];
             }
-            [playlistTableView reloadData];
         }
         else {
-            [playlistTableView reloadData];
             [playlistTableView selectRowAtIndexPath:storeSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
             [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
         }
@@ -2335,7 +2333,6 @@
                 }
             }
             else {
-                [playlistTableView reloadData];
                 [playlistTableView selectRowAtIndexPath:storeSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
                 [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
             }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2292,22 +2292,30 @@
     };
     [[Utilities getJsonRPC] callMethod:actionRemove withParameters:paramsRemove onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (error == nil && methodError == nil) {
-            [[Utilities getJsonRPC] callMethod:actionInsert withParameters:paramsInsert];
-            if (sourceIndexPath.row < playlistData.count) {
-                [playlistData removeObjectAtIndex:sourceIndexPath.row];
-            }
-            if (destinationIndexPath.row <= playlistData.count) {
-                [playlistData insertObject:objSource atIndex:destinationIndexPath.row];
-            }
-            if (sourceIndexPath.row > storeSelection.row && destinationIndexPath.row <= storeSelection.row) {
-                storeSelection = [NSIndexPath indexPathForRow:storeSelection.row + 1 inSection:storeSelection.section];
-            }
-            else if (sourceIndexPath.row < storeSelection.row && destinationIndexPath.row >= storeSelection.row) {
-                storeSelection = [NSIndexPath indexPathForRow:storeSelection.row - 1 inSection:storeSelection.section];
-            }
+            [[Utilities getJsonRPC] callMethod:actionInsert withParameters:paramsInsert onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+                if (error == nil && methodError == nil) {
+                    if (sourceIndexPath.row < playlistData.count) {
+                        [playlistData removeObjectAtIndex:sourceIndexPath.row];
+                    }
+                    if (destinationIndexPath.row <= playlistData.count) {
+                        [playlistData insertObject:objSource atIndex:destinationIndexPath.row];
+                    }
+                    if (sourceIndexPath.row > storeSelection.row && destinationIndexPath.row <= storeSelection.row) {
+                        storeSelection = [NSIndexPath indexPathForRow:storeSelection.row + 1 inSection:storeSelection.section];
+                    }
+                    else if (sourceIndexPath.row < storeSelection.row && destinationIndexPath.row >= storeSelection.row) {
+                        storeSelection = [NSIndexPath indexPathForRow:storeSelection.row - 1 inSection:storeSelection.section];
+                    }
+                }
+                else {
+                    [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
+                    [self createPlaylistAnimated:YES];
+                }
+            }];
         }
         else {
             [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
+            [self createPlaylistAnimated:YES];
         }
     }];
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2307,7 +2307,6 @@
             }
         }
         else {
-            [playlistTableView selectRowAtIndexPath:storeSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
             [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
         }
     }];
@@ -2333,7 +2332,6 @@
                 }
             }
             else {
-                [playlistTableView selectRowAtIndexPath:storeSelection animated:YES scrollPosition:UITableViewScrollPositionMiddle];
                 [Utilities showMessage:LOCALIZED_STR(@"Cannot do that") color:ERROR_MESSAGE_COLOR];
             }
         }];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR was motivated by reviewing the implementation of editing `UITableView`. The review showed four main findings:

#### Unneeded calls of `reloadData` and `selectRowAtIndexPath`
Calls of `reloadData` and `selectRowAtIndexPath` are not required inside `commitEditingStyle` and `moveRowAtIndexPath:ToIndexPath`. They got removed.

#### Handling removal last playlist
It was also found that after deleting the last playlist item the info label "No items found." was not shown, and that the edit button was still shown active and selected. This is now corrected.

#### Improper error handling in moveRowAtIndexPath:ToIndexPath
In case an error was reported for `Playlist.Remove` (e.g. when attempting to move the current playing item) the playlist was not properly reloaded. This resulted in inconsistency between the real playlist in Kodi and the one displayed by the remote app. Also, the wrong item was shown as playing. The correct solution is to call `createPlaylistAnimated` which will reload the playlist from Kodi and update the `UITableView`. In case of a (theoretical) issue with `Playlist.Insert` the same error handling is applied.

#### Repeated action to remove playlist on server disconnect
In case of server being disconnected a set of actions (fade out `playlistTableView`, delete `playlistData`, `reloadData`, send notification for iPad that playlist is empty) was called repeated, even though `playlistData` is already empty. An early return is added to `serverIsDisconnected` to avoid this.

**Important:** Needs minor rebasing once #1441 and #1442 were merged.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fixes wrong playlist state when facing an error during moving an item in the playlist
Improvement: Shows "No items found." in the playlist once all items were removed by user