### PR TITLE
Improvement: Rework view preference

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -327,7 +327,7 @@
 
 #pragma mark - Library disk cache management
 
-- (NSString*)getCacheKey:(NSString*)fieldA parameters:(NSMutableDictionary*)fieldB {
+- (NSString*)getCacheKey:(NSString*)method parameters:(NSMutableDictionary*)params {
     // Which server are we connected to?
     GlobalData *obj = [GlobalData getInstance];
     NSString *serverInfo = [NSString stringWithFormat:@"%@ %@ %@", obj.serverIP, obj.serverPort, obj.serverDescription];
@@ -339,7 +339,7 @@
     NSString *appVersion = [Utilities getAppVersionString];
     
     // Which JSON request's results do we cache??
-    NSString *jsonRequest = [NSString stringWithFormat:@"%@ %@", fieldA, fieldB];
+    NSString *jsonRequest = [NSString stringWithFormat:@"%@ %@", method, params];
     
     // Get SHA256 hash for the combination given above
     NSString *text = [NSString stringWithFormat:@"%@%@%@%@", serverInfo, serverVersion, appVersion, jsonRequest];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -327,7 +327,7 @@
 
 #pragma mark - Library disk cache management
 
-- (NSString*)getCacheKey:(NSString*)method parameters:(NSMutableDictionary*)params {
+- (NSString*)getCacheKey:(NSString*)method parameters:(NSDictionary*)params {
     // Which server are we connected to?
     GlobalData *obj = [GlobalData getInstance];
     NSString *serverInfo = [NSString stringWithFormat:@"%@ %@ %@", obj.serverIP, obj.serverPort, obj.serverDescription];
@@ -346,14 +346,14 @@
     return [text SHA256String];
 }
 
-- (void)saveData:(NSMutableDictionary*)mutableParameters {
+- (void)saveData:(NSDictionary*)parameters {
     if (!enableDiskCache) {
         return;
     }
-    if (mutableParameters != nil) {
+    if (parameters != nil) {
         MainMenu *menuItem = self.detailItem;
         NSDictionary *methods = menuItem.mainMethod[chosenTab];
-        NSString *viewKey = [self getCacheKey:methods[@"method"] parameters:mutableParameters];
+        NSString *viewKey = [self getCacheKey:methods[@"method"] parameters:parameters];
         
         NSString *filename = [NSString stringWithFormat:@"%@.richResults.dat", viewKey];
         [Utilities archivePath:libraryCachePath file:filename data:self.richResults];
@@ -373,7 +373,7 @@
     self.extraSectionRichResults = nil;
     self.sections = [NSMutableDictionary new];
     
-    NSString *viewKey = [self getCacheKey:params[@"methodToCall"] parameters:params[@"mutableParameters"]];
+    NSString *viewKey = [self getCacheKey:params[@"methodToCall"] parameters:params[@"parametersToCall"]];
     NSString *filename = [NSString stringWithFormat:@"%@.richResults.dat", viewKey];
     NSMutableArray *tempArray = [Utilities unarchivePath:libraryCachePath file:filename];
     self.richResults = tempArray;
@@ -386,20 +386,20 @@
     [self performSelectorOnMainThread:@selector(indexAndDisplayData) withObject:nil waitUntilDone:YES];
 }
 
-- (BOOL)loadedDataFromDisk:(NSString*)methodToCall parameters:(NSMutableDictionary*)mutableParameters refresh:(BOOL)forceRefresh {
+- (BOOL)loadedDataFromDisk:(NSString*)methodToCall parameters:(NSDictionary*)parameters refresh:(BOOL)forceRefresh {
     if (forceRefresh) {
         return NO;
     }
     if (!enableDiskCache) {
         return NO;
     }
-    NSString *viewKey = [self getCacheKey:methodToCall parameters:mutableParameters];
+    NSString *viewKey = [self getCacheKey:methodToCall parameters:parameters];
     NSString *filename = [NSString stringWithFormat:@"%@.richResults.dat", viewKey];
     NSString *path = [libraryCachePath stringByAppendingPathComponent:filename];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     if ([fileManager fileExistsAtPath:path]) {
         NSDictionary *extraParams = [NSDictionary dictionaryWithObjectsAndKeys:
-                                     mutableParameters, @"mutableParameters",
+                                     parameters, @"parametersToCall",
                                      methodToCall, @"methodToCall",
                                      nil];
         [self updateSyncDate:path];
@@ -4352,7 +4352,7 @@
         
         // Save and display
         MainMenu *menuItem = self.detailItem;
-        NSMutableDictionary *parameters = [menuItem.mainParameters[chosenTab] mutableCopy];
+        NSMutableDictionary *parameters = menuItem.mainParameters[chosenTab];
         [self saveData:parameters];
         [self indexAndDisplayData];
         return;
@@ -4698,7 +4698,7 @@
      }];
 }
 
-- (void)saveAndShowResultsRefresh:(BOOL)forceRefresh params:(NSMutableDictionary*)mutableParameters {
+- (void)saveAndShowResultsRefresh:(BOOL)forceRefresh params:(NSDictionary*)parameters {
     if (forceRefresh) {
         [self stopPullToRefreshViewAnimation];
     }
@@ -4707,12 +4707,12 @@
         filterModeType == ViewModeListened ||
         filterModeType == ViewModeNotListened) {
         if (forceRefresh) {
-            [self saveData:mutableParameters];
+            [self saveData:parameters];
         }
         [self changeViewMode:filterModeType forceRefresh:forceRefresh];
     }
     else {
-        [self saveData:mutableParameters];
+        [self saveData:parameters];
         [self indexAndDisplayData];
     }
 }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -431,6 +431,18 @@
 
 #pragma mark - Utility
 
+- (NSString*)getViewPreferenceKeyFromTemplate:(NSString*)template method:(NSString*)method parameters:(NSDictionary*)params {
+    // View's preference shall be independent of the active filter (e.g. Genre > Pop). So remove the filter specifics.
+    NSMutableDictionary *tmpJsonParams = [params mutableCopy];
+    if (params[@"parameters"][@"filter"] != nil) {
+        NSMutableDictionary *tmpParameters = [params[@"parameters"] mutableCopy];
+        [tmpParameters removeObjectForKey:@"filter"];
+        tmpJsonParams[@"parameters"] = tmpParameters;
+    }
+    NSString *key = [NSString stringWithFormat:template, [self getCacheKey:method parameters:tmpJsonParams]];
+    return key;
+}
+
 - (void)updateTimerIcon:(NSDictionary*)item {
     id cell = [self getCell:selectedIndexPath];
     NSNumber *status = @(![item[@"isrecording"] boolValue]);
@@ -3330,7 +3342,9 @@
 - (void)saveSortMethod:(NSString*)sortMethod parameters:(NSDictionary*)parameters {
     MainMenu *menuItem = self.detailItem;
     NSDictionary *methods = menuItem.mainMethod[chosenTab];
-    NSString *sortKey = [NSString stringWithFormat:@"%@_sort_method", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
+    NSString *sortKey = [self getViewPreferenceKeyFromTemplate:@"%@_sort_method"
+                                                        method:methods[@"method"]
+                                                    parameters:parameters];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [userDefaults setObject:sortMethod forKey:sortKey];
 }
@@ -3338,7 +3352,9 @@
 - (void)saveSortAscDesc:(NSString*)sortAscDescSave parameters:(NSDictionary*)parameters {
     MainMenu *menuItem = self.detailItem;
     NSDictionary *methods = menuItem.mainMethod[chosenTab];
-    NSString *sortKey = [NSString stringWithFormat:@"%@_sort_ascdesc", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
+    NSString *sortKey = [self getViewPreferenceKeyFromTemplate:@"%@_sort_ascdesc"
+                                                        method:methods[@"method"]
+                                                    parameters:parameters];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [userDefaults setObject:sortAscDescSave forKey:sortKey];
 }
@@ -5311,18 +5327,17 @@
     MainMenu *menuItem = self.detailItem;
     NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     NSDictionary *methods = menuItem.mainMethod[chosenTab];
-    NSMutableDictionary *tempDict = [NSMutableDictionary dictionaryWithDictionary:parameters[@"parameters"]];
-    if (tempDict[@"filter"] != nil) {
-        [tempDict removeObjectForKey:@"filter"];
-        tempDict[@"filtered"] = @"YES";
-    }
-    NSString *viewKey = [NSString stringWithFormat:@"%@_grid_preference", [self getCacheKey:methods[@"method"] parameters:tempDict]];
+    NSString *viewKey = [self getViewPreferenceKeyFromTemplate:@"%@_grid_preference"
+                                                        method:methods[@"method"]
+                                                    parameters:parameters];
     return ([parameters[@"enableCollectionView"] boolValue] && [userDefaults boolForKey:viewKey]);
 }
 
 - (NSString*)getCurrentSortMethod:(NSDictionary*)methods withParameters:(NSDictionary*)parameters {
     NSString *sortMethod = parameters[@"parameters"][@"sort"][@"method"];
-    NSString *sortKey = [NSString stringWithFormat:@"%@_sort_method", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
+    NSString *sortKey = [self getViewPreferenceKeyFromTemplate:@"%@_sort_method"
+                                                        method:methods[@"method"]
+                                                    parameters:parameters];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     if ([userDefaults objectForKey:sortKey] != nil) {
         sortMethod = [userDefaults objectForKey:sortKey];
@@ -5490,7 +5505,9 @@
 
 - (NSString*)getCurrentSortAscDesc:(NSDictionary*)methods withParameters:(NSDictionary*)parameters {
     NSString *sortAscDescSaved = parameters[@"parameters"][@"sort"][@"order"];
-    NSString *sortKey = [NSString stringWithFormat:@"%@_sort_ascdesc", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
+    NSString *sortKey = [self getViewPreferenceKeyFromTemplate:@"%@_sort_ascdesc"
+                                                        method:methods[@"method"]
+                                                    parameters:parameters];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     if ([userDefaults objectForKey:sortKey] != nil) {
         sortAscDescSaved = [userDefaults objectForKey:sortKey];
@@ -5831,12 +5848,9 @@
     NSDictionary *methods = menuItem.mainMethod[chosenTab];
     NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     if ([self collectionViewCanBeEnabled] && self.view.superview != nil && ![methods[@"method"] isEqualToString:@""]) {
-        NSMutableDictionary *tempDict = [NSMutableDictionary dictionaryWithDictionary:parameters[@"parameters"]];
-        if (tempDict[@"filter"] != nil) {
-            [tempDict removeObjectForKey:@"filter"];
-            tempDict[@"filtered"] = @"YES";
-        }
-        NSString *viewKey = [NSString stringWithFormat:@"%@_grid_preference", [self getCacheKey:methods[@"method"] parameters:tempDict]];
+        NSString *viewKey = [self getViewPreferenceKeyFromTemplate:@"%@_grid_preference"
+                                                            method:methods[@"method"]
+                                                        parameters:parameters];
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
         [userDefaults setBool:![userDefaults boolForKey:viewKey] forKey:viewKey];
         [self setGridListButtonImage:!enableCollectionView];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -429,6 +429,18 @@
 
 #pragma mark - Utility
 
+- (NSString*)getViewPreferenceKey:(NSString*)template method:(NSString*)method parameters:(NSDictionary*)params {
+    // View's preference shall be independent of the active filter (e.g. Genre > Pop). So remove the filter specifics.
+    NSMutableDictionary *tmpJsonParams = [params mutableCopy];
+    NSMutableDictionary *tmpParameters = [params[@"parameters"] mutableCopy];
+    if (tmpParameters[@"filter"] != nil) {
+        [tmpParameters removeObjectForKey:@"filter"];
+        tmpJsonParams[@"parameters"] = tmpParameters;
+    }
+    NSString *key = [NSString stringWithFormat:template, [self getCacheKey:method parameters:tmpJsonParams]];
+    return key;
+}
+
 - (void)updateTimerIcon:(NSDictionary*)item {
     id cell = [self getCell:selectedIndexPath];
     NSNumber *status = @(![item[@"isrecording"] boolValue]);
@@ -3328,7 +3340,9 @@
 - (void)saveSortMethod:(NSString*)sortMethod parameters:(NSDictionary*)parameters {
     MainMenu *menuItem = self.detailItem;
     NSDictionary *methods = menuItem.mainMethod[chosenTab];
-    NSString *sortKey = [NSString stringWithFormat:@"%@_sort_method", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
+    NSString *sortKey = [self getViewPreferenceKey:@"%@_sort_method"
+                                            method:methods[@"method"]
+                                        parameters:parameters];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [userDefaults setObject:sortMethod forKey:sortKey];
 }
@@ -3336,7 +3350,9 @@
 - (void)saveSortAscDesc:(NSString*)sortAscDescSave parameters:(NSDictionary*)parameters {
     MainMenu *menuItem = self.detailItem;
     NSDictionary *methods = menuItem.mainMethod[chosenTab];
-    NSString *sortKey = [NSString stringWithFormat:@"%@_sort_ascdesc", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
+    NSString *sortKey = [self getViewPreferenceKey:@"%@_sort_ascdesc"
+                                            method:methods[@"method"]
+                                        parameters:parameters];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     [userDefaults setObject:sortAscDescSave forKey:sortKey];
 }
@@ -5309,18 +5325,17 @@
     MainMenu *menuItem = self.detailItem;
     NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     NSDictionary *methods = menuItem.mainMethod[chosenTab];
-    NSMutableDictionary *tempDict = [NSMutableDictionary dictionaryWithDictionary:parameters[@"parameters"]];
-    if (tempDict[@"filter"] != nil) {
-        [tempDict removeObjectForKey:@"filter"];
-        tempDict[@"filtered"] = @"YES";
-    }
-    NSString *viewKey = [NSString stringWithFormat:@"%@_grid_preference", [self getCacheKey:methods[@"method"] parameters:tempDict]];
+    NSString *viewKey = [self getViewPreferenceKey:@"%@_grid_preference"
+                                            method:methods[@"method"]
+                                        parameters:parameters];
     return ([parameters[@"enableCollectionView"] boolValue] && [userDefaults boolForKey:viewKey]);
 }
 
 - (NSString*)getCurrentSortMethod:(NSDictionary*)methods withParameters:(NSDictionary*)parameters {
     NSString *sortMethod = parameters[@"parameters"][@"sort"][@"method"];
-    NSString *sortKey = [NSString stringWithFormat:@"%@_sort_method", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
+    NSString *sortKey = [self getViewPreferenceKey:@"%@_sort_method"
+                                            method:methods[@"method"]
+                                        parameters:parameters];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     if ([userDefaults objectForKey:sortKey] != nil) {
         sortMethod = [userDefaults objectForKey:sortKey];
@@ -5488,7 +5503,9 @@
 
 - (NSString*)getCurrentSortAscDesc:(NSDictionary*)methods withParameters:(NSDictionary*)parameters {
     NSString *sortAscDescSaved = parameters[@"parameters"][@"sort"][@"order"];
-    NSString *sortKey = [NSString stringWithFormat:@"%@_sort_ascdesc", [self getCacheKey:methods[@"method"] parameters:[parameters mutableCopy]]];
+    NSString *sortKey = [self getViewPreferenceKey:@"%@_sort_ascdesc"
+                                            method:methods[@"method"]
+                                        parameters:parameters];
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     if ([userDefaults objectForKey:sortKey] != nil) {
         sortAscDescSaved = [userDefaults objectForKey:sortKey];
@@ -5829,12 +5846,9 @@
     NSDictionary *methods = menuItem.mainMethod[chosenTab];
     NSDictionary *parameters = menuItem.mainParameters[chosenTab];
     if ([self collectionViewCanBeEnabled] && self.view.superview != nil && ![methods[@"method"] isEqualToString:@""]) {
-        NSMutableDictionary *tempDict = [NSMutableDictionary dictionaryWithDictionary:parameters[@"parameters"]];
-        if (tempDict[@"filter"] != nil) {
-            [tempDict removeObjectForKey:@"filter"];
-            tempDict[@"filtered"] = @"YES";
-        }
-        NSString *viewKey = [NSString stringWithFormat:@"%@_grid_preference", [self getCacheKey:methods[@"method"] parameters:tempDict]];
+        NSString *viewKey = [self getViewPreferenceKey:@"%@_grid_preference"
+                                                method:methods[@"method"]
+                                            parameters:parameters];
         NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
         [userDefaults setBool:![userDefaults boolForKey:viewKey] forKey:viewKey];
         [self setGridListButtonImage:!enableCollectionView];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -325,7 +325,7 @@
 
 #pragma mark - Library disk cache management
 
-- (NSString*)getCacheKey:(NSString*)fieldA parameters:(NSMutableDictionary*)fieldB {
+- (NSString*)getCacheKey:(NSString*)method parameters:(NSMutableDictionary*)params {
     // Which server are we connected to?
     GlobalData *obj = [GlobalData getInstance];
     NSString *serverInfo = [NSString stringWithFormat:@"%@ %@ %@", obj.serverIP, obj.serverPort, obj.serverDescription];
@@ -337,7 +337,7 @@
     NSString *appVersion = [Utilities getAppVersionString];
     
     // Which JSON request's results do we cache??
-    NSString *jsonRequest = [NSString stringWithFormat:@"%@ %@", fieldA, fieldB];
+    NSString *jsonRequest = [NSString stringWithFormat:@"%@ %@", method, params];
     
     // Get SHA256 hash for the combination given above
     NSString *text = [NSString stringWithFormat:@"%@%@%@%@", serverInfo, serverVersion, appVersion, jsonRequest];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -325,7 +325,7 @@
 
 #pragma mark - Library disk cache management
 
-- (NSString*)getCacheKey:(NSString*)method parameters:(NSMutableDictionary*)params {
+- (NSString*)getCacheKey:(NSString*)method parameters:(NSDictionary*)params {
     // Which server are we connected to?
     GlobalData *obj = [GlobalData getInstance];
     NSString *serverInfo = [NSString stringWithFormat:@"%@ %@ %@", obj.serverIP, obj.serverPort, obj.serverDescription];
@@ -344,14 +344,14 @@
     return [text SHA256String];
 }
 
-- (void)saveData:(NSMutableDictionary*)mutableParameters {
+- (void)saveData:(NSDictionary*)parameters {
     if (!enableDiskCache) {
         return;
     }
-    if (mutableParameters != nil) {
+    if (parameters != nil) {
         MainMenu *menuItem = self.detailItem;
         NSDictionary *methods = menuItem.mainMethod[chosenTab];
-        NSString *viewKey = [self getCacheKey:methods[@"method"] parameters:mutableParameters];
+        NSString *viewKey = [self getCacheKey:methods[@"method"] parameters:parameters];
         
         NSString *filename = [NSString stringWithFormat:@"%@.richResults.dat", viewKey];
         [Utilities archivePath:libraryCachePath file:filename data:self.richResults];
@@ -371,7 +371,7 @@
     self.extraSectionRichResults = nil;
     self.sections = [NSMutableDictionary new];
     
-    NSString *viewKey = [self getCacheKey:params[@"methodToCall"] parameters:params[@"mutableParameters"]];
+    NSString *viewKey = [self getCacheKey:params[@"methodToCall"] parameters:params[@"parametersToCall"]];
     NSString *filename = [NSString stringWithFormat:@"%@.richResults.dat", viewKey];
     NSMutableArray *tempArray = [Utilities unarchivePath:libraryCachePath file:filename];
     self.richResults = tempArray;
@@ -384,20 +384,20 @@
     [self performSelectorOnMainThread:@selector(indexAndDisplayData) withObject:nil waitUntilDone:YES];
 }
 
-- (BOOL)loadedDataFromDisk:(NSString*)methodToCall parameters:(NSMutableDictionary*)mutableParameters refresh:(BOOL)forceRefresh {
+- (BOOL)loadedDataFromDisk:(NSString*)methodToCall parameters:(NSDictionary*)parameters refresh:(BOOL)forceRefresh {
     if (forceRefresh) {
         return NO;
     }
     if (!enableDiskCache) {
         return NO;
     }
-    NSString *viewKey = [self getCacheKey:methodToCall parameters:mutableParameters];
+    NSString *viewKey = [self getCacheKey:methodToCall parameters:parameters];
     NSString *filename = [NSString stringWithFormat:@"%@.richResults.dat", viewKey];
     NSString *path = [libraryCachePath stringByAppendingPathComponent:filename];
     NSFileManager *fileManager = [NSFileManager defaultManager];
     if ([fileManager fileExistsAtPath:path]) {
         NSDictionary *extraParams = [NSDictionary dictionaryWithObjectsAndKeys:
-                                     mutableParameters, @"mutableParameters",
+                                     parameters, @"parametersToCall",
                                      methodToCall, @"methodToCall",
                                      nil];
         [self updateSyncDate:path];
@@ -4350,7 +4350,7 @@
         
         // Save and display
         MainMenu *menuItem = self.detailItem;
-        NSMutableDictionary *parameters = [menuItem.mainParameters[chosenTab] mutableCopy];
+        NSMutableDictionary *parameters = menuItem.mainParameters[chosenTab];
         [self saveData:parameters];
         [self indexAndDisplayData];
         return;
@@ -4696,7 +4696,7 @@
      }];
 }
 
-- (void)saveAndShowResultsRefresh:(BOOL)forceRefresh params:(NSMutableDictionary*)mutableParameters {
+- (void)saveAndShowResultsRefresh:(BOOL)forceRefresh params:(NSDictionary*)parameters {
     if (forceRefresh) {
         [self stopPullToRefreshViewAnimation];
     }
@@ -4705,12 +4705,12 @@
         filterModeType == ViewModeListened ||
         filterModeType == ViewModeNotListened) {
         if (forceRefresh) {
-            [self saveData:mutableParameters];
+            [self saveData:parameters];
         }
         [self changeViewMode:filterModeType forceRefresh:forceRefresh];
     }
     else {
-        [self saveData:mutableParameters];
+        [self saveData:parameters];
         [self indexAndDisplayData];
     }
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
In #1499 it was discussed to rework saving the view preference as some code duplication was found. This PR implements this rework.

Each library view in the app stores its mode (grid/list, sort by and sort order). This is done by creating a key from the JSON APIs method and the menu parameters. For filtered lists, like a view shown after selecting a genre (Genre > Pop), the active filter needs to be removed, as otherwise this key is different for each selected genre. Before this rework, only the grid/list mode was kept independent of the filter, but sort by / sort order were saved per genre. With this change, all preferences are stored the same way, and by this kept same for each selected genre.

The implementation is done by adding the new helper `getViewPreferenceKey` and inside handle the tweaking of the parameters to remove the "filter" key, if present. In addition, some small code improvements are done to prefer using non-mutable variables where mutable its not needed and rename variables to better match their content.

This PR needs rebasing after #1499 was merged.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Rework view preference