### PR TITLE
Improvement: Minor rework iPad's StackVC

### DIFF
--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -96,6 +96,17 @@
     return self;
 }
 
+- (void)clearStackState {
+    viewAtLeft2 = nil;
+    viewAtRight = nil;
+    viewAtLeft = nil;
+    viewAtRight2 = nil;
+    for (UIView *subview in slideViews.subviews) {
+        [subview removeFromSuperview];
+    }
+    [viewControllersStack removeAllObjects];
+}
+
 - (void)handleStackScrollFullScreenEnabled:(NSNotification*)sender {
     UIView *senderView = nil;
     if ([sender.object isKindOfClass:[UIView class]]) {
@@ -210,16 +221,9 @@
                                        viewAtLeft.frame.size.width,
                                        viewAtLeft.frame.size.height);
         }
-        viewAtLeft2 = nil;
-        viewAtRight = nil;
-        viewAtLeft = nil;
-        viewAtRight2 = nil;
     }
                     completion:^(BOOL finished) {
-        for (UIView *subview in slideViews.subviews) {
-            [subview removeFromSuperview];
-        }
-        [viewControllersStack removeAllObjects];
+        [self clearStackState];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"StackScrollOffScreen" object:nil];
     }];
 }
@@ -470,11 +474,7 @@
         slideStartPosition = SLIDE_VIEWS_START_X_POS;
         viewXPosition = slideStartPosition;
         
-        for (UIView *subview in slideViews.subviews) {
-            [subview removeFromSuperview];
-        }
-        
-        [viewControllersStack removeAllObjects];
+        [self clearStackState];
     }
     
     if (viewControllersStack.count > 1) {
@@ -495,10 +495,7 @@
         }
     }
     else if (viewControllersStack.count == 0) {
-        for (UIView *subview in slideViews.subviews) {
-            [subview removeFromSuperview];
-        }		
-        [viewControllersStack removeAllObjects];
+        [self clearStackState];
     }
     
     [viewControllersStack addObject:controller];

--- a/XBMC Remote/iPad/StackScrollViewController.m
+++ b/XBMC Remote/iPad/StackScrollViewController.m
@@ -515,21 +515,21 @@
     if (slideViews.subviews.count > 0) {
         if (slideViews.subviews.count == 1) {
             viewAtLeft = slideViews.subviews[slideViews.subviews.count - 1];
-            controller.view.frame = CGRectMake(animX, 0, controller.view.frame.size.width, self.view.frame.size.height - bottomPadding);
+            viewAtLeft2 = nil;
+            viewAtRight = nil;
+            viewAtRight2 = nil;
+            [viewAtLeft setX:animX];
             
             [UIView transitionWithView:viewAtLeft
                               duration:SLIDE_TRANSITION_TIME
                                options:UIViewAnimationOptionTransitionNone
                             animations:^{
-                controller.view.frame = CGRectMake(viewXPosition, 0, controller.view.frame.size.width, self.view.frame.size.height - bottomPadding);
+                [viewAtLeft setX:viewXPosition];
             }
                             completion:^(BOOL finished) {
                 [self bounceView:viewAtLeft amount:-BOUNCE_X];
             }
             ];
-            viewAtLeft2 = nil;
-            viewAtRight = nil;
-            viewAtRight2 = nil;
         }
         else if (slideViews.subviews.count == 2) {
             viewAtRight = slideViews.subviews[slideViews.subviews.count - 1];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Motivated by an AI code review.
<img width="1151" height="342" alt="Bildschirmfoto 2026-08-22 um 18 26 59" src="https://github.com/user-attachments/assets/b7f2f765-8300-40b5-9444-fa03e85f3f77" />

Introduces `clearStackState` to clear the view variables `viewAtLeft2`, `viewAtRight`, `viewAtLeft` and `viewAtRight2` and remove all views from the stack. This is now called in three places, some of which did not clean up the view-variables. 

In `addViewInSlider:invokeByController:isStackStartView:` apply some minor refactoring for the case `slideViews.subviews.count == 1` to use `viewAtLeft` and `setX` instead if manipulating `controller` with `CGRectMake`. This is in line with how this is done for other values of `slideViews.subviews.count`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Minor rework iPad's StackVC