### PR TITLE
Improvement: Display TV Show specials in logical order inside seasons

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2669,7 +2669,7 @@
     }
     else if (episodesView) {
         UILabel *trackNumber = (UILabel*)[cell viewWithTag:ALBUM_VIEW_CELL_TRACKNUMBER];
-        trackNumber.text = item[@"episode"];
+        trackNumber.text = item[@"specialEpisode"] ?: item[@"episode"];
     }
     else if (channelGuideView) {
         runtimeyear.hidden = YES;
@@ -4788,6 +4788,25 @@
                                                                                  useBanner:tvshowsView
                                                                                    useIcon:recordingListView];
                              
+                             // Use TV Show episode's "specialsort", if present, to place a copy of a special
+                             // within the common seasons. This is in line with Kodi behaviour.
+                             if ([methodName isEqualToString:@"VideoLibrary.GetEpisodes"]) {
+                                 // Flag specials for sorting reasons and provide track number in "Sx" scheme.
+                                 BOOL isTVShowSpecial = [newDict[@"season"] integerValue] == 0;
+                                 newDict[@"isTVShowSpecial"] = @(isTVShowSpecial);
+                                 if (isTVShowSpecial) {
+                                     newDict[@"specialEpisode"] = [Utilities formatTVShowStringForSpecialEpisode:item[@"episode"]];
+                                 }
+                                 
+                                 // In case "specialsort" is valid, add an item copy with according season/episode.
+                                 if ([item[@"specialsortseason"] intValue] > 0 && [item[@"specialsortepisode"] intValue] > 0) {
+                                     NSMutableDictionary *specialSortedDict = [newDict mutableCopy];
+                                     specialSortedDict[@"season"] = [Utilities getStringFromItem:item[@"specialsortseason"]];
+                                     specialSortedDict[@"episode"] = [Utilities getStringFromItem:item[@"specialsortepisode"]];
+                                     [resultStoreArray addObject:specialSortedDict];
+                                 }
+                             }
+                             
                              // JSON API does not return the expected "filetype" when retrieving list of "sources".
                              // The correct "filetype" is "directory". But we also need to be aware this is a source
                              // and not a directory yet.
@@ -5068,7 +5087,20 @@
     }
     
     if (episodesView) {
-        for (NSDictionary *item in self.richResults) {
+        // First run will ensure the specials are in correct order
+        SEL selector = [self buildSelectorForSortMethod:@"specialEpisode" inArray:copyRichResults];
+        copyRichResults = [self applySortByMethod:copyRichResults sortmethod:@"specialEpisode" ascending:YES selector:selector];
+        
+        // Second run will ensure the specials are on top of the list
+        selector = [self buildSelectorForSortMethod:@"isTVShowSpecial" inArray:copyRichResults];
+        copyRichResults = [self applySortByMethod:copyRichResults sortmethod:@"isTVShowSpecial" ascending:NO selector:selector];
+        
+        // Third run will sort by order of episodes
+        selector = [self buildSelectorForSortMethod:@"episode" inArray:copyRichResults];
+        copyRichResults = [self applySortByMethod:copyRichResults sortmethod:@"episode" ascending:YES selector:selector];
+        
+        // Now pick the episodes top-down from the list into sections defined by seasons
+        for (NSDictionary *item in copyRichResults) {
             NSString *c = [NSString stringWithFormat:@"%@", item[@"season"]];
             BOOL found = [[self.sections allKeys] containsObject:c];
             if (!found) {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4830,7 +4830,7 @@
                                  BOOL isTVShowSpecial = [newDict[@"season"] integerValue] == 0;
                                  newDict[@"isTVShowSpecial"] = @(isTVShowSpecial);
                                  if (isTVShowSpecial) {
-                                     newDict[@"specialEpisode"] = [NSString stringWithFormat:@"S%i", [item[@"episode"] intValue]];
+                                     newDict[@"specialEpisode"] = [Utilities formatTVShowStringForSpecialEpisode:item[@"episode"]];
                                  }
                                  
                                  // In case "specialsort" is valid, add an item copy with according season/episode.

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2681,7 +2681,7 @@
     }
     else if (episodesView) {
         UILabel *trackNumber = (UILabel*)[cell viewWithTag:ALBUM_VIEW_CELL_TRACKNUMBER];
-        trackNumber.text = item[@"episode"];
+        trackNumber.text = item[@"specialEpisode"] ?: item[@"episode"];
     }
     else if (channelGuideView) {
         runtimeyear.hidden = YES;
@@ -4823,6 +4823,25 @@
                                                                                  useBanner:tvshowsView
                                                                                    useIcon:recordingListView];
                              
+                             // Use TV Show episode's "specialsort", if present, to place a copy of a special
+                             // within the common seasons. This is in line with Kodi behaviour.
+                             if ([methodName isEqualToString:@"VideoLibrary.GetEpisodes"]) {
+                                 // Flag specials for sorting reasons and provide track number in "Sx" scheme.
+                                 BOOL isTVShowSpecial = [newDict[@"season"] integerValue] == 0;
+                                 newDict[@"isTVShowSpecial"] = @(isTVShowSpecial);
+                                 if (isTVShowSpecial) {
+                                     newDict[@"specialEpisode"] = [NSString stringWithFormat:@"S%i", [item[@"episode"] intValue]];
+                                 }
+                                 
+                                 // In case "specialsort" is valid, add an item copy with according season/episode.
+                                 if ([item[@"specialsortseason"] intValue] > 0 && [item[@"specialsortepisode"] intValue] > 0) {
+                                     NSMutableDictionary *specialSortedDict = [newDict mutableCopy];
+                                     specialSortedDict[@"season"] = [Utilities getStringFromItem:item[@"specialsortseason"]];
+                                     specialSortedDict[@"episode"] = [Utilities getStringFromItem:item[@"specialsortepisode"]];
+                                     [resultStoreArray addObject:specialSortedDict];
+                                 }
+                             }
+                             
                              // JSON API does not return the expected "filetype" when retrieving list of "sources".
                              // The correct "filetype" is "directory". But we also need to be aware this is a source
                              // and not a directory yet.
@@ -5107,7 +5126,20 @@
     }
     
     if (episodesView) {
-        for (NSDictionary *item in self.richResults) {
+        // First run will ensure the specials are in correct order
+        SEL selector = [self buildSelectorForSortMethod:@"specialEpisode" inArray:copyRichResults];
+        copyRichResults = [self applySortByMethod:copyRichResults sortmethod:@"specialEpisode" ascending:YES selector:selector];
+        
+        // Second run will ensure the specials are on top of the list
+        selector = [self buildSelectorForSortMethod:@"isTVShowSpecial" inArray:copyRichResults];
+        copyRichResults = [self applySortByMethod:copyRichResults sortmethod:@"isTVShowSpecial" ascending:NO selector:selector];
+        
+        // Third run will sort by order of episodes
+        selector = [self buildSelectorForSortMethod:@"episode" inArray:copyRichResults];
+        copyRichResults = [self applySortByMethod:copyRichResults sortmethod:@"episode" ascending:YES selector:selector];
+        
+        // Now pick the episodes top-down from the list into sections defined by seasons
+        for (NSDictionary *item in copyRichResults) {
             NSString *c = [NSString stringWithFormat:@"%@", item[@"season"]];
             BOOL found = [[self.sections allKeys] containsObject:c];
             if (!found) {

--- a/XBMC Remote/MainMenu.m
+++ b/XBMC Remote/MainMenu.m
@@ -4053,6 +4053,12 @@
                     @"title",
                 ],
             },
+            @"kodiExtrasPropertiesMinimumVersion": @{
+                @"12": @[
+                    @"specialsortseason",
+                    @"specialsortepisode",
+                ],
+            },
             @"extra_info_parameters": @{
                 @"properties": @[
                     @"episode",
@@ -4387,6 +4393,12 @@
                     @"runtime",
                     @"file",
                     @"title",
+                ],
+            },
+            @"kodiExtrasPropertiesMinimumVersion": @{
+                @"12": @[
+                    @"specialsortseason",
+                    @"specialsortepisode",
                 ],
             },
             @"extra_info_parameters": @{

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -87,6 +87,7 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (void)archivePath:(NSString*)path file:(NSString*)filename data:(id)data;
 + (float)getPercentElapsed:(NSDate*)startDate EndDate:(NSDate*)endDate;
 + (void)createTransparentToolbar:(UIToolbar*)toolbar;
++ (NSString*)formatTVShowStringForSpecialEpisode:(id)episode;
 + (NSString*)formatTVShowStringForSeasonTrailing:(id)season episode:(id)episode title:(NSString*)title;
 + (NSString*)formatTVShowStringForSeasonLeading:(id)season episode:(id)episode title:(NSString*)title;
 + (NSString*)formatTVShowStringForSeason:(id)season episode:(id)episode;

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -111,6 +111,7 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (void)imageView:(UIImageView*)view AnimDuration:(NSTimeInterval)seconds Image:(UIImage*)image;
 + (float)getPercentElapsed:(NSDate*)startDate EndDate:(NSDate*)endDate;
 + (void)createTransparentToolbar:(UIToolbar*)toolbar;
++ (NSString*)formatTVShowStringForSpecialEpisode:(id)episode;
 + (NSString*)formatTVShowStringForSeasonTrailing:(id)season episode:(id)episode title:(NSString*)title;
 + (NSString*)formatTVShowStringForSeasonLeading:(id)season episode:(id)episode title:(NSString*)title;
 + (NSString*)formatTVShowStringForSeason:(id)season episode:(id)episode;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1016,6 +1016,10 @@
          forToolbarPosition:UIBarPositionAny];
 }
 
++ (NSString*)formatTVShowStringForSpecialEpisode:(id)episode {
+    return [NSString stringWithFormat:@"S%i", [episode intValue]];
+}
+
 + (NSString*)formatTVShowStringForSeasonLeading:(id)season episode:(id)episode title:(NSString*)title {
     NSString *seasonAndEpisode = [Utilities formatTVShowStringForSeason:season episode:episode];
     NSString *text = [NSString stringWithFormat:@"%@%@%@", seasonAndEpisode, seasonAndEpisode.length ? @" " : @"", title];
@@ -1035,6 +1039,9 @@
     if ([season respondsToSelector:@selector(intValue)] && [episode respondsToSelector:@selector(intValue)]) {
         if ([season intValue] && [episode intValue]) {
             text = [NSString stringWithFormat:format, [season intValue], [episode intValue]];
+        }
+        else if (![season intValue] && [episode intValue]) {
+            text = [self formatTVShowStringForSpecialEpisode:episode];
         }
     }
     return text;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1277,6 +1277,10 @@
         if ([season intValue] && [episode intValue]) {
             text = [NSString stringWithFormat:format, [season intValue], [episode intValue]];
         }
+        else if (![season intValue] && [episode intValue]) {
+            // Special episode
+            text = [NSString stringWithFormat:@"S%i", [episode intValue]];
+        }
     }
     return text;
 }

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1257,6 +1257,10 @@
          forToolbarPosition:UIBarPositionAny];
 }
 
++ (NSString*)formatTVShowStringForSpecialEpisode:(id)episode {
+    return [NSString stringWithFormat:@"S%i", [episode intValue]];
+}
+
 + (NSString*)formatTVShowStringForSeasonLeading:(id)season episode:(id)episode title:(NSString*)title {
     NSString *seasonAndEpisode = [Utilities formatTVShowStringForSeason:season episode:episode];
     NSString *text = [NSString stringWithFormat:@"%@%@%@", seasonAndEpisode, seasonAndEpisode.length ? @" " : @"", title];
@@ -1278,8 +1282,7 @@
             text = [NSString stringWithFormat:format, [season intValue], [episode intValue]];
         }
         else if (![season intValue] && [episode intValue]) {
-            // Special episode
-            text = [NSString stringWithFormat:@"S%i", [episode intValue]];
+            text = [self formatTVShowStringForSpecialEpisode:episode];
         }
     }
     return text;

--- a/XBMC Remote/mainMenu.m
+++ b/XBMC Remote/mainMenu.m
@@ -4053,6 +4053,12 @@
                     @"title",
                 ],
             },
+            @"kodiExtrasPropertiesMinimumVersion": @{
+                @"12": @[
+                    @"specialsortseason",
+                    @"specialsortepisode",
+                ],
+            },
             @"extra_info_parameters": @{
                 @"properties": @[
                     @"episode",
@@ -4387,6 +4393,12 @@
                     @"runtime",
                     @"file",
                     @"title",
+                ],
+            },
+            @"kodiExtrasPropertiesMinimumVersion": @{
+                @"12": @[
+                    @"specialsortseason",
+                    @"specialsortepisode",
                 ],
             },
             @"extra_info_parameters": @{


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Closes #57.

Usually, TV Show specials are listed under season 0. Many TV Shows have special episodes which are important to watch in logical order, ex. "Doctor Who". Kodi is able to display special episodes in both season 0 and in the correct place inside the common seasons. This PR implements the same functionality based on information shared within #57 and links provided from there.

To allow correct logical sorting, the Kodi API shares `specialsortseason` and `specialsortepisode`, which represent the logical position of the special episode inside the common seasons. The app does now request this information to
show special episodes in both season 0 and the logical position. 3-staged sorting is applied to ensure the special episodes are added in correct order to the desired position.

To differentiate special episodes from common episodes the naming convention for track numbers and episode IDs is adapted. It follows Kodi's implementation by using "Sx" (x = special episode) which clearly visualizes the type of episode.

Screenshots, suing dummy database with episodes from "Doctor Who":
<img width="990" height="536" alt="Bildschirmfoto 2026-04-11 um 18 43 41" src="https://github.com/user-attachments/assets/44b16cb8-eb4c-471e-add9-8872c743d2d9"/>

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Display TV Show specials in logical order inside seasons