### PR TITLE
Improvement: Invalidate timeout timer and stop long-running JSON requests when leaving DetailVC

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5105,11 +5105,13 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputCanceled" object:nil userInfo:nil];
     [self setNavigationBarTint:ICON_TINT_COLOR];
     [channelListUpdateTimer invalidate];
+    [countExecutionTime invalidate];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
     [channelListUpdateTimer invalidate];
+    [countExecutionTime invalidate];
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5106,6 +5106,9 @@
     [self setNavigationBarTint:ICON_TINT_COLOR];
     [channelListUpdateTimer invalidate];
     [countExecutionTime invalidate];
+    
+    // Invalidate potentially long-running library JSON requests when leaving the view
+    [[Utilities getJsonRPC] invalidate];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -525,6 +525,7 @@
     
     // Create JSONRPC object if not yet created or new configuration is required
     if (jsonRPC == nil || ![checkRPC isEqualToString:checksum]) {
+        [jsonRPC invalidate];
         jsonRPC = [[DSJSONRPC alloc] initWithServiceEndpoint:AppDelegate.instance.getServerJSONEndPoint
                                               andHTTPHeaders:AppDelegate.instance.getServerHTTPHeaders];
         checkRPC = checksum;

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.h
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.h
@@ -69,6 +69,7 @@ typedef void (^DSJSONRPCCompletionHandler)(NSString *methodName, NSInteger callI
 
 - (id)initWithServiceEndpoint:(NSURL*)serviceEndpoint;
 - (id)initWithServiceEndpoint:(NSURL*)serviceEndpoint andHTTPHeaders:(NSDictionary*)httpHeaders;
+- (void)invalidate;
 
 #pragma mark - Web Service Invocation Methods
 - (NSInteger)callMethod:(NSString*)methodName;

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -68,6 +68,11 @@
     return self;
 }
 
+- (void)invalidate {
+    [self.rpcSession invalidateAndCancel];
+    self.rpcSession = nil;
+}
+
 #pragma mark - Web Service Invocation Methods
 
 - (NSInteger)callMethod:(NSString*)methodName {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses findings from AI code review.
<img width="1171" height="334" alt="Bildschirmfoto 2026-08-07 um 07 24 51" src="https://github.com/user-attachments/assets/84171949-302d-4286-9c93-667b03bed482" />

When leaving DetailVC:
1. Invalidate `countExecutionTime` timer along with others
2. Invalidate running JSON request

#1514 must be merged first as this implements the `invalidate` method for JSON requests.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Invalidate timeout timer and stop long-running JSON requests when leaving DetailVC