### PR TITLE
Bugfix: Make sure the translations for FooterText are used

### DIFF
--- a/XBMC Remote/Settings.bundle/Root.plist
+++ b/XBMC Remote/Settings.bundle/Root.plist
@@ -130,7 +130,7 @@
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 			<key>FooterText</key>
-			<string>Filemode and Theme changes need app restart.</string>
+			<string>Filemode and Theme changes need app restart</string>
 		</dict>
 		<dict>
 			<key>DefaultValue</key>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Make sure the translations for settings' `FooterText` are used. The additional "." at the end caused the translations to not be used.

Example: German
<img width="357" height="55" alt="Bildschirmfoto 2026-04-11 um 12 17 39" src="https://github.com/user-attachments/assets/5a656352-2594-45cf-89ec-3e762395ad80" />


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Make sure the translations for FooterText are used