### PR TITLE
Maintenance: Rework handling of minimum supported Kodi version

### DIFF
--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -10,6 +10,12 @@
 #define ConvenienceMacros_h
 
 /*
+ * Minimum supported Kodi version
+ */
+#define MIN_SUPPORTED_SERVER_VERSION 11
+#define MIN_SUPPORTED_SERVER_VERSION_NAME @"Eden"
+
+/*
  * Device and orientation checks
  */
 #define IS_IPHONE (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPhone)

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -546,7 +546,9 @@
     editTableButton.titleLabel.numberOfLines = 1;
     editTableButton.titleLabel.adjustsFontSizeToFitWidth = YES;
     editTableButton.titleLabel.lineBreakMode = NSLineBreakByClipping;
-    supportedVersionLabel.text = LOCALIZED_STR(@"Supported XBMC version is Eden (11) or higher");
+    
+    NSString *minVersion = [NSString stringWithFormat:@"%d (%@)", MIN_SUPPORTED_SERVER_VERSION, MIN_SUPPORTED_SERVER_VERSION_NAME];
+    supportedVersionLabel.text = LOCALIZED_STR_ARGS(@"Supports Kodi version %@ or higher", minVersion);
     
     editTableButton.titleLabel.font = [UIFont systemFontOfSize:15];
     [editTableButton setTextStyle];

--- a/XBMC Remote/HostManagementViewController.xib
+++ b/XBMC Remote/HostManagementViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -108,7 +108,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="320" height="34"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                     <subviews>
-                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Supported XBMC version is Eden (11) or higher" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.90000000000000002" translatesAutoresizingMaskIntoConstraints="NO" id="12">
+                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" fixedFrame="YES" text="Supports Kodi version %@ or higher" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.90000000000000002" translatesAutoresizingMaskIntoConstraints="NO" id="12">
                             <rect key="frame" x="0.0" y="7" width="320" height="20"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" type="system" pointSize="12"/>

--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -104,7 +104,7 @@ NSInputStream *inStream;
 
         case NSStreamEventOpenCompleted:
             AppDelegate.instance.serverTCPConnectionOpen = YES;
-            [self tcpConnectionNotifications:YES];
+            [self notifyJsonConnected:YES];
             break;
             
         case NSStreamEventHasBytesAvailable:
@@ -147,14 +147,14 @@ NSInputStream *inStream;
             [theStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
             theStream.delegate = nil;
             [[NSNotificationCenter defaultCenter] postNotificationName:@"tcpJSONRPCConnectionClosed" object:nil userInfo:nil];
-            [self tcpConnectionNotifications:NO];
+            [self notifyJsonConnected:NO];
             break;
         default:
             break;
     }
 }
 
-- (void)tcpConnectionNotifications:(BOOL)hasTcpConnection {
+- (void)notifyJsonConnected:(BOOL)hasTcpConnection {
     NSString *connectionIcon = hasTcpConnection ? @"connection_on" : @"connection_on_notcp";
     NSString *connectionName = infoTitle ?: @"";
     NSDictionary *params = @{
@@ -164,7 +164,7 @@ NSInputStream *inStream;
     [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerConnectionSuccess" object:nil userInfo:params];
 }
 
-- (void)jsonConnectionNotifications:(BOOL)hasJsonConnection {
+- (void)notifyTcpConnected:(BOOL)hasJsonConnection {
     NSString *connectionIcon = hasJsonConnection ? @"connection_on_notcp" : @"connection_off";
     NSString *connectionName = hasJsonConnection ? (infoTitle ?: @"") : LOCALIZED_STR(@"No connection");
     NSDictionary *params = @{
@@ -175,16 +175,16 @@ NSInputStream *inStream;
     [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCChangeServerStatus" object:nil userInfo:params];
 }
 
-- (void)showSetupNotifications:(BOOL)showSetup {
+- (void)notifyShowSetupMenu:(BOOL)showSetup {
     NSDictionary *params = @{@"showSetup": @(showSetup)};
     [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
 }
 
 - (void)notifyConnectionProblem {
     if (AppDelegate.instance.serverOnLine) {
-        [self jsonConnectionNotifications:NO];
+        [self notifyTcpConnected:NO];
     }
-    [self showSetupNotifications:YES];
+    [self notifyShowSetupMenu:YES];
 }
 
 - (void)checkServer {
@@ -238,8 +238,8 @@ NSInputStream *inStream;
                                  serverInfo[@"major"],
                                  serverInfo[@"minor"],
                                  serverInfo[@"tag"]];
-                    [self jsonConnectionNotifications:YES];
-                    [self showSetupNotifications:NO];
+                    [self notifyTcpConnected:YES];
+                    [self notifyShowSetupMenu:NO];
                 }
                 else {
                     [self notifyConnectionProblem];

--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -223,6 +223,15 @@ NSInputStream *inStream;
                     if ([realServerName isEqualToString:@"MrMC"]) {
                         AppDelegate.instance.serverVersion += MRMC_TIMEWARP;
                     }
+                    if (AppDelegate.instance.serverVersion < MIN_SUPPORTED_SERVER_VERSION) {
+                        NSString *message = LOCALIZED_STR_ARGS(@"Kodi version %d not supported.", AppDelegate.instance.serverVersion);
+                        [Utilities showMessage:message color:ERROR_MESSAGE_COLOR];
+                        if (AppDelegate.instance.serverOnLine) {
+                            [self jsonConnectionNotifications:NO];
+                        }
+                        [self showSetupNotifications:YES];
+                        return;
+                    }
                     infoTitle = [NSString stringWithFormat:@"%@ v%@.%@ %@",
                                  AppDelegate.instance.obj.serverDescription,
                                  serverInfo[@"major"],

--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -180,15 +180,19 @@ NSInputStream *inStream;
     [[NSNotificationCenter defaultCenter] postNotificationName:@"TcpJSONRPCShowSetup" object:nil userInfo:params];
 }
 
+- (void)notifyConnectionProblem {
+    if (AppDelegate.instance.serverOnLine) {
+        [self jsonConnectionNotifications:NO];
+    }
+    [self showSetupNotifications:YES];
+}
+
 - (void)checkServer {
     if (inCheck) {
         return;
     }
     if (AppDelegate.instance.obj.serverIP.length == 0) {
-        [self showSetupNotifications:YES];
-        if (AppDelegate.instance.serverOnLine) {
-            [self jsonConnectionNotifications:NO];
-        }
+        [self notifyConnectionProblem];
         return;
     }
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"wol_preference"] &&
@@ -226,10 +230,7 @@ NSInputStream *inStream;
                     if (AppDelegate.instance.serverVersion < MIN_SUPPORTED_SERVER_VERSION) {
                         NSString *message = LOCALIZED_STR_ARGS(@"Kodi version %d not supported.", AppDelegate.instance.serverVersion);
                         [Utilities showMessage:message color:ERROR_MESSAGE_COLOR];
-                        if (AppDelegate.instance.serverOnLine) {
-                            [self jsonConnectionNotifications:NO];
-                        }
-                        [self showSetupNotifications:YES];
+                        [self notifyConnectionProblem];
                         return;
                     }
                     infoTitle = [NSString stringWithFormat:@"%@ v%@.%@ %@",
@@ -241,10 +242,7 @@ NSInputStream *inStream;
                     [self showSetupNotifications:NO];
                 }
                 else {
-                    if (AppDelegate.instance.serverOnLine) {
-                        [self jsonConnectionNotifications:NO];
-                    }
-                    [self showSetupNotifications:YES];
+                    [self notifyConnectionProblem];
                 }
             }
         }
@@ -252,10 +250,7 @@ NSInputStream *inStream;
             if (error != nil) {
                 [[NSNotificationCenter defaultCenter] postNotificationName:@"XBMCServerConnectionError" object:nil userInfo:@{@"error_message": [error localizedDescription]}];
             }
-            if (AppDelegate.instance.serverOnLine) {
-                [self jsonConnectionNotifications:NO];
-            }
-            [self showSetupNotifications:YES];
+            [self notifyConnectionProblem];
         }
     }];
 }

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -231,7 +231,8 @@
 "Party" = "Party";
 "Search" = "Search";
 
-"Supported XBMC version is Eden (11) or higher" = "Supported Kodi version is Eden (11) or higher";
+"Supports Kodi version %@ or higher" = "Supports Kodi version %@ or higher";
+"Kodi version %d not supported." = "Kodi version %d not supported.";
 "Add Host" = "Add Host";
 "Kodi connection notice" = "Kodi connection notice";
 "It seems that the TCP connection with Kodi cannot be established. This will prevent the app from listening to Kodi. For example, the keyboard input within the app will not show when Kodi requests keyboard input." = "It seems that the TCP connection with Kodi cannot be established. This will prevent the app from listening to Kodi. For example, the keyboard input within the app will not show when Kodi requests keyboard input.";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR applies some rework around the minimum supported Kodi version.
1. Define macros for minimum supported Kodi version (version number and name)
2. Check the supported Kodi version on connection attempt. Reject connection and throw error message in case not supported.
3. Rebuild the info string to let the localization become agnostic to the version itself. This prepares the code / localization for future changes in the minimum supported version.

Screenshot when tailoring the minimum supported version to Kodi 22 (Piers):
<img width="405" height="273" alt="Bildschirmfoto 2026-05-14 um 10 12 46" src="https://github.com/user-attachments/assets/73dc067b-db77-44f6-8b00-8622ffd58cc1" />

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Rework handling of minimum supported Kodi version