### PR TITLE
Improvement: Avoid displaying "(null)" if item is nil

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -539,7 +539,7 @@
 }
 
 - (NSDictionary*)getNewDictionaryFromExtraInfoItem:(NSDictionary*)item mainFields:(NSDictionary*)mainFields serverURL:(NSString*)serverURL sec2min:(int)sec2min useBanner:(BOOL)useBanner useIcon:(BOOL)useIcon {
-    NSString *label = [NSString stringWithFormat:@"%@", item[mainFields[@"row1"]]];
+    NSString *label = [Utilities getStringFromItem:item[mainFields[@"row1"]]];
     NSString *genre = [Utilities getStringFromItem:item[mainFields[@"row2"]]];
     NSString *year = [Utilities getYearFromItem:item[mainFields[@"row3"]]];
     NSString *runtime = [Utilities getTimeFromItem:item[mainFields[@"row4"]] sec2min:sec2min];
@@ -594,7 +594,7 @@
 }
 
 - (NSMutableDictionary*)getNewDictionaryFromItem:(NSDictionary*)item mainFields:(NSDictionary*)mainFields serverURL:(NSString*)serverURL sec2min:(int)sec2min useBanner:(BOOL)useBanner useIcon:(BOOL)useIcon {
-    NSString *label = [NSString stringWithFormat:@"%@", item[mainFields[@"row1"]]];
+    NSString *label = [Utilities getStringFromItem:item[mainFields[@"row1"]]];
     NSString *genre = [Utilities getStringFromItem:item[mainFields[@"row2"]]];
     NSString *year = [Utilities getYearFromItem:item[mainFields[@"row3"]]];
     NSString *runtime = [Utilities getTimeFromItem:item[mainFields[@"row4"]] sec2min:sec2min];
@@ -608,10 +608,10 @@
         stringURL = [Utilities getItemIconFromDictionary:item];
     }
     NSString *row7key = mainFields[@"row7"] ?: @"none";
-    NSString *row7obj = mainFields[@"row7"] ? [NSString stringWithFormat:@"%@", item[mainFields[@"row7"]]] : @"";
+    NSString *row7obj = mainFields[@"row7"] ? [Utilities getStringFromItem:item[mainFields[@"row7"]]] : @"";
     
-    NSString *seasonNumber = [NSString stringWithFormat:@"%@", item[mainFields[@"row10"]]];
-    NSString *family = [NSString stringWithFormat:@"%@", mainFields[@"row8"]];
+    NSString *seasonNumber = [Utilities getStringFromItem:item[mainFields[@"row10"]]];
+    NSString *family = [Utilities getStringFromItem:mainFields[@"row8"]];
     
     NSString *row19key = mainFields[@"row19"] ?: @"episode";
     id row19obj = @"";
@@ -622,7 +622,7 @@
         row19obj = [Utilities getStringFromItem:item[@"label"]];
     }
     else {
-        row19obj = [NSString stringWithFormat:@"%@", item[mainFields[@"row19"]]];
+        row19obj = [Utilities getStringFromItem:item[mainFields[@"row19"]]];
     }
     id row13key = mainFields[@"row13"];
     id row13obj = [row13key isEqualToString:@"options"] ? (item[row13key] ?: @"") : item[row13key];
@@ -1069,7 +1069,7 @@
         }
         [moreMenu addObject:
          [NSDictionary dictionaryWithObjectsAndKeys:
-          [NSString stringWithFormat:@"%@", menuItem.mainParameters[i][@"morelabel"]], @"label",
+          [Utilities getStringFromItem:menuItem.mainParameters[i][@"morelabel"]], @"label",
           icon, @"icon",
           nil]];
     }
@@ -1709,7 +1709,7 @@
     NSString *stringURL = item[@"thumbnail"];
     NSString *fanartURL = item[@"fanart"];
     NSString *displayThumb = [NSString stringWithFormat:@"%@_wall", defaultThumb];
-    NSString *playcount = [NSString stringWithFormat:@"%@", item[@"playcount"]];
+    NSString *playcount = [Utilities getStringFromItem:item[@"playcount"]];
     
     CGFloat cellthumbWidth = cellGridWidth;
     CGFloat cellthumbHeight = cellGridHeight;
@@ -4873,7 +4873,7 @@
         
         // Now pick the episodes top-down from the list into sections defined by seasons
         for (NSDictionary *item in copyRichResults) {
-            NSString *c = [NSString stringWithFormat:@"%@", item[@"season"]];
+            NSString *c = [Utilities getStringFromItem:item[@"season"]];
             BOOL found = [[self.sections allKeys] containsObject:c];
             if (!found) {
                 [self.sections setValue:[NSMutableArray new] forKey:c];
@@ -5002,7 +5002,7 @@
 }
 
 - (NSString*)getIndexTableKey:(NSString*)value sortMethod:(NSString*)sortMethod {
-    NSString *currentValue = [NSString stringWithFormat:@"%@", value];
+    NSString *currentValue = [Utilities getStringFromItem:value];
     if ([sortMethod isEqualToString:@"year"]) {
         int year = [currentValue intValue];
         if (year >= 1900 && year <= 2099) {
@@ -5026,7 +5026,7 @@
     else if ([sortMethod isEqualToString:@"playcount"] ||
              [sortMethod isEqualToString:@"itemgroup"] ||
              [sortMethod isEqualToString:@"track"]) {
-        currentValue = [NSString stringWithFormat:@"%@", value];
+        currentValue = [Utilities getStringFromItem:value];
     }
     else if (currentValue.length) {
         NSCharacterSet *set = [[NSCharacterSet characterSetWithCharactersInString:@"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLKMNOPQRSTUVWXYZ"] invertedSet];

--- a/XBMC Remote/NowPlaying.m
+++ b/XBMC Remote/NowPlaying.m
@@ -1979,7 +1979,7 @@
         if (![parameters[@"disableFilterParameter"] boolValue]) {
             if ([objKey isEqualToString:@"artistid"]) {
                 // WORKAROUND due to the lack of the artistid with Playlist.GetItems
-                NSString *artistFrodoWorkaround = [NSString stringWithFormat:@"%@", [item[@"artist"] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
+                NSString *artistFrodoWorkaround = [Utilities getStringFromItem:[item[@"artist"] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
                 obj = @{@"artist": artistFrodoWorkaround};
             }
             else {

--- a/XBMC Remote/SettingsValuesViewController.m
+++ b/XBMC Remote/SettingsValuesViewController.m
@@ -124,7 +124,7 @@
             footerMessage = LOCALIZED_STR(@"-- WARNING --\nThis kind of setting cannot be configured remotely. Use the XBMC GUI for changing this setting.\nThank you.");
         }
         else if (xbmcSetting == SettingTypeList || xbmcSetting == SettingTypeDefault || xbmcSetting == SettingTypeMultiselect) {
-            footerMessage = [NSString stringWithFormat:@"%@", self.detailItem[@"genre"] ?: self.detailItem[@"label"]];
+            footerMessage = [Utilities getStringFromItem:self.detailItem[@"genre"] ?: self.detailItem[@"label"]];
         }
         if (xbmcSetting != SettingTypeUnsupported) {
             footerMessage = [NSString stringWithFormat:@"%@%@ⓘ %@",
@@ -243,7 +243,7 @@
     NSString *subTitle = @"";
     switch (xbmcSetting) {
         case SettingTypeList:
-            subTitle = [NSString stringWithFormat:@"%@", settingOptions[longPressRow.row][@"label"]];
+            subTitle = [Utilities getStringFromItem:settingOptions[longPressRow.row][@"label"]];
             break;
             
         case SettingTypeSlider:
@@ -268,7 +268,7 @@
                 value = @([settingOptions[longPressRow.row][@"value"] intValue]);
             }
             else {
-                value = [NSString stringWithFormat:@"%@", settingOptions[longPressRow.row][@"value"]];
+                value = [Utilities getStringFromItem:settingOptions[longPressRow.row][@"value"]];
             }
             break;
             
@@ -458,7 +458,7 @@
     onoff.hidden = YES;
     textInputField.hidden = YES;
     
-    NSString *descriptionString = [NSString stringWithFormat:@"%@", self.detailItem[@"genre"]];
+    NSString *descriptionString = [Utilities getStringFromItem:self.detailItem[@"genre"]];
     descriptionString = [descriptionString stringByReplacingOccurrencesOfString:@"[CR]" withString:@"\n"];
     descriptionString = [descriptionString stripBBandHTML];
     switch (xbmcSetting) {
@@ -467,7 +467,7 @@
             descriptionLabel.hidden = NO;
             onoff.hidden = NO;
             
-            cellLabel.text = [NSString stringWithFormat:@"%@", self.detailItem[@"label"]];
+            cellLabel.text = [Utilities getStringFromItem:self.detailItem[@"label"]];
             cellLabel.numberOfLines = 0;
             cellLabel.frame = CGRectMake(PADDING_HORIZONTAL,
                                          PADDING_VERTICAL,
@@ -493,7 +493,7 @@
             
         case SettingTypeList:
             self.navigationItem.title = self.detailItem[@"label"];
-            cellLabel.text = [NSString stringWithFormat:@"%@", settingOptions[indexPath.row][@"label"]];
+            cellLabel.text = [Utilities getStringFromItem:settingOptions[indexPath.row][@"label"]];
             if ([self.detailItem[@"value"] isKindOfClass:[NSArray class]]) {
                 if ([self.detailItem[@"value"] containsObject:settingOptions[indexPath.row][@"value"]]) {
                     cell.accessoryType = UITableViewCellAccessoryCheckmark;
@@ -516,7 +516,7 @@
             descriptionLabel.hidden = NO;
             
             cellLabel.textAlignment = NSTextAlignmentCenter;
-            cellLabel.text = [NSString stringWithFormat:@"%@", self.detailItem[@"label"]];
+            cellLabel.text = [Utilities getStringFromItem:self.detailItem[@"label"]];
             cellLabel.numberOfLines = 0;
             cellLabel.frame = CGRectMake(PADDING_HORIZONTAL,
                                          PADDING_VERTICAL,
@@ -556,7 +556,7 @@
             textInputField.hidden = NO;
             
             cellLabel.textAlignment = NSTextAlignmentCenter;
-            cellLabel.text = [NSString stringWithFormat:@"%@", self.detailItem[@"label"]];
+            cellLabel.text = [Utilities getStringFromItem:self.detailItem[@"label"]];
             cellLabel.numberOfLines = 0;
             cellLabel.frame = CGRectMake(PADDING_HORIZONTAL,
                                          PADDING_VERTICAL,
@@ -573,7 +573,7 @@
                                                 LABEL_HEIGHT_DEFAULT);
             [self setAutomaticLabelHeight:descriptionLabel];
             
-            textInputField.text = [NSString stringWithFormat:@"%@", self.detailItem[@"value"]];
+            textInputField.text = [Utilities getStringFromItem:self.detailItem[@"value"]];
             textInputField.frame = CGRectMake(SLIDER_PADDING,
                                               CGRectGetMaxY(descriptionLabel.frame) + PADDING_VERTICAL,
                                               cellWidth - 2 * SLIDER_PADDING,
@@ -636,7 +636,7 @@
             if (self.detailItem[@"value"] != nil) {
                 cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
                 
-                cellLabel.text = [NSString stringWithFormat:@"%@", self.detailItem[@"value"]];
+                cellLabel.text = [Utilities getStringFromItem:self.detailItem[@"value"]];
                 cellLabel.text = cellLabel.text.length ? cellLabel.text : descriptionString;
                 cellLabel.numberOfLines = 0;
                 cellLabel.frame = CGRectMake(PADDING_HORIZONTAL,
@@ -873,7 +873,7 @@
 
 - (BOOL)textFieldShouldReturn:(UITextField*)textField {
     [textField resignFirstResponder];
-    [self setSettingValue:[NSString stringWithFormat:@"%@", textField.text] sender:textField];
+    [self setSettingValue:[Utilities getStringFromItem:textField.text] sender:textField];
     return YES;
 }
 

--- a/XBMC Remote/ShowInfoViewController.m
+++ b/XBMC Remote/ShowInfoViewController.m
@@ -242,20 +242,20 @@
         notificationName = @"MainMenuDeselectSection";
         menuItem = [AppDelegate.instance.playlistArtistAlbums copy];
         chosenMenuItem = menuItem.subItem;
-        chosenMenuItem.mainLabel = [NSString stringWithFormat:@"%@", item[@"label"]];
+        chosenMenuItem.mainLabel = [Utilities getStringFromItem:item[@"label"]];
     }
     else if ([item[@"family"] isEqualToString:@"tvshowid"] && ![sender isKindOfClass:[NSString class]]) {
         notificationName = @"MainMenuDeselectSection";
         menuItem = [AppDelegate.instance.playlistTvShows copy];
         chosenMenuItem = menuItem.subItem;
-        chosenMenuItem.mainLabel = [NSString stringWithFormat:@"%@", item[@"label"]];
+        chosenMenuItem.mainLabel = [Utilities getStringFromItem:item[@"label"]];
     }
     else if ([item[@"family"] isEqualToString:@"artistid"]) {
         notificationName = @"MainMenuDeselectSection";
         activeTab = 1;
         menuItem = [AppDelegate.instance.playlistArtistAlbums copy];
         chosenMenuItem = menuItem.subItem;
-        chosenMenuItem.mainLabel = [NSString stringWithFormat:@"%@", item[@"label"]];
+        chosenMenuItem.mainLabel = [Utilities getStringFromItem:item[@"label"]];
     }
     else if ([item[@"family"] isEqualToString:@"movieid"]) {
         if ([sender isKindOfClass:[NSString class]]) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Motivated by an AI code review
<img width="1173" height="234" alt="Bildschirmfoto 2026-08-20 um 19 25 07" src="https://github.com/user-attachments/assets/23e41113-cd7f-4d23-b510-cec3fc6dfe9d" />

Use `getStringFromItem` instead of calling `stringWithFormat:@"%@", x`. This avoids displaying "(null)" in the UI, if `item` is `nil`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Avoid displaying "(null)" if item is nil