### PR TITLE
Improvement: Avoid potential crash when presenting "Share" popover on iPad

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3968,8 +3968,8 @@
                 UIActivityViewController *activityController = [[UIActivityViewController alloc] initWithActivityItems:activityItems applicationActivities:nil];
                 activityController.excludedActivityTypes = excludeActivities;
                 
-                // Origin of popover is the selected item
-                UIView *itemCell = [self getCell:indexPath];
+                // Origin of popover is the selected item, falls back to self.view on nil
+                UIView *itemCell = [self getCell:indexPath] ?: self.view;
                 
                 // Position the source of the popover
                 UIPopoverPresentationController *popPresenter = [activityController popoverPresentationController];

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -3986,8 +3986,8 @@
                 UIActivityViewController *activityController = [[UIActivityViewController alloc] initWithActivityItems:activityItems applicationActivities:nil];
                 activityController.excludedActivityTypes = excludeActivities;
                 
-                // Origin of popover is the selected item
-                UIView *itemCell = [self getCell:indexPath];
+                // Origin of popover is the selected item, falls back to self.view on nil
+                UIView *itemCell = [self getCell:indexPath] ?: self.view;
                 
                 // Position the source of the popover
                 UIPopoverPresentationController *popPresenter = [activityController popoverPresentationController];


### PR DESCRIPTION
Avoids a potential crash if getCell should return nil.

## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1169" height="282" alt="Bildschirmfoto 2026-08-07 um 18 35 32" src="https://github.com/user-attachments/assets/b108ff80-3f57-47b1-a032-85a68977ed99" />

Always provide a non-nil `sourceView` and `sourceRect` as anchor for the popover. Avoids a potential crash on iPad if `getCell` should return `nil`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Avoid potential crash when presenting "Share" popover on iPad