### PR TITLE
Improvement: Avoid memory leak and potential crash in Wake-On-LAN

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -294,6 +294,16 @@
                 NSLog(@"CFSocketSendData error: %li", CFSocketSendData_error);
             }
         }
+        
+        // Clean up memory
+        if (message_data) {
+            CFRelease(message_data);
+        }
+        if (destinationAddressData) {
+            CFRelease(destinationAddressData);
+        }
+        CFSocketInvalidate(WOLsocket);
+        CFRelease(WOLsocket);
     }
 }
 

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -288,10 +288,11 @@
         CFDataRef message_data = CFDataCreate(NULL, (unsigned char*)&message, sizeof(message));
         CFDataRef destinationAddressData = CFDataCreate(NULL, (const UInt8*)&addr, sizeof(addr));
         
-        CFSocketError CFSocketSendData_error = CFSocketSendData(WOLsocket, destinationAddressData, message_data, 30);
-        
-        if (CFSocketSendData_error) {
-            NSLog(@"CFSocketSendData error: %li", CFSocketSendData_error);
+        if (message_data) {
+            CFSocketError CFSocketSendData_error = CFSocketSendData(WOLsocket, destinationAddressData, message_data, 30);
+            if (CFSocketSendData_error) {
+                NSLog(@"CFSocketSendData error: %li", CFSocketSendData_error);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses findings of an AI code review. 
1. Only call `CFSocketSendData` with non-`NULL` parameters
2. Release `CFData` and `CFSocket` once Wake-On-LAN signal was sent

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Avoid memory leak and potential crash in Wake-On-LAN