### PR TITLE
Bugfix: Use deep mutable copy when loading the custom buttons

### DIFF
--- a/XBMC Remote/CustomButton.m
+++ b/XBMC Remote/CustomButton.m
@@ -27,18 +27,20 @@
     return [[NSString stringWithFormat:@"%@%@%@", obj.serverIP, obj.serverPort, obj.serverDescription] SHA256String];
 }
 
+- (NSMutableArray*)mutableDeepCopy:(NSMutableArray*)array {
+    return (NSMutableArray*)CFBridgingRelease(CFPropertyListCreateDeepCopy(kCFAllocatorDefault,
+                                                                           (CFArrayRef)array,
+                                                                           kCFPropertyListMutableContainers));
+}
+
 - (void)loadData {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *filename = [NSString stringWithFormat:@"customButtons_%@.dat", [self getServerKey]];
     NSMutableArray *tempArray = [Utilities unarchivePath:paths[0] file:filename];
     
-    // Make sure the objects in the button array are mutable. The user might edit them.
-    NSMutableArray *buttonArray = [[NSMutableArray alloc] initWithCapacity:tempArray.count];
-    for (id object in tempArray) {
-        id mutableObject = [object mutableCopy];
-        [buttonArray addObject:mutableObject];
-    }
-    buttons = buttonArray;
+    // Use deep mutable copy to ensure all the objects in the button array are mutable as elements could be
+    // edited by user or overwritten to reflect a UISwitch's state. Fall back to an empty mutable array.
+    buttons = tempArray ? [self mutableDeepCopy:tempArray] : [NSMutableArray new];
 }
 
 - (void)saveData {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes an issue with custom toggle buttons. Since https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1481/changes/d7c1d1f52d951db5c5769ec65317fee5adfdb500 (only changed after 1.19.1 for TestFlight builds so far) adding such toggle buttons caused a crash on loading, which could only be resolved by deleting the custom button persistence file by deleting the app. Reasons for this is that `customButton`'s `loadData` did not do a deep mutable copy, leaving the dictionary `button[@"action"]["params"]` non-mutable. While loading the custom button view, this non-mutable array was write accessed to set the boolean state for the setting.

This was found by an AI code review.
<img width="1173" height="399" alt="Bildschirmfoto 2026-08-08 um 20 08 28" src="https://github.com/user-attachments/assets/92e0fdb9-f902-4e95-b3e5-ca61c38c9d46" />

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Use deep mutable copy when loading the custom buttons
Bugfix: Fix crash after adding a toggle button to custom buttons