### PR TITLE
Improvement: Correctly invalidate holdKeyTimer before assigning a new timer

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -185,6 +185,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     [self processButtonPress:buttonID];
     
     NSDictionary *params = @{@"buttontag": @(buttonID)};
+    [self.holdKeyTimer invalidate];
     self.holdKeyTimer = [NSTimer scheduledTimerWithTimeInterval:KEY_HOLD_TIMEOUT
                                                          target:self
                                                        selector:@selector(longpressKey:)


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses finding from an AI code review.
<img width="1173" height="294" alt="Bildschirmfoto 2026-08-06 um 22 38 07" src="https://github.com/user-attachments/assets/ce1293df-1d62-4bb7-9615-e8213db43013" />

Correctly invalidate `holdKeyTimer` before assigning a new timer.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Correctly invalidate holdKeyTimer before assigning a new timer