### PR TITLE
Improvement: Rework local network access discovery

### DIFF
--- a/XBMC Remote/LocalNetwork/LocalNetworkAccess.m
+++ b/XBMC Remote/LocalNetwork/LocalNetworkAccess.m
@@ -10,16 +10,17 @@
 
 @import UIKit;
 
-/* Implementation taken from stackoverflow
+/* Implementation inspired by stackoverflow
  * https://stackoverflow.com/questions/67058134/objective-c-ios-14-how-to-do-network-privacy-permission-check
  */
+
+#define DISCOVERY_TIMEOUT 5.0
 
 @interface LocalNetworkAccess () <NSNetServiceDelegate>
 
 @property (nonatomic) NSNetService *service;
 @property (nonatomic) void (^completion)(BOOL);
 @property (nonatomic) NSTimer *timer;
-@property (nonatomic) BOOL publishing;
 
 @end
 
@@ -39,29 +40,29 @@
 - (void)checkAccessState:(void (^)(BOOL))completion {
     self.completion = completion;
     
-    self.timer = [NSTimer scheduledTimerWithTimeInterval:2 repeats:YES block:^(NSTimer * _Nonnull timer) {
+    self.service.delegate = self;
+    [self.service publish];
+    
+    self.timer = [NSTimer scheduledTimerWithTimeInterval:DISCOVERY_TIMEOUT repeats:NO block:^(NSTimer * _Nonnull timer) {
         if (UIApplication.sharedApplication.applicationState != UIApplicationStateActive) {
             return;
         }
         
-        if (self.publishing) {
-            [self.timer invalidate];
-            self.completion(NO);
-        }
-        else {
-            self.publishing = YES;
-            self.service.delegate = self;
-            [self.service publish];
-        }
+        // Discovery timed out, report failure.
+        [self endDiscoveryWithSuccess:NO];
     }];
 }
 
+- (void)endDiscoveryWithSuccess:(BOOL)success {
+    [self.timer invalidate];
+    [self.service stop];
+    self.completion(success);
+}
 
 #pragma mark - NSNetServiceDelegate
 
 - (void)netServiceDidPublish:(NSNetService *)sender {
-    [self.timer invalidate];
-    self.completion(YES);
+    [self endDiscoveryWithSuccess:YES];
 }
 
 @end


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses findings of an AI code review. Increase the timeout for the local network access discovery to avoid a false negative result. Also stop the service after coming to a result.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Rework local network access discovery