### PR TITLE
Improvement: Add missing and remove obsolete timer invalidation 

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5105,6 +5105,7 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputCanceled" object:nil userInfo:nil];
     [self setNavigationBarTint:ICON_TINT_COLOR];
     [channelListUpdateTimer invalidate];
+    [countExecutionTime invalidate];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5109,7 +5109,6 @@
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
-    [channelListUpdateTimer invalidate];
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5127,7 +5127,6 @@
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
-    [channelListUpdateTimer invalidate];
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -5123,6 +5123,7 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:@"Input.OnInputCanceled" object:nil userInfo:nil];
     [self setNavigationBarTint:ICON_TINT_COLOR];
     [channelListUpdateTimer invalidate];
+    [countExecutionTime invalidate];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI review which pointed out the missing invalidation.

Invalidate timer `countExecutionTime` in `viewWillDisappear`. In addition, remove invalidation of timer `channelListUpdateTimer` from `viewDidDisappear` as it is already called in `viewWillDisappear`.
 
## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Add missing and remove obsolete timer invalidation 