### PR TITLE
Improvement: Avoid retain cycle of UIAlertController

### DIFF
--- a/XBMC Remote/RightMenuViewController.m
+++ b/XBMC Remote/RightMenuViewController.m
@@ -317,8 +317,9 @@
         textField.placeholder = @"";
         textField.text = tableData[indexPath.row][@"label"];
     }];
+    __weak UIAlertController *weakAlertCtrl = alertCtrl;
     UIAlertAction *updateButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Update label") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-        NSString *newLabel = alertCtrl.textFields[0].text;
+        NSString *newLabel = weakAlertCtrl.textFields[0].text;
         
         CustomButton *arrayButtons = [CustomButton new];
         if (indexPath.row >= tableData.count ||

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -228,8 +228,9 @@
                 textField.placeholder = @"";
                 textField.text = [self getActionButtonTitle];
             }];
+            __weak UIAlertController *weakAlertCtrl = alertCtrl;
             UIAlertAction *addButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Add button") style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-                    [self addActionButton:alertCtrl];
+                    [self addActionButton:weakAlertCtrl];
                 }];
             UIAlertAction *cancelButton = [UIAlertAction actionWithTitle:LOCALIZED_STR(@"Cancel") style:UIAlertActionStyleCancel handler:nil];
             [alertCtrl addAction:addButton];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding of an AI code review. Also verified via Xcode memory graph.
<img width="1173" height="253" alt="Bildschirmfoto 2026-08-09 um 00 10 21" src="https://github.com/user-attachments/assets/27059819-7304-47d1-b99f-76b7bfcf56fd" />

Only call weak `alertCtrl` inside the action block to avoid a retain cycle.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Avoid retain cycle of UIAlertController