### PR TITLE
Improvement: Synchronize via completion block instead of using a timer

### DIFF
--- a/XBMC Remote/AppDelegate.h
+++ b/XBMC Remote/AppDelegate.h
@@ -82,7 +82,7 @@
 + (AppDelegate*)instance;
 
 - (void)saveServerList;
-- (void)clearAppDiskCache;
+- (void)clearAppDiskCache:(void(^)(void))completionHandler;
 - (void)sendWOL:(NSString*)MAC withPort:(NSInteger)WOLport;
 - (NSURL*)getServerJSONEndPoint;
 - (NSDictionary*)getServerHTTPHeaders;

--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -350,10 +350,7 @@
                                                     error:NULL];
 }
 
-- (void)clearAppDiskCache {
-    // Clear SDWebImage image cache
-    [[SDImageCache sharedImageCache] clearDisk];
-    
+- (void)clearAppDiskCache:(void(^)(void))completionHandler {
     // Clear library cache
     [self clearDiskCacheAtPath:self.libraryCachePath];
     
@@ -362,6 +359,13 @@
     
     // Clear network cache
     [[NSURLCache sharedURLCache] removeAllCachedResponses];
+    
+    // Clear SDWebImage image cache
+    [[SDImageCache sharedImageCache] clearDiskOnCompletion:^{
+        if (completionHandler) {
+            completionHandler();
+        }
+    }];
 }
 
 @end

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -163,16 +163,17 @@
 }
 
 - (void)clearAppDiskCacheFinished:(ClearCacheView*)clearView {
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    [userDefaults removeObjectForKey:@"clearcache_preference"];
+    
+    // Stop indicator animation, fade out and then remove view.
     [UIView animateWithDuration:0.3
                      animations:^{
         [clearView stopActivityIndicator];
         clearView.alpha = 0;
     }
                      completion:^(BOOL finished) {
-        [clearView stopActivityIndicator];
         [clearView removeFromSuperview];
-        NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-        [userDefaults removeObjectForKey:@"clearcache_preference"];
     }];
 }
 

--- a/XBMC Remote/BaseMasterViewController.m
+++ b/XBMC Remote/BaseMasterViewController.m
@@ -157,10 +157,9 @@
 #pragma mark - App clear disk cache methods
 
 - (void)startClearAppDiskCache:(ClearCacheView*)clearView {
-    [AppDelegate.instance clearAppDiskCache];
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, CLEARCACHE_TIMEOUT * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    [AppDelegate.instance clearAppDiskCache:^{
         [self clearAppDiskCacheFinished:clearView];
-    });
+    }];
 }
 
 - (void)clearAppDiskCacheFinished:(ClearCacheView*)clearView {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Inspired by findings from an AI code review.
<img width="1154" height="376" alt="Bildschirmfoto 2026-08-09 um 14 30 07" src="https://github.com/user-attachments/assets/58151470-a378-4c91-b7c1-598ac23675e0" />

Use completion blocks to synchronize with real end of image cache cleanup instead of using timers.

In addition apply some minor refactoring of `clearAppDiskCacheFinished` by removing the "clearcache_preference" key right before the animation, removing double call of `stopActivityIndicator` and commenting the animation steps.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Synchronize via completion block instead of using a timer