### PR TITLE
Bugfix: Fix position of "nothing found" label for custom button view

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -423,13 +423,13 @@
     menuTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
     [self.view addSubview:menuTableView];
     
-    noFoundLabel = [[UILabel alloc] initWithFrame:CGRectMake(CGRectGetMinX(menuTableView.frame) + LABEL_SPACING,
-                                                             CGRectGetMinY(menuTableView.frame),
+    noFoundLabel = [[UILabel alloc] initWithFrame:CGRectMake(LABEL_SPACING,
+                                                             0,
                                                              CGRectGetWidth(menuTableView.frame) - 2 * LABEL_SPACING,
                                                              LABEL_HEIGHT)];
     noFoundLabel.text = LOCALIZED_STR(@"No custom button defined.");
     [noFoundLabel setNoFoundStyle];
-    [self.view addSubview:noFoundLabel];
+    [menuTableView addSubview:noFoundLabel];
 
     [self loadCustomButtons];
     


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR fixes a regression of #1440. The `noFoundLabel` must be placed inside `menuTableView` to benefit from auto-scaling.

Screenshots (left = before, right = after):
<img width="546" height="134" alt="Bildschirmfoto 2026-03-29 um 15 43 55" src="https://github.com/user-attachments/assets/4143b416-8b1e-4de6-8c79-7d1e2504630d" />

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix position of "nothing found" label for custom button view