### PR TITLE
Bugfix: Remove checkmark after editing active server

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -58,9 +58,7 @@
 - (void)modifyHost:(NSIndexPath*)item {
     NSIndexPath *selectedPath = storeServerSelection;
     if (selectedPath && item.row == selectedPath.row) {
-        [Utilities resetKodiServerParameters];
-        [Utilities saveLastServerIndex:nil];
-        [connectingActivityIndicator stopAnimating];
+        [self deselectServer];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerHasChanged" object:nil];
     }
     HostViewController *hostController = [[HostViewController alloc] initWithNibName:@"HostViewController" bundle:nil];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Adds a fix for a use case missed in #1473.

Call `deselectServer` when editing the active server. This takes care the checkmark is also properly removed after editing ends.

Screenshots:
<img width="1169" height="502" alt="Bildschirmfoto 2026-05-10 um 13 55 22" src="https://github.com/user-attachments/assets/1c151d4d-ab98-4942-b288-ee1557e88c58" />

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Remove checkmark after editing active server