### PR TITLE
Improvement: Minor rework when changing subtitles and audiostreams

### DIFF
--- a/XBMC Remote/RemoteController.h
+++ b/XBMC Remote/RemoteController.h
@@ -49,7 +49,6 @@ typedef NS_ENUM(NSInteger, RemotePositionType) {
     BOOL torchIsOn;
     BOOL isEmbeddedMode;
     BOOL isGestureViewActive;
-    NSDictionary *subsDictionary;
 }
 
 - (IBAction)startVibrate:(id)sender;

--- a/XBMC Remote/RemoteController.h
+++ b/XBMC Remote/RemoteController.h
@@ -50,7 +50,6 @@ typedef NS_ENUM(NSInteger, RemotePositionType) {
     BOOL isEmbeddedMode;
     BOOL isGestureViewActive;
     NSDictionary *subsDictionary;
-    NSDictionary *audiostreamsDictionary;
 }
 
 - (IBAction)startVibrate:(id)sender;

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -412,15 +412,13 @@ static void *TorchRemoteContext = &TorchRemoteContext;
                              if ([methodResult count]) {
                                  NSDictionary *currentAudiostream = methodResult[@"currentaudiostream"];
                                  NSArray *audiostreams = methodResult[@"audiostreams"];
-                                 if (audiostreams.count) {
-                                     audiostreamsDictionary = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                                       currentAudiostream, @"currentaudiostream",
-                                                       audiostreams, @"audiostreams",
-                                                       nil];
+                                 if ([audiostreams isKindOfClass:[NSArray class]] && audiostreams.count) {
                                      NSArray *actionSheetTitles = [self buildActionSheetForArray:audiostreams
                                                                                  currentLanguage:currentAudiostream
                                                                                   featureEnabled:YES];
-                                     [self showActionAudiostreams:actionSheetTitles];
+                                     [self showActionAudiostreams:actionSheetTitles
+                                                     audiostreams:audiostreams
+                                                          current:currentAudiostream];
                                  }
                                  else {
                                      [self showSubInfo:LOCALIZED_STR(@"Audiostreams not available") color:ERROR_MESSAGE_COLOR];
@@ -446,7 +444,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
 
 #pragma mark - Action Sheet Method
 
-- (void)showActionAudiostreams:(NSArray*)sheetActions {
+- (void)showActionAudiostreams:(NSArray*)sheetActions audiostreams:(NSArray*)allAudiostreams current:(NSDictionary*)currentAudiostream {
     NSInteger numActions = sheetActions.count;
     if (numActions) {
         UIAlertController *alertCtrl = [UIAlertController alertControllerWithTitle:LOCALIZED_STR(@"Audio stream") message:nil preferredStyle:UIAlertControllerStyleActionSheet];
@@ -456,10 +454,11 @@ static void *TorchRemoteContext = &TorchRemoteContext;
         for (int i = 0; i < numActions; i++) {
             NSString *actiontitle = sheetActions[i];
             UIAlertAction *action = [UIAlertAction actionWithTitle:actiontitle style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-                if (audiostreamsDictionary[@"audiostreams"]) {
-                    if (audiostreamsDictionary[@"audiostreams"][i]) {
-                        if (![audiostreamsDictionary[@"audiostreams"][i] isEqual:audiostreamsDictionary[@"currentaudiostream"]]) {
-                            id audiostreamIndex = audiostreamsDictionary[@"audiostreams"][i][@"index"];
+                if (allAudiostreams && [allAudiostreams isKindOfClass:[NSArray class]]) {
+                    id selectedAudiostream = allAudiostreams[i];
+                    if (selectedAudiostream && [selectedAudiostream isKindOfClass:[NSDictionary class]]) {
+                        if (![selectedAudiostream isEqual:currentAudiostream]) {
+                            id audiostreamIndex = selectedAudiostream[@"index"];
                             if (audiostreamIndex) {
                                 [self playerAction:@"Player.SetAudioStream" params:@{@"stream": audiostreamIndex}];
                                 [self showSubInfo:actiontitle color:SUCCESS_MESSAGE_COLOR];

--- a/XBMC Remote/RemoteController.m
+++ b/XBMC Remote/RemoteController.m
@@ -368,16 +368,14 @@ static void *TorchRemoteContext = &TorchRemoteContext;
                                  NSDictionary *currentSubtitle = methodResult[@"currentsubtitle"];
                                  BOOL subtitleEnabled = [methodResult[@"subtitleenabled"] boolValue];
                                  NSArray *subtitles = methodResult[@"subtitles"];
-                                 if (subtitles.count) {
-                                     subsDictionary = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                                       currentSubtitle, @"currentsubtitle",
-                                                       @(subtitleEnabled), @"subtitleenabled",
-                                                       subtitles, @"subtitles",
-                                                       nil];
+                                 if ([subtitles isKindOfClass:[NSArray class]] && subtitles.count) {
                                      NSArray *actionSheetTitles = [self buildActionSheetForArray:subtitles
                                                                                  currentLanguage:currentSubtitle
                                                                                   featureEnabled:subtitleEnabled];
-                                     [self showActionSubtitles:actionSheetTitles];
+                                     [self showActionSubtitles:actionSheetTitles
+                                                     subtitles:subtitles
+                                                       current:currentSubtitle
+                                                       enabled:subtitleEnabled];
                                  }
                                  else {
                                      [self showSubInfo:LOCALIZED_STR(@"Subtitles not available") color:ERROR_MESSAGE_COLOR];
@@ -481,7 +479,7 @@ static void *TorchRemoteContext = &TorchRemoteContext;
     }
 }
 
-- (void)showActionSubtitles:(NSArray*)sheetActions {
+- (void)showActionSubtitles:(NSArray*)sheetActions subtitles:(NSArray*)allSubtitles current:(NSDictionary*)currentSubtitle enabled:(BOOL)subtitlesEnabled {
     NSInteger numActions = sheetActions.count;
     if (numActions) {
         UIAlertController *alertCtrl = [UIAlertController alertControllerWithTitle:LOCALIZED_STR(@"Subtitles") message:nil preferredStyle:UIAlertControllerStyleActionSheet];
@@ -492,18 +490,18 @@ static void *TorchRemoteContext = &TorchRemoteContext;
             [self showSubInfo:LOCALIZED_STR(@"Subtitles disabled") color:SUCCESS_MESSAGE_COLOR];
             [self playerAction:@"Player.SetSubtitle" params:@{@"subtitle": @"off"}];
         }];
-        if ([subsDictionary[@"subtitleenabled"] boolValue]) {
+        if (subtitlesEnabled) {
             [alertCtrl addAction:action_disable];
         }
         
         for (int i = 0; i < numActions; i++) {
             NSString *actiontitle = sheetActions[i];
             UIAlertAction *action = [UIAlertAction actionWithTitle:actiontitle style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-                if (subsDictionary[@"subtitles"]) {
-                    if (subsDictionary[@"subtitles"][i]) {
-                        if (![subsDictionary[@"subtitles"][i] isEqual:subsDictionary[@"currentsubtitle"]] ||
-                            ![subsDictionary[@"subtitleenabled"] boolValue]) {
-                            id subsIndex = subsDictionary[@"subtitles"][i][@"index"];
+                if (allSubtitles && [allSubtitles isKindOfClass:[NSArray class]]) {
+                    id selectedSubtitle = allSubtitles[i];
+                    if (selectedSubtitle && [selectedSubtitle isKindOfClass:[NSDictionary class]]) {
+                        if (![selectedSubtitle isEqual:currentSubtitle] || !subtitlesEnabled) {
+                            id subsIndex = selectedSubtitle[@"index"];
                             if (subsIndex) {
                                 [self playerAction:@"Player.SetSubtitle" params:@{@"subtitle": subsIndex}];
                                 [self playerAction:@"Player.SetSubtitle" params:@{@"subtitle": @"on"}];


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
When reviewing the code due to a reported issue (which finally was fixed inside Kodi), I came around some ancient code which I now refactored a bit. The ivars `audiostreamsDictionary` and `subsDictionary` are not needed. Instead, hand over the existing variables as parameters. This PR also adds some guards for the variable's types to avoid potential crashes when the JSON response from Kodi should be mal-formatted.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Improvement: Minor rework when changing subtitles and audiostreams