### PR TITLE
Improvement: Use regular expression to check for valid MAC address

### DIFF
--- a/XBMC Remote/Utilities.m
+++ b/XBMC Remote/Utilities.m
@@ -1042,7 +1042,17 @@
 }
 
 + (BOOL)isValidMacAddress:(NSString*)macAddress {
-    return macAddress && macAddress.length && ![macAddress isEqualToString:@":::::"];
+    if (!macAddress) {
+        return NO;
+    }
+    // Check for standard patterns like 00:1A:2B:3C:4D:5E or 00:1a:2b:3c:4d:5e
+    NSString *macAdressPattern = @"^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$";
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:macAdressPattern
+                                                                           options:0
+                                                                             error:nil];
+    return [regex firstMatchInString:macAddress
+                             options:0
+                               range:NSMakeRange(0, macAddress.length)] != nil;
 }
 
 + (void)wakeUp:(NSString*)macAddress {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.

Use regular expression to check for a valid MAC address which covers patterns like `00:1A:2B:3C:4D:5E` or `00:1a:2b:3c:4d:5e`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Use regular expression to check for valid MAC address