### PR TITLE
Improvement: Rework getChannelEpgInfo

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -157,23 +157,15 @@
     NSIndexPath *indexPath = parameters[@"indexPath"];
     NSMutableDictionary *item = parameters[@"item"];
     if ([channelid longValue] > 0) {
-        NSMutableArray *retrievedEPG = [self loadEPGFromMemory:channelid];
-        NSMutableDictionary *channelEPG = [self parseEpgData:retrievedEPG];
-        NSDictionary *epgparams = [NSDictionary dictionaryWithObjectsAndKeys:
-                                   channelEPG, @"channelEPG",
-                                   indexPath, @"indexPath",
-                                   item, @"item",
-                                   nil];
-        [self performSelectorOnMainThread:@selector(updateEpgTableInfo:) withObject:epgparams waitUntilDone:NO];
+        NSMutableArray *retrievedEPG_RAM = [self loadEPGFromMemory:channelid];
+        NSMutableDictionary *channelEPG = [self parseEpgData:retrievedEPG_RAM];
+        
+        // If no channel EPG available from RAM, try to read from disk
         if ([channelEPG[@"refresh_data"] boolValue]) {
-            retrievedEPG = [self loadEPGFromDisk:channelid parameters:parameters];
-            channelEPG = [self parseEpgData:retrievedEPG];
-            NSDictionary *epgparams = [NSDictionary dictionaryWithObjectsAndKeys:
-                                       channelEPG, @"channelEPG",
-                                       indexPath, @"indexPath",
-                                       item, @"item",
-                                       nil];
-            [self performSelectorOnMainThread:@selector(updateEpgTableInfo:) withObject:epgparams waitUntilDone:NO];
+            NSMutableArray *retrievedEPG_Disk = [self loadEPGFromDisk:channelid parameters:parameters];
+            channelEPG = [self parseEpgData:retrievedEPG_Disk];
+            
+            // If no channel EPG available from disk as well, request update via JSON API
             dispatch_sync(epglockqueue, ^{
                 if ([channelEPG[@"refresh_data"] boolValue] && ![epgDownloadQueue containsObject:channelid]) {
                     [epgDownloadQueue addObject:channelid];
@@ -181,6 +173,14 @@
                 }
             });
         }
+        
+        // Trigger update of the channel list view
+        NSDictionary *epgparams = [NSDictionary dictionaryWithObjectsAndKeys:
+                                   channelEPG, @"channelEPG",
+                                   indexPath, @"indexPath",
+                                   item, @"item",
+                                   nil];
+        [self performSelectorOnMainThread:@selector(updateEpgTableInfo:) withObject:epgparams waitUntilDone:NO];
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
While working on reducing warnings, the method `getChannelEpgInfo` came up because the local variable `epgparams` was shadowed. It showed that this method was not well documented and did some repeated steps which caused doubled updates of the UI for each channel update.

The code is now reworked with proper documentation. 
- Not shadowing local variables anymore
- Added documentation
- UI is only updated once per channel update

Tested with Kodi 21.3, using the add-on "IPTV Simple Client".

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
