### PR TITLE
Bugfix: Re-enable fullscreen art animation after coming back from background

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1600,10 +1600,7 @@
     self.kenView.delegate = self;
     self.kenView.alpha = 0;
     self.kenView.tag = FANART_FULLSCREEN_DISABLE;
-    NSArray *backgroundImages = [NSArray arrayWithObjects:
-                                 image,
-                                 nil];
-    [self.kenView animateWithImages:backgroundImages
+    [self.kenView animateWithImages:@[image]
                  transitionDuration:45
                                loop:YES
                         isLandscape:YES];

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1614,6 +1614,20 @@
     [self.view insertSubview:self.kenView atIndex:1];
 }
 
+- (void)relaunchKenBurnsAnimation {
+    if (self.kenView != nil && ![self isModal]) {
+        CGFloat alphaValue = closeButton.alpha == 1 ? 1.0 : 0.2;
+        [UIView animateWithDuration:0.1
+                         animations:^{
+            self.kenView.alpha = 0;
+        }
+                         completion:^(BOOL finished) {
+            [self elabKenBurns:fanartView.image];
+            [self.kenView animateAlpha:alphaValue duration:0.2];
+        }];
+    }
+}
+
 - (void)leaveFullscreen {
     if (isFullscreenFanArt) {
         [self showBackgroundForTag:FANART_FULLSCREEN_DISABLE];
@@ -1743,6 +1757,11 @@
                                              selector:@selector(leaveFullscreen)
                                                  name:@"LeaveFullscreen"
                                                object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleEnterForeground)
+                                                 name:UIApplicationWillEnterForegroundNotification
+                                               object:nil];
 }
 
 - (BOOL)shouldAutorotate {
@@ -1754,22 +1773,12 @@
     
     [coordinator animateAlongsideTransition:nil
                                  completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-        if (self.kenView != nil && ![self isModal]) {
-            CGFloat alphaValue = 0.2;
-            if (closeButton.alpha == 1) {
-                alphaValue = 1;
-            }
-            [UIView animateWithDuration:0.1
-                             animations:^{
-                                 self.kenView.alpha = 0;
-                             }
-                             completion:^(BOOL finished) {
-                                 [self elabKenBurns:fanartView.image];
-                                 [self.kenView animateAlpha:alphaValue duration:0.2];
-                             }
-             ];
-        }
+        [self relaunchKenBurnsAnimation];
     }];
+}
+
+- (void)handleEnterForeground {
+    [self relaunchKenBurnsAnimation];
 }
 
 @end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Resolves an issue reported in [this forum post](https://forum.kodi.tv/showthread.php?tid=359717&pid=3297934#pid3297934).

Extract the helper method `relaunchKenBurnsAnimation` from `viewWillTransitionToSize` and also call it when the app is entering foreground.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Re-enable fullscreen art animation after coming back from background