### PR TITLE
Bugfix: Correct position of playlist toolbar on some iPad models

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2859,8 +2859,7 @@
     if (bottomPadding > 0) {
         [playlistToolbarView offsetYBy:-bottomPadding];
         [nowPlayingView setHeight:CGRectGetHeight(nowPlayingView.frame) - bottomPadding];
-        [playlistTableView setHeight:CGRectGetHeight(playlistTableView.frame) - bottomPadding];
-        playlistView.frame = playlistTableView.frame;
+        [playlistView setHeight:CGRectGetHeight(playlistView.frame) - bottomPadding];
     }
     playlistTableView.contentInset = UIEdgeInsetsMake(0, 0, CGRectGetHeight(playlistActionView.frame), 0);
     self.edgesForExtendedLayout = UIRectEdgeNone;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue reported [in this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3287527#pid3287527) and introduced by https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1428.

Even before #1428 the code was not correct, but with #1428 the order of the dimension assignment changed, which caused autoscaling to adapt the child view `playlistTableView` _again_ -- it got lesser height. Correct solution is to only change the parent view's (`playlistView`) dimension. `playlistTableView` anyway follows the parent's dimension via autoscaling. This fixes the issue where the playlist toolbar was wrongly placed ob iPad w/o home button.

Screenshot:
<img width="226" height="193" alt="Bildschirmfoto 2026-05-19 um 07 52 29" src="https://github.com/user-attachments/assets/1fe05c07-3a65-4a8a-add2-51828ed22ee7" />


## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Correct position of playlist toolbar on some iPad models