### PR TITLE
Improvement: Frosted glass navbar on iPhone

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -112,7 +112,6 @@
     // Make navigation bar transparent
     if (@available(iOS 13, *)) {
         UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
-        [appearance configureWithOpaqueBackground];
         [appearance configureWithTransparentBackground];
         appearance.backgroundEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
         appearance.titleTextAttributes = @{NSForegroundColorAttributeName : UIColor.whiteColor};

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -109,12 +109,14 @@
 }
 
 - (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-    // iOS 13 and later use appearance for the navigationbar, from iOS 15 this is required as it else defaults to unwanted transparency
+    // Make navigation bar transparent
     if (@available(iOS 13, *)) {
         UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
         [appearance configureWithOpaqueBackground];
+        [appearance configureWithTransparentBackground];
+        appearance.backgroundEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
         appearance.titleTextAttributes = @{NSForegroundColorAttributeName : UIColor.whiteColor};
-        appearance.backgroundColor = NAVBAR_TINT_COLOR;
+        appearance.backgroundColor = UIColor.clearColor;
         [UINavigationBar appearance].standardAppearance = appearance;
         [UINavigationBar appearance].scrollEdgeAppearance = appearance;
     }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5535,6 +5535,7 @@
     UIEdgeInsets viewInsets = dataList.contentInset;
     viewInsets.top = [self getTableInsetTop];
     dataList.contentInset = viewInsets;
+    dataList.scrollIndicatorInsets = viewInsets;
     dataList.indicatorStyle = UIScrollViewIndicatorStyleDefault;
     
     CGRect frame = maskView.frame;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1063,6 +1063,7 @@
         moreItemsViewController = [[MoreItemsViewController alloc] initWithFrame:CGRectMake(dataList.bounds.size.width, 0, dataList.bounds.size.width, dataList.bounds.size.height) mainMenu:moreMenu];
         moreItemsViewController.view.backgroundColor = UIColor.clearColor;
         moreItemsViewController.tableView.contentInset = activeLayoutView.contentInset;
+        moreItemsViewController.tableView.scrollIndicatorInsets = activeLayoutView.contentInset;
         [self setViewInset:moreItemsViewController.tableView bottom:buttonsViewBgToolbar.frame.size.height];
         [moreItemsViewController.tableView setContentOffset:CGPointMake(0, -moreItemsViewController.tableView.contentInset.top) animated:NO];
         [maskView insertSubview:moreItemsViewController.view aboveSubview:dataList];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1062,11 +1062,9 @@
     if (moreItemsViewController == nil) {
         moreItemsViewController = [[MoreItemsViewController alloc] initWithFrame:CGRectMake(dataList.bounds.size.width, 0, dataList.bounds.size.width, dataList.bounds.size.height) mainMenu:moreMenu];
         moreItemsViewController.view.backgroundColor = UIColor.clearColor;
-        UIEdgeInsets tableViewInsets = UIEdgeInsetsZero;
-        tableViewInsets.bottom = buttonsViewBgToolbar.frame.size.height;
-        moreItemsViewController.tableView.contentInset = tableViewInsets;
-        moreItemsViewController.tableView.scrollIndicatorInsets = tableViewInsets;
-        [moreItemsViewController.tableView setContentOffset:CGPointMake(0, - tableViewInsets.top) animated:NO];
+        moreItemsViewController.tableView.contentInset = activeLayoutView.contentInset;
+        [self setViewInset:moreItemsViewController.tableView bottom:buttonsViewBgToolbar.frame.size.height];
+        [moreItemsViewController.tableView setContentOffset:CGPointMake(0, -moreItemsViewController.tableView.contentInset.top) animated:NO];
         [maskView insertSubview:moreItemsViewController.view aboveSubview:dataList];
     }
 
@@ -1890,13 +1888,13 @@
     }
     else if (sender.currentIndex == 0) {
         if (enableCollectionView) {
-            [collectionView setContentOffset:CGPointZero animated:NO];
+            [collectionView setContentOffset:CGPointMake(0, -collectionView.contentInset.top) animated:NO];
             if (sectionNameOverlayView == nil && stackscrollFullscreen) {
                 [self initSectionNameOverlayView];
             }
         }
         else {
-            [dataList setContentOffset:CGPointZero animated:NO];
+            [dataList setContentOffset:CGPointMake(0, -dataList.contentInset.top) animated:NO];
         }
         sectionNameLabel.text = @"🔍";
         return;
@@ -1937,7 +1935,7 @@
         if (index != NSNotFound) {
             NSIndexPath *path = [NSIndexPath indexPathForItem:index inSection:0];
             [collectionView scrollToItemAtIndexPath:path atScrollPosition:UICollectionViewScrollPositionTop animated:NO];
-            collectionView.contentOffset = CGPointMake(collectionView.contentOffset.x, collectionView.contentOffset.y - GRID_SECTION_HEADER_HEIGHT);
+            collectionView.contentOffset = CGPointMake(collectionView.contentOffset.x, collectionView.contentOffset.y - GRID_SECTION_HEADER_HEIGHT + [Utilities getTopPadding]);
         }
         return;
     }
@@ -2099,6 +2097,10 @@
 }
 
 #pragma mark - Table Management
+
+- (CGFloat)getTableInsetTop {
+    return IS_IPHONE ? [Utilities getTopPaddingWithNavBar:self.navigationController] : 0;
+}
 
 - (void)setSearchBar:(UISearchBar*)searchBar toDark:(BOOL)isDark {
     if (isDark) {
@@ -5210,7 +5212,7 @@
         case 0:
             // no button, no toolbar
             button1.hidden = button2.hidden = button3.hidden = button4.hidden = button5.hidden = YES;
-            [dataList setHeight:self.view.bounds.size.height];
+            [dataList setHeight:maskView.bounds.size.height];
             break;
         case 1:
             button2.hidden = button3.hidden = button4.hidden = button5.hidden = YES;
@@ -5518,7 +5520,7 @@
     [self initSearchController];
     self.navigationController.view.backgroundColor = UIColor.blackColor;
     self.definesPresentationContext = NO;
-    iOSYDelta = self.searchController.searchBar.frame.size.height;
+    iOSYDelta = self.searchController.searchBar.frame.size.height - [self getTableInsetTop];
     dataList.tableHeaderView = [self createFakeSearchbarInDark:NO];
 
     if (@available(iOS 15.0, *)) {
@@ -5529,9 +5531,16 @@
 
     [button7 addTarget:self action:@selector(handleChangeSortLibrary) forControlEvents:UIControlEventTouchUpInside];
     self.edgesForExtendedLayout = UIRectEdgeNone;
+    UIEdgeInsets viewInsets = dataList.contentInset;
+    viewInsets.top = [self getTableInsetTop];
+    dataList.contentInset = viewInsets;
     dataList.indicatorStyle = UIScrollViewIndicatorStyleDefault;
     
-    [dataList setHeight:self.view.bounds.size.height];
+    CGRect frame = maskView.frame;
+    frame.origin.y -= [self getTableInsetTop];
+    frame.size.height += [self getTableInsetTop];
+    maskView.frame = frame;
+    
     buttonsViewBgToolbar.hidden = NO;
     
     __weak DetailViewController *weakSelf = self;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1076,11 +1076,9 @@
     if (moreItemsViewController == nil) {
         moreItemsViewController = [[MoreItemsViewController alloc] initWithFrame:CGRectMake(dataList.bounds.size.width, 0, dataList.bounds.size.width, dataList.bounds.size.height) mainMenu:moreMenu];
         moreItemsViewController.view.backgroundColor = UIColor.clearColor;
-        UIEdgeInsets tableViewInsets = UIEdgeInsetsZero;
-        tableViewInsets.bottom = buttonsViewBgToolbar.frame.size.height;
-        moreItemsViewController.tableView.contentInset = tableViewInsets;
-        moreItemsViewController.tableView.scrollIndicatorInsets = tableViewInsets;
-        [moreItemsViewController.tableView setContentOffset:CGPointMake(0, - tableViewInsets.top) animated:NO];
+        moreItemsViewController.tableView.contentInset = activeLayoutView.contentInset;
+        [self setViewInset:moreItemsViewController.tableView bottom:buttonsViewBgToolbar.frame.size.height];
+        [moreItemsViewController.tableView setContentOffset:CGPointMake(0, -moreItemsViewController.tableView.contentInset.top) animated:NO];
         [maskView insertSubview:moreItemsViewController.view aboveSubview:dataList];
     }
 
@@ -1904,13 +1902,13 @@
     }
     else if (sender.currentIndex == 0) {
         if (enableCollectionView) {
-            [collectionView setContentOffset:CGPointZero animated:NO];
+            [collectionView setContentOffset:CGPointMake(0, -collectionView.contentInset.top) animated:NO];
             if (sectionNameOverlayView == nil && stackscrollFullscreen) {
                 [self initSectionNameOverlayView];
             }
         }
         else {
-            [dataList setContentOffset:CGPointZero animated:NO];
+            [dataList setContentOffset:CGPointMake(0, -dataList.contentInset.top) animated:NO];
         }
         sectionNameLabel.text = @"🔍";
         return;
@@ -1951,7 +1949,7 @@
         if (index != NSNotFound) {
             NSIndexPath *path = [NSIndexPath indexPathForItem:index inSection:0];
             [collectionView scrollToItemAtIndexPath:path atScrollPosition:UICollectionViewScrollPositionTop animated:NO];
-            collectionView.contentOffset = CGPointMake(collectionView.contentOffset.x, collectionView.contentOffset.y - GRID_SECTION_HEADER_HEIGHT);
+            collectionView.contentOffset = CGPointMake(collectionView.contentOffset.x, collectionView.contentOffset.y - GRID_SECTION_HEADER_HEIGHT + [Utilities getTopPadding]);
         }
         return;
     }
@@ -2113,6 +2111,10 @@
 }
 
 #pragma mark - Table Management
+
+- (CGFloat)getTableInsetTop {
+    return IS_IPHONE ? [Utilities getTopPaddingWithNavBar:self.navigationController] : 0;
+}
 
 - (void)setSearchBar:(UISearchBar*)searchBar toDark:(BOOL)isDark {
     if (isDark) {
@@ -5228,7 +5230,7 @@
         case 0:
             // no button, no toolbar
             button1.hidden = button2.hidden = button3.hidden = button4.hidden = button5.hidden = YES;
-            [dataList setHeight:self.view.bounds.size.height];
+            [dataList setHeight:maskView.bounds.size.height];
             break;
         case 1:
             button2.hidden = button3.hidden = button4.hidden = button5.hidden = YES;
@@ -5537,7 +5539,7 @@
     [self initSearchController];
     self.navigationController.view.backgroundColor = UIColor.blackColor;
     self.definesPresentationContext = NO;
-    iOSYDelta = self.searchController.searchBar.frame.size.height;
+    iOSYDelta = self.searchController.searchBar.frame.size.height - [self getTableInsetTop];
     dataList.tableHeaderView = [self createFakeSearchbarInDark:NO];
 
     if (@available(iOS 15.0, *)) {
@@ -5548,9 +5550,16 @@
 
     [button7 addTarget:self action:@selector(handleChangeSortLibrary) forControlEvents:UIControlEventTouchUpInside];
     self.edgesForExtendedLayout = UIRectEdgeNone;
+    UIEdgeInsets viewInsets = dataList.contentInset;
+    viewInsets.top = [self getTableInsetTop];
+    dataList.contentInset = viewInsets;
     dataList.indicatorStyle = UIScrollViewIndicatorStyleDefault;
     
-    [dataList setHeight:self.view.bounds.size.height];
+    CGRect frame = maskView.frame;
+    frame.origin.y -= [self getTableInsetTop];
+    frame.size.height += [self getTableInsetTop];
+    maskView.frame = frame;
+    
     buttonsViewBgToolbar.hidden = NO;
     
     __weak DetailViewController *weakSelf = self;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1077,6 +1077,7 @@
         moreItemsViewController = [[MoreItemsViewController alloc] initWithFrame:CGRectMake(dataList.bounds.size.width, 0, dataList.bounds.size.width, dataList.bounds.size.height) mainMenu:moreMenu];
         moreItemsViewController.view.backgroundColor = UIColor.clearColor;
         moreItemsViewController.tableView.contentInset = activeLayoutView.contentInset;
+        moreItemsViewController.tableView.scrollIndicatorInsets = activeLayoutView.contentInset;
         [self setViewInset:moreItemsViewController.tableView bottom:buttonsViewBgToolbar.frame.size.height];
         [moreItemsViewController.tableView setContentOffset:CGPointMake(0, -moreItemsViewController.tableView.contentInset.top) animated:NO];
         [maskView insertSubview:moreItemsViewController.view aboveSubview:dataList];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5554,6 +5554,7 @@
     UIEdgeInsets viewInsets = dataList.contentInset;
     viewInsets.top = [self getTableInsetTop];
     dataList.contentInset = viewInsets;
+    dataList.scrollIndicatorInsets = viewInsets;
     dataList.indicatorStyle = UIScrollViewIndicatorStyleDefault;
     
     CGRect frame = maskView.frame;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2740,7 +2740,6 @@
         // Make navigation bar transparent
         if (@available(iOS 13, *)) {
             UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
-            [appearance configureWithOpaqueBackground];
             [appearance configureWithTransparentBackground];
             appearance.titleTextAttributes = @{NSForegroundColorAttributeName : UIColor.whiteColor};
             appearance.backgroundColor = UIColor.clearColor;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2736,7 +2736,6 @@
         // Make navigation bar transparent
         if (@available(iOS 13, *)) {
             UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
-            [appearance configureWithOpaqueBackground];
             [appearance configureWithTransparentBackground];
             appearance.titleTextAttributes = @{NSForegroundColorAttributeName : UIColor.whiteColor};
             appearance.backgroundColor = UIColor.clearColor;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
### Frosted Glass Effect

Use frosted glass effect (`[UIBlurEffect effectWithStyle:UIBlurEffectStyleDark]`) for navbar. Let the table views extend underneath the frosted glass and adapt `contentInset` accordingly.

Special care is needed for the following areas:

- To have `SVPullToRefresh` working as expected it is important to explicitly set `contentInset` instead of automatic adjustment.
- For iPad it is important to hide the toolbar's effect view `buttonsViewEffect` while being in fullscreen library view.

### Screenshots

Screenshots (left = current, right = dark blur): https://ibb.co/zW9r4NRv
Video: [link to video](https://www.dropbox.com/scl/fi/yv2ma9anvczqejw5pa6ka/frosted_glass_scrolling.mov?rlkey=skzfynudzmx3rr4rf9undo55k&e=1&st=ww0lfs3k&dl=0)

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Frosted glass navbar on iPhone