### PR TITLE
Improvement: Directly set message's start position/alpha instead of animating

### DIFF
--- a/XBMC Remote/MessagesView.m
+++ b/XBMC Remote/MessagesView.m
@@ -45,16 +45,9 @@
 # pragma mark - view Effects
 
 - (void)showMessage:(NSString*)message timeout:(NSTimeInterval)timeout color:(UIColor*)color {
-    // first slide out
-    CGRect frame = self.frame;
-    [UIView animateWithDuration:0.1
-                          delay:0.0
-                        options:UIViewAnimationOptionCurveEaseInOut
-                     animations:^{
-        self.frame = CGRectMake(frame.origin.x, messageOrigin - slideHeight, frame.size.width, frame.size.height);
-        self.alpha = 0.0;
-                     }
-                     completion:nil];
+    // first set start position out of visible area
+    [self setY:messageOrigin - slideHeight];
+    self.alpha = 0.0;
     viewMessage.text = message;
     self.backgroundColor = color;
     // then slide in
@@ -62,7 +55,7 @@
                           delay:0.0
                         options:UIViewAnimationOptionCurveEaseInOut
                      animations:^{
-        self.frame = CGRectMake(frame.origin.x, messageOrigin, frame.size.width, frame.size.height);
+        [self setY:messageOrigin];
         self.alpha = 1.0;
                      }
                      completion:nil];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review
<img width="1032" height="224" alt="Bildschirmfoto 2026-08-23 um 19 59 02" src="https://github.com/user-attachments/assets/5134dc5c-48b7-4189-8a54-11f0d4dcba6a" />

Directly set message's start position/alpha instead of animating. Use `UIView`'s extension `setY` to manipulate the position.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Directly set message's start position/alpha instead of animating