### PR TITLE
Maintenance: Cleanup remote xib

### DIFF
--- a/XBMC Remote/RemoteController.h
+++ b/XBMC Remote/RemoteController.h
@@ -25,7 +25,6 @@ typedef NS_ENUM(NSInteger, RemotePositionType) {
     IBOutlet UILabel *quickHelpSubLabel;
     IBOutlet UIView *gestureZoneView;
     IBOutlet UIView *buttonZoneView;
-    IBOutlet UIImageView *panFallbackImageView;
     IBOutlet UIButton *buttonSeekBackward;
     IBOutlet UIButton *buttonPlayPause;
     IBOutlet UIButton *buttonSeekForward;

--- a/XBMC Remote/RemoteController.xib
+++ b/XBMC Remote/RemoteController.xib
@@ -25,7 +25,6 @@
                 <outlet property="buttonZoneView" destination="173" id="177"/>
                 <outlet property="gestureZoneImageView" destination="175" id="191"/>
                 <outlet property="gestureZoneView" destination="174" id="176"/>
-                <outlet property="panFallbackImageView" destination="117" id="181"/>
                 <outlet property="quickHelpImageView" destination="168" id="172"/>
                 <outlet property="quickHelpMainLabel" destination="2TM-YH-uLa" id="mrb-EG-ORr"/>
                 <outlet property="quickHelpSubLabel" destination="Cnv-Gh-EaD" id="mjN-ph-iNk"/>

--- a/XBMC Remote/RemoteController.xib
+++ b/XBMC Remote/RemoteController.xib
@@ -604,8 +604,6 @@
         <image name="remote_button_left_up" width="424" height="424"/>
         <image name="remote_button_right_down" width="424" height="424"/>
         <image name="remote_button_right_up" width="424" height="424"/>
-        <image name="remote_button_tv_down" width="130.33332824707031" height="69.666664123535156"/>
-        <image name="remote_button_tv_up" width="130.33332824707031" height="69.666664123535156"/>
         <image name="remote_button_up_down" width="424" height="424"/>
         <image name="remote_button_up_up" width="424" height="424"/>
         <image name="remote_button_xbmc_select_down" width="424" height="424"/>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
This PR does some minor clean of the `RemoteController` xib. This resolves a Xcode warning when opening this xib, but otherwise has no functional impact.

1. Remove unused `IBOutlet` and remove connection from xib.
2. Fix xib by removing double defined images "remote_button_tv_down" and "remote_button_tv_up".

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Cleanup remote xib