### PR TITLE
Improvement: Decouple TCP from HTTP heartbeat

### DIFF
--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -64,6 +64,7 @@ NSInputStream *inStream;
     [Utilities checkLocalNetworkAccess];
     
     [heartbeatTimer invalidate];
+    inCheck = NO;
     [self checkServer];
     // Add timer to RunLoopCommonModes to decouple the timer from touch events like dragging
     heartbeatTimer = [NSTimer timerWithTimeInterval:SERVER_CHECK_TIMER target:self selector:@selector(checkServer) userInfo:nil repeats:YES];

--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -218,7 +218,7 @@ NSInputStream *inStream;
                 NSDictionary *serverInfo = methodResult[@"version"];
                 AppDelegate.instance.serverVersion = [serverInfo[@"major"] intValue];
                 AppDelegate.instance.serverMinorVersion = [serverInfo[@"minor"] intValue];
-                NSString *realServerName = methodResult[@"name"];
+                NSString *realServerName = [Utilities getStringFromItem:methodResult[@"name"]];
                 if ([realServerName isEqualToString:@"MrMC"]) {
                     AppDelegate.instance.serverVersion += MRMC_TIMEWARP;
                 }
@@ -230,9 +230,9 @@ NSInputStream *inStream;
                 }
                 infoTitle = [NSString stringWithFormat:@"%@ v%@.%@ %@",
                              AppDelegate.instance.obj.serverDescription,
-                             serverInfo[@"major"],
-                             serverInfo[@"minor"],
-                             serverInfo[@"tag"]];
+                             [Utilities getStringFromItem:serverInfo[@"major"]],
+                             [Utilities getStringFromItem:serverInfo[@"minor"]],
+                             [Utilities getStringFromItem:serverInfo[@"tag"]]];
                 [self notifyHttpConnected:YES];
                 [self notifyShowSetupMenu:NO];
             }

--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -213,32 +213,31 @@ NSInputStream *inStream;
             // Read if ignorearticles is enabled
             [self readIgnoreArticlesEnabled];
 
-            if (!AppDelegate.instance.serverOnLine) {
-                if ([methodResult isKindOfClass:[NSDictionary class]]) {
-                    NSDictionary *serverInfo = methodResult[@"version"];
-                    AppDelegate.instance.serverVersion = [serverInfo[@"major"] intValue];
-                    AppDelegate.instance.serverMinorVersion = [serverInfo[@"minor"] intValue];
-                    NSString *realServerName = methodResult[@"name"];
-                    if ([realServerName isEqualToString:@"MrMC"]) {
-                        AppDelegate.instance.serverVersion += MRMC_TIMEWARP;
-                    }
-                    if (AppDelegate.instance.serverVersion < MIN_SUPPORTED_SERVER_VERSION) {
-                        NSString *message = LOCALIZED_STR_ARGS(@"Kodi version %d not supported.", AppDelegate.instance.serverVersion);
-                        [Utilities showMessage:message color:ERROR_MESSAGE_COLOR];
-                        [self notifyConnectionProblem];
-                        return;
-                    }
-                    infoTitle = [NSString stringWithFormat:@"%@ v%@.%@ %@",
-                                 AppDelegate.instance.obj.serverDescription,
-                                 serverInfo[@"major"],
-                                 serverInfo[@"minor"],
-                                 serverInfo[@"tag"]];
-                    [self notifyHttpConnected:YES];
-                    [self notifyShowSetupMenu:NO];
+            // Read server name and Kodi version
+            if ([methodResult isKindOfClass:[NSDictionary class]]) {
+                NSDictionary *serverInfo = methodResult[@"version"];
+                AppDelegate.instance.serverVersion = [serverInfo[@"major"] intValue];
+                AppDelegate.instance.serverMinorVersion = [serverInfo[@"minor"] intValue];
+                NSString *realServerName = methodResult[@"name"];
+                if ([realServerName isEqualToString:@"MrMC"]) {
+                    AppDelegate.instance.serverVersion += MRMC_TIMEWARP;
                 }
-                else {
+                if (AppDelegate.instance.serverVersion < MIN_SUPPORTED_SERVER_VERSION) {
+                    NSString *message = LOCALIZED_STR_ARGS(@"Kodi version %d not supported.", AppDelegate.instance.serverVersion);
+                    [Utilities showMessage:message color:ERROR_MESSAGE_COLOR];
                     [self notifyConnectionProblem];
+                    return;
                 }
+                infoTitle = [NSString stringWithFormat:@"%@ v%@.%@ %@",
+                             AppDelegate.instance.obj.serverDescription,
+                             serverInfo[@"major"],
+                             serverInfo[@"minor"],
+                             serverInfo[@"tag"]];
+                [self notifyHttpConnected:YES];
+                [self notifyShowSetupMenu:NO];
+            }
+            else {
+                [self notifyConnectionProblem];
             }
         }
         else {

--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -203,10 +203,10 @@ NSInputStream *inStream;
      withTimeout:SERVER_JSON_TIMEOUT
      onCompletion:^(NSString *methodName, NSInteger callId, id methodResult, DSJSONRPCError *methodError, NSError *error) {
         inCheck = NO;
+        if (AppDelegate.instance.serverOnLine) {
+            return;
+        }
         if (error == nil && methodError == nil) {
-            if (AppDelegate.instance.serverOnLine) {
-                return;
-            }
             // Read JSON RPC API version
             [self readJSONRPCAPIVersion];
 

--- a/XBMC Remote/TcpJSONRPC.m
+++ b/XBMC Remote/TcpJSONRPC.m
@@ -132,13 +132,11 @@ NSInputStream *inStream;
             
         case NSStreamEventErrorOccurred:
             AppDelegate.instance.serverTCPConnectionOpen = NO;
-            inCheck = NO;
             [[NSNotificationCenter defaultCenter] postNotificationName:@"tcpJSONRPCConnectionError" object:nil userInfo:nil];
             break;
 
         case NSStreamEventEndEncountered:
             AppDelegate.instance.serverTCPConnectionOpen = NO;
-            inCheck = NO;
             [theStream close];
             [theStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
             theStream.delegate = nil;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1141" height="369" alt="Bildschirmfoto 2026-08-23 um 10 18 18" src="https://github.com/user-attachments/assets/02c43ea0-3dc2-4752-857e-a66afb52af87" />

The TCP connection is independent of the HTTP connection to the Kodi server. Failure of TCP shall not influence any ongoing HTTP heartbeat. The code was 15 years old and might have been of use in former times. Now, it was only allowing a new heartbeat check to be executed while another check was going on. This anyway should not happen as the HTTP/JSON check times our before a next heartbeat check would be attempted.

In addition, reset `inCheck` when restarting the HTTP heartbeat. This avoids early return of `checkServer`, which would delay the next check by `SERVER_CHECK_TIMER` seconds, in case a JSON request did not yet return. Use case would be a state where the app tries to connect to a non-reachable server and the user then selects a different, reachable server. Before this change, the app would not immediately reconnect, but wait for `SERVER_CHECK_TIMER` seconds before reconnecting. With the change, the reconnect happens immediately.

This requires another change to be added to avoid that after the successful connection to the reachable server, the JSON request to the non-reachable server times out later and throws an error and updates the connection status.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Faster connection to reachable server after attempting to connect to a non-reachable server