### PR TITLE
Maintenance: Remove support for outdated Kodi 11 (Eden)

### DIFF
--- a/XBMC Remote/ActorCell.m
+++ b/XBMC Remote/ActorCell.m
@@ -27,10 +27,7 @@
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
         self.backgroundColor = UIColor.clearColor;
-        self.selectionStyle = UITableViewCellSelectionStyleNone;
-        if (AppDelegate.instance.serverVersion > 11) {
-            self.selectionStyle = UITableViewCellSelectionStyleGray;
-        }
+        self.selectionStyle = UITableViewCellSelectionStyleGray;
         
         UIView *actorContainer = [[UIView alloc] initWithFrame:CGRectMake(THUMB_PADDING, VERTICAL_PADDING, castWidth, castHeight)];
         actorContainer.clipsToBounds = NO;

--- a/XBMC Remote/BaseActionViewController.m
+++ b/XBMC Remote/BaseActionViewController.m
@@ -149,21 +149,17 @@
 
 - (void)startPlaybackItems:(NSDictionary*)playbackItems using:(NSString*)playername shuffle:(BOOL)shuffled resume:(BOOL)resume indicator:(UIActivityIndicatorView*)cellActivityIndicator {
     [cellActivityIndicator startAnimating];
-    NSString *optionsKey;
-    NSDictionary *optionsValue;
-    if (AppDelegate.instance.serverVersion > 11) {
-        optionsKey = @"options";
-        optionsValue = [NSDictionary dictionaryWithObjectsAndKeys:
-                        @(resume), @"resume",
-                        @(shuffled), @"shuffled",
-                        playername, @"playername",
-                        nil];
-    }
+    NSString *optionsKey = @"options";
+    NSDictionary *optionsValue = [NSDictionary dictionaryWithObjectsAndKeys:
+                                  @(resume), @"resume",
+                                  @(shuffled), @"shuffled",
+                                  playername, @"playername",
+                                  nil];
     NSDictionary *playbackParams = [NSDictionary dictionaryWithObjectsAndKeys:
                                     playbackItems, @"item",
                                     optionsValue, optionsKey,
                                     nil];
-    if (shuffled && AppDelegate.instance.serverVersion > 11) {
+    if (shuffled) {
         [[Utilities getJsonRPC]
          callMethod:@"Player.SetPartymode"
          withParameters:@{@"playerid": @0, @"partymode": @NO}

--- a/XBMC Remote/ConvenienceMacros.h
+++ b/XBMC Remote/ConvenienceMacros.h
@@ -12,8 +12,8 @@
 /*
  * Minimum supported Kodi version
  */
-#define MIN_SUPPORTED_SERVER_VERSION 11
-#define MIN_SUPPORTED_SERVER_VERSION_NAME @"Eden"
+#define MIN_SUPPORTED_SERVER_VERSION 12
+#define MIN_SUPPORTED_SERVER_VERSION_NAME @"Frodo"
 
 /*
  * Device and orientation checks

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -479,11 +479,6 @@
     if (dict[@"file_properties"] != nil) {
         dict[@"properties"] = [dict[@"file_properties"] mutableCopy];
         [dict removeObjectForKey:@"file_properties"];
-        
-        // Kodi 11 does not support art for file properties
-        if (AppDelegate.instance.serverVersion <= 11) {
-            [dict[@"properties"] removeObject:@"art"];
-        }
     }
 }
 
@@ -491,7 +486,7 @@
     NSMutableDictionary *newParameters = [mainParameters[@"parameters"] mutableCopy];
     NSArray *properties = mainParameters[@"parameters"][@"properties"];
     NSMutableArray *newProperties = [[Utilities addExtraProperties:properties parameters:mainParameters] mutableCopy];
-    if ([mainParameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
+    if ([mainParameters[@"FrodoExtraArt"] boolValue]) {
         [newProperties addObject:@"art"];
     }
     if (newProperties != nil) {
@@ -1309,7 +1304,7 @@
         }
         id objKey = mainFields[@"row6"];
         id obj = item[objKey];
-        if (AppDelegate.instance.serverVersion > 11 && ![parameters[@"disableFilterParameter"] boolValue]) {
+        if (![parameters[@"disableFilterParameter"] boolValue]) {
             NSDictionary *currentParams = menuItem.mainParameters[activeTab];
             obj = [NSDictionary dictionaryWithObjectsAndKeys:
                    obj, objKey,
@@ -1568,7 +1563,7 @@
     if ([parameters[@"isMusicPlaylist"] boolValue] ||
         [parameters[@"isVideoPlaylist"] boolValue]) { // NOTE: sheetActions objects must be moved outside from there
         if ([sheetActions isKindOfClass:[NSMutableArray class]]) {
-            if (![[item[@"file"] pathExtension] isEqualToString:@"xsp"] || AppDelegate.instance.serverVersion <= 11) {
+            if (![[item[@"file"] pathExtension] isEqualToString:@"xsp"]) {
                 [sheetActions removeObject:LOCALIZED_STR(@"Play in party mode")];
             }
         }
@@ -3328,7 +3323,7 @@
     NSDictionary *parameters = menuItem.mainParameters[activeTab];
     NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
     NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
-    if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
+    if ([parameters[@"FrodoExtraArt"] boolValue]) {
         [mutableProperties addObject:@"art"];
         mutableParameters[@"properties"] = mutableProperties;
     }
@@ -3875,7 +3870,7 @@
     NSNumber *filemodeRowHeight = parameters[@"rowHeight"] ?: @FILEMODE_ROW_HEIGHT;
     NSNumber *filemodeThumbWidth = parameters[@"thumbWidth"] ?: @FILEMODE_THUMB_WIDTH;
     NSMutableArray *mutableProperties = [parameters[@"parameters"][@"file_properties"] mutableCopy];
-    if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
+    if ([parameters[@"FrodoExtraArt"] boolValue]) {
         [mutableProperties addObject:@"art"];
     }
     NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
@@ -4197,7 +4192,7 @@
     NSMutableDictionary *mutableParameters = [parameters[@"extra_info_parameters"] mutableCopy];
     NSMutableArray *mutableProperties = [parameters[@"extra_info_parameters"][@"properties"] mutableCopy];
     
-    if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
+    if ([parameters[@"FrodoExtraArt"] boolValue]) {
         [mutableProperties addObject:@"art"];
         mutableParameters[@"properties"] = mutableProperties;
     }
@@ -4451,11 +4446,6 @@
             [mutableParameters removeObjectForKey:@"sort"];
         }
         else if ([mutableParameters[@"channelgroupid"] intValue] == -1) {
-            [self animateNoResultsFound];
-            return;
-        }
-        // PVR functions not supported with xbmc 11
-        if (AppDelegate.instance.serverVersion == 11) {
             [self animateNoResultsFound];
             return;
         }
@@ -5342,32 +5332,9 @@
     NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     NSDictionary *methods = menuItem.mainMethod[chosenTab];
     NSMutableDictionary *tempDict = [NSMutableDictionary dictionaryWithDictionary:parameters[@"parameters"]];
-    if (AppDelegate.instance.serverVersion > 11) {
-        if (tempDict[@"filter"] != nil) {
-            [tempDict removeObjectForKey:@"filter"];
-            tempDict[@"filtered"] = @"YES";
-        }
-    }
-    else {
-        if (tempDict.count > 2) {
-            [tempDict removeAllObjects];
-            NSArray *arr_properties = parameters[@"parameters"][@"properties"];
-            if (arr_properties == nil) {
-                arr_properties = parameters[@"parameters"][@"file_properties"];
-            }
-            
-            if (arr_properties == nil) {
-                arr_properties = @[];
-            }
-            
-            NSArray *arr_sort = parameters[@"parameters"][@"sort"];
-            if (arr_sort == nil) {
-                arr_sort = @[];
-            }
-            tempDict[@"properties"] = arr_properties;
-            tempDict[@"sort"] = arr_sort;
-            tempDict[@"filtered"] = @"YES";
-        }
+    if (tempDict[@"filter"] != nil) {
+        [tempDict removeObjectForKey:@"filter"];
+        tempDict[@"filtered"] = @"YES";
     }
     NSString *viewKey = [NSString stringWithFormat:@"%@_grid_preference", [self getCacheKey:methods[@"method"] parameters:tempDict]];
     return ([parameters[@"enableCollectionView"] boolValue] && [userDefaults boolForKey:viewKey]);
@@ -5636,7 +5603,7 @@
         episodesView = YES;
     }
     else if ([methods[@"tvshowsView"] boolValue]) {
-        tvshowsView = AppDelegate.instance.serverVersion > 11 && ![Utilities getPreferTvPosterMode];
+        tvshowsView = ![Utilities getPreferTvPosterMode];
         [self setTVshowThumbSize];
     }
     else if ([methods[@"channelGuideView"] boolValue]) {
@@ -5885,19 +5852,9 @@
     NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     if ([self collectionViewCanBeEnabled] && self.view.superview != nil && ![methods[@"method"] isEqualToString:@""]) {
         NSMutableDictionary *tempDict = [NSMutableDictionary dictionaryWithDictionary:parameters[@"parameters"]];
-        if (AppDelegate.instance.serverVersion > 11) {
-            if (tempDict[@"filter"] != nil) {
-                [tempDict removeObjectForKey:@"filter"];
-                tempDict[@"filtered"] = @"YES";
-            }
-        }
-        else {
-            if (tempDict.count > 2) {
-                [tempDict removeAllObjects];
-                tempDict[@"properties"] = parameters[@"parameters"][@"properties"];
-                tempDict[@"sort"] = parameters[@"parameters"][@"sort"];
-                tempDict[@"filtered"] = @"YES";
-            }
+        if (tempDict[@"filter"] != nil) {
+            [tempDict removeObjectForKey:@"filter"];
+            tempDict[@"filtered"] = @"YES";
         }
         NSString *viewKey = [NSString stringWithFormat:@"%@_grid_preference", [self getCacheKey:methods[@"method"] parameters:tempDict]];
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -475,6 +475,15 @@
     }
 }
 
+- (NSMutableDictionary*)rebuildParameters:(NSDictionary*)dict newKey:(id)key newValue:(id)value {
+    return [NSMutableDictionary dictionaryWithObjectsAndKeys:
+            value, key,
+            dict[@"media"], @"media",
+            dict[@"sort"], @"sort",
+            dict[@"file_properties"], @"file_properties",
+            nil];
+}
+
 - (void)addFileProperties:(NSMutableDictionary*)dict {
     if (dict[@"file_properties"] != nil) {
         dict[@"properties"] = [dict[@"file_properties"] mutableCopy];
@@ -1368,12 +1377,9 @@
             if ([item[@"filetype"] isEqualToString:@"directory"]) {
                 parameters = menuItem.mainParameters[activeTab];
                 NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                                      [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                                       item[mainFields[@"row6"]], @"directory",
-                                                       parameters[@"parameters"][@"media"], @"media",
-                                                       parameters[@"parameters"][@"sort"], @"sort",
-                                                       parameters[@"parameters"][@"file_properties"], @"file_properties",
-                                                       nil], @"parameters",
+                                                      [self rebuildParameters:parameters[@"parameters"]
+                                                                       newKey:@"directory"
+                                                                     newValue:item[mainFields[@"row6"]]], @"parameters",
                                                       parameters[@"label"], @"label",
                                                       @"nocover_filemode", @"defaultThumb",
                                                       filemodeRowHeight, @"rowHeight",
@@ -1438,12 +1444,9 @@
                 objValue = [@"plugin://" stringByAppendingString: objValue];
             }
             NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                                  [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                                   objValue, fileModeKey,
-                                                   parameters[@"parameters"][@"media"], @"media",
-                                                   parameters[@"parameters"][@"sort"], @"sort",
-                                                   parameters[@"parameters"][@"file_properties"], @"file_properties",
-                                                   nil], @"parameters",
+                                                  [self rebuildParameters:parameters[@"parameters"]
+                                                                   newKey:fileModeKey
+                                                                 newValue:objValue], @"parameters",
                                                   parameters[@"label"], @"label",
                                                   @"nocover_filemode", @"defaultThumb",
                                                   filemodeRowHeight, @"rowHeight",
@@ -3861,12 +3864,9 @@
     NSNumber *filemodeRowHeight = parameters[@"rowHeight"] ?: @FILEMODE_ROW_HEIGHT;
     NSNumber *filemodeThumbWidth = parameters[@"thumbWidth"] ?: @FILEMODE_THUMB_WIDTH;
     NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                          [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                           item[mainFields[@"row6"]], @"directory",
-                                           parameters[@"parameters"][@"media"], @"media",
-                                           parameters[@"parameters"][@"sort"], @"sort",
-                                           parameters[@"parameters"][@"file_properties"], @"file_properties",
-                                           nil], @"parameters",
+                                          [self rebuildParameters:parameters[@"parameters"]
+                                                           newKey:@"directory"
+                                                         newValue:item[mainFields[@"row6"]]], @"parameters",
                                           parameters[@"label"], @"label",
                                           @"nocover_filemode", @"defaultThumb",
                                           filemodeRowHeight, @"rowHeight",

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4411,26 +4411,24 @@
     if (filterModeType == ViewModeAlbumArtists ||
         filterModeType == ViewModeSongArtists ||
         filterModeType == ViewModeDefaultArtists) {
-        if ([VersionCheck hasAlbumArtistOnlySupport]) {
-            switch (filterModeType) {
-                case ViewModeAlbumArtists:
-                    mutableParameters[@"albumartistsonly"] = @YES;
-                    forceRefresh = YES;
-                    break;
-                    
-                case ViewModeSongArtists:
-                    mutableParameters[@"albumartistsonly"] = @NO;
-                    forceRefresh = YES;
-                    break;
-                    
-                case ViewModeDefaultArtists:
-                    [mutableParameters removeObjectForKey:@"albumartistsonly"];
-                    break;
-                    
-                default:
-                    NSAssert(NO, @"retrieveData: unexpected mode %ld", filterModeType);
-                    break;
-            }
+        switch (filterModeType) {
+            case ViewModeAlbumArtists:
+                mutableParameters[@"albumartistsonly"] = @YES;
+                forceRefresh = YES;
+                break;
+                
+            case ViewModeSongArtists:
+                mutableParameters[@"albumartistsonly"] = @NO;
+                forceRefresh = YES;
+                break;
+                
+            case ViewModeDefaultArtists:
+                [mutableParameters removeObjectForKey:@"albumartistsonly"];
+                break;
+                
+            default:
+                NSAssert(NO, @"retrieveData: unexpected mode %ld", filterModeType);
+                break;
         }
     }
     

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -486,9 +486,6 @@
     NSMutableDictionary *newParameters = [mainParameters[@"parameters"] mutableCopy];
     NSArray *properties = mainParameters[@"parameters"][@"properties"];
     NSMutableArray *newProperties = [[Utilities addExtraProperties:properties parameters:mainParameters] mutableCopy];
-    if ([mainParameters[@"FrodoExtraArt"] boolValue]) {
-        [newProperties addObject:@"art"];
-    }
     if (newProperties != nil) {
         newParameters[@"properties"] = newProperties;
     }
@@ -1341,7 +1338,6 @@
                                               libraryThumbWidth, @"thumbWidth",
                                               parameters[@"label"], @"label",
                                               parameters[@"itemSizes"] ?: @{}, @"itemSizes",
-                                              @([parameters[@"FrodoExtraArt"] boolValue]), @"FrodoExtraArt",
                                               @([parameters[@"enableLibraryCache"] boolValue]), @"enableLibraryCache",
                                               @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
                                               @([parameters[@"forcePlayback"] boolValue]), @"forcePlayback",
@@ -3322,11 +3318,6 @@
     int activeTab = [self getActiveTab:item];
     NSDictionary *parameters = menuItem.mainParameters[activeTab];
     NSMutableDictionary *mutableParameters = [parameters[@"parameters"] mutableCopy];
-    NSMutableArray *mutableProperties = [parameters[@"parameters"][@"properties"] mutableCopy];
-    if ([parameters[@"FrodoExtraArt"] boolValue]) {
-        [mutableProperties addObject:@"art"];
-        mutableParameters[@"properties"] = mutableProperties;
-    }
     [self addFileProperties:mutableParameters];
     [self saveData:mutableParameters];
 }
@@ -3869,16 +3860,12 @@
     NSMutableDictionary *parameters = menuItem.subItem.mainParameters[activeTab];
     NSNumber *filemodeRowHeight = parameters[@"rowHeight"] ?: @FILEMODE_ROW_HEIGHT;
     NSNumber *filemodeThumbWidth = parameters[@"thumbWidth"] ?: @FILEMODE_THUMB_WIDTH;
-    NSMutableArray *mutableProperties = [parameters[@"parameters"][@"file_properties"] mutableCopy];
-    if ([parameters[@"FrodoExtraArt"] boolValue]) {
-        [mutableProperties addObject:@"art"];
-    }
     NSMutableDictionary *newParameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                           [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                            item[mainFields[@"row6"]], @"directory",
                                            parameters[@"parameters"][@"media"], @"media",
                                            parameters[@"parameters"][@"sort"], @"sort",
-                                           mutableProperties, @"file_properties",
+                                           parameters[@"parameters"][@"file_properties"], @"file_properties",
                                            nil], @"parameters",
                                           parameters[@"label"], @"label",
                                           @"nocover_filemode", @"defaultThumb",
@@ -4189,15 +4176,8 @@
     NSDictionary *methods = menuItem.mainMethod[tabToShow];
     NSDictionary *parameters = menuItem.mainParameters[tabToShow];
     
-    NSMutableDictionary *mutableParameters = [parameters[@"extra_info_parameters"] mutableCopy];
-    NSMutableArray *mutableProperties = [parameters[@"extra_info_parameters"][@"properties"] mutableCopy];
-    
-    if ([parameters[@"FrodoExtraArt"] boolValue]) {
-        [mutableProperties addObject:@"art"];
-        mutableParameters[@"properties"] = mutableProperties;
-    }
     if (parameters[@"extra_info_parameters"] != nil && methods[@"extra_info_method"] != nil) {
-        [self retrieveExtraInfoData:methods[@"extra_info_method"] parameters:mutableParameters index:indexPath item:item menuItem:menuItem tabToShow:tabToShow];
+        [self retrieveExtraInfoData:methods[@"extra_info_method"] parameters:parameters[@"extra_info_parameters"] index:indexPath item:item menuItem:menuItem tabToShow:tabToShow];
     }
     else {
         [self displayInfoView:item];

--- a/XBMC Remote/MainMenu.m
+++ b/XBMC Remote/MainMenu.m
@@ -2096,6 +2096,7 @@
                     @"director",
                     @"file",
                     @"dateadded",
+                    @"art",
                 ],
             },
             @"extra_info_parameters": @{
@@ -2118,6 +2119,7 @@
                     @"trailer",
                     @"dateadded",
                     @"tagline",
+                    @"art",
                 ],
             },
             @"available_sort_methods": @{
@@ -2142,7 +2144,6 @@
             },
             @"label": LOCALIZED_STR(@"Movies"),
             @"defaultThumb": @"nocover_movies",
-            @"FrodoExtraArt": @YES,
             @"enableCollectionView": @YES,
             @"enableLibraryCache": @YES,
             @"enableLibraryFullScreen": @YES,
@@ -2172,6 +2173,7 @@
                     @"plot",
                     @"fanart",
                     @"playcount",
+                    @"art",
                 ],
             },
             @"extra_info_parameters": @{
@@ -2180,6 +2182,7 @@
                     @"plot",
                     @"fanart",
                     @"playcount",
+                    @"art",
                 ],
             },
             @"available_sort_methods": @{
@@ -2192,7 +2195,6 @@
                     @"playcount",
                 ],
             },
-            @"FrodoExtraArt": @YES,
             @"enableCollectionView": @YES,
             @"enableLibraryCache": @YES,
             @"defaultThumb": @"nocover_movie_sets",
@@ -2213,6 +2215,7 @@
                     @"trailer",
                     @"fanart",
                     @"file",
+                    @"art",
                 ],
             },
             @"label": LOCALIZED_STR(@"Added Movies"),
@@ -2237,9 +2240,9 @@
                     @"trailer",
                     @"dateadded",
                     @"tagline",
+                    @"art",
                 ],
             },
-            @"FrodoExtraArt": @YES,
             @"enableCollectionView": @YES,
             @"collectionViewRecentlyAdded": @YES,
             @"enableLibraryFullScreen": @YES,
@@ -2527,6 +2530,7 @@
                     @"trailer",
                     @"file",
                     @"dateadded",
+                    @"art",
                 ],
             },
             @"extra_info_parameters": @{
@@ -2549,6 +2553,7 @@
                     @"trailer",
                     @"dateadded",
                     @"tagline",
+                    @"art",
                 ],
             },
             @"available_sort_methods": @{
@@ -2571,7 +2576,6 @@
             },
             @"label": LOCALIZED_STR(@"Movies"),
             @"defaultThumb": @"nocover_movies",
-            @"FrodoExtraArt": @YES,
             @"enableCollectionView": @YES,
             @"enableLibraryCache": @YES,
             @"itemSizes": [self itemSizes_Movie],
@@ -2590,6 +2594,7 @@
                     @"trailer",
                     @"file",
                     @"dateadded",
+                    @"art",
                 ],
             },
             @"extra_info_parameters": @{
@@ -2612,6 +2617,7 @@
                     @"trailer",
                     @"dateadded",
                     @"tagline",
+                    @"art",
                 ],
             },
             @"available_sort_methods": @{
@@ -2634,7 +2640,6 @@
             },
             @"label": LOCALIZED_STR(@"Movies"),
             @"defaultThumb": @"nocover_movies",
-            @"FrodoExtraArt": @YES,
             @"enableCollectionView": @YES,
             @"itemSizes": [self itemSizes_Movie],
         },
@@ -2654,6 +2659,7 @@
                     @"trailer",
                     @"file",
                     @"dateadded",
+                    @"art",
                 ],
             },
             @"extra_info_parameters": @{
@@ -2676,6 +2682,7 @@
                     @"trailer",
                     @"dateadded",
                     @"tagline",
+                    @"art",
                 ],
             },
             @"available_sort_methods": @{
@@ -2698,7 +2705,6 @@
             },
             @"label": LOCALIZED_STR(@"Movies"),
             @"defaultThumb": @"nocover_movies",
-            @"FrodoExtraArt": @YES,
             @"enableCollectionView": @YES,
             @"enableLibraryCache": @YES,
             @"itemSizes": [self itemSizes_Movie],
@@ -2759,6 +2765,7 @@
                     @"fanart",
                     @"resume",
                     @"tagline",
+                    @"art",
                 ],
                 @"media": @"video",
             },
@@ -2767,7 +2774,6 @@
             @"rowHeight": @PORTRAIT_ROW_HEIGHT,
             @"thumbWidth": @DEFAULT_THUMB_WIDTH,
             @"enableCollectionView": @YES,
-            @"FrodoExtraArt": @YES,
             @"itemSizes": [self itemSizes_Movie],
         },
     ] mutableCopy];
@@ -3517,6 +3523,7 @@
                     @"cast",
                     @"fanart",
                     @"resume",
+                    @"art",
                 ],
                 @"media": @"video",
             },
@@ -3525,7 +3532,6 @@
             @"rowHeight": @PORTRAIT_ROW_HEIGHT,
             @"thumbWidth": @DEFAULT_THUMB_WIDTH,
             @"enableCollectionView": @YES,
-            @"FrodoExtraArt": @YES,
             @"itemSizes": [self itemSizes_Movie],
         },
     ] mutableCopy];
@@ -3734,6 +3740,7 @@
                     @"genre",
                     @"studio",
                     @"episode",
+                    @"art",
                 ],
             },
             @"extra_info_parameters": @{
@@ -3751,6 +3758,7 @@
                     @"premiered",
                     @"episode",
                     @"fanart",
+                    @"art",
                 ],
             },
             @"available_sort_methods": @{
@@ -3769,7 +3777,6 @@
             },
             @"label": LOCALIZED_STR(@"TV Shows"),
             @"defaultThumb": @"nocover_tvshows",
-            @"FrodoExtraArt": @YES,
             @"enableLibraryCache": @YES,
             @"enableCollectionView": @YES,
             @"enableLibraryFullScreen": @YES,
@@ -3788,6 +3795,7 @@
                     @"file",
                     @"title",
                     @"season",
+                    @"art",
                 ],
             },
             @"extra_info_parameters": @{
@@ -3808,13 +3816,13 @@
                     @"fanart",
                     @"playcount",
                     @"resume",
+                    @"art",
                 ],
             },
             @"label": LOCALIZED_STR(@"Added Episodes"),
             @"rowHeight": @DEFAULT_ROW_HEIGHT,
             @"thumbWidth": @EPISODE_THUMB_WIDTH,
             @"defaultThumb": @"nocover_tvshows_episode",
-            @"FrodoExtraArt": @YES,
             @"itemSizes": [self itemSizes_TVShowsfullscreen],
         },
         
@@ -4051,6 +4059,7 @@
                     @"runtime",
                     @"file",
                     @"title",
+                    @"art",
                 ],
             },
             @"kodiExtrasPropertiesMinimumVersion": @{
@@ -4077,6 +4086,7 @@
                     @"resume",
                     @"playcount",
                     @"file",
+                    @"art",
                 ],
             },
             @"extra_section_parameters": @{
@@ -4093,7 +4103,6 @@
             @"label": LOCALIZED_STR(@"Episodes"),
             @"defaultThumb": @"nocover_tvshows_episode",
             @"disableFilterParameter": @YES,
-            @"FrodoExtraArt": @YES,
         },
         
         @{},
@@ -4109,6 +4118,7 @@
                     @"genre",
                     @"studio",
                     @"episode",
+                    @"art",
                 ],
             },
             @"extra_info_parameters": @{
@@ -4126,6 +4136,7 @@
                     @"premiered",
                     @"episode",
                     @"fanart",
+                    @"art",
                 ],
             },
             @"available_sort_methods": @{
@@ -4143,7 +4154,6 @@
                 ],
             },
             @"label": LOCALIZED_STR(@"TV Shows"),
-            @"FrodoExtraArt": @YES,
             @"enableCollectionView": @YES,
             @"rowHeight": @PHONE_TV_SHOWS_POSTER_HEIGHT,
             @"thumbWidth": @PHONE_TV_SHOWS_POSTER_WIDTH,
@@ -4204,6 +4214,7 @@
                     @"cast",
                     @"fanart",
                     @"resume",
+                    @"art",
                 ],
                 @"media": @"video",
             },
@@ -4212,7 +4223,6 @@
             @"rowHeight": @PORTRAIT_ROW_HEIGHT,
             @"thumbWidth": @DEFAULT_THUMB_WIDTH,
             @"enableCollectionView": @YES,
-            @"FrodoExtraArt": @YES,
             @"itemSizes": [self itemSizes_Movie],
         },
     ] mutableCopy];
@@ -4393,6 +4403,7 @@
                     @"runtime",
                     @"file",
                     @"title",
+                    @"art",
                 ],
             },
             @"kodiExtrasPropertiesMinimumVersion": @{
@@ -4419,6 +4430,7 @@
                     @"resume",
                     @"playcount",
                     @"file",
+                    @"art",
                 ],
             },
             @"extra_section_parameters": @{
@@ -4434,7 +4446,6 @@
             },
             @"label": LOCALIZED_STR(@"Episodes"),
             @"disableFilterParameter": @YES,
-            @"FrodoExtraArt": @YES,
         },
         
         @{},

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -242,10 +242,7 @@
         PartyModeButton.selected = NO;
         [[Utilities getJsonRPC]
          callMethod:@"Player.SetPartymode"
-         withParameters:@{@"playerid": @(0), @"partymode": @"toggle"}
-         onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-            PartyModeButton.selected = NO;
-        }];
+         withParameters:@{@"playerid": @(0), @"partymode": @"toggle"}];
     }
     else {
         PartyModeButton.selected = YES;
@@ -253,7 +250,6 @@
          callMethod:@"Player.Open"
          withParameters:@{@"item": @{@"partymode": @"music"}}
          onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-            PartyModeButton.selected = YES;
             storedItemID = SELECTED_NONE;
         }];
     }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1358,17 +1358,9 @@
     NSDictionary *methods = menuItem.mainMethod[activeTab];
     NSDictionary *parameters = menuItem.mainParameters[activeTab];
     NSDictionary *mainFields = menuItem.mainFields[activeTab];
-    
-    NSMutableDictionary *mutableParameters = [parameters[@"extra_info_parameters"] mutableCopy];
-    NSMutableArray *mutableProperties = [parameters[@"extra_info_parameters"][@"properties"] mutableCopy];
-    
-    if ([parameters[@"FrodoExtraArt"] boolValue]) {
-        [mutableProperties addObject:@"art"];
-        mutableParameters[@"properties"] = mutableProperties;
-    }
 
     if (parameters[@"extra_info_parameters"] != nil && methods[@"extra_info_method"] != nil) {
-        [self retrieveExtraInfoData:methods[@"extra_info_method"] parameters:mutableParameters mainFields:mainFields index:indexPath item:item];
+        [self retrieveExtraInfoData:methods[@"extra_info_method"] parameters:parameters[@"extra_info_parameters"] mainFields:mainFields index:indexPath item:item];
     }
     else {
         [self displayInfoView:item];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -238,31 +238,24 @@
 }
 
 - (IBAction)togglePartyMode:(id)sender {
-    if (AppDelegate.instance.serverVersion == 11) {
-        storedItemID = SELECTED_NONE;
-        PartyModeButton.selected = YES;
-        [Utilities sendXbmcHttp:@"ExecBuiltIn&parameter=PlayerControl(Partymode('music'))"];
+    if (musicPartyMode) {
+        PartyModeButton.selected = NO;
+        [[Utilities getJsonRPC]
+         callMethod:@"Player.SetPartymode"
+         withParameters:@{@"playerid": @(0), @"partymode": @"toggle"}
+         onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+            PartyModeButton.selected = NO;
+        }];
     }
     else {
-        if (musicPartyMode) {
-            PartyModeButton.selected = NO;
-            [[Utilities getJsonRPC]
-             callMethod:@"Player.SetPartymode"
-             withParameters:@{@"playerid": @(0), @"partymode": @"toggle"}
-             onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-                 PartyModeButton.selected = NO;
-             }];
-        }
-        else {
+        PartyModeButton.selected = YES;
+        [[Utilities getJsonRPC]
+         callMethod:@"Player.Open"
+         withParameters:@{@"item": @{@"partymode": @"music"}}
+         onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
             PartyModeButton.selected = YES;
-            [[Utilities getJsonRPC]
-             callMethod:@"Player.Open"
-             withParameters:@{@"item": @{@"partymode": @"music"}}
-             onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-                 PartyModeButton.selected = YES;
-                 storedItemID = SELECTED_NONE;
-             }];
-        }
+            storedItemID = SELECTED_NONE;
+        }];
     }
 }
 
@@ -709,24 +702,22 @@
 }
 
 - (void)getPlayerItems {
-    NSMutableArray *properties = [@[@"album",
-                                    @"artist",
-                                    @"title",
-                                    @"thumbnail",
-                                    @"track",
-                                    @"studio",
-                                    @"showtitle",
-                                    @"episode",
-                                    @"season",
-                                    @"fanart",
-                                    @"channel",
-                                    @"description",
-                                    @"year",
-                                    @"director",
-                                    @"plot"] mutableCopy];
-    if (AppDelegate.instance.serverVersion > 11) {
-        [properties addObject:@"art"];
-    }
+    NSArray *properties = @[@"album",
+                            @"artist",
+                            @"title",
+                            @"thumbnail",
+                            @"track",
+                            @"studio",
+                            @"showtitle",
+                            @"episode",
+                            @"season",
+                            @"fanart",
+                            @"channel",
+                            @"description",
+                            @"year",
+                            @"director",
+                            @"art",
+                            @"plot"];
     [[Utilities getJsonRPC]
      callMethod:@"Player.GetItem"
      withParameters:@{@"playerid": @(currentPlayerID),
@@ -1164,29 +1155,7 @@
         [self serverIsDisconnected];
         return;
     }
-    if (AppDelegate.instance.serverVersion == 11) {
-        [[Utilities getJsonRPC]
-         callMethod:@"XBMC.GetInfoBooleans" 
-         withParameters:@{@"booleans": @[@"Window.IsActive(virtualkeyboard)", @"Window.IsActive(selectdialog)"]}
-         onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-             
-             if (error == nil && methodError == nil && [methodResult isKindOfClass:[NSDictionary class]]) {
-                 if (methodResult[@"Window.IsActive(virtualkeyboard)"] != [NSNull null] && methodResult[@"Window.IsActive(selectdialog)"] != [NSNull null]) {
-                     NSNumber *virtualKeyboardActive = methodResult[@"Window.IsActive(virtualkeyboard)"];
-                     NSNumber *selectDialogActive = methodResult[@"Window.IsActive(selectdialog)"];
-                     if ([virtualKeyboardActive intValue] == 1 || [selectDialogActive intValue] == 1) {
-                         return;
-                     }
-                     else {
-                         [self getActivePlayers];
-                     }
-                 }
-             }
-         }];
-    }
-    else {
-        [self getActivePlayers];
-    }
+    [self getActivePlayers];
 }
 
 - (void)clearPlaylist:(int)playlistID {
@@ -1393,7 +1362,7 @@
     NSMutableDictionary *mutableParameters = [parameters[@"extra_info_parameters"] mutableCopy];
     NSMutableArray *mutableProperties = [parameters[@"extra_info_parameters"][@"properties"] mutableCopy];
     
-    if ([parameters[@"FrodoExtraArt"] boolValue] && AppDelegate.instance.serverVersion > 11) {
+    if ([parameters[@"FrodoExtraArt"] boolValue]) {
         [mutableProperties addObject:@"art"];
         mutableParameters[@"properties"] = mutableProperties;
     }
@@ -1424,7 +1393,7 @@
 - (void)retrieveExtraInfoData:(NSString*)methodToCall parameters:(NSDictionary*)parameters mainFields:(NSDictionary*)mainFields index:(NSIndexPath*)indexPath item:(NSDictionary*)item {
     NSString *itemid = mainFields[@"row6"] ?: @"";
     id object = [Utilities getNumberFromItem:item[itemid]];
-    if (AppDelegate.instance.serverVersion > 11 && [methodToCall isEqualToString:@"AudioLibrary.GetArtistDetails"]) {
+    if ([methodToCall isEqualToString:@"AudioLibrary.GetArtistDetails"]) {
         // WORKAROUND due to the lack of the artistid with Playlist.GetItems
         methodToCall = @"AudioLibrary.GetArtists";
         object = @{@"songid": [Utilities getNumberFromItem:item[@"idItem"]]};
@@ -1449,7 +1418,7 @@
          if (error == nil && methodError == nil) {
              if ([methodResult isKindOfClass:[NSDictionary class]]) {
                  NSDictionary *itemExtraDict;
-                 if (AppDelegate.instance.serverVersion > 11 && [methodToCall isEqualToString:@"AudioLibrary.GetArtists"]) {
+                 if ([methodToCall isEqualToString:@"AudioLibrary.GetArtists"]) {
                      // WORKAROUND due to the lack of the artistid with Playlist.GetItems
                      NSString *itemid_extra_info = @"artists";
                      if ([methodResult[itemid_extra_info] count]) {
@@ -1595,16 +1564,9 @@
     NSDictionary *params;
     switch ([sender tag]) {
         case TAG_ID_PREVIOUS:
-            if (AppDelegate.instance.serverVersion > 11) {
-                action = @"Player.GoTo";
-                params = @{@"to": @"previous"};
-                [self playerAction:action params:params];
-            }
-            else {
-                action = @"Player.GoPrevious";
-                params = nil;
-                [self playerAction:action params:nil];
-            }
+            action = @"Player.GoTo";
+            params = @{@"to": @"previous"};
+            [self playerAction:action params:params];
             ProgressSlider.value = 0;
             break;
             
@@ -1622,16 +1584,9 @@
             break;
             
         case TAG_ID_NEXT:
-            if (AppDelegate.instance.serverVersion > 11) {
-                action = @"Player.GoTo";
-                params = @{@"to": @"next"};
-                [self playerAction:action params:params];
-            }
-            else {
-                action = @"Player.GoNext";
-                params = nil;
-                [self playerAction:action params:nil];
-            }
+            action = @"Player.GoTo";
+            params = @{@"to": @"next"};
+            [self playerAction:action params:params];
             break;
             
         case TAG_ID_TOGGLE:
@@ -1699,25 +1654,13 @@
     BOOL newShuffleStatus = !shuffled;
     
     // Send the command to Kodi
-    if (AppDelegate.instance.serverVersion > 11) {
-        [[Utilities getJsonRPC] callMethod:@"Player.SetShuffle"
-                            withParameters:@{@"playerid": @(currentPlayerID), @"shuffle": @"toggle"}
-                              onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-            if (error == nil && methodError == nil) {
-                [self createPlaylistAnimated:YES];
-            }
-        }];
-    }
-    else {
-        NSString *shuffleCommand = newShuffleStatus ? @"Player.Shuffle" : @"Player.UnShuffle";
-        [[Utilities getJsonRPC] callMethod:shuffleCommand
-                            withParameters:@{@"playerid": @(currentPlayerID)}
-                              onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-            if (error == nil && methodError == nil) {
-                [self createPlaylistAnimated:YES];
-            }
-        }];
-    }
+    [[Utilities getJsonRPC] callMethod:@"Player.SetShuffle"
+                        withParameters:@{@"playerid": @(currentPlayerID), @"shuffle": @"toggle"}
+                          onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+        if (error == nil && methodError == nil) {
+            [self createPlaylistAnimated:YES];
+        }
+    }];
     
     // Update the button status
     [self updateShuffleButton:newShuffleStatus];
@@ -1740,12 +1683,7 @@
     }
     
     // Send the command to Kodi
-    if (AppDelegate.instance.serverVersion > 11) {
-        [self playerAction:@"Player.SetRepeat" params:@{@"playerid": @(currentPlayerID), @"repeat": @"cycle"}];
-    }
-    else {
-        [self playerAction:@"Player.Repeat" params:@{@"playerid": @(currentPlayerID), @"state": newRepeatStatus}];
-    }
+    [self playerAction:@"Player.SetRepeat" params:@{@"playerid": @(currentPlayerID), @"repeat": @"cycle"}];
     
     // Update the button status
     [self updateRepeatButton:newRepeatStatus];
@@ -1842,7 +1780,7 @@
             if ([item[@"albumid"] longLongValue] > 0) {
                 [sheetActions addObjectsFromArray:@[LOCALIZED_STR(@"Album Details"), LOCALIZED_STR(@"Album Tracks")]];
             }
-            if ([item[@"artistid"] longLongValue] > 0 || ([item[@"type"] isEqualToString:@"song"] && AppDelegate.instance.serverVersion > 11)) {
+            if ([item[@"artistid"] longLongValue] > 0 || [item[@"type"] isEqualToString:@"song"]) {
                 [sheetActions addObjectsFromArray:@[LOCALIZED_STR(@"Artist Details"), LOCALIZED_STR(@"Artist Albums")]];
             }
             if ([item[@"movieid"] longLongValue] > 0) {
@@ -2054,7 +1992,7 @@
         }
         id objKey = mainFields[@"row6"];
         id obj = [Utilities getNumberFromItem:item[objKey]];
-        if (AppDelegate.instance.serverVersion > 11 && ![parameters[@"disableFilterParameter"] boolValue]) {
+        if (![parameters[@"disableFilterParameter"] boolValue]) {
             if ([objKey isEqualToString:@"artistid"]) {
                 // WORKAROUND due to the lack of the artistid with Playlist.GetItems
                 NSString *artistFrodoWorkaround = [NSString stringWithFormat:@"%@", [item[@"artist"] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -444,10 +444,6 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     [[Utilities getJsonRPC] callMethod:action
                         withParameters:params
                           onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-        // Backwards compatibility for Kodi "Eden" which supports xbmchttp but not JSON API for some commands
-        if ((methodError != nil || error != nil) && command != nil && AppDelegate.instance.serverVersion == 11) {
-            [Utilities sendXbmcHttp:command];
-        }
     }];
 }
 
@@ -581,48 +577,46 @@ static void *TorchRemoteContext = &TorchRemoteContext;
 }
 
 - (void)playerActionVideo:(NSInteger)videoButton actionMusic:(NSInteger)musicButton {
-    if (AppDelegate.instance.serverVersion > 11) {
-        [[Utilities getJsonRPC]
-         callMethod:@"GUI.GetProperties"
-         withParameters:@{@"properties": @[@"currentwindow",
-                                           @"fullscreen"]}
-         onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-             if (error == nil && methodError == nil && [methodResult isKindOfClass:[NSDictionary class]]) {
-                 long winID = 0;
-                 BOOL isFullscreen = NO;
-                 if (methodResult[@"fullscreen"] != [NSNull null]) {
-                     isFullscreen = [methodResult[@"fullscreen"] boolValue];
-                 }
-                 if (methodResult[@"currentwindow"] != [NSNull null]) {
-                     winID = [methodResult[@"currentwindow"][@"id"] longLongValue];
-                 }
-                 if (isFullscreen && (winID == WINDOW_FULLSCREEN_VIDEO || winID == WINDOW_VISUALISATION)) {
-                     [[Utilities getJsonRPC]
-                      callMethod:@"XBMC.GetInfoBooleans"
-                      withParameters:@{@"booleans": @[@"VideoPlayer.HasMenu",
-                                                      @"Pvr.IsPlayingTv"]}
-                      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-                          if (error == nil && methodError == nil && [methodResult isKindOfClass:[NSDictionary class]]) {
-                              BOOL videoPlayerHasMenu = NO;
-                              BOOL pvrIsPlayingTv = NO;
-                              if (methodResult[@"VideoPlayer.HasMenu"] != [NSNull null]) {
-                                  videoPlayerHasMenu = [methodResult[@"VideoPlayer.HasMenu"] boolValue];
-                              }
-                              if (methodResult[@"Pvr.IsPlayingTv"] != [NSNull null]) {
-                                  pvrIsPlayingTv = [methodResult[@"Pvr.IsPlayingTv"] boolValue];
-                              }
-                              if (winID == WINDOW_FULLSCREEN_VIDEO && !pvrIsPlayingTv && !videoPlayerHasMenu) {
-                                  [self processButtonPress:videoButton];
-                              }
-                              else if (winID == WINDOW_VISUALISATION) {
-                                  [self processButtonPress:musicButton];
-                              }
-                          }
-                      }];
-                 }
-             }
-         }];
-    }
+    [[Utilities getJsonRPC]
+     callMethod:@"GUI.GetProperties"
+     withParameters:@{@"properties": @[@"currentwindow",
+                                       @"fullscreen"]}
+     onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+        if (error == nil && methodError == nil && [methodResult isKindOfClass:[NSDictionary class]]) {
+            long winID = 0;
+            BOOL isFullscreen = NO;
+            if (methodResult[@"fullscreen"] != [NSNull null]) {
+                isFullscreen = [methodResult[@"fullscreen"] boolValue];
+            }
+            if (methodResult[@"currentwindow"] != [NSNull null]) {
+                winID = [methodResult[@"currentwindow"][@"id"] longLongValue];
+            }
+            if (isFullscreen && (winID == WINDOW_FULLSCREEN_VIDEO || winID == WINDOW_VISUALISATION)) {
+                [[Utilities getJsonRPC]
+                 callMethod:@"XBMC.GetInfoBooleans"
+                 withParameters:@{@"booleans": @[@"VideoPlayer.HasMenu",
+                                                 @"Pvr.IsPlayingTv"]}
+                 onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
+                    if (error == nil && methodError == nil && [methodResult isKindOfClass:[NSDictionary class]]) {
+                        BOOL videoPlayerHasMenu = NO;
+                        BOOL pvrIsPlayingTv = NO;
+                        if (methodResult[@"VideoPlayer.HasMenu"] != [NSNull null]) {
+                            videoPlayerHasMenu = [methodResult[@"VideoPlayer.HasMenu"] boolValue];
+                        }
+                        if (methodResult[@"Pvr.IsPlayingTv"] != [NSNull null]) {
+                            pvrIsPlayingTv = [methodResult[@"Pvr.IsPlayingTv"] boolValue];
+                        }
+                        if (winID == WINDOW_FULLSCREEN_VIDEO && !pvrIsPlayingTv && !videoPlayerHasMenu) {
+                            [self processButtonPress:videoButton];
+                        }
+                        else if (winID == WINDOW_VISUALISATION) {
+                            [self processButtonPress:musicButton];
+                        }
+                    }
+                }];
+            }
+        }
+    }];
 }
 
 - (void)processButtonPress:(NSInteger)buttonTag {
@@ -713,16 +707,9 @@ static void *TorchRemoteContext = &TorchRemoteContext;
             break;
             
         case TAG_BUTTON_PREVIOUS:
-            if (AppDelegate.instance.serverVersion > 11) {
-                action = @"Player.GoTo";
-                params = @{@"to": @"previous"};
-                [self playerAction:action params:params];
-            }
-            else {
-                action = @"Player.GoPrevious";
-                params = nil;
-                [self playerAction:action params:nil];
-            }
+            action = @"Player.GoTo";
+            params = @{@"to": @"previous"};
+            [self playerAction:action params:params];
             break;
             
         case TAG_BUTTON_STOP:
@@ -732,16 +719,9 @@ static void *TorchRemoteContext = &TorchRemoteContext;
             break;
             
         case TAG_BUTTON_NEXT:
-            if (AppDelegate.instance.serverVersion > 11) {
-                action = @"Player.GoTo";
-                params = @{@"to": @"next"};
-                [self playerAction:action params:params];
-            }
-            else {
-                action = @"Player.GoNext";
-                params = nil;
-                [self playerAction:action params:nil];
-            }
+            action = @"Player.GoTo";
+            params = @{@"to": @"next"};
+            [self playerAction:action params:params];
             break;
         
         case TAG_BUTTON_HOME: // HOME

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -440,13 +440,6 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     }];
 }
 
-- (void)simpleAction:(NSString*)action params:(NSDictionary*)params xbmcHttp:(NSString*)command {
-    [[Utilities getJsonRPC] callMethod:action
-                        withParameters:params
-                          onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
-    }];
-}
-
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
     if (IS_IPAD) {
         // Disable gestures to move the modal remote as this would conflict with the gesture zone
@@ -673,7 +666,8 @@ static void *TorchRemoteContext = &TorchRemoteContext;
             
         case TAG_BUTTON_FULLSCREEN:
             action = @"GUI.SetFullscreen";
-            [self simpleAction:action params:@{@"fullscreen": @"toggle"} xbmcHttp:@"SendKey(0xf009)"];
+            [[Utilities getJsonRPC] callMethod:action
+                                withParameters:@{@"fullscreen": @"toggle"}];
             break;
             
         case TAG_BUTTON_SEEK_BACKWARD:
@@ -731,7 +725,8 @@ static void *TorchRemoteContext = &TorchRemoteContext;
             
         case TAG_BUTTON_INFO: // INFO
             action = @"Input.Info";
-            [self simpleAction:action params:@{} xbmcHttp:@"SendKey(0xF049)"];
+            [[Utilities getJsonRPC] callMethod:action
+                                withParameters:@{}];
             break;
             
         case TAG_BUTTON_SELECT:
@@ -742,7 +737,8 @@ static void *TorchRemoteContext = &TorchRemoteContext;
             
         case TAG_BUTTON_MENU: // MENU OSD
             action = @"Input.ShowOSD";
-            [self simpleAction:action params:@{} xbmcHttp:@"SendKey(0xF04D)"];
+            [[Utilities getJsonRPC] callMethod:action
+                                withParameters:@{}];
             break;
         
         case TAG_BUTTON_SUBTITLES:
@@ -756,27 +752,31 @@ static void *TorchRemoteContext = &TorchRemoteContext;
         case TAG_BUTTON_MUSIC:
             action = @"GUI.ActivateWindow";
             params = @{@"window": @"music"};
-            [self simpleAction:action params:params xbmcHttp:@"ExecBuiltIn&parameter=ActivateWindow(Music)"];
+            [[Utilities getJsonRPC] callMethod:action
+                                withParameters:params];
             break;
             
         case TAG_BUTTON_MOVIES:
             action = @"GUI.ActivateWindow";
             params = @{@"window": @"videos",
                        @"parameters": @[@"MovieTitles"]};
-            [self simpleAction:action params:params xbmcHttp:@"ExecBuiltIn&parameter=ActivateWindow(Videos,MovieTitles)"];
+            [[Utilities getJsonRPC] callMethod:action
+                                withParameters:params];
             break;
         
         case TAG_BUTTON_TVSHOWS:
             action = @"GUI.ActivateWindow";
             params = @{@"window": @"videos",
                        @"parameters": @[@"tvshowtitles"]};
-            [self simpleAction:action params:params xbmcHttp:@"ExecBuiltIn&parameter=ActivateWindow(Videos,tvshowtitles)"];
+            [[Utilities getJsonRPC] callMethod:action
+                                withParameters:params];
             break;
         
         case TAG_BUTTON_PICTURES:
             action = @"GUI.ActivateWindow";
             params = @{@"window": @"pictures"};
-            [self simpleAction:action params:params xbmcHttp:@"ExecBuiltIn&parameter=ActivateWindow(Pictures)"];
+            [[Utilities getJsonRPC] callMethod:action
+                                withParameters:params];
             break;
             
         default:
@@ -813,7 +813,8 @@ static void *TorchRemoteContext = &TorchRemoteContext;
             break;
             
         case TAG_BUTTON_FULLSCREEN:
-            [self simpleAction:@"Input.ExecuteAction" params:@{@"action": @"togglefullscreen"} xbmcHttp:@"Action(199)"];
+            [[Utilities getJsonRPC] callMethod:@"Input.ExecuteAction"
+                                withParameters:@{@"action": @"togglefullscreen"}];
             break;
             
         case TAG_BUTTON_SEEK_BACKWARD: // DECREASE PLAYBACK SPEED
@@ -829,13 +830,15 @@ static void *TorchRemoteContext = &TorchRemoteContext;
                 [[Utilities getJsonRPC] callMethod:@"Input.ExecuteAction" withParameters:@{@"action": @"playerdebug"}];
             }
             else {
-                [self simpleAction:@"Input.ShowCodec" params:@{} xbmcHttp:@"SendKey(0xF04F)"];
+                [[Utilities getJsonRPC] callMethod:@"Input.ShowCodec"
+                                    withParameters:@{}];
             }
             break;
 
         case TAG_BUTTON_SELECT: // CONTEXT MENU
         case TAG_BUTTON_MENU:
-            [self simpleAction:@"Input.ContextMenu" params:@{} xbmcHttp:@"SendKey(0xF043)"];
+            [[Utilities getJsonRPC] callMethod:@"Input.ContextMenu"
+                                withParameters:@{}];
             break;
 
         case TAG_BUTTON_SUBTITLES: // SUBTITLES BUTTON
@@ -844,9 +847,8 @@ static void *TorchRemoteContext = &TorchRemoteContext;
                                     withParameters:@{@"window": @"subtitlesearch"}];
             }
             else {
-                [self simpleAction:@"Addons.ExecuteAddon"
-                            params:@{@"addonid": @"script.xbmc.subtitles"}
-                          xbmcHttp:@"ExecBuiltIn&parameter=RunScript(script.xbmc.subtitles)"];
+                [[Utilities getJsonRPC] callMethod:@"Addons.ExecuteAddon"
+                                    withParameters:@{@"addonid": @"script.xbmc.subtitles"}];
             }
             break;
             

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -74,7 +74,7 @@
         if (resumePointDict && [resumePointDict isKindOfClass:[NSDictionary class]]) {
             float position = [Utilities getFloatValueFromItem:resumePointDict[@"position"]];
             float total = [Utilities getFloatValueFromItem:resumePointDict[@"total"]];
-            if (position > 0 && total > 0 && [VersionCheck hasPlayerOpenOptions]) {
+            if (position > 0 && total > 0) {
                 [sheetActions addObject:LOCALIZED_STR_ARGS(@"Resume from %@", [Utilities convertTimeFromSeconds:@(position)])];
             }
         }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -261,7 +261,7 @@
         chosenMenuItem = menuItem.subItem;
         chosenMenuItem.mainLabel = [NSString stringWithFormat:@"%@", item[@"label"]];
     }
-    else if ([item[@"family"] isEqualToString:@"movieid"] && AppDelegate.instance.serverVersion > 11) {
+    else if ([item[@"family"] isEqualToString:@"movieid"]) {
         if ([sender isKindOfClass:[NSString class]]) {
             NSString *actorName = (NSString*)sender;
             activeTab = 2;
@@ -272,7 +272,7 @@
             chosenMenuItem.mainLabel = actorName;
         }
     }
-    else if (([item[@"family"] isEqualToString:@"episodeid"] || [item[@"family"] isEqualToString:@"tvshowid"]) && AppDelegate.instance.serverVersion > 11) {
+    else if (([item[@"family"] isEqualToString:@"episodeid"] || [item[@"family"] isEqualToString:@"tvshowid"])) {
         if ([sender isKindOfClass:[NSString class]]) {
             NSString *actorName = (NSString*)sender;
             activeTab = 0;
@@ -304,7 +304,7 @@
             obj = movieObj;
             objKey = movieObjKey;
         }
-        else if (AppDelegate.instance.serverVersion > 11 && ![parameters[@"disableFilterParameter"] boolValue]) {
+        else if (![parameters[@"disableFilterParameter"] boolValue]) {
             obj = [NSDictionary dictionaryWithObjectsAndKeys:obj, objKey, nil];
             objKey = @"filter";
         }
@@ -1498,7 +1498,7 @@
 }
 
 - (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
-    if (AppDelegate.instance.serverVersion > 11 && ![self isModal]) {
+    if (![self isModal]) {
         UIImage *image = [[UIImage imageNamed:@"table_arrow_right"] colorizeWithColor:ICON_TINT_COLOR];
         cell.accessoryView = [[UIImageView alloc] initWithImage:image];
         cell.accessoryView.alpha = ARROW_ALPHA;
@@ -1509,7 +1509,7 @@
 }
 
 - (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath {
-    if (AppDelegate.instance.serverVersion > 11 && ![self isModal] && castList.count > indexPath.row) {
+    if (![self isModal] && castList.count > indexPath.row) {
         [self showContent:castList[indexPath.row][@"name"]];
     }
 }

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -328,7 +328,6 @@
                                               @([parameters[@"enableCollectionView"] boolValue]), @"enableCollectionView",
                                               parameters[@"itemSizes"] ?: @{}, @"itemSizes",
                                               parameters[@"extra_info_parameters"], @"extra_info_parameters",
-                                              @([parameters[@"FrodoExtraArt"] boolValue]), @"FrodoExtraArt",
                                               @([parameters[@"enableLibraryCache"] boolValue]), @"enableLibraryCache",
                                               @([parameters[@"collectionViewRecentlyAdded"] boolValue]), @"collectionViewRecentlyAdded",
                                               newSectionParameters, @"extra_section_parameters",

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -713,12 +713,12 @@
 }
 
 + (int)getSec2Min:(BOOL)convert {
-    return (AppDelegate.instance.serverVersion > 11 && convert) ? 60 : 1;
+    return convert ? 60 : 1;
 }
 
 + (NSString*)getImageServerURL {
     GlobalData *obj = [GlobalData getInstance];
-    NSString *stringFormat = (AppDelegate.instance.serverVersion > 11) ? @"%@:%@/image/" : @"%@:%@/vfs/";
+    NSString *stringFormat = @"%@:%@/image/";
     return [NSString stringWithFormat:stringFormat, obj.serverIP, obj.serverPort];
 }
 

--- a/XBMC Remote/VersionCheck.h
+++ b/XBMC Remote/VersionCheck.h
@@ -20,7 +20,6 @@
 + (BOOL)hasAlbumArtistOnlySupport;
 + (BOOL)hasInputButtonEventSupport;
 + (BOOL)hasPlayUsingSupport;
-+ (BOOL)hasPlayerOpenOptions;
 + (BOOL)hasProfilesSupport;
 
 @end

--- a/XBMC Remote/VersionCheck.h
+++ b/XBMC Remote/VersionCheck.h
@@ -17,7 +17,6 @@
 + (BOOL)hasShowEmptyTvShowsSupport;
 + (BOOL)hasSortTokenReadSupport;
 + (BOOL)hasPvrSortSupport;
-+ (BOOL)hasAlbumArtistOnlySupport;
 + (BOOL)hasInputButtonEventSupport;
 + (BOOL)hasPlayUsingSupport;
 + (BOOL)hasProfilesSupport;

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -61,11 +61,6 @@
     return AppDelegate.instance.serverVersion >= 21;
 }
 
-+ (BOOL)hasPlayerOpenOptions {
-    // "options" for Player.Open were introduced with Kodi 12. This is required to support resume.
-    return YES;
-}
-
 + (BOOL)hasProfilesSupport {
     // Profiles methods are supported from API 8 on
     return AppDelegate.instance.APImajorVersion >= 8;

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -63,7 +63,7 @@
 
 + (BOOL)hasPlayerOpenOptions {
     // "options" for Player.Open were introduced with Kodi 12. This is required to support resume.
-    return AppDelegate.instance.serverVersion > 11;
+    return YES;
 }
 
 + (BOOL)hasProfilesSupport {

--- a/XBMC Remote/VersionCheck.m
+++ b/XBMC Remote/VersionCheck.m
@@ -43,11 +43,6 @@
     return (AppDelegate.instance.APImajorVersion == 12 && AppDelegate.instance.APIminorVersion >= 1) || AppDelegate.instance.APImajorVersion > 12;
 }
 
-+ (BOOL)hasAlbumArtistOnlySupport {
-    // "albumartistonly" parameter is supported from API 4.0.0 on
-    return AppDelegate.instance.APImajorVersion >= 4;
-}
-
 + (BOOL)hasInputButtonEventSupport {
     // Input.ButtonEvent is supported from API 12 on
     return AppDelegate.instance.APImajorVersion >= 12;

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -105,7 +105,7 @@
              if (error == nil && methodError == nil && [methodResult isKindOfClass:[NSDictionary class]]) {
                  if (methodResult[@"currentwindow"] != [NSNull null]) {
                      if ([methodResult[@"currentwindow"][@"id"] longLongValue] == WINDOW_VIRTUAL_KEYBOARD) {
-                         [self simpleAction:@"Input.Back" params:@{}];
+                         [[Utilities getJsonRPC] callMethod:@"Input.Back" withParameters:@{}];
                      }
                  }
              }
@@ -188,7 +188,8 @@
         }
     }
     stringToSend = stringToSend ?: @"";
-    [self simpleAction:@"Input.SendText" params:@{@"text": stringToSend, @"done": @(inputFinished)}];
+    [[Utilities getJsonRPC] callMethod:@"Input.SendText"
+                        withParameters:@{@"text": stringToSend, @"done": @(inputFinished)}];
     return YES;
 }
 
@@ -196,12 +197,6 @@
     if (textField.tag == VIRTUAL_KEYBOARD_TEXTFIELD) {
         [self performSelectorOnMainThread:@selector(hideKeyboard) withObject:nil waitUntilDone:NO];
     }
-}
-
-#pragma mark - JSON commands
-
-- (void)simpleAction:(NSString*)action params:(NSDictionary*)params {
-    [[Utilities getJsonRPC] callMethod:action withParameters:params];
 }
 
 @end

--- a/XBMC Remote/XBMCVirtualKeyboard.m
+++ b/XBMC Remote/XBMCVirtualKeyboard.m
@@ -121,9 +121,6 @@
 }
 
 - (void)showKeyboard:(NSNotification*)note {
-    if (AppDelegate.instance.serverVersion == 11) {
-        backgroundTextField.text = @" ";
-    }
     NSDictionary *params;
     if (note != nil) {
         NSDictionary *theData = note.userInfo;
@@ -178,40 +175,21 @@
 }
 
 - (BOOL)textField:(UITextField*)theTextField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString*)string {
-    if (AppDelegate.instance.serverVersion == 11) {
-        if (range.location == 0) { //BACKSPACE
-            [Utilities sendXbmcHttp:@"SendKey(0xf108)"];
+    BOOL inputFinished = NO;
+    NSString *stringToSend = [theTextField.text stringByReplacingCharactersInRange:range withString:string];
+    if (string.length != 0) {
+        unichar x = [string characterAtIndex:0];
+        if (x == '\n') {
+            stringToSend = [stringToSend substringToIndex:stringToSend.length - 1];
+            [backgroundTextField resignFirstResponder];
+            [xbmcVirtualKeyboard resignFirstResponder];
+            theTextField.text = @"";
+            inputFinished = YES;
         }
-        else { // CHARACTER
-            unichar x = [string characterAtIndex:0];
-            if (x == '\n') {
-                [self simpleAction:@"Input.Select" params:@{}];
-                [backgroundTextField resignFirstResponder];
-                [xbmcVirtualKeyboard resignFirstResponder];
-            }
-            else if (x < 1000) {
-                [Utilities sendXbmcHttp:[NSString stringWithFormat:@"SendKey(0xf1%x)", x]];
-            }
-        }
-        return NO;
     }
-    else {
-        BOOL inputFinished = NO;
-        NSString *stringToSend = [theTextField.text stringByReplacingCharactersInRange:range withString:string];
-        if (string.length != 0) {
-            unichar x = [string characterAtIndex:0];
-            if (x == '\n') {
-                stringToSend = [stringToSend substringToIndex:stringToSend.length - 1];
-                [backgroundTextField resignFirstResponder];
-                [xbmcVirtualKeyboard resignFirstResponder];
-                theTextField.text = @"";
-                inputFinished = YES;
-            }
-        }
-        stringToSend = stringToSend ?: @"";
-        [self simpleAction:@"Input.SendText" params:@{@"text": stringToSend, @"done": @(inputFinished)}];
-        return YES;
-    }
+    stringToSend = stringToSend ?: @"";
+    [self simpleAction:@"Input.SendText" params:@{@"text": stringToSend, @"done": @(inputFinished)}];
+    return YES;
 }
 
 - (void)textFieldDidEndEditing:(UITextField*)textField {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
As discussed [in this review comment](https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1378#discussion_r3566798352) it is beneficial for the maintainability of this app to remove support for outdated Kodi versions, which are anyway hard or (for me) impossible to verify. This PR removes special handling which was introduced to handle Kodi version 11 (Eden). Most of the Kodi version related conditions can be removed by this.

Simple applied logic:
- treat `AppDelegate.instance.serverVersion > 11` as `YES`
- treat `AppDelegate.instance.serverVersion <= 11` as `NO`
- treat `AppDelegate.instance.serverVersion == 11` as `NO`
- treat `AppDelegate.instance.APImajorVersion >= 4` as `YES`

In addition
- remove the key `"FrodoExtraArt"` and instead place the key `"art"` directly in the JSON request's parameters
- remove the `simpleAction` helper methods as they do not do not add any value anymore

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Remove support for outdated Kodi 11 (Eden)