### PR TITLE
Bugfix: Avoid unintended swipe when using remote's touch pad on iOS26 iPhone

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -989,6 +989,11 @@ static void *TorchRemoteContext = &TorchRemoteContext;
         self.slidingViewController.anchorLeftRevealAmount = 0;
         self.slidingViewController.panGesture.delegate = self;
         
+        // Turn off unintended swipe in iOS26
+        if (@available(iOS 26.0, *)) {
+            self.navigationController.interactiveContentPopGestureRecognizer.enabled = NO;
+        }
+        
         // Create custom button view and attach it to underRight view
         RightMenuViewController *rightMenuViewController = [[RightMenuViewController alloc] initWithNibName:@"RightMenuViewController" bundle:nil];
         self.slidingViewController.underRightViewController = rightMenuViewController;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
FIxes an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3276409#pid3276409), which is a regression seen since #1451.

Since using XCode26 and only on iOS26 devices `interactiveContentPopGestureRecognizer` must be explicitly disabled to avoid swiping when using the remote's touch pad.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid unintended swipe when using remote's touch pad on iOS26 iPhone