### PR TITLE
Maintenance: Refactoring extra properties and use of mutable dictionaries

### DIFF
--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -108,10 +108,10 @@
 }
 
 - (void)changeServerStatus:(BOOL)status infoText:(NSString*)infoText icon:(NSString*)iconName {
-    NSMutableDictionary *params = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                   infoText, @"message",
-                                   iconName, @"icon_connection",
-                                   nil];
+    NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
+                            infoText, @"message",
+                            iconName, @"icon_connection",
+                            nil];
     AppDelegate.instance.serverOnLine = status;
     AppDelegate.instance.serverName = infoText;
     NSString *notificationName;

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -535,7 +535,7 @@
     id row7 = item[mainFields[@"row7"]] ?: @0;
     NSString *row7key = mainFields[@"row7"] ?: @"";
 
-    NSDictionary *newItem = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+    NSDictionary *newItem = [NSDictionary dictionaryWithObjectsAndKeys:
                              @(albumView), @"fromAlbumView",
                              @(episodesView), @"fromEpisodesView",
                              clearlogo, @"clearlogo",
@@ -1307,9 +1307,9 @@
                    nil];
             objKey = @"filter";
         }
-        NSMutableDictionary *newSectionParameters = [NSMutableDictionary dictionary];
+        NSDictionary *newSectionParameters = @{};
         if (parameters[@"extra_section_parameters"] != nil) {
-            newSectionParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+            newSectionParameters = [NSDictionary dictionaryWithObjectsAndKeys:
                                     obj, objKey,
                                     parameters[@"extra_section_parameters"][@"properties"], @"properties",
                                     parameters[@"extra_section_parameters"][@"sort"], @"sort",
@@ -3506,7 +3506,7 @@
         NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
                                 item[@"addonid"], @"addonid",
                                 nil];
-        NSDictionary *newButton = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+        NSDictionary *newButton = [NSDictionary dictionaryWithObjectsAndKeys:
                                    item[@"label"], @"label",
                                    @"xbmc-exec-addon", @"type",
                                    item[@"thumbnail"], @"icon",
@@ -3521,7 +3521,7 @@
         NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
                                 item[@"label"], @"action",
                                 nil];
-        NSDictionary *newButton = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+        NSDictionary *newButton = [NSDictionary dictionaryWithObjectsAndKeys:
                                    item[@"label"], @"label",
                                    @"string", @"type",
                                    @"", @"icon",
@@ -3536,7 +3536,7 @@
         NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
                                 item[@"label"], @"window",
                                 nil];
-        NSDictionary *newButton = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+        NSDictionary *newButton = [NSDictionary dictionaryWithObjectsAndKeys:
                                    item[@"label"], @"label",
                                    @"string", @"type",
                                    @"", @"icon",
@@ -4445,10 +4445,10 @@
     [cellActivityIndicator startAnimating];
     
     NSArray *newProperties = [Utilities addExtraProperties:parameters[@"properties"] parameters:parameters];
-    NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                          newProperties, @"properties",
-                                          object, itemid,
-                                          nil];
+    NSDictionary *newParameters = [NSDictionary dictionaryWithObjectsAndKeys:
+                                   newProperties, @"properties",
+                                   object, itemid,
+                                   nil];
     [[Utilities getJsonRPC]
      callMethod:methodToCall
      withParameters:newParameters

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -1339,10 +1339,7 @@
             pvrExtraInfo[@"channelid"] = item[@"channelid"];
         }
         
-        NSMutableDictionary *kodiExtrasPropertiesMinimumVersion = [NSMutableDictionary dictionary];
-        if (parameters[@"kodiExtrasPropertiesMinimumVersion"]) {
-            kodiExtrasPropertiesMinimumVersion = parameters[@"kodiExtrasPropertiesMinimumVersion"];
-        }
+        NSDictionary *kodiExtrasPropertiesMinimumVersion = parameters[@"kodiExtrasPropertiesMinimumVersion"] ?: @{};
         NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                               [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                                obj, objKey,

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -477,12 +477,13 @@
     }
 }
 
-- (NSDictionary*)addExtraProperties:(NSArray*)properties params:(NSDictionary*)parameters mainParams:(NSDictionary*)mainParameters {
+- (NSDictionary*)addExtraProperties:(NSDictionary*)mainParameters {
+    NSMutableDictionary *newParameters = [mainParameters[@"parameters"] mutableCopy];
+    NSArray *properties = mainParameters[@"parameters"][@"properties"];
     NSMutableArray *newProperties = [[Utilities addExtraProperties:properties parameters:mainParameters] mutableCopy];
     if ([mainParameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
         [newProperties addObject:@"art"];
     }
-    NSMutableDictionary *newParameters = [parameters mutableCopy];
     if (newProperties != nil) {
         newParameters[@"properties"] = newProperties;
     }
@@ -1187,10 +1188,6 @@
     [self stopPullToRefreshViewAnimation];
     
     MainMenu *menuItem = self.detailItem;
-    NSDictionary *methods = nil;
-    NSDictionary *parameters = nil;
-    NSDictionary *currentParameters = nil;
-    NSArray *currentProperties = nil;
     BOOL refresh = NO;
     
     // Read new tab index
@@ -1205,11 +1202,6 @@
     
     // Handle modes (pressing same tab) or changed tabs
     if (newChoosedTab == chosenTab && !fromMoreItems) {
-        // Read relevant data from configuration
-        methods = menuItem.mainMethod[chosenTab];
-        parameters = menuItem.mainParameters[chosenTab];
-        currentParameters = parameters[@"parameters"];
-        currentProperties = parameters[@"parameters"][@"properties"];
         
         NSInteger num_modes = [menuItem.filterModes[chosenTab][@"modes"] count];
         if (!num_modes) {
@@ -1243,11 +1235,6 @@
         if (chosenTab < buttonsIB.count) {
             [buttonsIB[chosenTab] setSelected:YES];
         }
-        // Read relevant data from configuration (important: new value for chosenTab)
-        methods = menuItem.mainMethod[chosenTab];
-        parameters = menuItem.mainParameters[chosenTab];
-        currentParameters = parameters[@"parameters"];
-        currentProperties = parameters[@"parameters"][@"properties"];
     }
     self.indexView.indexTitles = nil;
     self.indexView.hidden = YES;
@@ -1260,6 +1247,10 @@
     [moreItemsViewController.view animateX:viewWidth alpha:1.0 duration:0.3];
     
     [activityIndicatorView startAnimating];
+    
+    // Read relevant data from configuration (important: new value for chosenTab)
+    NSDictionary *methods = menuItem.mainMethod[chosenTab];
+    NSDictionary *parameters = menuItem.mainParameters[chosenTab];
 
     if ([parameters[@"numberOfStars"] intValue] > 0) {
         numberOfStars = [parameters[@"numberOfStars"] intValue];
@@ -1275,7 +1266,7 @@
     recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
     activeLayoutView.contentOffset = activeLayoutView.contentOffset;
     [self checkFullscreenButton:NO];
-    NSDictionary *newParameters = [self addExtraProperties:currentProperties params:currentParameters mainParams:parameters];
+    NSDictionary *newParameters = [self addExtraProperties:parameters];
     if (!tvshowsView || [Utilities getPreferTvPosterMode]) {
         [self setSearchBar:self.searchController.searchBar toDark:NO];
     }
@@ -4497,9 +4488,7 @@
     }
     NSDictionary *methods = menuItem.mainMethod[chosenTab];
     NSDictionary *parameters = menuItem.mainParameters[chosenTab];
-    NSDictionary *currentParameters = parameters[@"parameters"];
-    NSArray *currentProperties = parameters[@"parameters"][@"properties"];
-    NSDictionary *newParameters = [self addExtraProperties:currentProperties params:currentParameters mainParams:parameters];
+    NSDictionary *newParameters = [self addExtraProperties:parameters];
     NSString *methodToCall = methods[@"method"];
     if (parameters[@"exploreCommand"] != nil) {
         methodToCall = parameters[@"exploreCommand"];
@@ -4557,9 +4546,7 @@
     NSDictionary *parameters = menuItem.mainParameters[activeTab];
     NSDictionary *mainFields = menuItem.mainFields[activeTab];
     NSString *methodToCall = methods[@"method"];
-    NSDictionary *currentParameters = parameters[@"parameters"];
-    NSArray *currentProperties = parameters[@"parameters"][@"properties"];
-    NSDictionary *newParameters = [self addExtraProperties:currentProperties params:currentParameters mainParams:parameters];
+    NSDictionary *newParameters = [self addExtraProperties:parameters];
     [[Utilities getJsonRPC]
      callMethod:methodToCall
      withParameters:newParameters

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -477,23 +477,16 @@
     }
 }
 
-- (void)addExtraProperties:(NSMutableArray*)mutableProperties newParams:(NSMutableDictionary*)mutableParameters params:(NSDictionary*)parameters {
-    if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
-        [mutableProperties addObject:@"art"];
+- (NSDictionary*)addExtraProperties:(NSArray*)properties params:(NSDictionary*)parameters mainParams:(NSDictionary*)mainParameters {
+    NSMutableArray *newProperties = [[Utilities addExtraProperties:properties parameters:mainParameters] mutableCopy];
+    if ([mainParameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
+        [newProperties addObject:@"art"];
     }
-    if (parameters[@"kodiExtrasPropertiesMinimumVersion"] != nil) {
-        for (id key in parameters[@"kodiExtrasPropertiesMinimumVersion"]) {
-            if (AppDelegate.instance.serverVersion >= [key integerValue]) {
-                id arrayProperties = parameters[@"kodiExtrasPropertiesMinimumVersion"][key];
-                for (id value in arrayProperties) {
-                    [mutableProperties addObject:value];
-                }
-            }
-        }
+    NSMutableDictionary *newParameters = [parameters mutableCopy];
+    if (newProperties != nil) {
+        newParameters[@"properties"] = newProperties;
     }
-    if (mutableProperties != nil) {
-        mutableParameters[@"properties"] = mutableProperties;
-    }
+    return [newParameters copy];
 }
 
 - (void)setFilternameLabel:(NSString*)labelText {
@@ -1196,8 +1189,8 @@
     MainMenu *menuItem = self.detailItem;
     NSDictionary *methods = nil;
     NSDictionary *parameters = nil;
-    NSMutableDictionary *mutableParameters = nil;
-    NSMutableArray *mutableProperties = nil;
+    NSDictionary *currentParameters = nil;
+    NSArray *currentProperties = nil;
     BOOL refresh = NO;
     
     // Read new tab index
@@ -1215,8 +1208,8 @@
         // Read relevant data from configuration
         methods = menuItem.mainMethod[chosenTab];
         parameters = menuItem.mainParameters[chosenTab];
-        mutableParameters = [parameters[@"parameters"] mutableCopy];
-        mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
+        currentParameters = parameters[@"parameters"];
+        currentProperties = parameters[@"parameters"][@"properties"];
         
         NSInteger num_modes = [menuItem.filterModes[chosenTab][@"modes"] count];
         if (!num_modes) {
@@ -1253,8 +1246,8 @@
         // Read relevant data from configuration (important: new value for chosenTab)
         methods = menuItem.mainMethod[chosenTab];
         parameters = menuItem.mainParameters[chosenTab];
-        mutableParameters = [parameters[@"parameters"] mutableCopy];
-        mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
+        currentParameters = parameters[@"parameters"];
+        currentProperties = parameters[@"parameters"][@"properties"];
     }
     self.indexView.indexTitles = nil;
     self.indexView.hidden = YES;
@@ -1282,12 +1275,12 @@
     recentlyAddedView = [parameters[@"collectionViewRecentlyAdded"] boolValue];
     activeLayoutView.contentOffset = activeLayoutView.contentOffset;
     [self checkFullscreenButton:NO];
-    [self addExtraProperties:mutableProperties newParams:mutableParameters params:parameters];
+    NSDictionary *newParameters = [self addExtraProperties:currentProperties params:currentParameters mainParams:parameters];
     if (!tvshowsView || [Utilities getPreferTvPosterMode]) {
         [self setSearchBar:self.searchController.searchBar toDark:NO];
     }
     if (methods[@"method"] != nil) {
-        [self retrieveData:methods[@"method"] parameters:mutableParameters sectionMethod:methods[@"extra_section_method"] sectionParameters:parameters[@"extra_section_parameters"] resultStore:self.richResults extraSectionCall:NO refresh:refresh];
+        [self retrieveData:methods[@"method"] parameters:newParameters sectionMethod:methods[@"extra_section_method"] sectionParameters:parameters[@"extra_section_parameters"] resultStore:self.richResults extraSectionCall:NO refresh:refresh];
     }
     else {
         [activityIndicatorView stopAnimating];
@@ -4460,17 +4453,7 @@
     UIActivityIndicatorView *cellActivityIndicator = [self getCellActivityIndicator:indexPath];
     [cellActivityIndicator startAnimating];
     
-    NSMutableArray *newProperties = [parameters[@"properties"] mutableCopy];
-    if (parameters[@"kodiExtrasPropertiesMinimumVersion"] != nil) {
-        for (id key in parameters[@"kodiExtrasPropertiesMinimumVersion"]) {
-            if (AppDelegate.instance.serverVersion >= [key integerValue]) {
-                id arrayProperties = parameters[@"kodiExtrasPropertiesMinimumVersion"][key];
-                for (id value in arrayProperties) {
-                    [newProperties addObject:value];
-                }
-            }
-        }
-    }
+    NSArray *newProperties = [Utilities addExtraProperties:parameters[@"properties"] parameters:parameters];
     NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                           newProperties, @"properties",
                                           object, itemid,
@@ -4514,15 +4497,15 @@
     }
     NSDictionary *methods = menuItem.mainMethod[chosenTab];
     NSDictionary *parameters = menuItem.mainParameters[chosenTab];
-    NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
-    NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
-    [self addExtraProperties:mutableProperties newParams:mutableParameters params:parameters];
+    NSDictionary *currentParameters = parameters[@"parameters"];
+    NSArray *currentProperties = parameters[@"parameters"][@"properties"];
+    NSDictionary *newParameters = [self addExtraProperties:currentProperties params:currentParameters mainParams:parameters];
     NSString *methodToCall = methods[@"method"];
     if (parameters[@"exploreCommand"] != nil) {
         methodToCall = parameters[@"exploreCommand"];
     }
     if (methodToCall != nil) {
-        [self retrieveData:methodToCall parameters:mutableParameters sectionMethod:methods[@"extra_section_method"] sectionParameters:parameters[@"extra_section_parameters"] resultStore:self.richResults extraSectionCall:NO refresh:forceRefresh];
+        [self retrieveData:methodToCall parameters:newParameters sectionMethod:methods[@"extra_section_method"] sectionParameters:parameters[@"extra_section_parameters"] resultStore:self.richResults extraSectionCall:NO refresh:forceRefresh];
     }
     else if (globalSearchView) {
         [self retrieveGlobalData:forceRefresh];
@@ -4574,12 +4557,12 @@
     NSDictionary *parameters = menuItem.mainParameters[activeTab];
     NSDictionary *mainFields = menuItem.mainFields[activeTab];
     NSString *methodToCall = methods[@"method"];
-    NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
-    NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
-    [self addExtraProperties:mutableProperties newParams:mutableParameters params:parameters];
+    NSDictionary *currentParameters = parameters[@"parameters"];
+    NSArray *currentProperties = parameters[@"parameters"][@"properties"];
+    NSDictionary *newParameters = [self addExtraProperties:currentProperties params:currentParameters mainParams:parameters];
     [[Utilities getJsonRPC]
      callMethod:methodToCall
-     withParameters:mutableParameters
+     withParameters:newParameters
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         if (error == nil && methodError == nil) {
             [activeLayoutView reloadData];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1518,10 +1518,8 @@
                  if (!stringURL.length) {
                      stringURL = [Utilities getItemIconFromDictionary:itemExtraDict];
                  }
-                 NSObject *row11 = itemExtraDict[mainFields[@"row11"]];
-                 if (row11 == nil) {
-                     row11 = @(0);
-                 }
+                 id row11 = itemExtraDict[mainFields[@"row11"]] ?: @0;
+                 
                  NSDictionary *newItem =
                  [NSMutableDictionary dictionaryWithObjectsAndKeys:
                   clearlogo, @"clearlogo",

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1520,34 +1520,33 @@
                  }
                  id row11 = itemExtraDict[mainFields[@"row11"]] ?: @0;
                  
-                 NSDictionary *newItem =
-                 [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                  clearlogo, @"clearlogo",
-                  clearart, @"clearart",
-                  label, @"label",
-                  genre, @"genre",
-                  stringURL, @"thumbnail",
-                  fanartURL, @"fanart",
-                  runtime, @"runtime",
-                  itemExtraDict[mainFields[@"row6"]], mainFields[@"row6"],
-                  itemExtraDict[mainFields[@"row8"]], mainFields[@"row8"],
-                  year, @"year",
-                  rating, @"rating",
-                  mainFields[@"playlistid"], @"playlistid",
-                  mainFields[@"row8"], @"family",
-                  [Utilities getNumberFromItem:itemExtraDict[mainFields[@"row9"]]], mainFields[@"row9"],
-                  itemExtraDict[mainFields[@"row10"]], mainFields[@"row10"],
-                  row11, mainFields[@"row11"],
-                  itemExtraDict[mainFields[@"row12"]], mainFields[@"row12"],
-                  itemExtraDict[mainFields[@"row13"]], mainFields[@"row13"],
-                  itemExtraDict[mainFields[@"row14"]], mainFields[@"row14"],
-                  itemExtraDict[mainFields[@"row15"]], mainFields[@"row15"],
-                  itemExtraDict[mainFields[@"row16"]], mainFields[@"row16"],
-                  itemExtraDict[mainFields[@"row17"]], mainFields[@"row17"],
-                  itemExtraDict[mainFields[@"row18"]], mainFields[@"row18"],
-                  itemExtraDict[mainFields[@"row19"]], mainFields[@"row19"],
-                  itemExtraDict[mainFields[@"row20"]], mainFields[@"row20"],
-                  nil];
+                 NSDictionary *newItem = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                          clearlogo, @"clearlogo",
+                                          clearart, @"clearart",
+                                          label, @"label",
+                                          genre, @"genre",
+                                          stringURL, @"thumbnail",
+                                          fanartURL, @"fanart",
+                                          runtime, @"runtime",
+                                          itemExtraDict[mainFields[@"row6"]], mainFields[@"row6"],
+                                          itemExtraDict[mainFields[@"row8"]], mainFields[@"row8"],
+                                          year, @"year",
+                                          rating, @"rating",
+                                          mainFields[@"playlistid"], @"playlistid",
+                                          mainFields[@"row8"], @"family",
+                                          [Utilities getNumberFromItem:itemExtraDict[mainFields[@"row9"]]], mainFields[@"row9"],
+                                          itemExtraDict[mainFields[@"row10"]], mainFields[@"row10"],
+                                          row11, mainFields[@"row11"],
+                                          itemExtraDict[mainFields[@"row12"]], mainFields[@"row12"],
+                                          itemExtraDict[mainFields[@"row13"]], mainFields[@"row13"],
+                                          itemExtraDict[mainFields[@"row14"]], mainFields[@"row14"],
+                                          itemExtraDict[mainFields[@"row15"]], mainFields[@"row15"],
+                                          itemExtraDict[mainFields[@"row16"]], mainFields[@"row16"],
+                                          itemExtraDict[mainFields[@"row17"]], mainFields[@"row17"],
+                                          itemExtraDict[mainFields[@"row18"]], mainFields[@"row18"],
+                                          itemExtraDict[mainFields[@"row19"]], mainFields[@"row19"],
+                                          itemExtraDict[mainFields[@"row20"]], mainFields[@"row20"],
+                                          nil];
                  [self displayInfoView:newItem];
              }
          }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1298,7 +1298,7 @@
                            NSString *thumbnailPath = [self getNowPlayingThumbnailPath:item];
                            NSString *stringURL = [Utilities formatStringURL:thumbnailPath serverURL:serverURL];
                            NSString *file = [Utilities getStringFromItem:item[@"file"]];
-                           [playlistData addObject:[NSMutableDictionary dictionaryWithObjectsAndKeys:
+                           [playlistData addObject:[NSDictionary dictionaryWithObjectsAndKeys:
                                                     idItem, @"idItem",
                                                     file, @"file",
                                                     label, @"label",
@@ -1464,10 +1464,10 @@
     }
     [activityIndicator startAnimating];
     NSArray *newProperties = [Utilities addExtraProperties:parameters[@"properties"] parameters:parameters];
-    NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                          newProperties, @"properties",
-                                          object, itemid,
-                                          nil];
+    NSDictionary *newParameters = [NSDictionary dictionaryWithObjectsAndKeys:
+                                   newProperties, @"properties",
+                                   object, itemid,
+                                   nil];
     [[Utilities getJsonRPC]
      callMethod:methodToCall
      withParameters:newParameters
@@ -1510,7 +1510,7 @@
                  }
                  id row11 = itemExtraDict[mainFields[@"row11"]] ?: @0;
                  
-                 NSDictionary *newItem = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                 NSDictionary *newItem = [NSDictionary dictionaryWithObjectsAndKeys:
                                           clearlogo, @"clearlogo",
                                           clearart, @"clearart",
                                           label, @"label",

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1463,17 +1463,7 @@
         return; // something goes wrong
     }
     [activityIndicator startAnimating];
-    NSMutableArray *newProperties = [parameters[@"properties"] mutableCopy];
-    if (parameters[@"kodiExtrasPropertiesMinimumVersion"] != nil) {
-        for (id key in parameters[@"kodiExtrasPropertiesMinimumVersion"]) {
-            if (AppDelegate.instance.serverVersion >= [key integerValue]) {
-                id arrayProperties = parameters[@"kodiExtrasPropertiesMinimumVersion"][key];
-                for (id value in arrayProperties) {
-                    [newProperties addObject:value];
-                }
-            }
-        }
-    }
+    NSArray *newProperties = [Utilities addExtraProperties:parameters[@"properties"] parameters:parameters];
     NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                           newProperties, @"properties",
                                           object, itemid,

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -289,8 +289,8 @@
             value = @"";
             break;
     }
-    NSDictionary *params = [NSMutableDictionary dictionaryWithObjectsAndKeys:self.detailItem[@"id"], @"setting", value, @"value", nil];
-    NSDictionary *newButton = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+    NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:self.detailItem[@"id"], @"setting", value, @"value", nil];
+    NSDictionary *newButton = [NSDictionary dictionaryWithObjectsAndKeys:
                                alertCtrl.textFields[0].text, @"label",
                                type, @"type",
                                @"", @"icon",

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -68,6 +68,7 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (int)getSec2Min:(BOOL)convert;
 + (NSString*)getImageServerURL;
 + (NSString*)formatStringURL:(NSString*)path serverURL:(NSString*)serverURL;
++ (NSArray*)addExtraProperties:(NSArray*)properties parameters:(NSDictionary*)parameters;
 + (CGFloat)getBottomPadding;
 + (CGFloat)getTopPadding;
 + (CGFloat)getTopPaddingWithNavBar:(UINavigationController*)navCtrl;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -766,6 +766,21 @@
     return urlString;
 }
 
++ (NSArray*)addExtraProperties:(NSArray*)properties parameters:(NSDictionary*)parameters {
+    NSMutableArray *newProperties = [properties mutableCopy];
+    if (parameters[@"kodiExtrasPropertiesMinimumVersion"] != nil) {
+        for (id key in parameters[@"kodiExtrasPropertiesMinimumVersion"]) {
+            if (AppDelegate.instance.serverVersion >= [key integerValue]) {
+                id arrayProperties = parameters[@"kodiExtrasPropertiesMinimumVersion"][key];
+                for (id value in arrayProperties) {
+                    [newProperties addObject:value];
+                }
+            }
+        }
+    }
+    return [newProperties copy];
+}
+
 + (CGFloat)getBottomPadding {
     CGFloat bottomPadding = UIApplication.sharedApplication.keyWindow.safeAreaInsets.bottom;
     return bottomPadding;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR applies some refactoring of handling "kodiExtrasPropertiesMinimumVersion" which is used the add extra properties to "properties" inside "parameters" and "extra_info_parameters", depending on the Kodi version the app is connected to. This avoid some code duplication. In addition, remove `mutable` where not needed.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Refactoring extra properties and use of mutable dictionaries