### PR TITLE
Improvement: Resolve memory leak when creating new DSJSONRPC instance

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -525,6 +525,7 @@
     
     // Create JSONRPC object if not yet created or new configuration is required
     if (jsonRPC == nil || ![checkRPC isEqualToString:checksum]) {
+        [jsonRPC invalidate];
         jsonRPC = [[DSJSONRPC alloc] initWithServiceEndpoint:AppDelegate.instance.getServerJSONEndPoint
                                               andHTTPHeaders:AppDelegate.instance.getServerHTTPHeaders];
         checkRPC = checksum;

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.h
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.h
@@ -69,6 +69,7 @@ typedef void (^DSJSONRPCCompletionHandler)(NSString *methodName, NSInteger callI
 
 - (id)initWithServiceEndpoint:(NSURL*)serviceEndpoint;
 - (id)initWithServiceEndpoint:(NSURL*)serviceEndpoint andHTTPHeaders:(NSDictionary*)httpHeaders;
+- (void)invalidate;
 
 #pragma mark - Web Service Invocation Methods
 - (NSInteger)callMethod:(NSString*)methodName;

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -68,6 +68,11 @@
     return self;
 }
 
+- (void)invalidate {
+    [self.rpcSession invalidateAndCancel];
+    self.rpcSession = nil;
+}
+
 #pragma mark - Web Service Invocation Methods
 
 - (NSInteger)callMethod:(NSString*)methodName {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses finding of AI code review.
<img width="1046" height="370" alt="Bildschirmfoto 2026-08-06 um 22 13 20" src="https://github.com/user-attachments/assets/a0259238-4d42-442f-b82c-ede806916f9b" />

In `getJsonRPC` a new instance of `DSJSONRPC` is created when connecting to a new server or changing credentials. When doing this, the `NSURLSession` is not invalidated and is retaining the whole object. So, we invalidate the session of the old `DSJSONRPC` instance before creating the new one.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Resolve memory leak when creating new DSJSONRPC instance