### PR TITLE
Improvement: Stop services before starting a new instance and in viewDidDisappear

### DIFF
--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -364,6 +364,7 @@
 # pragma mark - resolveIPAddress Methods
 
 - (void)resolveIPAddress:(NSNetService*)service {
+    [remoteService stop];
     remoteService = service;
     remoteService.delegate = self;
     [remoteService resolveWithTimeout:0];
@@ -562,13 +563,17 @@
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     services = [NSMutableArray new];
+    [netServiceBrowser stop];
     netServiceBrowser = [NSNetServiceBrowser new];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
     [discoveryTimeoutTimer invalidate];
+    [netServiceBrowser stop];
     netServiceBrowser = nil;
+    [remoteService stop];
+    remoteService = nil;
     services = nil;
     [discoveredInstancesView setX:self.view.frame.size.width alpha:1.0];
     for (UITextField *textfield in [self getAllEntryMaskLabels]) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1172" height="357" alt="Bildschirmfoto 2026-08-06 um 22 30 00" src="https://github.com/user-attachments/assets/7fd3beb1-4c36-400a-ad76-92d1ab79d32b" />

Stop both `remoteService` and `netServiceBrowser` before starting a new instance and in `viewDidDisappear`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Stop services before starting a new instance and in viewDidDisappear