### PR TITLE
Improvement: Add fixed JSON RPC error string instead of empty message 

### DIFF
--- a/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
+++ b/XBMC Remote/dbowen-Demiurgic-JSON-RPC-168ecc9/DSJSONRPC.m
@@ -127,7 +127,8 @@
     // Create the JSON-RPC request
     if (!self.serviceEndpoint) {
         if (completionHandler) {
-            NSError *aError = [NSError errorWithDomain:RPC_DOMAIN code:DSJSONRPCNetworkError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:[error localizedDescription], NSLocalizedDescriptionKey, nil]];
+            NSString *errorText = LOCALIZED_STR(@"No Kodi server configured");
+            NSError *aError = [NSError errorWithDomain:RPC_DOMAIN code:DSJSONRPCNetworkError userInfo:[NSDictionary dictionaryWithObjectsAndKeys:errorText, NSLocalizedDescriptionKey, nil]];
             completionHandler(methodName, aID, nil, nil, aError);
         }
         return aID;

--- a/XBMC Remote/en.lproj/Localizable.strings
+++ b/XBMC Remote/en.lproj/Localizable.strings
@@ -337,6 +337,7 @@
 "kbit/s" = "kbit/s";
 
 "Received unexpected JSON object." = "Received unexpected JSON object.";
+"No Kodi server configured" = "No Kodi server configured";
 
 "QUICK HELP" = "QUICK HELP";
 "Gestures" = "Gestures";


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1171" height="272" alt="Bildschirmfoto 2026-08-09 um 14 47 46" src="https://github.com/user-attachments/assets/65656d33-1cd5-4a0a-8e33-ac68d345e640" />

When reaching the condition `!self.serviceEndpoint` the variable `error` is `nil` and would result in handing over an empty error message. Instead we place a fixed error string.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Add fixed JSON RPC error string instead of empty message 