### PR TITLE
Maintenance: remove soon deprecated canOpenURL

### DIFF
--- a/XBMC Remote/BaseActionViewController.m
+++ b/XBMC Remote/BaseActionViewController.m
@@ -180,13 +180,12 @@
     @try {
         svc = [[SFSafariViewController alloc] initWithURL:nsurl];
     } @catch (NSException *exception) {
-        if ([UIApplication.sharedApplication canOpenURL:nsurl]) {
-            [UIApplication.sharedApplication openURL:nsurl options:@{} completionHandler:nil];
-        }
-        else {
-            UIAlertController *alertView = [Utilities createAlertOK:LOCALIZED_STR(@"Error loading page") message:exception.reason];
-            [self presentViewController:alertView animated:YES completion:nil];
-        }
+        [UIApplication.sharedApplication openURL:nsurl options:@{} completionHandler:^(BOOL success) {
+            if (!success) {
+                UIAlertController *alertView = [Utilities createAlertOK:LOCALIZED_STR(@"Error loading page") message:exception.reason];
+                [self presentViewController:alertView animated:YES completion:nil];
+            }
+        }];
         return;
     }
     UIViewController *ctrl = self;


### PR DESCRIPTION
## Description
<!--- Detailed info for reviewers and developers -->
See https://developer.apple.com/documentation/uikit/uiapplication/canopenurl%28_:%29

Replacing `canOpenURL` by using the completion handler of `openURL:options:completionHandler:`.

## Summary for release notes
<!--- This will be shown in Testflight to end users / testers -->
<!--- Please fill in, as usually PR title isn't clear to ordinary users -->
<!--- You can keep it empty if it's identical to the PR title though -->
<!--- If your changes don't modify app files, please add prefix [not app] -->
Maintenance: remove soon deprecated canOpenURL