### PR TITLE
Improvement: Proper release of inStream and related CFReadStream instance

### DIFF
--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -89,8 +89,7 @@ NSInputStream *inStream;
 
 - (void)stopNetworkCommunication {
     AppDelegate.instance.serverTCPConnectionOpen = NO;
-    NSStreamStatus current_status = [inStream streamStatus];
-    if (current_status == NSStreamStatusOpen) {
+    if (inStream) {
         [inStream close];
         [inStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
         inStream.delegate = nil;

--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -76,7 +76,7 @@ NSInputStream *inStream;
     }
     CFReadStreamRef readStream;
     CFStreamCreatePairWithSocketToHost(NULL, (CFStringRef)CFBridgingRetain(server), port, &readStream, NULL);
-    inStream = (__bridge NSInputStream*)readStream;
+    inStream = CFBridgingRelease(readStream);
     inStream.delegate = self;
     [inStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     [inStream open];

--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -85,8 +85,7 @@ NSInputStream *inStream;
 
 - (void)stopNetworkCommunication {
     AppDelegate.instance.serverTCPConnectionOpen = NO;
-    NSStreamStatus current_status = [inStream streamStatus];
-    if (current_status == NSStreamStatusOpen) {
+    if (inStream) {
         [inStream close];
         [inStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
         inStream.delegate = nil;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses comments given from AI based code review.
1. In `stopNetworkCommunication` the stream `inStream` should be correctly disabled and released independent of its state.
2. In `startNetworkCommunicationWithServer` the stream `readStream` and its release should be handed off to ARC, avoiding memory leak (missing release) once a new stream is assigned by next call of `startNetworkCommunicationWithServer`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Proper release of inStream and related CFReadStream instance