### PR TITLE
Improvement: Rework iPad bounce / stack behaviour

### DIFF
--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -431,7 +431,7 @@
     animation.autoreverses = YES;
     animation.fillMode = kCAFillModeBackwards;
     animation.removedOnCompletion = YES;
-    animation.additive = NO;
+    animation.additive = YES;
     return animation;
 }
 
@@ -439,8 +439,8 @@
     [view.layer removeAnimationForKey:@"bounceAnimation"];
     CABasicAnimation *bounceAnimation = [CABasicAnimation animationWithKeyPath:@"position.x"];
     bounceAnimation = [self setBounceAnimation:bounceAnimation
-                                          from:view.center.x
-                                            to:view.center.x + amount];
+                                          from:0
+                                            to:amount];
     [view.layer addAnimation:bounceAnimation forKey:@"bounceAnimation"];
 }
 

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -459,13 +459,7 @@
 - (void)addViewInSlider:(UIViewController*)controller invokeByController:(UIViewController*)invokeByController isStackStartView:(BOOL)isStackStartView {
     CGFloat animX = 0;
     if (isStackStartView) {
-        NSInteger numViews = slideViews.subviews.count;
-        if (numViews == 0) {
-            animX = (IS_PORTRAIT ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT) - PAD_MENU_TABLE_WIDTH;
-        }
-        else {
-            animX = slideViews.subviews[0].frame.origin.x;
-        }
+        animX = (IS_PORTRAIT ? GET_MAINSCREEN_WIDTH : GET_MAINSCREEN_HEIGHT) - PAD_MENU_TABLE_WIDTH;
         slideStartPosition = SLIDE_VIEWS_START_X_POS;
         viewXPosition = slideStartPosition;
         

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -436,7 +436,7 @@
 }
 
 - (void)bounceView:(UIView*)view amount:(CGFloat)amount {
-    [view.layer removeAllAnimations];
+    [view.layer removeAnimationForKey:@"bounceAnimation"];
     CABasicAnimation *bounceAnimation = [CABasicAnimation animationWithKeyPath:@"position.x"];
     bounceAnimation = [self setBounceAnimation:bounceAnimation
                                           from:view.center.x

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -423,10 +423,10 @@
     }
 }
 
-- (CABasicAnimation*)setBounceAnimation:(CABasicAnimation*)animation from:(CGFloat)fromPos to:(CGFloat)toPos {
+- (CABasicAnimation*)setBounceAnimation:(CABasicAnimation*)animation amount:(CGFloat)amount {
     animation.duration = 0.2;
-    animation.fromValue = @(fromPos);
-    animation.toValue = @(toPos);
+    animation.fromValue = @0;
+    animation.byValue = @(amount);
     animation.repeatCount = 0;
     animation.autoreverses = YES;
     animation.fillMode = kCAFillModeBackwards;
@@ -439,8 +439,7 @@
     [view.layer removeAnimationForKey:@"bounceAnimation"];
     CABasicAnimation *bounceAnimation = [CABasicAnimation animationWithKeyPath:@"position.x"];
     bounceAnimation = [self setBounceAnimation:bounceAnimation
-                                          from:0
-                                            to:amount];
+                                        amount:amount];
     [view.layer addAnimation:bounceAnimation forKey:@"bounceAnimation"];
 }
 


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Motived by an AI code review.
<img width="1172" height="333" alt="Bildschirmfoto 2026-08-22 um 17 32 14" src="https://github.com/user-attachments/assets/107a32e6-2105-4d57-904a-1ad1d10ffe86" />

This PR changes the iPad's bounce animation to use additive animation. Also it now removes only any other bounce animation before adding a new one. Expectation is, that the bounce animation will interfere less with other animations.

While working on the bounce animation it became clear that the animation of opening a new stack was different for the use cases of starting from an _empty_ stack or a _non-empty_ stack. This caused the bounce animation to become less prominent when opening a new stack from a non-empty stack (e.g. showing Movies and then entering Music). This is now unified.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Entering new iPad stacks is animated always the same way
Improvement: Let bounce animation not interfere with other animations