### PR TITLE
Bugfix: Avoid crash in updateControlsAndPlaylist on mal-formatted JSON

### DIFF
--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -554,6 +554,15 @@
 }
 
 - (void)updateControlsAndPlaylist:(NSDictionary*)item {
+    // Early return, if selectors are not supported. Avoids (reported) potential app crashes.
+    if (![item[@"partymode"] respondsToSelector:@selector(boolValue)] ||
+        ![item[@"canrepeat"] respondsToSelector:@selector(boolValue)] ||
+        ![item[@"canshuffle"] respondsToSelector:@selector(boolValue)] ||
+        ![item[@"canseek"] respondsToSelector:@selector(boolValue)] ||
+        ![item[@"position"] respondsToSelector:@selector(longLongValue)]) {
+        return;
+    }
+    
     // Read percentage of playback progress and set progress slider
     float percentage = [Utilities getFloatValueFromItem:item[@"percentage"]];
     if (updateProgressBar) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Crash report from AppStore points to a crash processing mal-formatted JSON, ending up in "unrecognized selector".
```
Exception Type:  EXC_CRASH (SIGABRT)
Exception Codes: 0x0000000000000000, 0x0000000000000000
Exception Reason: -[NSNull boolValue]: unrecognized selector sent to instance 0x1f144e448
Termination Reason: SIGNAL 6 Abort trap: 6
Terminating Process: Kodi Remote [63131]

Triggered by Thread:  0

Last Exception Backtrace:
0   CoreFoundation                	0x1852c8964 0x185203000 + 809316
1   libobjc.A.dylib               	0x1821dd814 0x1821ac000 + 202772
2   CoreFoundation                	0x1853632c0 0x185203000 + 1442496
3   CoreFoundation                	0x18524835c 0x185203000 + 283484
4   CoreFoundation                	0x185250200 0x185203000 + 315904
5   Kodi Remote                   	0x100ee91e8 -[NowPlaying updateControlsAndPlaylist:] + 180 (NowPlaying.m:563)
6   Kodi Remote                   	0x100eea2a0 __33-[NowPlaying getPlayerProperties]_block_invoke + 184 (NowPlaying.m:794)
7   Kodi Remote                   	0x100f002d0 -[DSJSONRPC URLSession:task:didCompleteWithError:] + 1596 (DSJSONRPC.m:0)
```
To make the code more robust, an early return is added if selectors are not supported.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid crash in updateControlsAndPlaylist on mal-formatted JSON