### PR TITLE
Improvement: Avoid potential crashes in json decoding

### DIFF
--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -172,8 +172,8 @@
     NSData *data = dataTaskProp[@"dataBuffer"];
     long aID = [dataTaskProp[@"requestID"] longValue];
     
-    // No error, process the received data
-    if (error == nil) {
+    // If no error and data != nil, process the received data
+    if (error == nil && data) {
         // Attempt to deserialize result
         NSError *jsonError = nil;
         NSDictionary *jsonResult = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&jsonError];

--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -191,10 +191,11 @@
             // Pass the error to completion handler
             if (completionHandler) {
                 NSError *aError = [NSError errorWithDomain:RPC_DOMAIN code:DSJSONRPCParseError userInfo:@{NSLocalizedDescriptionKey: LOCALIZED_STR(@"Received unexpected JSON object.")}];
+                NSString *body = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] ?: [data description];
                 NSDictionary *jsonErrorDict = @{
                     @"code": @(JSONRPCInvalidObject),
                     @"message": LOCALIZED_STR(@"Received unexpected JSON object."),
-                    @"data": [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding],
+                    @"data": body,
                 };
                 DSJSONRPCError *jsonRPCError = [DSJSONRPCError errorWithData:jsonErrorDict];
                 completionHandler(methodName, aID, nil, jsonRPCError, aError);


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses findings from an AI code review.
<img width="1156" height="269" alt="Bildschirmfoto 2026-08-09 um 11 39 33" src="https://github.com/user-attachments/assets/b8e67485-c1ad-4d75-9b93-9d365a7b2cb4" />


Only enter `JSONObjectWithData` is `data != nil`, which avoids a potential crash and will show an error message. Add a fallback for `initWithData:encoding:` to avoid a potential crash in the literal dictionary assignment.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Avoid potential crashes in json decoding