### PR TITLE
Improvement: Better matching server when launching from Shortcuts

### DIFF
--- a/XBMC Remote/AppDelegate.m
+++ b/XBMC Remote/AppDelegate.m
@@ -168,19 +168,24 @@
 
 #pragma mark - Helper
 
-- (BOOL)connectToServerFromList:(NSString*)host {
+- (NSString*)unifyLocalHost:(NSString*)host {
+    // Make host name use ".local" at the end
+    if ([host hasSuffix:@".local."]) {
+        return [host substringToIndex:host.length - 1];
+    }
+    return host;
+}
+
+- (BOOL)connectToServerFromListForHost:(NSString*)host andName:(NSString*)name {
     if (!host.length) {
         return NO;
     }
     
-    // Host name needs ".local." at the end
-    if ([host hasSuffix:@".local"]) {
-        host = [host stringByAppendingString:@"."];
-    }
-    
-    // Try to map server name or IP address to the list of Kodi servers
+    // Try to map host and (if present) server name to the list of Kodi servers
     NSInteger index = [self.arrayServerList indexOfObjectPassingTest:^BOOL(NSDictionary *obj, NSUInteger idx, BOOL *stop) {
-        return [host isEqualToString:obj[@"serverDescription"]] || [host isEqualToString:obj[@"serverIP"]];
+        BOOL hostMatch = [[self unifyLocalHost:host] isEqualToString:[self unifyLocalHost:obj[@"serverIP"]]];
+        BOOL nameMatch = name.length && [name isEqualToString:obj[@"serverDescription"]];
+        return hostMatch && (!name.length || nameMatch);
     }];
     
     // We want to connect to the desired server only. If this is not present, disconnect from any active server.
@@ -298,12 +303,14 @@
 
 - (BOOL)application:(UIApplication*)app openURL:(NSURL*)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id>*)options {
     // Use URL host to map to server list and connect the server.
-    return [self connectToServerFromList:url.host.stringByRemovingPercentEncoding];
+    return [self connectToServerFromListForHost:url.host.stringByRemovingPercentEncoding
+                                        andName:nil];
 }
 
 - (void)application:(UIApplication*)application performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem completionHandler:(void(^)(BOOL))completionHandler {
     // Use shortcut title (= server description) to map to server list and connect the server.
-    completionHandler([self connectToServerFromList:shortcutItem.localizedTitle]);
+    completionHandler([self connectToServerFromListForHost:shortcutItem.localizedSubtitle
+                                                   andName:shortcutItem.localizedTitle]);
 }
 
 - (void)applicationDidEnterBackground:(UIApplication*)application {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses findings from AI code review.
<img width="1070" height="244" alt="Bildschirmfoto 2026-08-17 um 19 51 51" src="https://github.com/user-attachments/assets/cfd13f10-e334-4409-9bcd-f07aac1373b4" />

Add `host` and `name` parameters to `connectToServerFromList`. Allows to improve matching a Shortcut Item by using both the server name and host. In addition, unify local hosts to end with ".local".

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Better matching server when launching from Shortcuts