### PR TITLE
Bugfix: Fix crash when calling Ken Burns animation with nil image

### DIFF
--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -1599,7 +1599,8 @@
     self.kenView.delegate = self;
     self.kenView.alpha = 0;
     self.kenView.tag = FANART_FULLSCREEN_DISABLE;
-    [self.kenView animateWithImages:@[image]
+    NSArray *backgroundImages = image ? @[image] : @[];
+    [self.kenView animateWithImages:backgroundImages
                  transitionDuration:45
                                loop:YES
                         isLandscape:YES];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression of #1498 which resulted in a crash when `image = nil`. This PR avoids such crash by adding a fallback handling.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix crash when calling Ken Burns animation with nil image