### PR TITLE
Bugfix: Make scroll-to-top work in ShowInfoVC after coming back from artist/actors details

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2793,6 +2793,7 @@
         self.slidingViewController.underRightViewController = remoteController;
         self.slidingViewController.anchorLeftPeekAmount = ANCHOR_RIGHT_PEEK;
     }
+    playlistTableView.scrollsToTop = YES;
 }
 
 - (void)startFlipDemo {

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1878,6 +1878,7 @@
                                            clearlogoButton.frame.size.height);
         self.view.superview.backgroundColor = UIColor.clearColor;
     }
+    scrollView.scrollsToTop = YES;
 }
 
 - (void)viewWillDisappear:(BOOL)animated {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes #1470.

(Re-)enable `scrollsToTop` in `viewDidAppear`. This resolves non-working scroll-to-top after entering DetailVC, which resets SlidingVCs subviews to `scrollsToTop = NO` by calling `disableScrollsToTopPropertyOnAllSubviewsOf`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Make scroll-to-top work in ShowInfoVC after coming back from artist/actors details