### PR TITLE
Improvement: IP address resolving and security concerns

### DIFF
--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -367,7 +367,12 @@
     [remoteService stop];
     remoteService = service;
     remoteService.delegate = self;
-    [remoteService resolveWithTimeout:0];
+    [remoteService resolveWithTimeout:10];
+}
+
+- (void)netService:(NSNetService*)service didNotResolve:(NSDictionary<NSString*,NSNumber*>*)errorDict {
+    [activityIndicatorView stopAnimating];
+    [Utilities showMessage:LOCALIZED_STR(@"Cannot resolve IP address") color:ERROR_MESSAGE_COLOR];
 }
 
 - (void)netServiceDidResolveAddress:(NSNetService*)service {

--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -402,7 +402,9 @@
                 [self fillAddressPort:serverAddresses port:ntohs(addr6->sin6_port) addr:addr name:service.hostName ip:@"ipv6"];
             }
         }
+#if DEBUG
         NSLog(@"Resolved address/port for service '%@' by '%@': %@", type, service.name, serverAddresses);
+#endif
         
 #if (RESOLVE_MAC_ADDRESS)
         if (serverAddresses[@"ipv4"]) {
@@ -441,7 +443,9 @@
                 [self fillTcpPort:serverAddresses port:ntohs(addr6->sin6_port) ip:@"ipv6"];
             }
         }
+#if DEBUG
         NSLog(@"TCP port for '%@': %@", service.name, serverAddresses[@"hostname"][@"tcpport"]);
+#endif
         
         [discoveryTimeoutTimer invalidate];
     }

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -254,6 +254,7 @@
 "e.g. 192.168.0.8" = "e.g. 192.168.0.8";
 "Username" = "Username";
 "Password" = "Password";
+"Cannot resolve IP address" = "Cannot resolve IP address";
 
 "Sort by" = "Sort by";
 "tap the selection\nto reverse the sort order" = "tap the selection\nto reverse the sort order";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
An AI code review highlighted two potential issues. First is about indefinite timeout for resolving an IP address. Second is about sharing Kodi server details in logs even for RELEASE builds.
<img width="1153" height="567" alt="Bildschirmfoto 2026-08-09 um 11 02 50" src="https://github.com/user-attachments/assets/bfd94369-4cfd-47f3-a9f7-89d6137f03dc" />

This PR moves to a definite timeout of 10 seconds for `resolveWithTimeout` and implements `netService:didNotResolve:`. If the IP address cannot be resolved in time, `netService:didNotResolve:` is called, which will stop the activity indicator and show an error message. In addition, the `NSLog` calls which share details on the Kodi servers found are encapsulated in `#if DEBUG` macros.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: IP address resolving and security concerns