### PR TITLE
Bugfix: Fix a PVR regression caused by removing the support for Kodi 11

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4428,7 +4428,7 @@
             return;
         }
         // PVR.GetRecordings and PVR.GetTimers are not supported with xbmc 12
-        else if (AppDelegate.instance.serverVersion == 12 && ([methodToCall isEqualToString:@"PVR.GetRecordings"] || [methodToCall isEqualToString:@"PVR.GetTimers"])) {
+        if (AppDelegate.instance.serverVersion == 12 && ([methodToCall isEqualToString:@"PVR.GetRecordings"] || [methodToCall isEqualToString:@"PVR.GetTimers"])) {
             [self animateNoResultsFound];
             return;
         }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Fixes a regression caused by #1499:
<img width="1040" height="175" alt="Bildschirmfoto 2026-08-09 um 22 53 53" src="https://github.com/user-attachments/assets/3b7532e8-6b5d-4d5f-9dc3-c289a738f320" />

This fixes a regression caused by removing the support for Kodi 11, where an "if" condition was removed and the residual "else if" should have become the new "if" condition (see above). Just keeping the "else if" was hooking it up with another "if" statement, which resulted in non-reachable code inside the "else if" condition.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Fix a PVR regression caused by removing the support for Kodi 11