### PR TITLE
Bugfix: Do not show down arrow if content fits into bounds

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -980,8 +980,8 @@
     // Check if the arrow needs to be displayed (only if content is > visible area)
     int height_content = scrollView.contentSize.height;
     int height_bounds = scrollView.bounds.size.height;
-    int height_navbar = self.navigationController.navigationBar.frame.size.height;
-    arrow_continue_down.alpha = (height_content <= height_bounds - height_navbar) ? 0 : ARROW_ALPHA;
+    int height_topbar = toolbar.frame.size.height;
+    arrow_continue_down.alpha = (height_content <= height_bounds - height_topbar) ? 0 : ARROW_ALPHA;
     
     // Initially "up" arrow is not shown
     arrow_back_up.alpha = 0;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes the visibility of the down-arrow in `ShowInfoViewController`. This does not need to be shown, if the content cannot be scrolled anyway, which is the case if the content fits into the view's _visible_ height. On iPad the visible size is reduced by the top bar named `toolbar` which is added to the view. For iPhone this top bar does not exist, so its height is 0, and the visible area is same as the view's boundary. The screenshots below show a case where content height is 2 less than the boundary height.

Screenshots:
<img width="491" height="533" alt="Bildschirmfoto 2026-05-14 um 11 40 52" src="https://github.com/user-attachments/assets/25568f28-0315-45ae-9751-cd7ee5d8e032" />


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Do not show down arrow if content fits into bounds