### PR TITLE
Bugfix: Ensure EPG updates happen after valid but empty EPG response

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -145,7 +145,6 @@
         [Utilities archivePath:epgCachePath file:filename data:epgArray];
         dispatch_sync(epglockqueue, ^{
             epgDict[channelid] = epgArray;
-            [epgDownloadQueue removeObject:channelid];
         });
     }
 }
@@ -320,6 +319,10 @@
                        [NSThread detachNewThreadSelector:@selector(parseBroadcasts:) toTarget:self withObject:params];
                    }
                }
+               // Ensure the channelid is removed from the epgDownloadQueue to re-enable a next update attempt
+               dispatch_sync(epglockqueue, ^{
+                   [epgDownloadQueue removeObject:channelid];
+               });
            }];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1153" height="259" alt="Bildschirmfoto 2026-08-18 um 20 21 39" src="https://github.com/user-attachments/assets/561b8e6e-b4b5-4e8a-9b1f-73f41f52a8b3" />

`epgDownloadQueue` is used to avoid addressing multiple JSON EPG update requests for same `channelid`. This `channelid` must be removed in the JSON completion handler, independent of the result. Otherwise a valid JSON response with empty EPG data will result in `channelid` not being removed from `epgDownloadQueue`, in consequence blocking any further update attempt.

Before raising the PR I verified that without the change any empty EPG result will not allow further EPG updates for same `channelid`. After the change, for any `channelid` with an empty EPG, the EPG is requested again via JSON.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: Ensure EPG updates happen after valid but empty EPG response