### PR TITLE
Improvement: Only start EPG background thread for channel ids and not channel groups

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -2532,12 +2532,6 @@
             genre.font = [UIFont boldSystemFontOfSize:14];
             progressView.hidden = YES;
             timerView.hidden = ![item[@"isrecording"] boolValue];
-            NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
-                                    [Utilities getNumberFromItem:item[@"channelid"]], @"channelid",
-                                    indexPath, @"indexPath",
-                                    item, @"item",
-                                    nil];
-            [NSThread detachNewThreadSelector:@selector(getChannelEpgInfo:) toTarget:self withObject:params];
         }
         if (recordingListView) {
             genre.textColor = [UIColor get2ndLabelColor];
@@ -2573,6 +2567,12 @@
         else if ([item[@"family"] isEqualToString:@"channelid"]) {
             runtimeyear.hidden = YES;
             rating.hidden = YES;
+            NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
+                                    [Utilities getNumberFromItem:item[@"channelid"]], @"channelid",
+                                    indexPath, @"indexPath",
+                                    item, @"item",
+                                    nil];
+            [NSThread detachNewThreadSelector:@selector(getChannelEpgInfo:) toTarget:self withObject:params];
         }
         else if ([item[@"family"] isEqualToString:@"recordingid"] ||
                  [item[@"family"] isEqualToString:@"timerid"]) {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Move calling `getChannelEpgInfo` into the existing `family == channelid` condition. Avoids starting `getChannelEpgInfo` in a background thread in the case of `family == channelgroups`. In this case `channelid == 0` and `getChannelEpgInfo` would anyway immediately return.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Only start EPG background thread for channel ids and not channel groups