### PR TITLE
Improvement: Update text for haptic feedback setting

### DIFF
--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -76,7 +76,7 @@
 			<key>Key</key>
 			<string>vibrate_preference</string>
 			<key>Title</key>
-			<string>Vibrate remote control</string>
+			<string>Haptic feedback for remote</string>
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 		</dict>

--- a/XBMC Remote/Settings.bundle/en.lproj/Root.strings
+++ b/XBMC Remote/Settings.bundle/en.lproj/Root.strings
@@ -20,7 +20,7 @@
 "Light" = "Light";
 "Transparent" = "Transparent";
 "Remote Control" = "Remote Control";
-"Vibrate remote control" = "Vibrate remote control";
+"Haptic feedback for remote" = "Haptic feedback for remote";
 "Interface" = "Interface";
 "Cache Settings" = "Cache Settings";
 "Clear cache on next start" = "Clear cache on next start";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes https://github.com/xbmc/Official-Kodi-Remote-iOS/issues/1462.

With https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1427 a haptic feedback on remote key presses was introduced -- replacing the vibration. This PR updates the setting name. The setting's key `vibrate_preference` is not changed, to stay compatible with older app versions and to keep the user's chosen setting.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Update text for haptic feedback setting