### PR TITLE
Workaround: UIToolbar needs to extend into safe area on iOS26

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5916,6 +5916,16 @@
             frame.origin.y -= bottomPadding;
             buttonsView.frame = frame;
         }
+        if (@available(iOS 26.0, *)) {
+            /*
+             * Workaround: Make UIToolbar slightly higher to ensure its background always extends into safe area.
+             * Only required for iOS26 and until UIDesignRequiresCompatibility is removed. Once this flag is
+             * removed, the UIToolbar is anyway transparent and the extension into safe area is not relevant anymore.
+             */
+            frame = buttonsViewBgToolbar.frame;
+            frame.size.height += 0.00000001;
+            buttonsViewBgToolbar.frame = frame;
+        }
     }
     
     maskView.clipsToBounds = YES;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
While testing the app on iOS26 after migration XCode26, an issue came up which is causing a visual glitch. iOS26 does not allow to set a `UIToolbar` transparent anymore (it is by default transparent), but at the same time sets it translucent when using the flag to keep the app's UI backwards compatible (`UIDesignRequiresCompatibility = true`). Therefore, the app loses the desired dark frosted glass look for its toolbar, and at the same time makes an iOS layout problem visible:  On some iPhone models, most likely depending on display resolution and/or retina scaling, the `UIToolbar` does not extend into the safe area. This leads to a two-parted look of the toolbar.

This PR adds a workaround for iOS26 to let `UIToolbar` extend properly into the safe area. This way, the non-desired dark translucent layout is used, but at least there is no two-parted toolbar anymore. Once `UIDesignRequiresCompatibility` is disabled, the app will again show the desired dark frosted glass look.

Screenshots:
<img width="1099" height="592" alt="Bildschirmfoto 2026-04-03 um 13 55 23" src="https://github.com/user-attachments/assets/1cc524fb-b9b2-4845-8feb-2d2653526333" />

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Workaround: UIToolbar needs to extend into safe area on iOS26