### PR TITLE
Improvement: Rework presenting the SafariViewController

### DIFF
--- a/XBMC Remote/BaseActionViewController.m
+++ b/XBMC Remote/BaseActionViewController.m
@@ -195,10 +195,12 @@
         // On iPad presenting from the active ViewController results in blank screen
         ctrl = UIApplication.sharedApplication.keyWindow.rootViewController;
     }
-    if (![svc isBeingPresented]) {
-        if (ctrl.presentedViewController) {
-            [ctrl dismissViewControllerAnimated:YES completion:nil];
-        }
+    if (ctrl.presentedViewController) {
+        [ctrl dismissViewControllerAnimated:YES completion:^{
+            [ctrl presentViewController:svc animated:YES completion:nil];
+        }];
+    }
+    else {
         [ctrl presentViewController:svc animated:YES completion:nil];
     }
 }


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses findings from an AI code review.
<img width="1173" height="265" alt="Bildschirmfoto 2026-08-10 um 19 40 03" src="https://github.com/user-attachments/assets/25e750f6-00bd-4e58-b426-3783db650dee" />

Rework presenting the SafariViewController
- `isBeingPresented` is always `NO` as it was just created
- only present after the `dismissViewControllerAnimated` is completed

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Rework presenting the SafariViewController