### PR TITLE
Improvement: Only proceed with setting torch mode after successful lock

### DIFF
--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1079,12 +1079,12 @@ static void *TorchRemoteContext = &TorchRemoteContext;
 }
 
 - (void)toggleTorch {
-    torchIsOn = !torchIsOn;
-    
     AVCaptureDevice *device = self.avCaptureDevice;
-    [device lockForConfiguration:nil];
-    device.torchMode = torchIsOn ? AVCaptureTorchModeOn : AVCaptureTorchModeOff;
-    [device unlockForConfiguration];
+    if ([device lockForConfiguration:nil]) {
+        torchIsOn = !torchIsOn;
+        device.torchMode = torchIsOn ? AVCaptureTorchModeOn : AVCaptureTorchModeOff;
+        [device unlockForConfiguration];
+    }
 }
 
 - (void)setTorchIcon:(BOOL)torchActive {

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1076,12 +1076,12 @@ static void *TorchRemoteContext = &TorchRemoteContext;
 }
 
 - (void)toggleTorch {
-    torchIsOn = !torchIsOn;
-    
     AVCaptureDevice *device = self.avCaptureDevice;
-    [device lockForConfiguration:nil];
-    device.torchMode = torchIsOn ? AVCaptureTorchModeOn : AVCaptureTorchModeOff;
-    [device unlockForConfiguration];
+    if ([device lockForConfiguration:nil]) {
+        torchIsOn = !torchIsOn;
+        device.torchMode = torchIsOn ? AVCaptureTorchModeOn : AVCaptureTorchModeOff;
+        [device unlockForConfiguration];
+    }
 }
 
 - (void)setTorchIcon:(BOOL)torchActive {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1173" height="283" alt="Bildschirmfoto 2026-08-07 um 18 17 21" src="https://github.com/user-attachments/assets/9f127a5e-ce3c-4ca9-a84e-fe076b2aab23" />

Only proceed with setting torch mode after successful lock. Avoids a potential crash.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Only proceed with setting torch mode after successful lock