### PR TITLE
Bugfix: Avoid potential out-of-bounds crash when changing custom button title

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -318,17 +318,21 @@
         textField.text = tableData[indexPath.row][@"label"];
     }];
     UIAlertAction *updateButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Update label") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        if (indexPath.row >= tableData.count) {
-            return;
-        }
-        tableData[indexPath.row][@"label"] = alertCtrl.textFields[0].text;
-        
-        CustomButtonCell *cell = [menuTableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:indexPath.row inSection:0]];
-        UILabel *title = cell.buttonLabel;
-        title.text = alertCtrl.textFields[0].text;
+        NSString *newLabel = alertCtrl.textFields[0].text;
         
         customButton *arrayButtons = [customButton new];
-        arrayButtons.buttons[indexPath.row][@"label"] = alertCtrl.textFields[0].text;
+        if (indexPath.row >= tableData.count ||
+            indexPath.row >= arrayButtons.buttons.count ||
+            indexPath.row >= [menuTableView numberOfRowsInSection:0]) {
+            return;
+        }
+        
+        tableData[indexPath.row][@"label"] = newLabel;
+        
+        CustomButtonCell *cell = [menuTableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:indexPath.row inSection:0]];
+        cell.buttonLabel.text = newLabel;
+        
+        arrayButtons.buttons[indexPath.row][@"label"] = newLabel;
         [arrayButtons saveData];
     }];
     UIAlertAction *cancelButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:nil];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a crash reported via ASC for app version 1.19.1.

```
Exception Type:  EXC_CRASH (SIGABRT)
Exception Codes: 0x0000000000000000, 0x0000000000000000
Exception Reason: *** -[__NSArrayM objectAtIndexedSubscript:]: index 0 beyond bounds for empty array
Termination Reason: SIGNAL 6 Abort trap: 6
Terminating Process: Kodi Remote [41591]

Triggered by Thread:  0

Last Exception Backtrace:
0   CoreFoundation                	0x191d34964 __exceptionPreprocess + 164 (NSException.m:249)
1   libobjc.A.dylib               	0x18ec11814 objc_exception_throw + 88 (objc-exception.mm:356)
2   CoreFoundation                	0x191d491ec -[__NSArrayM objectAtIndexedSubscript:] + 592 (NSArrayM.m:309)
3   Kodi Remote                   	0x1005f5b2c __78-[RightMenuViewController tableView:accessoryButtonTappedForRowWithIndexPath:]_block_invoke.97 + 528 (RightMenuViewController.m:331)
4   UIKitCore                     	0x197f2d16c -[UIAlertController _invokeHandlersForAction:] + 88 (UIAlertController.m:1297)
5   UIKitCore                     	0x197f2d99c __103-[UIAlertController _dismissAnimated:triggeringAction:triggeredByPopoverDimmingView:dismissCompletion:]_block_invoke_2 + 36 (UIAlertController.m:1459)
6   UIKitCore                     	0x19823e57c -[UIPresentationController transitionDidFinish:] + 840 (UIPresentationController.m:685)
7   UIKitCore                     	0x198241e9c __77-[UIPresentationController runTransitionForCurrentStateAnimated:handoffData:]_block_invoke.106 + 344 (UIPresentationController.m:1434)
8   UIKitCore                     	0x19834cbb0 -[_UIViewControllerTransitionContext completeTransition:] + 192 (UIViewControllerTransitioning.m:366)
9   UIKitCore                     	0x19772d598 __UIVIEW_IS_EXECUTING_ANIMATION_COMPLETION_BLOCK__ + 36 (UIView.m:17615)
10  UIKitCore                     	0x199035e58 -[UIViewAnimationBlockDelegate _didEndBlockAnimation:finished:context:] + 628 (UIView.m:17648)
11  UIKitCore                     	0x1990156a0 -[UIViewAnimationState sendDelegateAnimationDidStop:finished:] + 260 (UIView.m:0)
12  UIKitCore                     	0x199015b04 -[UIViewAnimationState animationDidStop:finished:] + 192 (UIView.m:2540)
13  UIKitCore                     	0x199015b74 -[UIViewAnimationState animationDidStop:finished:] + 304 (UIView.m:2562)
14  QuartzCore                    	0x19271912c run_animation_callbacks(void*) + 132 (CALayer.mm:8062)
15  libdispatch.dylib             	0x1ca9ae7fc _dispatch_client_callout + 16 (client_callout.mm:85)
16  libdispatch.dylib             	0x1ca9cbb10 _dispatch_main_queue_drain.cold.5 + 812 (queue.c:8181)
17  libdispatch.dylib             	0x1ca9a3ec8 _dispatch_main_queue_drain + 180 (queue.c:8162)
18  libdispatch.dylib             	0x1ca9a3e04 _dispatch_main_queue_callback_4CF + 44 (queue.c:8341)
19  CoreFoundation                	0x191cd92b4 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 16 (CFRunLoop.c:1820)
20  CoreFoundation                	0x191c8cb3c __CFRunLoopRun + 1944 (CFRunLoop.c:3177)
21  CoreFoundation                	0x191c8ba6c _CFRunLoopRunSpecificWithOptions + 532 (CFRunLoop.c:3462)
22  GraphicsServices              	0x236611498 GSEventRunModal + 120 (GSEvent.c:2049)
23  UIKitCore                     	0x19773bdf8 -[UIApplication _run] + 792 (UIApplication.m:3904)
24  UIKitCore                     	0x1976e4e54 UIApplicationMain + 336 (UIApplication.m:5579)
25  Kodi Remote                   	0x10054cc2c main + 80 (main.m:15)
26  dyld                          	0x18ec66e28 start + 7116 (dyldMain.cpp:1477)
```


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid potential out-of-bounds crash when changing custom button title