### PR TITLE
Bugfix: Another fix for Ken Burns animation after coming from background

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1662,6 +1662,16 @@
         bottomShadow.hidden = YES;
     }
     [self createInfo];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(leaveFullscreen)
+                                                 name:@"LeaveFullscreen"
+                                               object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleEnterForeground)
+                                                 name:UIApplicationWillEnterForegroundNotification
+                                               object:nil];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -1749,16 +1759,6 @@
     localEndDateFormatter = [NSDateFormatter new];
     localEndDateFormatter.timeZone = [NSTimeZone systemTimeZone];
     localEndDateFormatter.dateFormat = @"HH:mm";
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(leaveFullscreen)
-                                                 name:@"LeaveFullscreen"
-                                               object:nil];
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleEnterForeground)
-                                                 name:UIApplicationWillEnterForegroundNotification
-                                               object:nil];
 }
 
 - (BOOL)shouldAutorotate {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Adds more one more fix on top of https://github.com/xbmc/Official-Kodi-Remote-iOS/pull/1498. Inspired by an AI code review.

Add observers in `viewWillAppear`, symmetrical to removing observers in `viewWillDisappear`. This resolves an issue where the Ken Burns animation is _not_ relaunched coming back from background, if the user _before_ moving to background left the view by e.g. selecting an actor from the cast.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Another fix for Ken Burns animation after coming from background