### PR TITLE
Improvement: Handle some uncovered use cases for custom buttons

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -467,8 +467,8 @@
                                                  name:@"UIInterfaceCustomButtonAdded"
                                                object:nil];
     
-    [[NSNotificationCenter defaultCenter] addObserver:menuTableView
-                                             selector:@selector(reloadData)
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(reloadCustomButtonTable:)
                                                  name:@"XBMCServerHasChanged"
                                                object:nil];
 }

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -186,6 +186,10 @@
 
 - (void)deleteCustomButton:(NSUInteger)idx {
     CustomButton *arrayButtons = [CustomButton new];
+    if (idx >= arrayButtons.buttons.count) {
+        return;
+    }
+    
     [arrayButtons.buttons removeObjectAtIndex:idx];
     [arrayButtons saveData];
     if (arrayButtons.buttons.count == 0) {
@@ -284,11 +288,17 @@
 }
 
 - (void)tableView:(UITableView*)tableView moveRowAtIndexPath:(NSIndexPath*)sourceIndexPath toIndexPath:(NSIndexPath*)destinationIndexPath {
+    CustomButton *arrayButtons = [CustomButton new];
+    if (sourceIndexPath.row >= arrayButtons.buttons.count ||
+        sourceIndexPath.row >= tableData.count ||
+        sourceIndexPath.row == destinationIndexPath.row) {
+        return;
+    }
+    
     id objectMove = tableData[sourceIndexPath.row];
     [tableData removeObjectAtIndex:sourceIndexPath.row];
     [tableData insertObject:objectMove atIndex:destinationIndexPath.row];
     
-    CustomButton *arrayButtons = [CustomButton new];
     objectMove = arrayButtons.buttons[sourceIndexPath.row];
     [arrayButtons.buttons removeObjectAtIndex:sourceIndexPath.row];
     [arrayButtons.buttons insertObject:objectMove atIndex:destinationIndexPath.row];

--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -471,6 +471,11 @@
                                              selector:@selector(reloadCustomButtonTable:)
                                                  name:@"XBMCServerHasChanged"
                                                object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(reloadCustomButtonTable:)
+                                                 name:UIApplicationDidBecomeActiveNotification
+                                               object:nil];
 }
 
 - (void)reloadCustomButtonTable:(NSNotification*)note {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Inspired by an AI code review pointing out some missed use cases and checks.
<img width="1172" height="352" alt="Bildschirmfoto 2026-08-08 um 21 20 58" src="https://github.com/user-attachments/assets/ff43a56d-33e9-4c78-bc5a-05fadb3f3118" />

The review points out some missing out-of-bounds checks as well as the need to not only reload the `menuTableView`, but also the underlying `tableData`. To update both, `reloadCustomButtonTable` can be called. This is now done when 
- the server is changed and 
- when the app comes back from background. 

The latter covers the use case where the server is changed via shortcuts (long pressing the app icon) while the app is in background.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Handle some uncovered use cases for custom buttons