### PR TITLE
Maintenance: Use an ivar instead of a global variable for inStream

### DIFF
--- a/XBMC Remote/TcpJSONRPC.h
+++ b/XBMC Remote/TcpJSONRPC.h
@@ -11,6 +11,7 @@
 @import Foundation;
 
 @interface TcpJSONRPC : NSObject <NSStreamDelegate> {
+    NSInputStream *inStream;
     BOOL inCheck;
     NSTimer *heartbeatTimer;
     NSString *infoTitle;

--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -15,8 +15,6 @@
 #define SERVER_JSON_TIMEOUT (SERVER_CHECK_TIMER - 1.0) // ensure result comes before next heartbeat check
 #define MRMC_TIMEWARP 14
 
-NSInputStream *inStream;
-
 @implementation TcpJSONRPC
 
 - (id)init {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1173" height="357" alt="Bildschirmfoto 2026-08-09 um 12 11 12" src="https://github.com/user-attachments/assets/7d0d2da2-10ee-46d0-947a-40a7134170b9" />

Make `inStream` an ivar instead of a global variable. Anyway `inStream` is accessed only from within the `TcpJSONRPC` class, and this will avoid future issues once parallel instances of `TcpJSONRPC` should be present.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: Use an ivar instead of a global variable for inStream