### PR TITLE
Improvement: Rework buildSelectorForSortMethod to avoid potential crash when attempting to filter a list

### DIFF
--- a/XBMC Remote/DetailViewController.m
+++ b/XBMC Remote/DetailViewController.m
@@ -4959,12 +4959,16 @@
 
 - (SEL)buildSelectorForSortMethod:(NSString*)sortByMethod inArray:(NSArray*)itemList {
     // Use localizedStandardCompare for all NSString items to be sorted (provides correct order for multi-digit
-    // numbers). But do not use for any other types as this crashes.
-    SEL selector = nil;
-    if (itemList.count > 0 && [itemList[0][sortByMethod] isKindOfClass:[NSString class]]) {
-        selector = @selector(localizedStandardCompare:);
+    // numbers). But do not use for any other types as this crashes. Check for all items in the list.
+    if (!itemList.count) {
+        return nil;
     }
-    return selector;
+    for (id item in itemList) {
+        if (![item[sortByMethod] isKindOfClass:[NSString class]]) {
+            return nil;
+        }
+    }
+    return @selector(localizedStandardCompare:);
 }
 
 - (void)buildSectionsForList:(NSArray*)itemList sortMethod:(NSString*)sortByMethod {


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
Addresses a finding from an AI code review.
<img width="1087" height="308" alt="Bildschirmfoto 2026-08-23 um 21 34 26" src="https://github.com/user-attachments/assets/8580eeca-ae4d-4b7a-8c6b-e0c3e115532d" />

Do not assume by sampling `first` item that `all` items will use the same class for the same key. Verify use of `NSSString` by checking for `all` items.

Generally, the formerly used sampling will work, if Kodi always provides the same class for values of same key for each item. But this is not guaranteed. I also thought of ensuring this already when creating the item array, but this seems difficult as the different menu views support different filter options.

With the change in this PR the approach is safe. But looping through all items and checking the class will consume some more processing time and needs some tests on real devices.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Rework buildSelectorForSortMethod to avoid potential crash when attempting to filter a list