### PR TITLE
Bugfix: PVR cell might show EPG data for wrong channel

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -238,11 +238,22 @@
 }
 
 - (void)updateEpgTableInfo:(NSDictionary*)parameters {
+    // Get the item currently represented by the cell and abort, if the item's channel id does
+    // not represent the EPG's channel id anymore. This can happen as EPG data is pulled and
+    // updated from outside the main thread, and in main thread the user might have changed
+    // the item list by entering channel groups.
+    NSIndexPath *indexPath = parameters[@"indexPath"];
+    NSMutableDictionary *item = parameters[@"item"];
+    NSDictionary *cellItem = [self getItemFromIndexPath:indexPath];
+    NSNumber *cellChannelid = [Utilities getNumberFromItem:cellItem[@"channelid"]];
+    NSNumber *epgChannelid = [Utilities getNumberFromItem:item[@"channelid"]];
+    if ([cellChannelid longValue] != [epgChannelid longValue]) {
+        return;
+    }
+    
     // We are back to main thread, so we can now update the item with "current_details". This is
     // shown when entering an action sheet.
     NSMutableDictionary *channelEPG = parameters[@"channelEPG"];
-    NSIndexPath *indexPath = parameters[@"indexPath"];
-    NSMutableDictionary *item = parameters[@"item"];
     if (channelEPG[@"current_details"] != nil) {
         item[@"genre"] = channelEPG[@"current_details"];
     }

--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -238,17 +238,23 @@
 }
 
 - (void)updateEpgTableInfo:(NSDictionary*)parameters {
+    // We are back to main thread, so we can now update the item with "current_details". This is
+    // shown when entering an action sheet.
     NSMutableDictionary *channelEPG = parameters[@"channelEPG"];
     NSIndexPath *indexPath = parameters[@"indexPath"];
     NSMutableDictionary *item = parameters[@"item"];
+    if (channelEPG[@"current_details"] != nil) {
+        item[@"genre"] = channelEPG[@"current_details"];
+    }
+        
+    // Get cell for the indexPath which needs an update and set the cell content
     UITableViewCell *cell = [dataList cellForRowAtIndexPath:indexPath];
     UILabel *current = (UILabel*)[cell viewWithTag:XIB_JSON_DATA_CELL_GENRE];
     UILabel *next = (UILabel*)[cell viewWithTag:XIB_JSON_DATA_CELL_RUNTIME];
     current.text = channelEPG[@"current"];
     next.text = channelEPG[@"next"];
-    if (channelEPG[@"current_details"] != nil) {
-        item[@"genre"] = channelEPG[@"current_details"];
-    }
+    
+    // Update the broadcast's progress view
     BroadcastProgressView *progressView = (BroadcastProgressView*)[cell viewWithTag:EPG_VIEW_CELL_PROGRESSVIEW];
     if (![current.text isEqualToString:LOCALIZED_STR(@"Not Available")] && [channelEPG[@"starttime"] isKindOfClass:[NSDate class]] && [channelEPG[@"endtime"] isKindOfClass:[NSDate class]]) {
         float percent_elapsed = [Utilities getPercentElapsed:channelEPG[@"starttime"] EndDate:channelEPG[@"endtime"]];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1156" height="370" alt="Bildschirmfoto 2026-08-19 um 07 56 27" src="https://github.com/user-attachments/assets/2a22d13f-f577-49e1-8965-e32bc989783f" />

In `updateEpgTableInfo` we are back to main thread after pulling the EPG update via JSON. The anchor is the `indexPath` for which the EPG was initially requested. In the meanwhile the item list might have changed (by e.g. user entering channel groups), now representing a different `channelid` at the same `indexPath`. 

Therefore this PR adds a guard by getting the item currently represented by `indexPath` and aborting, if the item's `channelid` does not represent the EPG's `channelid` anymore. By this, the cell does not show false program data and the item list is not updated with wrong "current_details".

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Bugfix: PVR cell might show EPG data for wrong channel