### PR TITLE
Bugfix: Correct server list selection state

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -85,6 +85,22 @@
     }
 }
 
+- (void)selectRowAtIndexPath:(NSIndexPath*)indexPath {
+    if (indexPath && indexPath.row < AppDelegate.instance.arrayServerList.count) {
+        UITableViewCell *cell = [serverListTableView cellForRowAtIndexPath:indexPath];
+        cell.accessoryType = UITableViewCellAccessoryCheckmark;
+        [serverListTableView selectRowAtIndexPath:indexPath animated:YES scrollPosition:UITableViewScrollPositionMiddle];
+    }
+}
+
+- (void)deselectRowAtIndexPath:(NSIndexPath*)indexPath {
+    if (indexPath && indexPath.row < AppDelegate.instance.arrayServerList.count) {
+        UITableViewCell *cell = [serverListTableView cellForRowAtIndexPath:indexPath];
+        cell.accessoryType = UITableViewCellAccessoryNone;
+        [serverListTableView deselectRowAtIndexPath:indexPath animated:YES];
+    }
+}
+
 #pragma mark - Table view methods & data source
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView*)tableView {
@@ -143,6 +159,8 @@
 }
 
 - (void)selectServerAtIndexPath:(NSIndexPath*)indexPath {
+    [self deselectRowAtIndexPath:storeServerSelection];
+    [self selectRowAtIndexPath:indexPath];
     NSDictionary *item = AppDelegate.instance.arrayServerList[indexPath.row];
     AppDelegate.instance.obj.serverDescription = item[@"serverDescription"];
     AppDelegate.instance.obj.serverUser = item[@"serverUser"];
@@ -157,6 +175,7 @@
 - (void)deselectServer {
     // Permanently disconnect the server. This will unselect the server from the server list and will
     // not reconnect after wakeup or restart.
+    [self deselectRowAtIndexPath:storeServerSelection];
     [connectingActivityIndicator stopAnimating];
     storeServerSelection = nil;
     [Utilities resetKodiServerParameters];
@@ -182,7 +201,7 @@
 
 - (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath {
     if (AppDelegate.instance.arrayServerList.count == 0) {
-        [serverListTableView deselectRowAtIndexPath:indexPath animated:YES];
+        [self deselectRowAtIndexPath:indexPath];
     }
     else {
         NSIndexPath *selectedPath = storeServerSelection;

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -200,10 +200,7 @@
 }
 
 - (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath {
-    if (AppDelegate.instance.arrayServerList.count == 0) {
-        [self deselectRowAtIndexPath:indexPath];
-    }
-    else {
+    if (AppDelegate.instance.arrayServerList.count > 0) {
         NSIndexPath *selectedPath = storeServerSelection;
         if (selectedPath && selectedPath.row == indexPath.row) {
             [self deselectServer];

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -161,6 +161,7 @@
 - (void)selectServerAtIndexPath:(NSIndexPath*)indexPath {
     [self deselectRowAtIndexPath:storeServerSelection];
     [self selectRowAtIndexPath:indexPath];
+    [connectingActivityIndicator startAnimating];
     NSDictionary *item = AppDelegate.instance.arrayServerList[indexPath.row];
     AppDelegate.instance.obj.serverDescription = item[@"serverDescription"];
     AppDelegate.instance.obj.serverUser = item[@"serverUser"];
@@ -170,6 +171,8 @@
     AppDelegate.instance.obj.serverPort = [Utilities getServerPort:item[@"serverPort"]];
     AppDelegate.instance.obj.serverHWAddr = item[@"serverMacAddress"];
     AppDelegate.instance.obj.tcpPort = [Utilities getTcpPort:item[@"tcpPort"]];
+    storeServerSelection = indexPath;
+    [Utilities saveLastServerIndex:indexPath];
 }
 
 - (void)deselectServer {
@@ -191,10 +194,7 @@
     else {
         NSInteger index = [notification.userInfo[@"index"] integerValue];
         NSIndexPath *indexPath = [NSIndexPath indexPathForRow:index inSection:0];
-        [connectingActivityIndicator startAnimating];
         [self selectServerAtIndexPath:indexPath];
-        storeServerSelection = indexPath;
-        [Utilities saveLastServerIndex:indexPath];
     }
     [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerHasChanged" object:nil];
 }
@@ -209,10 +209,7 @@
             [self deselectServer];
         }
         else {
-            [connectingActivityIndicator startAnimating];
             [self selectServerAtIndexPath:indexPath];
-            storeServerSelection = indexPath;
-            [Utilities saveLastServerIndex:indexPath];
         }
     }
     [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerHasChanged" object:nil];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression caused by #1442.

After removing the brute-force update of the server list via `reloadData`, only the connection status was correctly updated. This PR implements two helper methods `selectRowAtIndexPath` and `selectRowAtIndexPath` which handle the desired visualization for a selected row (set as selected + checkmark `accessoryType`). This selection state is changed when selecting/unselecting a server from the list.
In addition, minor refactoring of `selectServerAtIndexPath` is done to avoid code duplication.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct server list selection state