### PR TITLE
Maintenance: Remove UIRequiredDeviceCapabilities / arm7

### DIFF
--- a/XBMC Remote/Kodi Remote-Info.plist
+++ b/XBMC Remote/Kodi Remote-Info.plist
@@ -69,10 +69,6 @@
 	<string>Launch Screen</string>
 	<key>UIPrerenderedIcon</key>
 	<true/>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
 	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UIStatusBarStyle</key>


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1174" height="174" alt="Bildschirmfoto 2026-08-09 um 11 15 43" src="https://github.com/user-attachments/assets/427a7371-3ad6-4295-b254-0c8cc779d1c2" />

Since the app is only supporting devices with iOS 12 and later, armv7 is not supported anymore. The key `UIRequiredDeviceCapabilities` and its value "arm7" can be removed.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Remove UIRequiredDeviceCapabilities / arm7