### PR TITLE
Improvement: Remove obsolete 15th entry (Music structure holds 14 entries)

### DIFF
--- a/XBMC Remote/MainMenu.m
+++ b/XBMC Remote/MainMenu.m
@@ -1107,7 +1107,6 @@
         [self modes_icons_empty],
         [self modes_icons_empty],
         [self modes_icons_empty],
-        [self modes_icons_empty],
     ];
     
     menu_Music.sheetActions = @[


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review:
<img width="1091" height="220" alt="Bildschirmfoto 2026-08-16 um 15 31 47" src="https://github.com/user-attachments/assets/06811976-7941-44de-ad88-8659abeb76fa" />

The `menu_Music` array structure holds 14 entries everywhere, except for `filterModes` which holds 15. Remove the last entry, it is obsolete.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Remove obsolete 15th entry (Music structure holds 14 entries)