### PR TITLE
Maintenance: Remove obsolete assignments

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3885,8 +3885,6 @@
     int activeTab = [self getActiveTab:item];
     NSDictionary *mainFields = menuItem.mainFields[activeTab];
     NSMutableDictionary *parameters = menuItem.subItem.mainParameters[activeTab];
-    NSNumber *libraryRowHeight = parameters[@"rowHeight"] ?: @(menuItem.subItem.rowHeight);
-    NSNumber *libraryThumbWidth = parameters[@"thumbWidth"] ?: @(menuItem.subItem.thumbWidth);
     NSNumber *filemodeRowHeight = parameters[@"rowHeight"] ?: @FILEMODE_ROW_HEIGHT;
     NSNumber *filemodeThumbWidth = parameters[@"thumbWidth"] ?: @FILEMODE_THUMB_WIDTH;
     NSMutableArray *mutableProperties = [parameters[@"parameters"][@"file_properties"] mutableCopy];
@@ -3900,8 +3898,6 @@
                                            parameters[@"parameters"][@"sort"], @"sort",
                                            mutableProperties, @"file_properties",
                                            nil], @"parameters",
-                                          libraryRowHeight, @"rowHeight",
-                                          libraryThumbWidth, @"thumbWidth",
                                           parameters[@"label"], @"label",
                                           @"nocover_filemode", @"defaultThumb",
                                           filemodeRowHeight, @"rowHeight",


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Both `"rowHeight"` and `"thumbWidth"` are overwritten directly a few lines later. This also makes the variables `libraryRowHeight` and `libraryThumbWidth` unused.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Remove obsolete assignments