### PR TITLE
Improvement: Make reading data from storage thread safe

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -365,23 +365,23 @@
 }
 
 - (void)loadDataFromDisk:(NSDictionary*)params {
-    self.richResults = nil;
-    self.sectionArray = nil;
-    self.sectionArrayOpen = nil;
-    self.extraSectionRichResults = nil;
-    self.sections = [NSMutableDictionary new];
-    
     NSString *viewKey = [self getCacheKey:params[@"methodToCall"] parameters:params[@"mutableParameters"]];
     NSString *filename = [NSString stringWithFormat:@"%@.richResults.dat", viewKey];
-    NSMutableArray *tempArray = [Utilities unarchivePath:libraryCachePath file:filename];
-    self.richResults = tempArray;
+    NSMutableArray *tempRichResults = [Utilities unarchivePath:libraryCachePath file:filename];
     
     filename = [NSString stringWithFormat:@"%@.extraSectionRichResults.dat", viewKey];
-    tempArray = [Utilities unarchivePath:libraryCachePath file:filename];
-    self.extraSectionRichResults = tempArray;
+    NSMutableArray *tempExtraSectionRichResults = [Utilities unarchivePath:libraryCachePath file:filename];
     
-    storeRichResults = [self.richResults mutableCopy];
-    [self performSelectorOnMainThread:@selector(indexAndDisplayData) withObject:nil waitUntilDone:YES];
+    // Ensure an atomic update of the main library data
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.sectionArray = nil;
+        self.sectionArrayOpen = nil;
+        self.sections = [NSMutableDictionary new];
+        self.richResults = tempRichResults;
+        self.extraSectionRichResults = tempExtraSectionRichResults;
+        storeRichResults = [self.richResults mutableCopy];
+        [self indexAndDisplayData];
+    });
 }
 
 - (BOOL)loadedDataFromDisk:(NSString*)methodToCall parameters:(NSMutableDictionary*)mutableParameters refresh:(BOOL)forceRefresh {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -367,23 +367,23 @@
 }
 
 - (void)loadDataFromDisk:(NSDictionary*)params {
-    self.richResults = nil;
-    self.sectionArray = nil;
-    self.sectionArrayOpen = nil;
-    self.extraSectionRichResults = nil;
-    self.sections = [NSMutableDictionary new];
-    
     NSString *viewKey = [self getCacheKey:params[@"methodToCall"] parameters:params[@"parametersToCall"]];
     NSString *filename = [NSString stringWithFormat:@"%@.richResults.dat", viewKey];
-    NSMutableArray *tempArray = [Utilities unarchivePath:libraryCachePath file:filename];
-    self.richResults = tempArray;
+    NSMutableArray *tempRichResults = [Utilities unarchivePath:libraryCachePath file:filename];
     
     filename = [NSString stringWithFormat:@"%@.extraSectionRichResults.dat", viewKey];
-    tempArray = [Utilities unarchivePath:libraryCachePath file:filename];
-    self.extraSectionRichResults = tempArray;
+    NSMutableArray *tempExtraSectionRichResults = [Utilities unarchivePath:libraryCachePath file:filename];
     
-    storeRichResults = [self.richResults mutableCopy];
-    [self performSelectorOnMainThread:@selector(indexAndDisplayData) withObject:nil waitUntilDone:YES];
+    // Ensure an atomic update of the main library data
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.sectionArray = nil;
+        self.sectionArrayOpen = nil;
+        self.sections = [NSMutableDictionary new];
+        self.richResults = tempRichResults;
+        self.extraSectionRichResults = tempExtraSectionRichResults;
+        storeRichResults = [self.richResults mutableCopy];
+        [self indexAndDisplayData];
+    });
 }
 
 - (BOOL)loadedDataFromDisk:(NSString*)methodToCall parameters:(NSDictionary*)parameters refresh:(BOOL)forceRefresh {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review. 
<img width="1174" height="462" alt="Bildschirmfoto 2026-08-06 um 21 41 26" src="https://github.com/user-attachments/assets/aadd66eb-f11d-464f-ab39-c9cc33c022fb" />

The data is read from storage in a background thread. To ensure the main thread does not access the data while it is being changed in the background thread, only load to local variables in the background thread and assign to main data properties in a `dispatch_async` block.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Make reading data from storage thread safe