### PR TITLE
Improvement: Rework image download credentials

### DIFF
--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -145,8 +145,6 @@
 }
 
 - (void)connectionStatus:(NSNotification*)note {
-    // We are connected to server, we now need to share credentials with SDWebImageManager
-    [Utilities setWebImageAuthorizationOnSuccessNotification:note];
 }
 
 - (void)enterAppSettings {

--- a/XBMC Remote/SDWebImage/SDWebImageDownloader.m
+++ b/XBMC Remote/SDWebImage/SDWebImageDownloader.m
@@ -6,6 +6,7 @@
  * file that was distributed with this source code.
  */
 
+#import "Utilities.h"
 #import "SDWebImageDownloader.h"
 #import "SDWebImageDownloaderOperation.h"
 #import "SDWebImageManager.h"
@@ -141,6 +142,15 @@ static NSString *const kCompletedCallbackKey = @"completed";
         NSTimeInterval timeoutInterval = wself.downloadTimeout;
         if (timeoutInterval == 0.0) {
             timeoutInterval = 15.0;
+        }
+        
+        // Add credentials only, if needed and known for the server from the url
+        NSString* credentials = [Utilities getServerAuthorizationForURL:url];
+        if (credentials) {
+            wself.HTTPHeaders[@"Authorization"] = credentials;
+        }
+        else {
+            [wself.HTTPHeaders removeObjectForKey:@"Authorization"];
         }
 
         // In order to prevent from potential duplicate caching (NSURLCache + SDImageCache) we disable the cache for image requests if told otherwise

--- a/XBMC Remote/SDWebImage/SDWebImageDownloader.m
+++ b/XBMC Remote/SDWebImage/SDWebImageDownloader.m
@@ -9,6 +9,7 @@
 #import "SDWebImageDownloader.h"
 #import "SDWebImageDownloaderOperation.h"
 #import "SDWebImageManager.h"
+#import "Utilities.h"
 #import <ImageIO/ImageIO.h>
 
 static NSString *const kProgressCallbackKey = @"progress";
@@ -142,16 +143,26 @@ static NSString *const kCompletedCallbackKey = @"completed";
         if (timeoutInterval == 0.0) {
             timeoutInterval = 15.0;
         }
+        
+        // Add credentials only, if needed and known for the server from the url
+        NSString* credentials = [Utilities getServerAuthorizationForURL:url];
+        NSMutableDictionary *headers = [wself.HTTPHeaders mutableCopy];
+        if (credentials) {
+            headers[@"Authorization"] = credentials;
+        }
+        else {
+            [headers removeObjectForKey:@"Authorization"];
+        }
 
         // In order to prevent from potential duplicate caching (NSURLCache + SDImageCache) we disable the cache for image requests if told otherwise
         NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url cachePolicy:(options & SDWebImageDownloaderUseNSURLCache ? NSURLRequestUseProtocolCachePolicy : NSURLRequestReloadIgnoringLocalCacheData) timeoutInterval:timeoutInterval];
         request.HTTPShouldHandleCookies = (options & SDWebImageDownloaderHandleCookies);
         request.HTTPShouldUsePipelining = YES;
         if (wself.headersFilter) {
-            request.allHTTPHeaderFields = wself.headersFilter(url, [wself.HTTPHeaders copy]);
+            request.allHTTPHeaderFields = wself.headersFilter(url, [headers copy]);
         }
         else {
-            request.allHTTPHeaderFields = wself.HTTPHeaders;
+            request.allHTTPHeaderFields = [headers copy];
         }
         operation = [[wself.operationClass alloc] initWithRequest:request
                                                         inSession:self.session

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -51,7 +51,6 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (void)showMessage:(NSString*)messageText color:(UIColor*)messageColor;
 + (void)showLocalNetworkAccessError:(UIViewController*)viewCtrl;
 + (DSJSONRPC*)getJsonRPC;
-+ (void)setWebImageAuthorizationOnSuccessNotification:(NSNotification*)note;
 + (NSString*)convertTimeFromSeconds:(NSNumber*)seconds;
 + (NSString*)getItemIconFromDictionary:(NSDictionary*)dict;
 + (NSString*)getStringFromItem:(id)item;
@@ -64,6 +63,7 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (NSString*)getThumbnailFromDictionary:(NSDictionary*)dict useBanner:(BOOL)useBanner useIcon:(BOOL)useIcon;
 + (NSString*)getDateFromItem:(id)item dateStyle:(NSDateFormatterStyle)dateStyle;
 + (int)getSec2Min:(BOOL)convert;
++ (NSString*)getServerAuthorizationForURL:(NSURL*)url;
 + (NSString*)getImageServerURL;
 + (NSString*)formatStringURL:(NSString*)path serverURL:(NSString*)serverURL;
 + (NSArray*)addExtraProperties:(NSArray*)properties parameters:(NSDictionary*)parameters;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -532,16 +532,6 @@
     return jsonRPC;
 }
 
-+ (void)setWebImageAuthorizationOnSuccessNotification:(NSNotification*)note {
-    if ([note.name isEqualToString:@"XBMCServerConnectionSuccess"]) {
-        SDWebImageDownloader *manager = [SDWebImageManager sharedManager].imageDownloader;
-        NSDictionary *httpHeaders = AppDelegate.instance.getServerHTTPHeaders;
-        if (httpHeaders[@"Authorization"] != nil) {
-            [manager setValue:httpHeaders[@"Authorization"] forHTTPHeaderField:@"Authorization"];
-        }
-    }
-}
-
 + (NSString*)convertTimeFromSeconds:(NSNumber*)seconds {
     NSString *result = @"";
     if (![seconds respondsToSelector:@selector(intValue)]) {
@@ -714,6 +704,16 @@
 
 + (int)getSec2Min:(BOOL)convert {
     return convert ? 60 : 1;
+}
+
++ (NSString*)getServerAuthorizationForURL:(NSURL*)url {
+    // Return authorization (Kodi user + password), only if url points to active Kodi server
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:YES];
+    BOOL sameHost = [urlComponents.host isEqualToString:AppDelegate.instance.obj.serverIP];
+    BOOL samePort = [url.port intValue] == [AppDelegate.instance.obj.serverPort intValue];
+    
+    NSString *credentials = sameHost && samePort ? AppDelegate.instance.getServerHTTPHeaders[@"Authorization"] : nil;
+    return credentials;
 }
 
 + (NSString*)getImageServerURL {

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -532,16 +532,6 @@
     return jsonRPC;
 }
 
-+ (void)setWebImageAuthorizationOnSuccessNotification:(NSNotification*)note {
-    if ([note.name isEqualToString:@"XBMCServerConnectionSuccess"]) {
-        SDWebImageDownloader *manager = [SDWebImageManager sharedManager].imageDownloader;
-        NSDictionary *httpHeaders = AppDelegate.instance.getServerHTTPHeaders;
-        if (httpHeaders[@"Authorization"] != nil) {
-            [manager setValue:httpHeaders[@"Authorization"] forHTTPHeaderField:@"Authorization"];
-        }
-    }
-}
-
 + (NSString*)convertTimeFromSeconds:(NSNumber*)seconds {
     NSString *result = @"";
     if (![seconds respondsToSelector:@selector(intValue)]) {
@@ -714,6 +704,41 @@
 
 + (int)getSec2Min:(BOOL)convert {
     return convert ? 60 : 1;
+}
+
++ (NSString*)stripIPv6BracketsFromHost:(NSString*)host {
+    // Strip off leading and trailing brackets, if present
+    if ([host hasPrefix:@"["] && [host hasSuffix:@"]"]) {
+        return [host substringWithRange:NSMakeRange(1, host.length - 2)];
+    }
+    return host;
+}
+
++ (NSString*)getServerAuthorizationForURL:(NSURL*)url {
+    if (!url) {
+        return nil;
+    }
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:YES];
+    
+    // Compare host from URL to active Kodi server
+    NSString *appHost = [self stripIPv6BracketsFromHost:[AppDelegate.instance.obj.serverIP lowercaseString]];
+    NSString *urlHost = [self stripIPv6BracketsFromHost:[urlComponents.host lowercaseString]];
+    BOOL sameHost = [urlHost isEqualToString:appHost];
+    
+    // Compare port from URL to active Kodi server, taking into account defaults for http/https
+    NSInteger appPort = [AppDelegate.instance.obj.serverPort intValue];
+    NSInteger urlPort;
+    if (url.port) {
+        urlPort = [url.port intValue];
+    }
+    else {
+        urlPort = [url.scheme isEqualToString:@"https"] ? 443 : 80;
+    }
+    BOOL samePort = urlPort == appPort;
+    
+    // Return authorization (Kodi user + password), only if url points to active Kodi server
+    NSString *credentials = sameHost && samePort ? AppDelegate.instance.getServerHTTPHeaders[@"Authorization"] : nil;
+    return credentials;
 }
 
 + (NSString*)getImageServerURL {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses findings of an AI code review, which pointed to the fact that Kodi server credentials are shared as part of HTTPHeaders for each image download, even if not downloading from Kodi server. This PR checks, if the image download happens from the active Kodi server, and only adds credentials in this case.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Rework image download credentials