### PR TITLE
Improvement: Better performance by only colorizing once if possible

### DIFF
--- a/XBMC Remote/ShowInfoViewController.h
+++ b/XBMC Remote/ShowInfoViewController.h
@@ -75,6 +75,7 @@
     int lineSpacing;
     int thumbWidth;
     int tvshowHeight;
+    UIImage *table_arrow_right_colored;
     UITableView *actorsTable;
     NSURL *embedVideoURL;
     UIColor *foundTintColor;

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1494,8 +1494,7 @@
 
 - (void)tableView:(UITableView*)tableView willDisplayCell:(UITableViewCell*)cell forRowAtIndexPath:(NSIndexPath*)indexPath {
     if (![self isModal]) {
-        UIImage *image = [[UIImage imageNamed:@"table_arrow_right"] colorizeWithColor:ICON_TINT_COLOR];
-        cell.accessoryView = [[UIImageView alloc] initWithImage:image];
+        cell.accessoryView = [[UIImageView alloc] initWithImage:table_arrow_right_colored];
         cell.accessoryView.alpha = ARROW_ALPHA;
     }
     else {
@@ -1742,6 +1741,8 @@
     logoBackgroundMode = [Utilities getLogoBackgroundMode];
     foundTintColor = ICON_TINT_COLOR;
     [self configureView];
+    
+    table_arrow_right_colored = [[UIImage imageNamed:@"table_arrow_right"] colorizeWithColor:ICON_TINT_COLOR];
     
     coverView.layer.minificationFilter = kCAFilterTrilinear;
     coverView.layer.magnificationFilter = kCAFilterTrilinear;

--- a/XBMC Remote/VolumeSliderView.h
+++ b/XBMC Remote/VolumeSliderView.h
@@ -20,6 +20,10 @@
     BOOL isMuted;
     BOOL isChangingVolume;
     int serverVolume;
+    UIImage *volume_slash_muted;
+    UIImage *volume_slash_unmuted;
+    UIImage *pgbar_thumb_muted;
+    UIImage *pgbar_thumb_unmuted;
 }
 
 - (id)initWithFrame:(CGRect)frame leftAnchor:(CGFloat)leftAnchor isSliderType:(BOOL)isSliderType;

--- a/XBMC Remote/VolumeSliderView.m
+++ b/XBMC Remote/VolumeSliderView.m
@@ -34,12 +34,18 @@
     NSArray *nib = [[NSBundle mainBundle] loadNibNamed:@"VolumeSliderView" owner:nil options:nil];
     self = nib[0];
     if (self) {
-        UIImage *img = [UIImage imageNamed:@"pgbar_thumb"];
-        img = [img colorizeWithColor:KODI_BLUE_COLOR];
-        volumeSlider.minimumTrackTintColor = KODI_BLUE_COLOR;
+        UIImage *img = [UIImage imageNamed:@"volume_slash"];
+        volume_slash_muted = [img colorizeWithColor:[self getButtonColorMuted:YES]];
+        volume_slash_unmuted = [img colorizeWithColor:[self getButtonColorMuted:NO]];
+        
+        img = [UIImage imageNamed:@"pgbar_thumb"];
+        pgbar_thumb_muted = [img colorizeWithColor:[self getSliderColorMuted:YES]];
+        pgbar_thumb_unmuted = [img colorizeWithColor:[self getSliderColorMuted:NO]];
+        
+        volumeSlider.minimumTrackTintColor = [self getSliderColorMuted:NO];
         volumeSlider.maximumTrackTintColor = UIColor.darkGrayColor;
-        [volumeSlider setThumbImage:img forState:UIControlStateNormal];
-        [volumeSlider setThumbImage:img forState:UIControlStateHighlighted];
+        [volumeSlider setThumbImage:pgbar_thumb_unmuted forState:UIControlStateNormal];
+        [volumeSlider setThumbImage:pgbar_thumb_unmuted forState:UIControlStateHighlighted];
         [volumeSlider addTarget:self action:@selector(handleSliderValueChanged:) forControlEvents:UIControlEventValueChanged];
         [volumeSlider addTarget:self action:@selector(stopVolume:) forControlEvents:UIControlEventTouchUpInside];
         [volumeSlider addTarget:self action:@selector(stopVolume:) forControlEvents:UIControlEventTouchUpOutside];
@@ -90,9 +96,7 @@
             subView.center = CGPointMake(subView.center.x, center_y);
         }
         
-        img = [UIImage imageNamed:@"volume_slash"];
-        img = [img colorizeWithColor:UIColor.grayColor];
-        [muteButton setImage:img forState:UIControlStateNormal];
+        [muteButton setImage:volume_slash_unmuted forState:UIControlStateNormal];
         
         [minusButton setIconStyle:[UIImage imageNamed:@"volume_1"]];
         
@@ -150,6 +154,15 @@
     [self startTimer];
     [self setVolumeButtonMode];
 }
+
+- (UIColor*)getButtonColorMuted:(BOOL)muted {
+    return muted ? UIColor.systemRedColor : UIColor.grayColor;
+}
+
+- (UIColor*)getSliderColorMuted:(BOOL)muted {
+    return muted ? UIColor.darkGrayColor : KODI_BLUE_COLOR;
+}
+
 
 - (void)setVolumeButtonMode {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
@@ -237,17 +250,9 @@
 }
 
 - (void)showServerMute {
-    UIColor *buttonColor = isMuted ? UIColor.systemRedColor : UIColor.grayColor;
-    UIColor *sliderColor = isMuted ? UIColor.darkGrayColor : KODI_BLUE_COLOR;
-
-    UIImage *img = [UIImage imageNamed:@"volume_slash"];
-    img = [img colorizeWithColor:buttonColor];
-    [muteButton setImage:img forState:UIControlStateNormal];
-    
-    img = [UIImage imageNamed:@"pgbar_thumb"];
-    img = [img colorizeWithColor:sliderColor];
-    [volumeSlider setThumbImage:img forState:UIControlStateNormal];
-    volumeSlider.minimumTrackTintColor = sliderColor;
+    [muteButton setImage:isMuted ? volume_slash_muted : volume_slash_unmuted forState:UIControlStateNormal];
+    [volumeSlider setThumbImage:isMuted ? pgbar_thumb_muted : pgbar_thumb_unmuted forState:UIControlStateNormal];
+    volumeSlider.minimumTrackTintColor = [self getSliderColorMuted:isMuted];
     volumeSlider.userInteractionEnabled = !isMuted;
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses findings from AI code review.
<img width="1175" height="501" alt="Bildschirmfoto 2026-08-09 um 16 46 52" src="https://github.com/user-attachments/assets/95a6c8e9-dd85-4b89-a687-48c893f53424" />

In `VolumeSliderView` generate the colorized volume control images during `initWithFrame`, later only assign the desired image. In `ShowInfoVC` generate the colorized right arrow image during `viewDidLoad`, later only assign the image. This helps improving performance as calling `colorizeWithColor` is expensive.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Better performance by only colorizing once if possible