### PR TITLE
Improvement: Avoid potential out-of-bounds when replacing a server in the list

### DIFF
--- a/XBMC Remote/HostViewController.m
+++ b/XBMC Remote/HostViewController.m
@@ -103,13 +103,13 @@
         @"serverMacAddress": macAddress,
         @"tcpPort": tcpPortUI.text,
     };
-    if (self.detailItem == nil) {
-        [AppDelegate.instance.arrayServerList addObject:serverParameters];
-    }
-    else {
-        NSIndexPath *idx = self.detailItem;
+    NSIndexPath *idx = self.detailItem;
+    if (idx && idx.row < AppDelegate.instance.arrayServerList.count) {
         [AppDelegate.instance.arrayServerList removeObjectAtIndex:idx.row];
         [AppDelegate.instance.arrayServerList insertObject:serverParameters atIndex:idx.row];
+    }
+    else {
+        [AppDelegate.instance.arrayServerList addObject:serverParameters];
     }
     [AppDelegate.instance saveServerList];
     [self.navigationController popViewControllerAnimated:YES];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1257" height="319" alt="Bildschirmfoto 2026-08-17 um 22 56 38" src="https://github.com/user-attachments/assets/ef33fd94-7fac-4427-b455-382f6676967c" />

Checks the index before removing/inserting a server in the list. Falls back to adding a server, if there is no index given or the index is beyond the array size.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Avoid potential out-of-bounds when replacing a server in the list