### PR TITLE
Bugfix: Missing iPad corner info when entering settings from remote

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3753,6 +3753,19 @@
 - (void)configureView {
     mainMenu *menuItem = self.detailItem;
     if (menuItem && !menuItem.disableNavbarButtons) {
+        // Set up navigation bar items on upper right
+        UIImage *remoteButtonImage = [UIImage imageNamed:@"icon_menu_remote"];
+        UIBarButtonItem *remoteButton = [[UIBarButtonItem alloc] initWithImage:remoteButtonImage style:UIBarButtonItemStylePlain target:self action:@selector(showRemote)];
+        [remoteButton setAppDefaultStyle];
+        UIImage *nowPlayingButtonImage = [UIImage imageNamed:@"icon_menu_playing"];
+        UIBarButtonItem *nowPlayingButton = [[UIBarButtonItem alloc] initWithImage:nowPlayingButtonImage style:UIBarButtonItemStylePlain target:self action:@selector(showNowPlaying)];
+        [nowPlayingButton setAppDefaultStyle];
+        UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
+        self.navigationItem.rightBarButtonItems = @[remoteButton,
+                                                    fixedSpace,
+                                                    nowPlayingButton];
+    }
+    if (IS_IPAD) {
         topNavigationLabel = [UILabel new];
         topNavigationLabel.backgroundColor = UIColor.clearColor;
         topNavigationLabel.font = [UIFont boldSystemFontOfSize:11];
@@ -3765,18 +3778,6 @@
         topNavigationLabel.shadowOffset = CGSizeMake (0, -1);
         topNavigationLabel.highlightedTextColor = UIColor.blackColor;
         topNavigationLabel.opaque = YES;
-        
-        // Set up navigation bar items on upper right
-        UIImage *remoteButtonImage = [UIImage imageNamed:@"icon_menu_remote"];
-        UIBarButtonItem *remoteButton = [[UIBarButtonItem alloc] initWithImage:remoteButtonImage style:UIBarButtonItemStylePlain target:self action:@selector(showRemote)];
-        [remoteButton setAppDefaultStyle];
-        UIImage *nowPlayingButtonImage = [UIImage imageNamed:@"icon_menu_playing"];
-        UIBarButtonItem *nowPlayingButton = [[UIBarButtonItem alloc] initWithImage:nowPlayingButtonImage style:UIBarButtonItemStylePlain target:self action:@selector(showNowPlaying)];
-        [nowPlayingButton setAppDefaultStyle];
-        UIBarButtonItem *fixedSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
-        self.navigationItem.rightBarButtonItems = @[remoteButton,
-                                                    fixedSpace,
-                                                    nowPlayingButton];
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue  reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3276499#pid3276499).

Always create `topNavigationLabel` when running on iPad.

Screenshot:
<img width="375" height="237" alt="Bildschirmfoto 2026-04-07 um 19 49 09" src="https://github.com/user-attachments/assets/4b5f1970-f78a-42e9-8eeb-397b0718a34b" />

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Missing iPad corner info when entering settings from remote