### PR TITLE
Fix: First time enable rotation for Ken Burns

### DIFF
--- a/XBMC Remote/KenBurns/JBKenBurnsView.m
+++ b/XBMC Remote/KenBurns/JBKenBurnsView.m
@@ -179,7 +179,7 @@
     CGFloat maxMoveX = optimusWidth - frameWidth;
     CGFloat maxMoveY = optimusHeight - frameHeight;
     
-    CGFloat rotation = arc4random_uniform(9) / 100;
+    CGFloat rotation = arc4random_uniform(9) / 100.0;
     
     switch (arc4random_uniform(4)) {
         case 0:


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1150" height="261" alt="Bildschirmfoto 2026-08-09 um 19 58 35" src="https://github.com/user-attachments/assets/d676d2f8-778b-4581-8075-2eabf36a8821" />

Correct the calculation for Ken Burns rotation. Before, an integer value in the range of 0..9 was divided by an integer of value 100, which always results in 0. Now, divide by a float value of 100.0f, which will -- for the first time -- enable some minor rotation.

Remark: This _could_ cause an unwanted side effect where parts of the image are not reaching the vertical/horizontal borders of the view due to the image's rotation. In my tests I was not seeing such an issue. In worst case, the rotation can be easily switched off by simply setting `float rotation = 0;`. Then it would deliberately switch off, and by fault.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Fix: First time enable rotation for Ken Burns