### PR TITLE
Improvement: Make sourceView a parameter when creating the power control popover

### DIFF
--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -662,7 +662,7 @@
         alertCtrl = [Utilities createAlertOK:LOCALIZED_STR(@"No connection") message:nil];
     }
     else {
-        alertCtrl = [Utilities createPowerControl];
+        alertCtrl = [Utilities createPowerControlFromView:self.navigationController.navigationBar];
     }
     [self presentViewController:alertCtrl animated:YES completion:nil];
 }

--- a/XBMC Remote/HostManagementViewController.m
+++ b/XBMC Remote/HostManagementViewController.m
@@ -656,7 +656,7 @@
         alertCtrl = [Utilities createAlertOK:LOCALIZED_STR(@"No connection") message:nil];
     }
     else {
-        alertCtrl = [Utilities createPowerControl];
+        alertCtrl = [Utilities createPowerControlFromView:self.navigationController.navigationBar];
     }
     [self presentViewController:alertCtrl animated:YES completion:nil];
 }

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2614,7 +2614,7 @@
     if (AppDelegate.instance.obj.serverIP.length == 0) {
         return;
     }
-    UIAlertController *alertCtrl = [Utilities createPowerControl];
+    UIAlertController *alertCtrl = [Utilities createPowerControlFromView:self.navigationController.navigationBar];
     [self presentViewController:alertCtrl animated:YES completion:nil];
 }
 

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -2610,7 +2610,7 @@
     if (AppDelegate.instance.obj.serverIP.length == 0) {
         return;
     }
-    UIAlertController *alertCtrl = [Utilities createPowerControl];
+    UIAlertController *alertCtrl = [Utilities createPowerControlFromView:self.navigationController.navigationBar];
     [self presentViewController:alertCtrl animated:YES completion:nil];
 }
 

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1224,7 +1224,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     if (AppDelegate.instance.obj.serverIP.length == 0) {
         return;
     }
-    UIAlertController *alertCtrl = [Utilities createPowerControl];
+    UIAlertController *alertCtrl = [Utilities createPowerControlFromView:self.navigationController.navigationBar];
     [self presentViewController:alertCtrl animated:YES completion:nil];
 }
 

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -1221,7 +1221,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     if (AppDelegate.instance.obj.serverIP.length == 0) {
         return;
     }
-    UIAlertController *alertCtrl = [Utilities createPowerControl];
+    UIAlertController *alertCtrl = [Utilities createPowerControlFromView:self.navigationController.navigationBar];
     [self presentViewController:alertCtrl animated:YES completion:nil];
 }
 

--- a/XBMC Remote/Utilities.h
+++ b/XBMC Remote/Utilities.h
@@ -47,7 +47,7 @@ typedef NS_ENUM(NSInteger, LogoBackgroundType) {
 + (CGRect)createCoverInsideJewel:(UIImageView*)jewelView jewelType:(JewelType)type;
 + (UIAlertController*)createAlertOK:(NSString*)title message:(NSString*)msg;
 + (UIAlertController*)createAlertCopyClipboard:(NSString*)title message:(NSString*)msg;
-+ (UIAlertController*)createPowerControl;
++ (UIAlertController*)createPowerControlFromView:(UIView*)sourceView;
 + (void)showMessage:(NSString*)messageText color:(UIColor*)messageColor;
 + (void)showLocalNetworkAccessError:(UIViewController*)viewCtrl;
 + (DSJSONRPC*)getJsonRPC;

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -395,7 +395,7 @@
     }];
 }
 
-+ (UIAlertController*)createPowerControl {
++ (UIAlertController*)createPowerControlFromView:(UIView*)sourceView {
     NSString *title = [NSString stringWithFormat:@"%@\n%@", AppDelegate.instance.obj.serverDescription, AppDelegate.instance.obj.serverIP];
     UIAlertController *alertCtrl = [UIAlertController alertControllerWithTitle:title message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     
@@ -469,7 +469,13 @@
     
     UIAlertAction *cancelButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:nil];
     [alertCtrl addAction:cancelButton];
+    
     alertCtrl.modalPresentationStyle = UIModalPresentationPopover;
+    UIPopoverPresentationController *popPresenter = [alertCtrl popoverPresentationController];
+    if (popPresenter != nil) {
+        popPresenter.sourceView = sourceView;
+        popPresenter.sourceRect = sourceView.bounds;
+    }
     
     return alertCtrl;
 }

--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -394,7 +394,7 @@
     }];
 }
 
-+ (UIAlertController*)createPowerControl {
++ (UIAlertController*)createPowerControlFromView:(UIView*)sourceView {
     NSString *title = [NSString stringWithFormat:@"%@\n%@", AppDelegate.instance.obj.serverDescription, AppDelegate.instance.obj.serverIP];
     UIAlertController *alertCtrl = [UIAlertController alertControllerWithTitle:title message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     
@@ -468,7 +468,13 @@
     
     UIAlertAction *cancelButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:nil];
     [alertCtrl addAction:cancelButton];
+    
     alertCtrl.modalPresentationStyle = UIModalPresentationPopover;
+    UIPopoverPresentationController *popPresenter = [alertCtrl popoverPresentationController];
+    if (popPresenter != nil) {
+        popPresenter.sourceView = sourceView;
+        popPresenter.sourceRect = sourceView.bounds;
+    }
     
     return alertCtrl;
 }

--- a/XBMC Remote/ViewControllerIPad.m
+++ b/XBMC Remote/ViewControllerIPad.m
@@ -168,12 +168,7 @@
         [self toggleSetup];
         return;
     }
-    UIAlertController *alertCtrl = [Utilities createPowerControl];
-    UIPopoverPresentationController *popPresenter = [alertCtrl popoverPresentationController];
-    if (popPresenter != nil) {
-        popPresenter.sourceView = powerButton;
-        popPresenter.sourceRect = powerButton.bounds;
-    }
+    UIAlertController *alertCtrl = [Utilities createPowerControlFromView:powerButton];
     [self presentViewController:alertCtrl animated:YES completion:nil];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1174" height="265" alt="Bildschirmfoto 2026-08-08 um 18 31 47" src="https://github.com/user-attachments/assets/08652242-7448-48da-a646-96c85c27bf16" />

`createPowerControl` did set `modalPresentationStyle = UIModalPresentationPopover` but did never set `sourceView` or `sourceRect`, assuming it will be correct set for iPad later. With the change, the `sourceView` is handed over as parameter, forcing a correct use by design.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Make sourceView a parameter when creating the power control popover