### PR TITLE
Improvement: Do not share authorization header if user/password are not present

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -159,6 +159,9 @@
 }
 
 - (NSDictionary*)getServerHTTPHeaders {
+    if (![obj.serverUser length] && ![obj.serverPass length]) {
+        return nil;
+    }
     NSData *authCredential = [[NSString stringWithFormat:@"%@:%@", obj.serverUser, obj.serverPass] dataUsingEncoding:NSUTF8StringEncoding];
     NSString *base64AuthCredentials = [authCredential base64EncodedStringWithOptions:(NSDataBase64EncodingOptions)0];
     NSString *authValue = [NSString stringWithFormat:@"Basic %@", base64AuthCredentials];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1173" height="296" alt="Bildschirmfoto 2026-08-09 um 02 23 17" src="https://github.com/user-attachments/assets/57a44756-2245-40ab-a5f0-8948f2f6ae4d" />

Return `nil` instead empty authentication when there is no user and password set.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Do not share authorization header if user/password are not present