### PR TITLE
Rework iPad's menu resizing

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -140,12 +140,12 @@
     self.serverName = LOCALIZED_STR(@"No connection");
     if (IS_IPHONE) {
         InitialSlidingViewController *initialSlidingViewController = [[InitialSlidingViewController alloc] initWithNibName:@"InitialSlidingViewController" bundle:nil];
-        initialSlidingViewController.mainMenu = mainMenuItems;
+        initialSlidingViewController.mainMenuTable = mainMenuItems;
         self.window.rootViewController = initialSlidingViewController;
     }
     else {
         self.windowController = [[ViewControllerIPad alloc] initWithNibName:@"ViewControllerIPad" bundle:nil];
-        self.windowController.mainMenu = mainMenuItems;
+        self.windowController.mainMenuTable = mainMenuItems;
         self.window.rootViewController = self.windowController;
     }
     return YES;

--- a/XBMC Remote/HostManagementViewController.h
+++ b/XBMC Remote/HostManagementViewController.h
@@ -35,6 +35,6 @@
 
 - (id)initWithNibName:(NSString*)nibNameOrNil bundle:(NSBundle*)nibBundleOrNil;
 
-@property (nonatomic, strong) NSMutableArray *mainMenu;
+@property (nonatomic, strong) NSMutableArray *mainMenuTable;
 
 @end

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -35,8 +35,6 @@
 
 @implementation HostManagementViewController
 
-@synthesize mainMenu;
-
 - (id)initWithNibName:(NSString*)nibNameOrNil bundle:(NSBundle*)nibBundleOrNil {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     return self;

--- a/XBMC Remote/InitialSlidingViewController.h
+++ b/XBMC Remote/InitialSlidingViewController.h
@@ -13,6 +13,6 @@
 
 - (void)handleMenuButton;
 
-@property (nonatomic, strong) NSMutableArray *mainMenu;
+@property (nonatomic, strong) NSMutableArray *mainMenuTable;
 
 @end

--- a/XBMC Remote/InitialSlidingViewController.m
+++ b/XBMC Remote/InitialSlidingViewController.m
@@ -17,8 +17,6 @@
 
 @implementation InitialSlidingViewController
 
-@synthesize mainMenu;
-
 - (id)initWithNibName:(NSString*)nibNameOrNil bundle:(NSBundle*)nibBundleOrNil {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     return self;
@@ -28,7 +26,7 @@
     [super viewDidLoad];
     
     MasterViewController *masterViewController = [[MasterViewController alloc] initWithNibName:@"MasterViewController" bundle:nil];
-    masterViewController.mainMenu = self.mainMenu;
+    masterViewController.mainMenuTable = self.mainMenuTable;
     self.underLeftViewController = masterViewController;
     
     HostManagementViewController *hostManagementViewController = [[HostManagementViewController alloc] initWithNibName:@"HostManagementViewController" bundle:nil];
@@ -39,12 +37,12 @@
     
     self.view.tintColor = APP_TINT_COLOR;
     [navController hideNavBarBottomLine:YES];
-    hostManagementViewController.mainMenu = self.mainMenu;
+    hostManagementViewController.mainMenuTable = self.mainMenuTable;
     self.topViewController = navController;
     
     // Hide the inital HostManagementVC in case the "start view" is not main menu to avoid disturbing
     // sliding out (this view) and in (the targeted view).
-    self.topViewController.view.hidden = [Utilities getIndexPathForDefaultController:self.mainMenu] != nil;
+    self.topViewController.view.hidden = [Utilities getIndexPathForDefaultController:self.mainMenuTable] != nil;
     
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleTcpJSONRPCShowSetup:)

--- a/XBMC Remote/MasterViewController.h
+++ b/XBMC Remote/MasterViewController.h
@@ -21,6 +21,6 @@
     MessagesView *messagesView;
 }
 
-@property (nonatomic, strong) NSMutableArray *mainMenu;
+@property (nonatomic, strong) NSMutableArray *mainMenuTable;
 
 @end

--- a/XBMC Remote/MasterViewController.m
+++ b/XBMC Remote/MasterViewController.m
@@ -29,18 +29,15 @@
 
 @interface MasterViewController () {
     NSMutableArray *_objects;
-    NSMutableArray *mainMenu;
 }
 @end
 
 @implementation MasterViewController
-
-@synthesize mainMenu;
 	
 - (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName {
     [super changeServerStatus:status infoText:infoText icon:iconName];
     itemIsActive = NO;
-    [Utilities setStyleOfMenuItems:menuList active:status menu:self.mainMenu];
+    [Utilities setStyleOfMenuItems:menuList active:status menu:self.mainMenuTable];
 }
 
 #pragma mark - Table view methods & data source
@@ -50,11 +47,11 @@
 }
 
 - (NSInteger)tableView:(UITableView*)tableView numberOfRowsInSection:(NSInteger)section {
-    return self.mainMenu.count;
+    return self.mainMenuTable.count;
 }
 
 - (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
-    mainMenu *menuItem = self.mainMenu[indexPath.row];
+    mainMenu *menuItem = self.mainMenuTable[indexPath.row];
     [Utilities setStyleOfMenuItemCell:cell active:AppDelegate.instance.serverOnLine menuType:menuItem.type];
 }
 
@@ -69,7 +66,7 @@
         backgroundView.backgroundColor = MAINMENU_SELECTED_COLOR;
         cell.selectedBackgroundView = backgroundView;
     }
-    mainMenu *item = self.mainMenu[indexPath.row];
+    mainMenu *item = self.mainMenuTable[indexPath.row];
     NSString *iconName = item.icon;
     UIImageView *icon = (UIImageView*)[cell viewWithTag:XIB_MAIN_MENU_CELL_ICON];
     UILabel *title = (UILabel*)[cell viewWithTag:XIB_MAIN_MENU_CELL_TITLE];
@@ -100,7 +97,7 @@
 }
 
 - (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath {
-    mainMenu *item = self.mainMenu[indexPath.row];
+    mainMenu *item = self.mainMenuTable[indexPath.row];
     if (item.family == FamilyAppSettings) {
         [self enterAppSettings];
         
@@ -320,7 +317,7 @@
 }
 
 - (void)handleEnablingDefaultController {
-    [Utilities enableDefaultController:self tableView:menuList menuItems:self.mainMenu];
+    [Utilities enableDefaultController:self tableView:menuList menuItems:self.mainMenuTable];
 }
 
 - (BOOL)shouldAutorotate {

--- a/XBMC Remote/ViewControllerIPad.h
+++ b/XBMC Remote/ViewControllerIPad.h
@@ -50,7 +50,7 @@
     MessagesView *messagesView;
 }
 
-@property (nonatomic, strong) NSMutableArray *mainMenu;
+@property (nonatomic, strong) NSMutableArray *mainMenuTable;
 @property (nonatomic, strong) MenuViewController *menuViewController;
 @property (nonatomic, strong) NowPlaying *nowPlayingController;
 @property (nonatomic, strong) StackScrollViewController *stackScrollViewController;

--- a/XBMC Remote/ViewControllerIPad.h
+++ b/XBMC Remote/ViewControllerIPad.h
@@ -30,6 +30,7 @@
     MenuViewController *menuViewController;
     NowPlaying *nowPlayingController;
     StackScrollViewController *stackScrollViewController;
+    NSUInteger maxVisibleMenuItems;
     int YPOS;
     UIButton *xbmcLogo;
     UIButton *xbmcInfo;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -205,9 +205,8 @@
     CGPoint locationPoint = [touch locationInView:leftMenuView];
     if ([leftMenuView pointInside:locationPoint withEvent:event]) {
         // Change the left menu layout
-        CGFloat maxMenuItems = locationPoint.y / PAD_MENU_HEIGHT;
-        CGFloat tableHeight = MIN([(NSMutableArray*)mainMenu count], maxMenuItems) * PAD_MENU_HEIGHT;
-        [self changeLeftMenu:tableHeight];
+        CGFloat separatorPosition = MIN(locationPoint.y, CGRectGetHeight(leftMenuView.frame) - PLAYLIST_HEADER_HEIGHT);
+        [self changeLeftMenu:separatorPosition];
     }
 }
 
@@ -220,12 +219,15 @@
         playlistHeader.backgroundColor = UIColor.clearColor;
         playlistHeader.textColor = UIColor.lightGrayColor;
         
-        // Finalize the left menu layout
-        NSInteger maxMenuItems = round(CGRectGetMinY(playlistHeader.frame) / PAD_MENU_HEIGHT);
-        CGFloat tableHeight = MIN([(NSMutableArray*)mainMenu count], maxMenuItems) * PAD_MENU_HEIGHT;
-        [self changeLeftMenu:tableHeight];
+        // Finalize the left menu layout. Snap back to last menu item with separator above playlist toolbar
+        NSUInteger maxMenuItems = round(CGRectGetMinY(playlistHeader.frame) / PAD_MENU_HEIGHT);
+        if (maxMenuItems * PAD_MENU_HEIGHT > CGRectGetHeight(leftMenuView.frame) - PLAYLIST_HEADER_HEIGHT) {
+            maxMenuItems -= 1;
+        }
+        [self changeLeftMenu:maxMenuItems * PAD_MENU_HEIGHT];
         
         // Save configuration
+        maxVisibleMenuItems = maxMenuItems;
         [self saveLeftMenuSplit:maxMenuItems];
         didTouchLeftMenu = NO;
     }
@@ -265,6 +267,13 @@
 }
 
 - (void)changeLeftMenu:(CGFloat)tableHeight {
+    tableHeight = MIN([(NSMutableArray*)mainMenu count] * PAD_MENU_HEIGHT, tableHeight);
+    
+    // Keep separator above playlist toolbar
+    if (tableHeight > CGRectGetHeight(leftMenuView.frame) - PLAYLIST_HEADER_HEIGHT) {
+        tableHeight -= PAD_MENU_HEIGHT;
+    }
+    
     // Main menu
     [menuViewController setMenuHeight:tableHeight];
     
@@ -322,8 +331,8 @@
     AppDelegate.instance.obj = [GlobalData getInstance];
     
     // Create the left menu
-    NSInteger maxMenuItems = [self loadLeftMenuSplit];
-    [self createLeftMenu:maxMenuItems];
+    maxVisibleMenuItems = [self loadLeftMenuSplit];
+    [self createLeftMenu:maxVisibleMenuItems];
     
     rootView = [[UIViewExt alloc] initWithFrame:CGRectMake(0, deltaY, self.view.frame.size.width, self.view.frame.size.height - deltaY)];
 	rootView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
@@ -519,6 +528,11 @@
                                                object:nil];
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self changeLeftMenu:maxVisibleMenuItems * PAD_MENU_HEIGHT];
+}
+
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     BOOL showSetup = AppDelegate.instance.obj.serverIP.length == 0;
@@ -632,6 +646,7 @@
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         [menuViewController viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
         [stackScrollViewController viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+        [self changeLeftMenu:maxVisibleMenuItems * PAD_MENU_HEIGHT];
     }
                                  completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         // restore state

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -285,7 +285,7 @@
     NSInteger tableHeight = MIN([(NSMutableArray*)mainMenu count], maxMenuItems) * PAD_MENU_HEIGHT;
     
     // Create left menu
-    leftMenuView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, PAD_MENU_TABLE_WIDTH, self.view.frame.size.height)];
+    leftMenuView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, PAD_MENU_TABLE_WIDTH, self.view.frame.size.height - [Utilities getTopPadding] - [Utilities getBottomPadding] - TOOLBAR_HEIGHT - PLAYLIST_ACTION_HEIGHT)];
     leftMenuView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
     
     // Main menu

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -268,7 +268,7 @@
     // Main menu
     [menuViewController setMenuHeight:tableHeight];
     
-    // Seperator
+    // Separator
     CGRect frame = playlistHeader.frame;
     frame.origin.y = tableHeight;
     playlistHeader.frame = frame;
@@ -293,7 +293,7 @@
     menuViewController.view.backgroundColor = UIColor.clearColor;
     [leftMenuView addSubview:menuViewController.view];
     
-    // Seperator
+    // Separator
     playlistHeader = [[UILabel alloc] initWithFrame:CGRectMake(0, tableHeight, PAD_MENU_TABLE_WIDTH, PLAYLIST_HEADER_HEIGHT)];
     playlistHeader.backgroundColor = UIColor.clearColor;
     playlistHeader.textColor = UIColor.lightGrayColor;

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -35,11 +35,6 @@
 #define PLAYLIST_ACTION_HEIGHT 44
 #define PLAYLIST_CELL_HEIGHT 53
 
-@interface ViewControllerIPad () {
-    NSMutableArray *mainMenu;
-}
-@end
-
 @interface UIViewExt : UIView {}
 @end
 
@@ -72,7 +67,6 @@
 
 @implementation ViewControllerIPad
 
-@synthesize mainMenu;
 @synthesize menuViewController, stackScrollViewController;
 @synthesize nowPlayingController;
 @synthesize hostPickerViewController = _hostPickerViewController;
@@ -98,7 +92,7 @@
         }
     }
     [xbmcInfo setTitle:infoText forState:UIControlStateNormal];
-    [Utilities setStyleOfMenuItems:menuViewController.tableView active:status menu:mainMenu];
+    [Utilities setStyleOfMenuItems:menuViewController.tableView active:status menu:self.mainMenuTable];
 }
 
 - (void)offStackView {
@@ -267,7 +261,7 @@
 }
 
 - (void)changeLeftMenu:(CGFloat)tableHeight {
-    tableHeight = MIN([(NSMutableArray*)mainMenu count] * PAD_MENU_HEIGHT, tableHeight);
+    tableHeight = MIN(self.mainMenuTable.count * PAD_MENU_HEIGHT, tableHeight);
     
     // Keep separator above playlist toolbar
     if (tableHeight > CGRectGetHeight(leftMenuView.frame) - PLAYLIST_HEADER_HEIGHT) {
@@ -291,14 +285,14 @@
 }
 
 - (void)createLeftMenu:(NSInteger)maxMenuItems {
-    NSInteger tableHeight = MIN([(NSMutableArray*)mainMenu count], maxMenuItems) * PAD_MENU_HEIGHT;
+    NSInteger tableHeight = MIN(self.mainMenuTable.count, maxMenuItems) * PAD_MENU_HEIGHT;
     
     // Create left menu
     leftMenuView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, PAD_MENU_TABLE_WIDTH, self.view.frame.size.height - [Utilities getTopPadding] - [Utilities getBottomPadding] - TOOLBAR_HEIGHT - PLAYLIST_ACTION_HEIGHT)];
     leftMenuView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
     
     // Main menu
-    menuViewController = [[MenuViewController alloc] initWithFrame:CGRectMake(0, 0, leftMenuView.frame.size.width, leftMenuView.frame.size.height) mainMenu:mainMenu menuHeight:tableHeight];
+    menuViewController = [[MenuViewController alloc] initWithFrame:CGRectMake(0, 0, leftMenuView.frame.size.width, leftMenuView.frame.size.height) mainMenu:self.mainMenuTable menuHeight:tableHeight];
     menuViewController.view.backgroundColor = UIColor.clearColor;
     [leftMenuView addSubview:menuViewController.view];
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR reworks the menu resizing on iPad. It also fixes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=385078) and via AppStore review. Before this rework it was possible to hide the playlist view completely. This could happen because the movable playlist header could be placed behind the playlist toolbar, either by user or by rotation to landscape mode. 

The rework takes care that the playlist header is always kept visible and touchable above the playlist toolbar, including rotation use cases.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Always keep playlist header visible on iPad