### PR TITLE
Bugfix: Avoid gap in playlist between segment control and bottom toolbar

### DIFF
--- a/XBMC Remote/NowPlaying.h
+++ b/XBMC Remote/NowPlaying.h
@@ -58,7 +58,7 @@
     IBOutlet UIView *playlistActionView;
     NSString *currentType;
     BOOL nothingIsPlaying;
-    IBOutlet UIButton *playlistButton;
+    IBOutlet UIButton *toggleButton;
     int animationOptionTransition;
     BOOL startFlipDemo;
     IBOutlet OBSlider *ProgressSlider;
@@ -68,7 +68,6 @@
     IBOutlet UIButton *shuffleButton;
     IBOutlet UIButton *repeatButton;
     IBOutlet UIButton *closeButton;
-    UIButton *fullscreenToggleButton;
     BOOL shuffled;
     NSString *repeatStatus;
     BOOL updateProgressBar;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2522,7 +2522,6 @@
 }
 
 - (void)setIphoneInterface {
-    [playlistActionView setY:CGRectGetMinY(playlistToolbarView.frame) - CGRectGetHeight(playlistActionView.frame)];
     playlistActionView.alpha = 0.0;
 }
 
@@ -2532,7 +2531,6 @@
     nowPlayingView.hidden = NO;
     playlistView.hidden = NO;
     
-    [playlistActionView setY:CGRectGetHeight(playlistTableView.frame) - CGRectGetHeight(playlistActionView.frame)];
     playlistActionView.alpha = 1.0;
     
     // Prepare iPad fullscreen toggle button

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1558,14 +1558,12 @@
 }
 
 - (void)animViews {
-    __block CGFloat playtoolbarAlpha = 1.0;
     if (!nowPlayingView.hidden) {
         transitionFromView = nowPlayingView;
         transitionToView = playlistView;
         self.navigationItem.title = [self getPlaylistHeaderLabel];
         self.navigationItem.titleView.hidden = YES;
         animationOptionTransition = UIViewAnimationOptionTransitionCrossDissolve;
-        playtoolbarAlpha = 1.0;
     }
     else {
         transitionFromView = playlistView;
@@ -1573,7 +1571,6 @@
         self.navigationItem.title = LOCALIZED_STR(@"Now Playing");
         self.navigationItem.titleView.hidden = YES;
         animationOptionTransition = UIViewAnimationOptionTransitionCrossDissolve;
-        playtoolbarAlpha = 0.0;
     }
     
     [UIView transitionWithView:transitionView
@@ -1584,7 +1581,6 @@
         self.slidingViewController.underLeftViewController.view.hidden = YES;
         transitionFromView.hidden = YES;
         transitionToView.hidden = NO;
-        playlistActionView.alpha = playtoolbarAlpha;
         self.navigationItem.titleView.hidden = NO;
                      }
                      completion:^(BOOL finished) {
@@ -2456,7 +2452,7 @@
     [toolbarBackground setWidth:viewSize.width];
     
     backgroundImageView.frame = nowPlayingView.frame;
-    playlistActionView.alpha = playlistView.alpha = isFullscreen ? 0 : 1;
+    playlistView.alpha = isFullscreen ? 0 : 1;
     
     // Adapt fullscreen toggle button icon to current screen mode
     NSString *imageName = isFullscreen ? @"button_exit_fullscreen" : @"button_fullscreen";
@@ -2519,22 +2515,6 @@
     [self setAVCodecFont:songSampleRate size:floor(14 * scale)];
     [self setAVCodecFont:songNumChannels size:floor(14 * scale)];
     descriptionFontSize = floor(12 * scale);
-}
-
-- (void)setIphoneInterface {
-    playlistActionView.alpha = 0.0;
-}
-
-- (void)setIpadInterface {
-    playlistToolbarView.alpha = 1.0;
-    
-    nowPlayingView.hidden = NO;
-    playlistView.hidden = NO;
-    
-    playlistActionView.alpha = 1.0;
-    
-    // Prepare iPad fullscreen toggle button
-    fullscreenToggleButton = [self.view viewWithTag:TAG_ID_TOGGLE];
 }
 
 - (BOOL)enableJewelCases {
@@ -2857,11 +2837,9 @@
     lastSelected = SELECTED_NONE;
     storedItemID = SELECTED_NONE;
     storeSelection = nil;
-    if (IS_IPHONE) {
-        [self setIphoneInterface];
-    }
-    else {
-        [self setIpadInterface];
+    if (IS_IPAD) {
+        // Prepare iPad fullscreen toggle button
+        fullscreenToggleButton = [self.view viewWithTag:TAG_ID_TOGGLE];
     }
     nowPlayingView.hidden = NO;
     playlistView.hidden = IS_IPHONE;

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -109,8 +109,8 @@
 # pragma mark - toolbar management
 
 - (UIImage*)resizeToolbarThumb:(UIImage*)img {
-    CGSize thumbSize = CGSizeMake(CGRectGetWidth(playlistButton.frame) * UIScreen.mainScreen.scale,
-                                  CGRectGetHeight(playlistButton.frame) * UIScreen.mainScreen.scale);
+    CGSize thumbSize = CGSizeMake(CGRectGetWidth(toggleButton.frame) * UIScreen.mainScreen.scale,
+                                  CGRectGetHeight(toggleButton.frame) * UIScreen.mainScreen.scale);
     return [img resizedImageSize:thumbSize aspectMode:UIViewContentModeScaleAspectFit];
 }
 
@@ -424,7 +424,7 @@
 
 - (void)setButtonImageAndStartDemo:(UIImage*)buttonImage {
     if (nowPlayingView.hidden || startFlipDemo) {
-        [playlistButton setImage:buttonImage forState:UIControlStateNormal];
+        [toggleButton setImage:buttonImage forState:UIControlStateNormal];
         if (startFlipDemo) {
             [NSTimer scheduledTimerWithTimeInterval:FLIP_DEMO_DELAY target:self selector:@selector(startFlipDemo) userInfo:nil repeats:NO];
             startFlipDemo = NO;
@@ -1587,7 +1587,7 @@
         self.slidingViewController.underRightViewController.view.hidden = NO;
         self.slidingViewController.underLeftViewController.view.hidden = NO;
     }];
-    [self flipAnimButton:playlistButton demo:NO];
+    [self flipAnimButton:toggleButton demo:NO];
 }
 
 #pragma mark - Bottom toolbar
@@ -2457,7 +2457,7 @@
     // Adapt fullscreen toggle button icon to current screen mode
     NSString *imageName = isFullscreen ? @"button_exit_fullscreen" : @"button_fullscreen";
     UIImage *image = [UIImage imageNamed:imageName];
-    [fullscreenToggleButton setImage:image forState:UIControlStateNormal];
+    [toggleButton setImage:image forState:UIControlStateNormal];
     
     [self setCoverSize:currentType];
 }
@@ -2732,7 +2732,7 @@
 }
 
 - (void)startFlipDemo {
-    [self flipAnimButton:playlistButton demo:YES];
+    [self flipAnimButton:toggleButton demo:YES];
 }
      
 - (void)startNowPlayingUpdates {
@@ -2837,10 +2837,6 @@
     lastSelected = SELECTED_NONE;
     storedItemID = SELECTED_NONE;
     storeSelection = nil;
-    if (IS_IPAD) {
-        // Prepare iPad fullscreen toggle button
-        fullscreenToggleButton = [self.view viewWithTag:TAG_ID_TOGGLE];
-    }
     nowPlayingView.hidden = NO;
     playlistView.hidden = IS_IPHONE;
     self.navigationItem.title = LOCALIZED_STR(@"Now Playing");

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -95,7 +95,7 @@
                                     <rect key="frame" x="141" y="165" width="37" height="37"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 </activityIndicatorView>
-                                <view opaque="NO" alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="128" userLabel="PlaylistActionView">
+                                <view opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="128" userLabel="PlaylistActionView">
                                     <rect key="frame" x="0.0" y="328" width="320" height="44"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     <subviews>

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -28,7 +28,6 @@
                 <outlet property="noFoundLabel" destination="134" id="cWH-OB-YZ6"/>
                 <outlet property="nowPlayingView" destination="92" id="95"/>
                 <outlet property="playlistActionView" destination="128" id="149"/>
-                <outlet property="playlistButton" destination="Z3l-yA-EDD" id="k08-dq-wTJ"/>
                 <outlet property="playlistTableView" destination="100" id="103"/>
                 <outlet property="playlistToolbarView" destination="h1i-BK-QLr" id="Kxz-AK-SDs"/>
                 <outlet property="playlistView" destination="93" id="96"/>
@@ -48,6 +47,7 @@
                 <outlet property="songSampleRate" destination="112" id="115"/>
                 <outlet property="songSampleRateImage" destination="b3u-Km-zml" id="mcn-U2-3U2"/>
                 <outlet property="thumbnailView" destination="52" id="53"/>
+                <outlet property="toggleButton" destination="Z3l-yA-EDD" id="9KT-Cz-mTm"/>
                 <outlet property="transitionView" destination="98" id="Hxy-bA-FyS"/>
                 <outlet property="upnp" destination="0M5-Mc-Eeb" id="oX5-s4-i6s"/>
                 <outlet property="view" destination="1" id="3"/>

--- a/XBMC Remote/NowPlaying.xib
+++ b/XBMC Remote/NowPlaying.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -95,6 +95,63 @@
                                     <rect key="frame" x="141" y="165" width="37" height="37"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 </activityIndicatorView>
+                                <view opaque="NO" alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="128" userLabel="PlaylistActionView">
+                                    <rect key="frame" x="0.0" y="328" width="320" height="44"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                    <subviews>
+                                        <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" fixedFrame="YES" barStyle="black" translatesAutoresizingMaskIntoConstraints="NO" id="i72-28-e1U">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                            <items/>
+                                        </toolbar>
+                                        <button hidden="YES" opaque="NO" tag="88" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="117">
+                                            <rect key="frame" x="235" y="8" width="74" height="28"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                            <gestureRecognizers/>
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
+                                            <size key="titleShadowOffset" width="1" height="1"/>
+                                            <state key="normal" title="Edit">
+                                                <color key="titleColor" red="0.94702327251434326" green="0.94702327251434326" blue="0.94702327251434326" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <state key="selected" title="Done">
+                                                <color key="titleColor" red="0.94702327251434326" green="0.94702327251434326" blue="0.94702327251434326" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <state key="highlighted">
+                                                <color key="titleColor" red="1" green="1" blue="1" alpha="0.90000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="editTable:forceClose:" destination="-1" eventType="touchUpInside" id="138"/>
+                                                <outletCollection property="gestureRecognizers" destination="168" appends="YES" id="169"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="141">
+                                            <rect key="frame" x="-95" y="8" width="95" height="28"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
+                                            <inset key="contentEdgeInsets" minX="6" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                            <size key="titleShadowOffset" width="1" height="1"/>
+                                            <state key="normal" title="Party" image="button_party_off">
+                                                <color key="titleColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <state key="selected" title="Party" image="button_party_on">
+                                                <color key="titleColor" red="0.94702327251434326" green="0.94702327251434326" blue="0.94702327251434326" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <state key="highlighted" title="Party" image="button_party_on">
+                                                <color key="titleColor" red="1" green="1" blue="1" alpha="0.90000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="togglePartyMode:" destination="-1" eventType="touchUpInside" id="144"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </view>
                             </subviews>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
@@ -351,63 +408,6 @@
                             </subviews>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
-                    </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                </view>
-                <view opaque="NO" alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="128" userLabel="PlaylistActionView">
-                    <rect key="frame" x="0.0" y="416" width="320" height="44"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <subviews>
-                        <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" fixedFrame="YES" barStyle="black" translatesAutoresizingMaskIntoConstraints="NO" id="i72-28-e1U">
-                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                            <items/>
-                        </toolbar>
-                        <button hidden="YES" opaque="NO" tag="88" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="117">
-                            <rect key="frame" x="235" y="8" width="74" height="28"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                            <gestureRecognizers/>
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
-                            <size key="titleShadowOffset" width="1" height="1"/>
-                            <state key="normal" title="Edit">
-                                <color key="titleColor" red="0.94702327251434326" green="0.94702327251434326" blue="0.94702327251434326" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="selected" title="Done">
-                                <color key="titleColor" red="0.94702327251434326" green="0.94702327251434326" blue="0.94702327251434326" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="highlighted">
-                                <color key="titleColor" red="1" green="1" blue="1" alpha="0.90000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <connections>
-                                <action selector="editTable:forceClose:" destination="-1" eventType="touchUpInside" id="138"/>
-                                <outletCollection property="gestureRecognizers" destination="168" appends="YES" id="169"/>
-                            </connections>
-                        </button>
-                        <button opaque="NO" alpha="0.0" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="141">
-                            <rect key="frame" x="-95" y="8" width="95" height="28"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                            <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
-                            <inset key="contentEdgeInsets" minX="6" minY="0.0" maxX="0.0" maxY="0.0"/>
-                            <size key="titleShadowOffset" width="1" height="1"/>
-                            <state key="normal" title="Party" image="button_party_off">
-                                <color key="titleColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="selected" title="Party" image="button_party_on">
-                                <color key="titleColor" red="0.94702327251434326" green="0.94702327251434326" blue="0.94702327251434326" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="highlighted" title="Party" image="button_party_on">
-                                <color key="titleColor" red="1" green="1" blue="1" alpha="0.90000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <connections>
-                                <action selector="togglePartyMode:" destination="-1" eventType="touchUpInside" id="144"/>
-                            </connections>
-                        </button>
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Move `playlistActionView` into `PlaylistView` and keep it at bottom, instead moving the `playlistActionView` programmatically. This avoids a visual gap in the playlist between segment control and bottom toolbar, which could only be seen on some iPhone models.

Screenshots from iPhone 16 Pro Max simulator:
<img width="497" height="113" alt="Bildschirmfoto 2026-07-14 um 08 04 43" src="https://github.com/user-attachments/assets/452660c8-c3a3-4153-ae00-29a58981525a" />

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Avoid gap in playlist between segment control and bottom toolbar